### PR TITLE
Backport "airflow_settings.yaml" and ".env" feature to 0.7

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -75,6 +75,7 @@ func Init(path string) error {
 			version.GetTagFromVersion()),
 		"packages.txt":              "",
 		"requirements.txt":          "",
+		"airflow_settings.yaml":     include.Settingsyml,
 		"dags/example-dag.py":       include.Exampledag,
 		"plugins/example-plugin.py": include.ExamplePlugin,
 	}

--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -75,6 +75,7 @@ func Init(path string) error {
 			version.GetTagFromVersion()),
 		"packages.txt":              "",
 		"requirements.txt":          "",
+		".env":                      "",
 		"airflow_settings.yaml":     include.Settingsyml,
 		"dags/example-dag.py":       include.Exampledag,
 		"plugins/example-plugin.py": include.ExamplePlugin,

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -139,6 +139,8 @@ func createProject(projectName, airflowHome string) (project.APIProject, error) 
 func Start(airflowHome string) error {
 	// Get project name from config
 	projectName := config.CFG.ProjectName.GetString()
+	replacer := strings.NewReplacer("_", "", "-", "")
+	strippedProjectName := replacer.Replace(projectName)
 
 	// Create a libcompose project
 	project, err := createProject(projectName, airflowHome)
@@ -193,7 +195,7 @@ func Start(airflowHome string) error {
 
 	if fileState {
 		for _, info := range psInfo {
-			if strings.Contains(info["Name"], projectName) &&
+			if strings.Contains(info["Name"], strippedProjectName) &&
 				strings.Contains(info["Name"], "webserver") {
 				settings.ConfigSettings(info["Id"])
 			}

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -56,6 +56,7 @@ services:
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:ro
       - {{ .AirflowHome }}/include:/usr/local/airflow/include:ro
       - airflow_logs:/usr/local/airflow/logs
+    {{ .AirflowEnvFile }}
 
   webserver:
     image: {{ .AirflowImage }}
@@ -83,4 +84,5 @@ services:
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:ro
       - {{ .AirflowHome }}/include:/usr/local/airflow/include:ro
       - airflow_logs:/usr/local/airflow/logs
+    {{ .AirflowEnvFile }}
 `)

--- a/airflow/include/settingsyml.go
+++ b/airflow/include/settingsyml.go
@@ -1,0 +1,26 @@
+package include
+
+import "strings"
+
+// Settingsyml is the settings template
+var Settingsyml = strings.TrimSpace(`
+# This feature is in Beta.
+# Please report any bugs to https://github.com/astronomer/astro-cli/issues
+# NOTE: If putting a dict for any field, please wrap in single quotes.
+# More details you can find https://github.com/astronomer/docs/blob/master/docs/cli-airflow-configuration.md 
+airflow:
+  connections:
+    - conn_id:
+      conn_type:
+      conn_host:
+      conn_login:
+      conn_password:
+      conn_port:
+      conn_extra:
+  pools:
+    - pool_name:
+      pool_slot:
+      pool_description:
+  variables:
+    - variable_name:
+      variable_value:`)

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -23,6 +23,7 @@ import (
 
 var (
 	projectName      string
+	envFile          string
 	followLogs       bool
 	forceDeploy      bool
 	forcePrompt      bool
@@ -56,6 +57,7 @@ var (
 		Use:     "start",
 		Short:   "Start a development airflow cluster",
 		Long:    "Start a development airflow cluster",
+		Args:    cobra.MaximumNArgs(1),
 		PreRunE: ensureProjectDir,
 		RunE:    airflowStart,
 	}
@@ -110,6 +112,7 @@ func init() {
 
 	// Airflow start
 	airflowRootCmd.AddCommand(airflowStartCmd)
+	airflowStartCmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 
 	// Airflow kill
 	airflowRootCmd.AddCommand(airflowKillCmd)
@@ -233,7 +236,12 @@ func airflowStart(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	return airflow.Start(config.WorkingPath)
+	// Get release name from args, if passed
+	if len(args) > 0 {
+		envFile = args[0]
+	}
+
+	return airflow.Start(config.WorkingPath, envFile)
 }
 
 // Kill an airflow cluster

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -49,3 +49,20 @@ func ExecLogin(registry, username, password string) error {
 
 	return cmd.Run()
 }
+
+// AirflowCommand is the main method of interaction with Airflow
+func AirflowCommand(id string, airflowCommand string) string {
+
+	cmd := exec.Command("docker", "exec", "-it", id, "bash", "-c", airflowCommand)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+
+	if err != nil {
+		errors.Wrapf(err, "error encountered")
+	}
+
+	stringOut := string(out)
+	return stringOut
+}

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -41,6 +41,10 @@ var (
 	COMPOSE_LINK_WEBSERVER       = "Airflow Webserver: http://localhost:%s/admin/"
 	COMPOSE_LINK_POSTGRES        = "Postgres Database: localhost:%s/postgres"
 
+	ENV_PATH      = "Error looking for \"%s\""
+	ENV_FOUND     = "Env file \"%s\" found. Loading...\n"
+	ENV_NOT_FOUND = "Env file \"%s\" not found. Skipping...\n"
+
 	HOUSTON_BASIC_AUTH_DISABLED      = "Basic authentication is disabled, conact administrator or defer back to oAuth"
 	HOUSTON_DEPLOYMENT_HEADER        = "Authenticated to %s \n\n"
 	HOUSTON_DEPLOYING_PROMPT         = "Deploying: %s\n"

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -57,5 +57,7 @@ var (
 	REGISTRY_AUTH_FAIL           = "Failed to authenticate to the registry, this can occur when registry is offline. Until authenticated you will not be able to push new images to your Airflow clusters\n"
 	REGISTRY_UNCOMMITTED_CHANGES = "Project directory has uncommmited changes, use `astro airflow deploy [releaseName] -f` to force deploy."
 
+	SETTINGS_PATH = "Error looking for airflow_settings.yaml"
+
 	NA = "N/A"
 )

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -1,0 +1,175 @@
+package settings
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/astronomer/astro-cli/docker"
+	"github.com/astronomer/astro-cli/messages"
+	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+)
+
+var (
+	// ConfigFileName is the name of the config files (home / project)
+	ConfigFileName = "airflow_settings"
+	// ConfigFileType is the config file extension
+	ConfigFileType = "yaml"
+	// ConfigFileNameWithExt is the config filename with extension
+	ConfigFileNameWithExt = fmt.Sprintf("%s.%s", ConfigFileName, ConfigFileType)
+	// HomePath is the path to a users home directory
+	HomePath, _ = fileutil.GetHomeDir()
+	// HomeConfigFile is the global config file
+	HomeConfigFile = filepath.Join(HomePath, ConfigFileNameWithExt)
+	// WorkingPath is the path to the working directory
+	WorkingPath, _ = fileutil.GetWorkingDir()
+
+	// viperSettings is the viper object in a project directory
+	viperSettings *viper.Viper
+
+	settings Config
+)
+
+// ConfigSettings is the main builder of the settings package
+func ConfigSettings(id string) {
+	InitSettings()
+	AddConnections(id)
+	AddPools(id)
+	AddVariables(id)
+}
+
+// InitSettings initializes settings file
+func InitSettings() {
+	// Set up viper object for project config
+	viperSettings = viper.New()
+	viperSettings.SetConfigName(ConfigFileName)
+	viperSettings.SetConfigType(ConfigFileType)
+	workingConfigFile := filepath.Join(WorkingPath, ConfigFileNameWithExt)
+	// Add the path we discovered
+	viperSettings.SetConfigFile(workingConfigFile)
+
+	// Read in project config
+	readErr := viperSettings.ReadInConfig()
+
+	if readErr != nil {
+		fmt.Printf(messages.CONFIG_READ_ERROR, readErr)
+	}
+
+	err := viperSettings.Unmarshal(&settings)
+
+	if err != nil {
+		errors.Wrap(err, "unable to decode into struct")
+	}
+}
+
+// AddVariables is a function to add Variables from settings.yaml
+func AddVariables(id string) {
+	variables := settings.Airflow.Variables
+
+	for _, variable := range variables {
+		if !objectValidator(0, variable.VariableName) {
+			if objectValidator(0, variable.VariableValue) {
+				fmt.Print("Skipping Variable Creation: No Variable Name Specified.\n")
+			}
+		} else {
+			if objectValidator(0, variable.VariableValue) {
+
+				airflowCommand := fmt.Sprintf("airflow variables -s %s ", variable.VariableName)
+
+				airflowCommand += fmt.Sprintf("'%s'", variable.VariableValue)
+
+				docker.AirflowCommand(id, airflowCommand)
+				fmt.Printf("Added Variable: %s\n", variable.VariableName)
+			}
+		}
+	}
+}
+
+// AddConnections is a function to add Connections from settings.yaml
+func AddConnections(id string) {
+	connections := settings.Airflow.Connections
+	airflowCommand := fmt.Sprintf("airflow connections -l")
+	out := docker.AirflowCommand(id, airflowCommand)
+
+	for _, conn := range connections {
+		if objectValidator(0, conn.ConnID) {
+			quotedConnID := "'" + conn.ConnID + "'"
+
+			if strings.Contains(out, quotedConnID) {
+				fmt.Printf("Found Connection: \"%s\"...replacing...\n", conn.ConnID)
+				airflowCommand = fmt.Sprintf("airflow connections -d --conn_id \"%s\"", conn.ConnID)
+				docker.AirflowCommand(id, airflowCommand)
+			}
+
+			if !objectValidator(1, conn.ConnType, conn.ConnURI) {
+				fmt.Printf("Skipping %s: conn_type or conn_uri must be specified.\n", conn.ConnID)
+			} else {
+				airflowCommand = fmt.Sprintf("airflow connections -a --conn_id \"%s\" ", conn.ConnID)
+				if objectValidator(0, conn.ConnType) {
+					airflowCommand += fmt.Sprintf("--conn_type \"%s\" ", conn.ConnType)
+				}
+				if objectValidator(0, conn.ConnURI) {
+					airflowCommand += fmt.Sprintf("--conn_uri '%s' ", conn.ConnURI)
+				}
+				if objectValidator(0, conn.ConnExtra) {
+					airflowCommand += fmt.Sprintf("--conn_extra '%s' ", conn.ConnExtra)
+				}
+				if objectValidator(0, conn.ConnHost) {
+					airflowCommand += fmt.Sprintf("--conn_host '%s' ", conn.ConnHost)
+				}
+				if objectValidator(0, conn.ConnLogin) {
+					airflowCommand += fmt.Sprintf("--conn_login '%s' ", conn.ConnLogin)
+				}
+				if objectValidator(0, conn.ConnPassword) {
+					airflowCommand += fmt.Sprintf("--conn_password '%s' ", conn.ConnPassword)
+				}
+				if objectValidator(0, conn.ConnSchema) {
+					airflowCommand += fmt.Sprintf("--conn_schema '%s' ", conn.ConnSchema)
+				}
+				if conn.ConnPort != 0 {
+					airflowCommand += fmt.Sprintf("--conn_port %v", conn.ConnPort)
+				}
+
+				docker.AirflowCommand(id, airflowCommand)
+				fmt.Printf("Added Connection: %s\n", conn.ConnID)
+			}
+		}
+	}
+}
+
+// AddPools  is a function to add Pools from settings.yaml
+func AddPools(id string) {
+	pools := settings.Airflow.Pools
+	for _, pool := range pools {
+		if objectValidator(0, pool.PoolName) {
+			airflowCommand := fmt.Sprintf("airflow pool -s %s ", pool.PoolName)
+			if pool.PoolSlot != 0 {
+				airflowCommand += fmt.Sprintf("%v ", pool.PoolSlot)
+				if objectValidator(0, pool.PoolDescription) {
+					airflowCommand += fmt.Sprintf("'%s' ", pool.PoolDescription)
+				} else {
+					airflowCommand += fmt.Sprint("\"\"")
+				}
+				docker.AirflowCommand(id, airflowCommand)
+				fmt.Printf("Added Pool: %s\n", pool.PoolName)
+			} else {
+				fmt.Printf("Skipping %s: Pool Slot must be set.", pool.PoolName)
+			}
+		}
+	}
+}
+
+func objectValidator(bound int, args ...string) bool {
+	count := 0
+	for _, arg := range args {
+		if len(arg) == 0 {
+			count++
+		}
+	}
+	if count > bound {
+		return false
+	}
+	return true
+}

--- a/settings/types.go
+++ b/settings/types.go
@@ -1,0 +1,39 @@
+package settings
+
+// Connections contains structure of airflow connections
+type Connections []struct {
+	ConnID       string `mapstructure:"conn_id"`
+	ConnType     string `mapstructure:"conn_type"`
+	ConnHost     string `mapstructure:"conn_host"`
+	ConnSchema   string `mapstructure:"conn_schema"`
+	ConnLogin    string `mapstructure:"conn_login"`
+	ConnPassword string `mapstructure:"conn_password"`
+	ConnPort     int    `mapstructure:"conn_port"`
+	ConnURI      string `mapstructure:"conn_uri"`
+	ConnExtra    string `mapstructure:"conn_extra"`
+}
+
+// Pools contains structure of airflow pools
+type Pools []struct {
+	PoolName        string `mapstructure:"pool_name"`
+	PoolSlot        int    `mapstructure:"pool_slot"`
+	PoolDescription string `mapstructure:"pool_description"`
+}
+
+// Variables contains structure of airflow variables
+type Variables []struct {
+	VariableName  string `mapstructure:"variable_name"`
+	VariableValue string `mapstructure:"variable_value"`
+}
+
+// Airflow contains structure of airflow settings
+type Airflow struct {
+	Connections `mapstructure:"connections"`
+	Pools       `mapstructure:"pools"`
+	Variables   `mapstructure:"variables"`
+}
+
+// Config is input data to generate connections, pools, and variables
+type Config struct {
+	Airflow `mapstructure:"airflow"`
+}


### PR DESCRIPTION
Backports some 0.8 features to 0.7:
- Add connections, variable, and pool creation via airflow_settings.yaml
- Add support for ".env" and other env files via `-e` flag