### PR TITLE
fix astro workspace user add

### DIFF
--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -308,7 +308,7 @@ func workspaceUserAdd(cmd *cobra.Command, client *houston.Client, out io.Writer,
 
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
-	return workspace.Add(ws, args[0], role, client, out)
+	return workspace.Add(ws, args[0], workspaceRole, client, out)
 }
 
 func workspaceUserUpdate(cmd *cobra.Command, client *houston.Client, out io.Writer, args []string) error {

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -323,7 +323,7 @@ func workspaceUserUpdate(cmd *cobra.Command, client *houston.Client, out io.Writ
 
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
-	return workspace.UpdateRole(ws, args[0], role, client, out)
+	return workspace.UpdateRole(ws, args[0], workspaceRole, client, out)
 }
 
 func workspaceUserRm(cmd *cobra.Command, client *houston.Client, out io.Writer, args []string) error {


### PR DESCRIPTION
Before change:
```
astro workspace user add andrii+1@astronomer.io --role=WORKSPACE_VIEWER
Error: API error (400): {"errors":[{"message":"Variable \"$role\" got invalid value \"viewer\"; Expected type Role.","locations":[{"line":2,"column":66}],"extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}
```

After change:
```
$ workspace user add andrii+1@astronomer.io --role=WORKSPACE_VIEWER --workspace-id=ck8c9lxy42d6a0968n2waller
 NAME              WORKSPACE ID                  EMAIL                      ROLE
 Astro Demo WS     ck8c9lxy42d6a0968n2waller     andrii+1@astronomer.io     WORKSPACE_VIEWER
Successfully added andrii+1@astronomer.io to Astro Demo WS
```

P.S. it was typo.