### PR TITLE
remove .astro from .gitignore template #260

### DIFF
--- a/airflow/include/gitignore.go
+++ b/airflow/include/gitignore.go
@@ -4,7 +4,6 @@ import "strings"
 
 // Gitignore is the .gitignore template
 var Gitignore = strings.TrimSpace(`
-.astro
 .git
 .env
 airflow_setttings.yaml


### PR DESCRIPTION
Remove `.astro` from `.gitignore` so users don't have to run `astro airflow init` after cloning a repo