### PR TITLE
change link to get oauth token

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -119,7 +119,7 @@ func Login(domain string, oAuthOnly bool, username, password string, client *hou
 
 	if len(username) == 0 {
 		if len(authConfig.AuthProviders) > 0 {
-			token = oAuth(c.GetAppURL() + "/login?source=cli")
+			token = oAuth(c.GetAppURL() + "/token")
 		} else {
 			return errors.New("cannot authenticate, oauth is disabled")
 		}


### PR DESCRIPTION
fix https://github.com/astronomer/issues/issues/876
```
astro  auth login staging.astronomer.io
 CLUSTER                             WORKSPACE
 staging.astronomer.io

 Switched cluster
Username (leave blank for oAuth):

Please visit the following URL, authenticate and paste token in next prompt

https://app.staging.astronomer.io/token

oAuth Token:
```