### PR TITLE
Add ability to configure airflow version on init

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -64,7 +64,7 @@ func initFiles(root string, files map[string]string) error {
 }
 
 // Init will scaffold out a new airflow project
-func Init(path string) error {
+func Init(path string, airflowVersion string) error {
 	// List of directories to create
 	dirs := []string{"dags", "plugins", "include"}
 
@@ -72,7 +72,7 @@ func Init(path string) error {
 	files := map[string]string{
 		".dockerignore": include.Dockerignore,
 		"Dockerfile": fmt.Sprintf(include.Dockerfile,
-			version.GetTagFromVersion()),
+			version.GetTagFromVersion(airflowVersion)),
 		"packages.txt":              "",
 		"requirements.txt":          "",
 		"dags/example-dag.py":       include.Exampledag,

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -23,6 +23,7 @@ import (
 
 var (
 	projectName      string
+	airflowVersion   string
 	followLogs       bool
 	forceDeploy      bool
 	forcePrompt      bool
@@ -40,6 +41,7 @@ var (
 		Use:   "init",
 		Short: "Scaffold a new airflow project",
 		Long:  "Scaffold a new airflow project directory. Will create the necessary files to begin development locally as well as be deployed to the Astronomer Platform.",
+		Args:  cobra.MaximumNArgs(1),
 		RunE:  airflowInit,
 	}
 
@@ -99,6 +101,7 @@ func init() {
 
 	// Airflow init
 	airflowInitCmd.Flags().StringVarP(&projectName, "name", "n", "", "Name of airflow project")
+	airflowInitCmd.Flags().StringVarP(&airflowVersion, "airflow-version", "v", "", "Version of airflow you want to deploy")
 	airflowRootCmd.AddCommand(airflowInitCmd)
 
 	// Airflow deploy
@@ -167,6 +170,12 @@ func airflowInit(cmd *cobra.Command, args []string) error {
 		projectName = strings.Replace(strcase.ToSnake(projectDirectory), "_", "-", -1)
 	}
 
+	acceptableAirflowVersions := []string{"1.9.0", "1.10.1"}
+
+	if airflowVersion != "" && !acceptableVersion(airflowVersion, acceptableAirflowVersions) {
+		return errors.Errorf(messages.ERROR_INVALID_AIRFLOW_VERSION, strings.Join(acceptableAirflowVersions, ", "))
+	}
+
 	emtpyDir := fileutil.IsEmptyDir(config.WorkingPath)
 	if !emtpyDir {
 		i, _ := input.InputConfirm(
@@ -187,7 +196,7 @@ func airflowInit(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 
 	// Execute method
-	airflow.Init(config.WorkingPath)
+	airflow.Init(config.WorkingPath, airflowVersion)
 
 	if exists {
 		fmt.Printf(messages.CONFIG_REINIT_PROJECT_CONFIG+"\n", config.WorkingPath)
@@ -272,4 +281,13 @@ func airflowPS(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 
 	return airflow.PS(config.WorkingPath)
+}
+
+func acceptableVersion(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -3,6 +3,7 @@ package messages
 var (
 	ERROR_INVALID_CLI_VERSION     = "Astronomer CLI version is not valid"
 	ERROR_GITHUB_JSON_MARSHALLING = "Failed to JSON decode Github response from %s"
+	ERROR_INVALID_AIRFLOW_VERSION = "Unsupported Airflow Version specified. Please choose from: %s \n"
 
 	CLI_CMD_DEPRECATE         = "Deprecated in favor of %s\n"
 	CLI_CURR_VERSION          = "Astro CLI Version: %s "

--- a/version/version.go
+++ b/version/version.go
@@ -79,12 +79,17 @@ func isValidVersion(version string) bool {
 	return true
 }
 
-func GetTagFromVersion() string {
+func GetTagFromVersion(airflowVersion string) string {
+
+	if airflowVersion == "" {
+		airflowVersion = "1.9.0"
+	}
+
 	version := CurrVersion
 
 	if !isValidVersion(version) || s.HasPrefix(version, "SNAPSHOT-") {
-		return "master-onbuild-1.9.0"
+		return fmt.Sprintf("master-onbuild-%s", airflowVersion)
 	} else {
-		return fmt.Sprintf("%s-%s-onbuild", version, "1.9.0")
+		return fmt.Sprintf("%s-%s-onbuild", version, airflowVersion)
 	}
 }


### PR DESCRIPTION
Example usage:

Create an Airflow 1.9.0 project:
```
astro airflow init
astro airflow init -v 1.9.0
```

Create an Airflow 1.10.1 project:
```
astro airflow init -v 1.10.1
```

Create an Airflow 2.0.0 project:
```
astro airflow init -v 2.0.0
> Error: Unsupported Airflow Version specified. Please choose from: 1.9.0, 1.10.1
```