### PR TITLE
Rethink login to registry

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,7 @@ pipeline:
   # Test the code
   test:
     image: asoldatenko/dnd-golang
+    privileged: true
     commands:
       - make test
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ pipeline:
 
   # Test the code
   test:
-    image: golang
+    image: docker:dind
     commands:
       - make test
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,9 +11,9 @@ pipeline:
 
   # Test the code
   test:
-    image: docker:dind
+    image: asoldatenko/dnd-golang
     commands:
-      - go test -v ./...
+      - make test
 
   # Cut releases with goreleaser when tagged
   push:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,8 +14,8 @@ pipeline:
     image: asoldatenko/dnd-golang
     privileged: true
     volumes:
-      - name: dockersock
-        path: /var/run
+    - name: dockersock
+      path: /var/run
     commands:
       - make test
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ pipeline:
   test:
     image: docker:dind
     commands:
-      - make test
+      - go test -v ./...
 
   # Cut releases with goreleaser when tagged
   push:

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,10 +12,8 @@ pipeline:
   # Test the code
   test:
     image: asoldatenko/dnd-golang
-    privileged: true
     volumes:
-    - name: dockersock
-      path: /var/run
+      - /var/run/docker.sock:/var/run/docker.sock
     commands:
       - make test
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,9 @@ pipeline:
   test:
     image: asoldatenko/dnd-golang
     privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
     commands:
       - make test
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,12 @@
+FROM docker:dind
+
+RUN apk add --no-cache git make musl-dev go
+
+# Configure Go
+ENV GOROOT /usr/lib/go
+ENV GOPATH /go
+ENV PATH /go/bin:$PATH
+
+RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
+
+WORKDIR $GOPATH

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -55,7 +55,7 @@ func ExecLogin(serverAddress, username, password string) error {
 		panic(err)
 	}
 
-	//
+	// Remove http|https from serverAddress
 	serverAddress = registry.ConvertToHostname(serverAddress)
 
 	authConfig := &types.AuthConfig{

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -8,10 +8,3 @@ func TestExecVersion(t *testing.T) {
 		t.Error(err)
 	}
 }
-
-func TestLoginFailed(t *testing.T) {
-	err := ExecLogin("https://quay.io/v1", "", "")
-	if err == nil {
-		t.Error(err)
-	}
-}

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -1,0 +1,17 @@
+package docker
+
+import "testing"
+
+func TestExecLogin(t *testing.T) {
+	err := Exec("version")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestLoginFailed(t *testing.T) {
+	err := ExecLogin("https://quay.io/v1", "", "")
+	if err == nil {
+		t.Error(err)
+	}
+}

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -2,7 +2,7 @@ package docker
 
 import "testing"
 
-func TestExecLogin(t *testing.T) {
+func TestExecVersion(t *testing.T) {
 	err := Exec("version")
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
i have created test:
```
func TestLoginFailed(t *testing.T) {
	err := ExecLogin("https://quay.io/v1", "", "")
	if err == nil {
		t.Error(err)
	}
}
```
and results we can check in OSX:
```
cat ~/.docker/config.json
{
	"auths": {
		"https://quay.io/v1": {},
		"quay.io": {}
	},
	"HttpHeaders": {
		"User-Agent": "Docker-Client/18.09.2 (darwin)"
	},
	"credsStore": "osxkeychain"
}%
```
and windows:

```
{
	"auths": {
		"https://index.docker.io/v1/": {},
		"quay.io": {},
		"registry.datarouter.ai": {}
	},
	"HttpHeaders": {
		"User-Agent": "Docker-Client/18.09.2 (windows)"
	},
	"credsStore": "wincred"
}
```