### PR TITLE
change strategy of how goreleaser get last tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ pipeline:
 
   # Cut releases with goreleaser when tagged
   push:
-    image: goreleaser/goreleaser:v0.113
+    image: astronomerio/goreleaser:v0.0.1
     secrets: [ github_token ]
     commands:
       - git fetch --tags


### PR DESCRIPTION
TODO:
- migrate to astronomer.io

Fix bug:
```639bddf [88 seconds ago] (HEAD -> master, tag: v0.10.1-alpha.5, tag: v0.10.1-alpha.4) first commit [Andrii Soldatenko]
➜  test_git git:(master) git ls
➜  test_git git:(master) git tag v0.10.1-alpha.4
➜  test_git git:(master) gs
On branch master
nothing to commit, working tree clean
➜  test_git git:(master) git ls
➜  test_git git:(master) git tag v0.10.1-alpha.5
➜  test_git git:(master) git ls
➜  test_git git:(master) git -c log.showSignature=false describe --tags --abbrev=0
v0.10.1-alpha.4
➜  test_git git:(master) git ls
➜  test_git git:(master)
```

possible fix:
git tag -l --sort=-v:refname | head -1
v0.10.1-alpha.5

fork:
docker push asoldatenko/goreleaser:v0.0.1
The push refers to repository [docker.io/asoldatenko/goreleaser]
https://github.com/andriisoldatenko/goreleaser/commit/e9f7c6d6f6473cfbba5de9c5fe8cf421b8626a11
