### PR TITLE
Remove update deployment sync flag

### DIFF
--- a/houston/queries.go
+++ b/houston/queries.go
@@ -90,8 +90,8 @@ var (
 	}`
 
 	DeploymentUpdateRequest = `
-	mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: String, $sync: Boolean) {
-		updateDeployment(deploymentUuid: $deploymentId, payload: $payload, cloudRole: $cloudRole, sync: $sync) {
+	mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: String) {
+		updateDeployment(deploymentUuid: $deploymentId, payload: $payload, cloudRole: $cloudRole) {
 			id
 			type
 			label


### PR DESCRIPTION
Remove deprecated sync flag from Update Deployment requests.

Fixes https://github.com/astronomer/issues/issues/1579