### PR TITLE
Fix corner case when same version without any changes in git ref log

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_{{ .Timestamp }}'
     files:
       - licence*
       - LICENCE*


### PR DESCRIPTION
```
POST https://uploads.github.com/repos/astronomer/astro-cli/releases/19926948/assets?name=astro_0.10.1-alpha.4_checksums.txt: 422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}]
```
`git -c log.showSignature=false describe --tags --abbrev=0`

git tag --contains e28eeba | sort -R | tail -1
v0.10.1-alpha.5

Solution: add timestamp to build artifact to fix uploading to Github?
@schnie confirmed in Slack.