### PR TITLE
Fix "gcc": executable file not found in $PATH

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ pipeline:
 
   # Cut releases with goreleaser when tagged
   push:
-    image: goreleaser/goreleaser:v0.103
+    image: goreleaser/goreleaser:v0.103-cgo
     secrets: [ github_token ]
     commands:
       - git fetch --no-tags origin +refs/tags/${DRONE_TAG}:refs/tags/${DRONE_TAG}


### PR DESCRIPTION
@schnie pls review

tl;dr

```
docker run --entrypoint "gcc" goreleaser/goreleaser:v0.103-cgo
gcc: fatal error: no input files
compilation terminated.
```

```
docker run --entrypoint "gcc" goreleaser/goreleaser:v0.103
docker: Error response from daemon: OCI runtime create failed: container_linux.go:344: starting container process caused "exec: \"gcc\": executable file not found in $PATH": unknown.
ERRO[0001] error waiting for container: context canceled
```