### PR TITLE
avoid validate comparability during astro auth

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -16,10 +16,15 @@ var (
 
 func newAuthRootCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		Use:   "auth",
 		Short: "Manage astronomer identity",
 		Long:  "Handles authentication to the Astronomer Platform",
 	}
+
 	cmd.AddCommand(
 		newAuthLoginCmd(client, out),
 		newAuthLogoutCmd(client, out),


### PR DESCRIPTION
hotfix of astro 0.16.0:
```
go run -ldflags '-X github.com/astronomer/astro-cli/version.CurrVersion=0.16.0' main.go auth login localhost
 CLUSTER                             WORKSPACE
 localhost

 Switched cluster
Username (leave blank for oAuth):

Please visit the following URL, authenticate and paste token in next prompt

http://localhost:5000/token

oAuth Token:
```

before this change now in prod version:
```
go run -ldflags '-X github.com/astronomer/astro-cli/version.CurrVersion=0.16.0' main.go auth login localhost
Error: No context set, have you authenticated to a cluster?
Usage:
  astro auth login [BASEDOMAIN] [flags]

Flags:
  -h, --help    help for login
  -o, --oauth   do not prompt for local auth

Global Flags:
      --skip-version-check   skip version compatibility check

exit status 1
```