### PR TITLE
Allow for custom env files

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -75,6 +75,7 @@ func Init(path string) error {
 			version.GetTagFromVersion()),
 		"packages.txt":              "",
 		"requirements.txt":          "",
+		".env":                      "",
 		"dags/example-dag.py":       include.Exampledag,
 		"plugins/example-plugin.py": include.ExamplePlugin,
 	}

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -51,6 +51,8 @@ services:
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@{{ .PostgresHost }}:5432
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+    env_file:
+           - {{ .AirflowEnvFile }}
     volumes:
       - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:ro
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:ro
@@ -78,6 +80,8 @@ services:
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
     ports:
       - {{ .AirflowWebserverPort }}:8080
+    env_file:
+           - {{ .AirflowEnvFile }}
     volumes:
       - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:ro
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:ro

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -52,7 +52,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
     env_file:
-           - {{ .AirflowEnvFile }}
+      - {{ .AirflowEnvFile }}
     volumes:
       - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:ro
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:ro
@@ -81,7 +81,7 @@ services:
     ports:
       - {{ .AirflowWebserverPort }}:8080
     env_file:
-           - {{ .AirflowEnvFile }}
+      - {{ .AirflowEnvFile }}
     volumes:
       - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:ro
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:ro

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -23,6 +23,7 @@ import (
 
 var (
 	projectName      string
+	envFile          string
 	followLogs       bool
 	forceDeploy      bool
 	forcePrompt      bool
@@ -56,6 +57,7 @@ var (
 		Use:     "start",
 		Short:   "Start a development airflow cluster",
 		Long:    "Start a development airflow cluster",
+		Args:    cobra.MaximumNArgs(1),
 		PreRunE: ensureProjectDir,
 		RunE:    airflowStart,
 	}
@@ -110,6 +112,7 @@ func init() {
 
 	// Airflow start
 	airflowRootCmd.AddCommand(airflowStartCmd)
+	airflowStartCmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 
 	// Airflow kill
 	airflowRootCmd.AddCommand(airflowKillCmd)
@@ -233,7 +236,12 @@ func airflowStart(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	return airflow.Start(config.WorkingPath)
+	// Get release name from args, if passed
+	if len(args) > 0 {
+		envFile = args[0]
+	}
+
+	return airflow.Start(config.WorkingPath, envFile)
 }
 
 // Kill an airflow cluster


### PR DESCRIPTION
Resolves https://github.com/astronomer/astro-cli/issues/159


- Creates .env on init

Example behavior:

Using .env file
```
astro airflow start
```

Using custom.env file
```
astro airflow start --env custom.env
```