### PR TITLE
add `conn_schema:` param to default airflow_settings.yaml file

### DIFF
--- a/airflow/include/settingsyml.go
+++ b/airflow/include/settingsyml.go
@@ -17,6 +17,7 @@ airflow:
     - conn_id:
       conn_type:
       conn_host:
+      conn_schema: 
       conn_login:
       conn_password:
       conn_port:


### PR DESCRIPTION
fix https://github.com/astronomer/issues/issues/739