### PR TITLE
fix cosmetic issue

### DIFF
--- a/.circleci/next_version.py
+++ b/.circleci/next_version.py
@@ -1,7 +1,6 @@
 import os
 import re
 import sys
-import json
 from github import Github
 from packaging.version import parse as semver
 
@@ -22,6 +21,8 @@ print(f"We are on a release branch: {branch}, detected major.minor version {majo
 print(f"We will find the most recent patch version of {major_minor_version} and return it incremented by one", file=sys.stderr)
 for release in repo.get_releases():
     version = semver(release.tag_name).release
+    if not version:
+        continue
     this_major_minor = f"{version[0]}.{version[1]}"
     if this_major_minor == major_minor_version:
         most_recent_tag = release.tag_name


### PR DESCRIPTION
practical test:
```
CIRCLE_BRANCH=release-0.13 GIT_ORG=astronomer CIRCLE_PROJECT_REPONAME=astro-cli python next_version.py
```

```
We are on a release branch: release-0.13, detected major.minor version 0.13
We will find the most recent patch version of 0.13 and return it incremented by one
Did not detect a most recent version. Setting patch number to zero.
Calculated new version as 0.13.0
0.13.0%
```

before this change (navigate to https://app.circleci.com/pipelines/github/astronomer/astro-cli/21/workflows/d8349804-3ac9-4ae2-891f-b48d2effadf7/jobs/361):
```
Successfully built wrapt
Installing collected packages: wrapt, deprecated, pyjwt, PyGithub, packaging
Successfully installed PyGithub-1.50 deprecated-1.2.9 packaging-20.3 pyjwt-1.7.1 wrapt-1.12.1
We are on a release branch: release-0.13, detected major.minor version 0.13
We will find the most recent patch version of 0.13 and return it incremented by one
Traceback (most recent call last):
  File ".circleci/next_version.py", line 25, in <module>
    this_major_minor = f"{version[0]}.{version[1]}"
TypeError: 'NoneType' object is not subscriptable

Exited with code exit status 1
```