### PR TITLE
Improve astro-cli UX when user trying to work locally without access houston

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -86,6 +86,10 @@ func newAirflowInitCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Short: "Scaffold a new airflow project",
 		Long:  "Scaffold a new airflow project directory. Will create the necessary files to begin development locally as well as be deployed to the Astronomer Platform.",
 		Args:  cobra.MaximumNArgs(1),
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return airflowInit(cmd, args, client, out)
 		},
@@ -121,6 +125,10 @@ func newAirflowStartCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Short:   "Start a development airflow cluster",
 		Long:    "Start a development airflow cluster",
 		Args:    cobra.MaximumNArgs(1),
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowStart,
 	}
@@ -133,6 +141,10 @@ func newAirflowKillCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Use:     "kill",
 		Short:   "Kill a development airflow cluster",
 		Long:    "Kill a development airflow cluster",
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowKill,
 	}
@@ -144,6 +156,10 @@ func newAirflowLogsCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Use:     "logs",
 		Short:   "Output logs for a development airflow cluster",
 		Long:    "Output logs for a development airflow cluster",
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowLogs,
 	}
@@ -158,6 +174,10 @@ func newAirflowStopCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Use:     "stop",
 		Short:   "Stop a development airflow cluster",
 		Long:    "Stop a development airflow cluster",
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowStop,
 	}
@@ -169,6 +189,10 @@ func newAirflowPSCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Use:     "ps",
 		Short:   "List airflow containers",
 		Long:    "List airflow containers",
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowPS,
 	}
@@ -180,6 +204,10 @@ func newAirflowRunCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Use:                "run",
 		Short:              "Run any command inside airflow webserver",
 		Long:               "Run any command inside airflow webserver",
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		PreRunE:            ensureProjectDir,
 		RunE:               airflowRun,
 		Example:            RunExample,

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/astronomer/astro-cli/houston"
@@ -32,4 +33,46 @@ func TestDevRootCommand(t *testing.T) {
 	output, err := executeCommand("dev")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "astro dev", output)
