### PR TITLE
Fix incorrect hint flag

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -33,7 +33,7 @@ var (
 `
 	deploymentSaCreateExample = `
 # Create service-account
-  $ astro deployment service-account create --deployment-uuid=xxxxx --label=my_label --role=ROLE
+  $ astro deployment service-account create --deployment-id=xxxxx --label=my_label --role=ROLE
 `
 	deploymentSaGetExample = `
   # Get deployment service-account


### PR DESCRIPTION
## Description

Fix the invalid flag suggestion

## 🎟 Issue(s)

Resolves astronomer/issues#1615

## 🧪 Functional Testing

Note: ` --deployment-id=xxxxx` in the example (changed from `--deployment-uuid=xxxxx`)

```
$ astro deployment service-account create --help
Create a service-account in the astronomer platform

Usage:
  astro deployment service-account create [flags]

Aliases:
  create, cr

Examples:

# Create service-account
  $ astro deployment service-account create --deployment-id=xxxxx --label=my_label --role=ROLE


Flags:
  -c, --category string        CATEGORY (default "default")
  -d, --deployment-id string   [ID]
  -h, --help                   help for create
  -l, --label string           LABEL
  -r, --role string            ROLE (default "viewer")
  -s, --system-sa
  -u, --user-id string         [ID]

Global Flags:
      --skip-version-check    skip version compatibility check
      --workspace-id string   workspace assigned to deployment
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `yarn lint && yarn test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-UI](https://github.com/astronomer/astro-ui/) and [Astro-CLI](https://github.com/astronomer/astro-cli/) clients.
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/astro-docs/)
