### PR TITLE
add validation to deployment executor

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -198,6 +198,8 @@ func deploymentCreate(cmd *cobra.Command, args []string) error {
 		deploymentConfig["executor"] = "CeleryExecutor"
 	case "kubernetes", "k8s":
 		deploymentConfig["executor"] = "KubernetesExecutor"
+	default:
+		return errors.New("please specify correct executor, one of: local, celery, kubernetes, k8s")
 	}
 
 	return deployment.Create(args[0], ws, deploymentConfig)


### PR DESCRIPTION
Fix bug:
```
$ astro deployment create LocalTest --executor=Local
 NAME          DEPLOYMENT NAME                   ASTRO      DEPLOYMENT ID
 LocalTest     interstellar-inclination-9854     0.10.3     ck3lx8u5703lu0a49jot69lvn
 Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs
 Airflow Dashboard: https://interstellar-inclination-9854-airflow.staging.astronomer.io
 Flower Dashboard: https://interstellar-inclination-9854-flower.staging.astronomer.io
```

```
$ astro deployment create new-deployment-name-local2 --executor=Local
Error: please specify correct executor, one of: local, celery, kubernetes, k8s
```