### PR TITLE
Remove active from Workspace type

### DIFF
--- a/houston/queries.go
+++ b/houston/queries.go
@@ -214,7 +214,6 @@ var (
 			id
 			label
 			description
-			active
 			createdAt
 			updatedAt
 			roleBindings {
@@ -233,7 +232,6 @@ var (
 			id
 			label
 			description
-			active
 			createdAt
 			updatedAt
 		}
@@ -245,7 +243,6 @@ var (
 			id
 			label
 			description
-			active
 			createdAt
 			updatedAt
 		}
@@ -257,7 +254,6 @@ var (
 			id
 			label
 			description
-			active
 			deploymentCount
 			createdAt
 			updatedAt
@@ -270,7 +266,6 @@ var (
 			id
 			label
 			description
-			active
 			users {
 				id
 				username
@@ -306,7 +301,6 @@ var (
 		  id
 		  label
 		  description
-		  active
 		  users {
 			id
 			username

--- a/houston/types.go
+++ b/houston/types.go
@@ -138,7 +138,6 @@ type Workspace struct {
 	Id          string `json:"id"`
 	Label       string `json:"label"`
 	Description string `json:"description"`
-	Active      bool   `json:"active"`
 	Users       []User `json:"users"`
 	// groups
 	CreatedAt    string        `json:"createdAt"`


### PR DESCRIPTION
We recently removed `active` from the `Workspace` type in Houston. This removes it from the CLI.