### PR TITLE
Negotiate docker api version

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -70,6 +70,7 @@ func ExecPush(serverAddress, token, image string) error {
 	if err != nil {
 		panic(err)
 	}
+	cli.NegotiateAPIVersion(ctx)
 	buf, err := json.Marshal(authConfig)
 
 	if err != nil {
@@ -96,6 +97,7 @@ func ExecLogin(serverAddress, username, token string) error {
 	if err != nil {
 		panic(err)
 	}
+	cli.NegotiateAPIVersion(ctx)
 
 	// Remove http|https from serverAddress
 	serverAddress = registry.ConvertToHostname(serverAddress)


### PR DESCRIPTION
fixed https://github.com/astronomer/issues/issues/493

Test results using `docker version`:
```
Client:
 Version:           18.06.1-ce
 API version:       1.38
 Go version:        go1.10.3
 Git commit:        e68fc7a
 Built:             Tue Aug 21 17:21:31 2018
 OS/Arch:           darwin/amd64
 Experimental:      false

Server:
 Engine:
  Version:          18.06.1-ce
  API version:      1.38 (minimum version 1.12)
  Go version:       go1.10.3
  Git commit:       e68fc7a
  Built:            Tue Aug 21 17:29:02 2018
  OS/Arch:          linux/amd64
  Experimental:     true
```
`astro deploy`:
```
Removing intermediate container 8e4c2672b4cf
 ---> 972051800110
Successfully built 972051800110
Successfully tagged ultraviolet-meteoroid-4788/airflow:latest
Pushing image to Astronomer registry
The push refers to repository [registry.staging.astronomer.io/ultraviolet-meteoroid-4788/airflow]
7ce812144097: Pushed
efc4b2b5c4ff: Pushed
d8c958a59a25: Pushed
9b89b7deb70e: Pushed
21b91b0a0383: Pushed
39a13329fc60: Pushed
f685b9691d51: Pushed
b63cd14ac579: Pushed
b7dfa8f4ea98: Pushed
b22519d0d4a1: Pushed
8a7e45b088f0: Pushed
e83116bf78e1: Pushed
03901b4a2ea8: Pushed
cli-1: digest: sha256:d9468ab04bebb4798f037c34b9d3113acb1bf7eaa54c0137987a4efb87818348 size: 3023
Untagged: registry.staging.astronomer.io/ultraviolet-meteoroid-4788/airflow:cli-1
Untagged: registry.staging.astronomer.io/ultraviolet-meteoroid-4788/airflow@sha256:d9468ab04bebb4798f037c34b9d3113acb1bf7eaa54c0137987a4efb87818348
Deploy succeeded!

```
astro auth login staging:
```
g
Default "w1" (ck1th7v2k0i3n0978cxljw6qs) workspace found, setting default workspace.
Successfully authenticated to registry.staging.astronomer.io

```