### PR TITLE
remove double command

### DIFF
--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -35,7 +35,7 @@ services:
 
   scheduler:
     image: {{ .AirflowImage }}
-    command: command: >
+    command: >
       bash -c "airflow upgradedb && airflow scheduler"
     restart: unless-stopped
     networks:


### PR DESCRIPTION
```
$ astro-cli dev start
Env file ".env" found. Loading...
Sending build context to Docker daemon  20.99kB
Step 1/1 : FROM astronomerinc/ap-airflow:master-1.10.5-onbuild
# Executing 5 build triggers
 ---> Using cache
 ---> Using cache
 ---> Using cache
 ---> Using cache
 ---> Using cache
 ---> 477ac5c54864
Successfully built 477ac5c54864
Successfully tagged t-t_d9dc85/airflow:latest
Creating volume "ttd9dc85_airflow_logs" with driver "local"
Creating volume "ttd9dc85_postgres_data" with driver "local"
INFO[0000] [0/3] [postgres]: Starting
Pulling postgres (postgres:10.1-alpine)...
^C

```