### PR TITLE
don't hide help if user run astro workspace wo arguments

### DIFF
--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -29,9 +29,6 @@ func newWorkspaceCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Aliases: []string{"wo"},
 		Short:   "Manage Astronomer workspaces",
 		Long:    "Workspaces contain a group of Airflow Cluster Deployments. The creator of the workspace can invite other users into it",
-		RunE: func(_ *cobra.Command, args []string) error {
-			return nil
-		},
 	}
 	cmd.AddCommand(
 		newWorkspaceListCmd(client, out),

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -177,10 +177,10 @@ func newWorkspaceUserRmCmd(client *houston.Client, out io.Writer) *cobra.Command
 
 func newWorkspaceUserListCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "remove EMAIL",
-		Aliases: []string{"rm"},
-		Short:   "Remove a user from a workspace",
-		Long:    "Remove a user from a workspace",
+		Use:   "list",
+		Aliases: []string{"ls"},
+		Short: "List astronomer workspaces",
+		Long:  "List astronomer workspaces",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return workspaceUserList(cmd, client, out, args)

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -180,7 +180,7 @@ func newWorkspaceUserListCmd(client *houston.Client, out io.Writer) *cobra.Comma
 		Use:   "list",
 		Aliases: []string{"ls"},
 		Short: "List Astronomer workspaces",
-		Long:  "List astronomer workspaces",
+		Long:  "List Astronomer workspaces",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return workspaceUserList(cmd, client, out, args)

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -179,7 +179,7 @@ func newWorkspaceUserListCmd(client *houston.Client, out io.Writer) *cobra.Comma
 	cmd := &cobra.Command{
 		Use:   "list",
 		Aliases: []string{"ls"},
-		Short: "List astronomer workspaces",
+		Short: "List Astronomer workspaces",
 		Long:  "List astronomer workspaces",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
@andrewhharmon found small bug if user run `astro workspace`, there is no help text in stdout:
```
curl -sSL https://install.astronomer.io | sudo bash -s -- v0.11.0-rc.6
Password:
astronomer/astro-cli: found version: 0.11.0-rc.6 for v0.11.0-rc.6/darwin/amd64
astronomer/astro-cli: downloading https://github.com/astronomer/astro-cli/releases/download/v0.11.0-rc.6/astro_0.11.0-rc.6_darwin_amd64.tar.gz
astronomer/astro-cli: downloading https://github.com/astronomer/astro-cli/releases/download/v0.11.0-rc.6/astro_0.11.0-rc.6_checksums.txt
astronomer/astro-cli: verifying checksums
astronomer/astro-cli: installed as /usr/local/bin/astro
(base) ➜  ~ astro version
Astro CLI Version: 0.11.0-rc.6
Git Commit: db7efc623b72291dea74827262f2af2df15b58c6
(base) ➜  ~ astro workspace
(base) ➜  ~ astro workspace help
(base) ➜  ~ astro version
Astro CLI Version: 0.11.0-rc.6
Git Commit: db7efc623b72291dea74827262f2af2df15b58c6
```

Now:
```
$ astro workspace
Workspaces contain a group of Airflow Cluster Deployments. The creator of the workspace can invite other users into it

Usage:
  astro workspace [command]

Aliases:
  workspace, wo

Available Commands:
  create          Create an astronomer workspaces
  delete          Delete an astronomer workspace
  list            List astronomer workspaces
  service-account Manage astronomer service accounts
  switch          Switch to a different astronomer workspace
  update          Update an Astronomer workspace
  user            Manage workspace user resources

Flags:
  -h, --help   help for workspace

Use "astro workspace [command] --help" for more information about a command.
```