### PR TITLE
Switch to safer "z" flag

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -137,7 +137,7 @@ func generateConfig(projectName, airflowHome string, envFile string) (string, er
 		AirflowUser:          "astro",
 		AirflowWebserverPort: config.CFG.WebserverPort.GetString(),
 		AirflowEnvFile:       envFile,
-		MountLabel:           "Z",
+		MountLabel:           "z",
 	}
 
 	buff := new(bytes.Buffer)


### PR DESCRIPTION
From docker docs:

If you use selinux you can add the z or Z options to modify the selinux label of the host file or directory being mounted into the container. This affects the file or directory on the host machine itself and can have consequences outside of the scope of Docker.

    The z option indicates that the bind mount content is shared among multiple containers.
    The Z option indicates that the bind mount content is private and unshared.

Use extreme caution with these options. Bind-mounting a system directory such as /home or /usr with the Z option renders your host machine inoperable and you may need to relabel the host machine files by hand.