### PR TITLE
hotfix: workspace user remove

### DIFF
--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -186,7 +186,6 @@ func newWorkspaceUserListCmd(client *houston.Client, out io.Writer) *cobra.Comma
 		Aliases: []string{"ls"},
 		Short:   "List Astronomer workspaces",
 		Long:    "List Astronomer workspaces",
-		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return workspaceUserList(cmd, client, out, args)
 		},

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -69,3 +69,25 @@ func TestNewWorkspaceUserListCmd(t *testing.T) {
 	assert.NotNil(t, cmd)
 	assert.Nil(t, cmd.Args)
 }
+
+func TestWorkspaceUserRm(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{"data":{"workspaceRemoveUser":{"id":"ckc0eir8e01gj07608ajmvia1"}}}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	expected := ` NAME                          WORKSPACE ID                                      USER_ID                                           
+                               ckc0eir8e01gj07608ajmvia1                         ckc0eir8e01gj07608ajmvia1                         
+Successfully removed user from workspace
+`
+	api := houston.NewHoustonClient(client)
+	buf := new(bytes.Buffer)
+	cmd := newWorkspaceUserRmCmd(api, buf)
+	err := cmd.RunE(cmd, []string{"ckc0eir8e01gj07608ajmvia1"})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, buf.String())
+}

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -53,3 +53,19 @@ func TestWorkspaceSaRootCommand(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, output, "astro workspace service-account")
 }
+
+func TestNewWorkspaceUserListCmd(t *testing.T) {
+	testUtil.InitTestConfig()
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	buf := new(bytes.Buffer)
+	cmd := newWorkspaceUserListCmd(api, buf)
+	assert.NotNil(t, cmd)
+	assert.Nil(t, cmd.Args)
+}

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -378,13 +378,11 @@ var (
 	WorkspaceUserRemoveRequest = `
 	mutation RemoveWorkspaceUser(
 		$workspaceId: Uuid!
-		$userId: Uuid
-		$email: String
+		$userId: Uuid!
 	  ) {
 		workspaceRemoveUser(
 		  workspaceUuid: $workspaceId
 		  userUuid: $userId
-		  email: $email
 		) {
 		  id
 		  label

--- a/workspace/user.go
+++ b/workspace/user.go
@@ -49,7 +49,7 @@ func Remove(workspaceId, userId string, client *houston.Client, out io.Writer) e
 
 	utab := printutil.Table{
 		Padding: []int{30, 50, 50},
-		Header:  []string{"NAME", "WORKSPACE ID", "EMAIL"},
+		Header:  []string{"NAME", "WORKSPACE ID", "USER_ID"},
 	}
 
 	utab.AddRow([]string{w.Label, w.Id, userId}, false)

--- a/workspace/user.go
+++ b/workspace/user.go
@@ -35,10 +35,10 @@ func Add(workspaceId, email, role string, client *houston.Client, out io.Writer)
 }
 
 // Remove a user from a workspace
-func Remove(workspaceId, email string, client *houston.Client, out io.Writer) error {
+func Remove(workspaceId, userId string, client *houston.Client, out io.Writer) error {
 	req := houston.Request{
 		Query:     houston.WorkspaceUserRemoveRequest,
-		Variables: map[string]interface{}{"workspaceId": workspaceId, "email": email},
+		Variables: map[string]interface{}{"workspaceId": workspaceId, "userId": userId},
 	}
 
 	r, err := req.DoWithClient(client)
@@ -52,7 +52,7 @@ func Remove(workspaceId, email string, client *houston.Client, out io.Writer) er
 		Header:  []string{"NAME", "WORKSPACE ID", "EMAIL"},
 	}
 
-	utab.AddRow([]string{w.Label, w.Id, email}, false)
+	utab.AddRow([]string{w.Label, w.Id, userId}, false)
 	utab.SuccessMsg = "Successfully removed user from workspace"
 	utab.Print(out)
 	return nil

--- a/workspace/user_test.go
+++ b/workspace/user_test.go
@@ -69,13 +69,13 @@ func TestRemove(t *testing.T) {
 	})
 	api := houston.NewHoustonClient(client)
 	id := "ck1qg6whg001r08691y117hub"
-	email := "andrii@test.com"
+	userId := "ckc0eir8e01gj07608ajmvia1"
 
 	buf := new(bytes.Buffer)
-	err := Remove(id, email, api, buf)
+	err := Remove(id, userId, api, buf)
 	assert.NoError(t, err)
-	expected := ` NAME                          WORKSPACE ID                                      EMAIL                                             
-                               ckc0eir8e01gj07608ajmvia1                         andrii@test.com                                   
+	expected := ` NAME                          WORKSPACE ID                                      USER_ID                                           
+                               ckc0eir8e01gj07608ajmvia1                         ckc0eir8e01gj07608ajmvia1                         
 Successfully removed user from workspace
 `
 	assert.Equal(t, buf.String(), expected)


### PR DESCRIPTION
```
astro-cli workspace user remove ckdj7pfxr00re0j0351fhhlcb
 NAME                          WORKSPACE ID                                      EMAIL
 Astro Demo WS                 ck8c9lxy42d6a0968n2waller                         ckdj7pfxr00re0j0351fhhlcb
Successfully removed user from workspace
```

depend on this very old PR https://github.com/astronomer/houston-api/pull/74/files