### PR TITLE
Add gitHub pre-releases on alpha, beta, rc versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ pipeline:
 
   # Cut releases with goreleaser when tagged
   push:
-    image: goreleaser/goreleaser:v0.86
+    image: goreleaser/goreleaser:v0.103
     secrets: [ github_token ]
     commands:
       - git fetch --no-tags origin +refs/tags/${DRONE_TAG}:refs/tags/${DRONE_TAG}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,9 @@ release:
   github:
     owner: astronomer
     name: astro-cli
+  # If set to auto, will mark the release as not ready for production
+  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  prerelease: auto
 brew:
   install: bin.install "astro"
 builds:


### PR DESCRIPTION
tl;dr
When the version tag is not stable; e.g. 1.0.0-alpha, 1.0.0-beta or 1.0.0-rc (see https://semver.org/#spec-item-11) I would like the github release to be a pre-release.