### PR TITLE
Bump airflow version astronomer/issues#377

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -213,7 +213,7 @@ func airflowInit(cmd *cobra.Command, args []string) error {
 		projectName = strings.Replace(strcase.ToSnake(projectDirectory), "_", "-", -1)
 	}
 
-	acceptableAirflowVersions := []string{"1.9.0", "1.10.3"}
+	acceptableAirflowVersions := []string{"1.9.0", "1.10.5"}
 
 	if airflowVersion != "" && !acceptableVersion(airflowVersion, acceptableAirflowVersions) {
 		return errors.Errorf(messages.ERROR_INVALID_AIRFLOW_VERSION, strings.Join(acceptableAirflowVersions, ", "))

--- a/version/version.go
+++ b/version/version.go
@@ -82,7 +82,7 @@ func isValidVersion(version string) bool {
 func GetTagFromVersion(airflowVersion string) string {
 
 	if airflowVersion == "" {
-		airflowVersion = "1.10.4"
+		airflowVersion = "1.10.5"
 	}
 
 	version := CurrVersion


### PR DESCRIPTION
* Bump airflow version to `1.10.5`
* I did not know if I needed to bump `acceptableAirflowVersions` in `cmd/airflow.go` but saw it bumped in a previous PR https://github.com/astronomer/astro-cli/commit/70374e90a1304024cb5f86757b3976b445777120#diff-036da75ff930f37d0e7765ce446cf663. It doesn't looked like it was bumped with `1.10.4`