### PR TITLE
Remove deploymentCount field no longer provided by Houston

### DIFF
--- a/houston/queries.go
+++ b/houston/queries.go
@@ -341,7 +341,6 @@ var (
 			id
 			label
 			description
-			deploymentCount
 			createdAt
 			updatedAt
 		}


### PR DESCRIPTION
Requires astronomer/houston-api#278 to be merged first (which requires astronomer/astro-ui#547 to be merged first.).

This is the only reference to `deploymentCount` I found in this application, but this is definitely far from my wheelhouse, so please add any additional changes needed. 

