### PR TITLE
Fixing ignored filename

### DIFF
--- a/airflow/include/dockerignore.go
+++ b/airflow/include/dockerignore.go
@@ -7,5 +7,5 @@ var Dockerignore = strings.TrimSpace(`
 .astro
 .git
 .env
-airflow_setttings.yaml
+airflow_settings.yaml
 `)

--- a/airflow/include/gitignore.go
+++ b/airflow/include/gitignore.go
@@ -6,5 +6,5 @@ import "strings"
 var Gitignore = strings.TrimSpace(`
 .git
 .env
-airflow_setttings.yaml
+airflow_settings.yaml
 `)


### PR DESCRIPTION
The file `airflow_settings.yaml` was intended to be ignored using `airflow_setttings.yaml`. This PR fixes that.
