### PR TITLE
Add more examples for astro deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -15,7 +15,7 @@ var (
 	deployExample = `
 Deployment you would like to deploy to Airflow cluster:
 
-  $ astro deploy physical-diameter-1566
+  $ astro deploy <deployment name>
 
 Deploy deployment using suggestion:
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -12,6 +12,19 @@ import (
 )
 
 var (
+	deployExample = `
+# Deployment you would like to deploy to Airflow cluster:
+astro deploy physical-diameter-1566
+
+# Deploy deployment using suggestion: 
+astro deploy
+
+Select which airflow deployment you want to deploy to:
+ #     LABEL                   DEPLOYMENT NAME            WORKSPACE     DEPLOYMENT ID
+ 1     new-deployment-name     physical-diameter-1566     w1            ck1ryz2jd00430f50a5dmu7g9
+
+>1
+`
 	deployCmd = &cobra.Command{
 		Use:     "deploy DEPLOYMENT",
 		Short:   "Deploy an airflow project",
@@ -19,6 +32,7 @@ var (
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: ensureProjectDir,
 		RunE:    deploy,
+		Example: deployExample,
 		Aliases: []string{"airflow deploy"},
 	}
 )

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -13,17 +13,19 @@ import (
 
 var (
 	deployExample = `
-# Deployment you would like to deploy to Airflow cluster:
-astro deploy physical-diameter-1566
+Deployment you would like to deploy to Airflow cluster:
 
-# Deploy deployment using suggestion: 
-astro deploy
+  $ astro deploy physical-diameter-1566
 
-Select which airflow deployment you want to deploy to:
- #     LABEL                   DEPLOYMENT NAME            WORKSPACE     DEPLOYMENT ID
- 1     new-deployment-name     physical-diameter-1566     w1            ck1ryz2jd00430f50a5dmu7g9
+Deploy deployment using suggestion:
 
->1
+  $ astro deploy
+
+  Select which airflow deployment you want to deploy to:
+   #     LABEL                   DEPLOYMENT NAME            WORKSPACE     DEPLOYMENT ID
+   1     new-deployment-name     physical-diameter-1566     w1            ck1ryz2jd00430f50a5dmu7g9
+  
+  >1
 `
 	deployCmd = &cobra.Command{
 		Use:     "deploy DEPLOYMENT",

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -17,15 +17,9 @@ Deployment you would like to deploy to Airflow cluster:
 
   $ astro deploy <deployment name>
 
-Deploy deployment using suggestion:
+Menu will be presented if you do not specify a deployment name:
 
   $ astro deploy
-
-  Select which airflow deployment you want to deploy to:
-   #     LABEL                   DEPLOYMENT NAME            WORKSPACE     DEPLOYMENT ID
-   1     new-deployment-name     physical-diameter-1566     w1            ck1ryz2jd00430f50a5dmu7g9
-  
-  >1
 `
 	deployCmd = &cobra.Command{
 		Use:     "deploy DEPLOYMENT",


### PR DESCRIPTION
fix https://github.com/astronomer/issues/issues/284

```
$ astro deploy -h
Deploy an airflow project to a given deployment

Usage:
  astro deploy DEPLOYMENT [flags]

Aliases:
  deploy, airflow deploy

Examples:

# Deployment you would like to deploy to Airflow cluster:
astro deploy physical-diameter-1566

# Deploy deployment using suggestion:
astro deploy

Select which airflow deployment you want to deploy to:
 #     LABEL                   DEPLOYMENT NAME            WORKSPACE     DEPLOYMENT ID
 1     new-deployment-name     physical-diameter-1566     w1            ck1ryz2jd00430f50a5dmu7g9

>1


Flags:
  -f, --force                 Force deploy if uncommitted changes
  -h, --help                  help for deploy
  -p, --prompt                Force prompt to choose target deployment
  -s, --save                  Save deployment in config for future deploys
      --workspace-id string   workspace assigned to deployment
```
@vparekh94 what do you think?