+}
+
+func TestNewAirflowInitCmd(t *testing.T) {
+	client := houston.NewHoustonClient(httputil.NewHTTPClient())
+	cmd := newAirflowInitCmd(client, os.Stdout)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
+}
+
+func TestNewAirflowStartCmd(t *testing.T) {
+	client := houston.NewHoustonClient(httputil.NewHTTPClient())
+	cmd := newAirflowStartCmd(client, os.Stdout)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
+}
+
+func TestNewAirflowKillCmd(t *testing.T) {
+	client := houston.NewHoustonClient(httputil.NewHTTPClient())
+	cmd := newAirflowKillCmd(client, os.Stdout)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
+}
+
+func TestNewAirflowLogsCmd(t *testing.T) {
+	client := houston.NewHoustonClient(httputil.NewHTTPClient())
+	cmd := newAirflowLogsCmd(client, os.Stdout)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
+}
+
+func TestNewAirflowStopCmd(t *testing.T) {
+	client := houston.NewHoustonClient(httputil.NewHTTPClient())
+	cmd := newAirflowStopCmd(client, os.Stdout)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
+}
+
+func TestNewAirflowPSCmd(t *testing.T) {
+	client := houston.NewHoustonClient(httputil.NewHTTPClient())
+	cmd := newAirflowPSCmd(client, os.Stdout)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
+}
+
+func TestNewAirflowRunCmd(t *testing.T) {
+	client := houston.NewHoustonClient(httputil.NewHTTPClient())
+	cmd := newAirflowRunCmd(client, os.Stdout)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,10 @@ func newVersionCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Use:   "version",
 		Short: "Astronomer CLI version",
 		Long:  "The astro-cli semantic version and git commit tied to that release.",
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return printVersion(client, cmd, out, args)
 		},

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/spf13/cobra"
+	"os"
 	"testing"
 
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
@@ -13,4 +17,10 @@ func TestVersionRootCommand(t *testing.T) {
 	expectedOut := "Error: Astronomer CLI version is not valid\n"
 	output, err := executeCommand("version")
 	assert.Equal(t, expectedOut, output, err)
+}
+
+func TestNewVersionCmd(t *testing.T) {
+	client := houston.NewHoustonClient(httputil.NewHTTPClient())
+	cmd := newVersionCmd(client, os.Stdout)
+	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -7,7 +7,7 @@ var (
 	ERROR_NEW_MAJOR_VERSION       = "There is an update for Astro CLI. You're using version %s, but %s is the server version.\nPlease upgrade to the matching version before continuing. See https://www.astronomer.io/docs/cli-quickstart for more information.\nTo skip this check use the --skip-version-check flag.\n"
 
 	CLI_CMD_DEPRECATE         = "Deprecated in favor of %s\n"
-	CLI_CURR_VERSION          = "Astro CLI Version: %s "
+	CLI_CURR_VERSION          = "Astro CLI Version: %s"
 	CLI_CURR_COMMIT           = "Git Commit: %s"
 	CLI_CURR_VERSION_DATE     = CLI_CURR_VERSION + " (%s)"
 	CLI_LATEST_VERSION        = "Astro CLI Latest: %s "

--- a/version/version.go
+++ b/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+
 	"io"
 
 	"github.com/pkg/errors"
@@ -19,10 +20,6 @@ var (
 
 // PrintVersion outputs current cli version and git commit if exists
 func PrintVersion(client *houston.Client, out io.Writer) error {
-	appCfg, err := deployment.AppConfig(client)
-	if err != nil {
-		return errors.Wrap(err, "can't get app config from houston api")
-	}
 	version := CurrVersion
 	gitCommit := CurrCommit
 
@@ -30,12 +27,18 @@ func PrintVersion(client *houston.Client, out io.Writer) error {
 		return errors.New(messages.ERROR_INVALID_CLI_VERSION)
 	}
 
+	fmt.Fprintf(out, messages.CLI_CURR_VERSION+"\n", version)
+	fmt.Fprintf(out, messages.CLI_CURR_COMMIT+"\n", gitCommit)
+
+	appCfg, err := deployment.AppConfig(client)
+	if err != nil {
+		fmt.Fprintf(out, messages.HOUSTON_CURRENT_VERSION+"\n", "Please authenticate to a cluster to see server version")
+	}
+
 	if appCfg != nil {
 		fmt.Fprintf(out, messages.HOUSTON_CURRENT_VERSION+"\n", appCfg.Version)
 	}
 
-	fmt.Fprintf(out, messages.CLI_CURR_VERSION+"\n", version)
-	fmt.Fprintf(out, messages.CLI_CURR_COMMIT+"\n", gitCommit)
 	return nil
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ func PrintVersion(client *houston.Client, out io.Writer) error {
 		return errors.New(messages.ERROR_INVALID_CLI_VERSION)
 	}
 
-	fmt.Fprintf(out, messages.CLI_CURR_VERSION+"\n", version)
+	fmt.Fprintf(out, messages.CLI_CURR_VERSION+", ", version)
 	fmt.Fprintf(out, messages.CLI_CURR_COMMIT+"\n", gitCommit)
 
 	appCfg, err := deployment.AppConfig(client)

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -38,7 +38,7 @@ func TestPrintVersionHoustonError(t *testing.T) {
 	CurrVersion = "0.15.0"
 	err := PrintVersion(api, output)
 	assert.NoError(t, err)
-	assert.Equal(t, output.String(), "Astro CLI Version: 0.15.0 \nGit Commit: \nAstro Server Version: Please authenticate to a cluster to see server version\n")
+	assert.Equal(t, output.String(), "Astro CLI Version: 0.15.0, Git Commit: \nAstro Server Version: Please authenticate to a cluster to see server version\n")
 }
 
 func TestPrintVersionError(t *testing.T) {
@@ -108,7 +108,7 @@ func TestCheckForUpdateVersionMatch(t *testing.T) {
 	githubClient := github.NewGithubClient(gitHubClient)
 	output := new(strings.Builder)
 	CheckForUpdate(githubClient, output)
-	expected := "Astro CLI Version: v0.15.0  (2020.06.01)\nAstro CLI Latest: v0.15.0  (2020.06.01)\nYou are running the latest version.\n"
+	expected := "Astro CLI Version: v0.15.0 (2020.06.01)\nAstro CLI Latest: v0.15.0  (2020.06.01)\nYou are running the latest version.\n"
 	actual := output.String()
 
 	assert.Equal(t, expected, actual)


### PR DESCRIPTION
fix https://github.com/astronomer/issues/issues/1516


**should work without access to houston server:**

- `astro dev init` 
- `astro dev start` 
- `astro dev kill` 
- `astro dev logs` 
- `astro dev stop` 
- `astro dev ps` 
- `astro dev run` 

and astro version should print correct message instead of crashing:
```
astro version
Astro CLI Version: 0.16.0
Git Commit:
Astro Server Version: Please authenticate to a cluster to see server version
```

cc @schnie @paolaperaza 