### PR TITLE
Remove Houston version check on upgrade

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,7 @@ func NewRootCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		newAuthRootCmd(client, out),
 		newWorkspaceCmd(client, out),
 		newVersionCmd(client, out),
-		newUpgradeCheckCmd(out),
+		newUpgradeCheckCmd(client, out),
 		newUserCmd(client, out),
 		newClusterRootCmd(client, out),
 		newDevRootCmd(client, out),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -27,7 +27,7 @@ func newVersionCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func newUpgradeCheckCmd(out io.Writer) *cobra.Command {
+func newUpgradeCheckCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Check for newer version of Astronomer CLI",
@@ -37,7 +37,7 @@ func newUpgradeCheckCmd(out io.Writer) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return upgradeCheck(cmd, out, args)
+			return upgradeCheck(client, cmd, out, args)
 		},
 	}
 	return cmd
@@ -54,12 +54,12 @@ func printVersion(client *houston.Client, cmd *cobra.Command, out io.Writer, arg
 	return nil
 }
 
-func upgradeCheck(cmd *cobra.Command, out io.Writer, args []string) error {
+func upgradeCheck(client *houston.Client, cmd *cobra.Command, out io.Writer, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
-	client := github.NewGithubClient(httputil.NewHTTPClient())
+	ghClient := github.NewGithubClient(httputil.NewHTTPClient())
 
-	err := version.CheckForUpdate(client, out)
+	err := version.CheckForUpdate(client, ghClient, out)
 	if err != nil {
 		return err
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -57,9 +57,9 @@ func printVersion(client *houston.Client, cmd *cobra.Command, out io.Writer, arg
 func upgradeCheck(client *houston.Client, cmd *cobra.Command, out io.Writer, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
-	ghClient := github.NewGithubClient(httputil.NewHTTPClient())
+	ghc := github.NewGithubClient(httputil.NewHTTPClient())
 
-	err := version.CheckForUpdate(client, ghClient, out)
+	err := version.CheckForUpdate(client, ghc, out)
 	if err != nil {
 		return err
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -32,6 +32,10 @@ func newUpgradeCheckCmd(out io.Writer) *cobra.Command {
 		Use:   "upgrade",
 		Short: "Check for newer version of Astronomer CLI",
 		Long:  "Check for newer version of Astronomer CLI",
+		// ignore PersistentPreRunE of root command
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return upgradeCheck(cmd, out, args)
 		},

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -16,7 +16,7 @@ var (
 	CLI_RUNNING_LATEST        = "You are running the latest version."
 	CLI_CHOOSE_WORKSPACE      = "Please choose a workspace:"
 	CLI_SET_WORKSPACE_EXAMPLE = "\nNo default workspace detected, you can list workspaces with \n\tastro workspace list\nand set your default workspace with \n\tastro workspace switch [WORKSPACEID]\n\n"
-	CLI_UPGRADE_PROMPT        = "A newer version of the Astronomer CLI is available.\nTo install the latest release run either of the following commands:"
+	CLI_UPGRADE_PROMPT        = "A newer version of the Astronomer CLI is available.\nTo upgrade to latest, run:"
 	CLI_UNTAGGED_PROMPT       = "Your current Astronomer CLI is not tagged.\nThis is likely the result of building from source. You can install the latest tagged release with the following command"
 
 	CONFIG_CREATE_DIR_ERROR        = "Error creating config directory\n"

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -12,11 +12,11 @@ var (
 	CLI_CURR_VERSION_DATE     = CLI_CURR_VERSION + " (%s)"
 	CLI_LATEST_VERSION        = "Astro CLI Latest: %s "
 	CLI_LATEST_VERSION_DATE   = CLI_LATEST_VERSION + " (%s)"
-	CLI_INSTALL_CMD           = "\t$ curl -sL https://install.astronomer.io | sudo bash"
+	CLI_INSTALL_CMD           = "\t$ curl -sL https://install.astronomer.io | sudo bash \nOR for homebrew users:\n\t$ brew install astronomer/tap/astro"
 	CLI_RUNNING_LATEST        = "You are running the latest version."
 	CLI_CHOOSE_WORKSPACE      = "Please choose a workspace:"
 	CLI_SET_WORKSPACE_EXAMPLE = "\nNo default workspace detected, you can list workspaces with \n\tastro workspace list\nand set your default workspace with \n\tastro workspace switch [WORKSPACEID]\n\n"
-	CLI_UPGRADE_PROMPT        = "There is a more recent version of the Astronomer CLI available.\nYou can install the latest tagged release with the following command"
+	CLI_UPGRADE_PROMPT        = "A newer version of the Astronomer CLI is available.\nTo install the latest release run either of the following commands:"
 	CLI_UNTAGGED_PROMPT       = "Your current Astronomer CLI is not tagged.\nThis is likely the result of building from source. You can install the latest tagged release with the following command"
 
 	CONFIG_CREATE_DIR_ERROR        = "Error creating config directory\n"

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -10,7 +10,7 @@ var (
 	CLI_CURR_VERSION          = "Astro CLI Version: %s"
 	CLI_CURR_COMMIT           = "Git Commit: %s"
 	CLI_CURR_VERSION_DATE     = CLI_CURR_VERSION + " (%s)"
-	CLI_LATEST_VERSION        = "Astro CLI Latest: %s "
+	CLI_LATEST_VERSION        = "Astro CLI Latest: %s"
 	CLI_LATEST_VERSION_DATE   = CLI_LATEST_VERSION + " (%s)"
 	CLI_INSTALL_CMD           = "\t$ curl -sL https://install.astronomer.io | sudo bash \nOR for homebrew users:\n\t$ brew install astronomer/tap/astro"
 	CLI_RUNNING_LATEST        = "You are running the latest version."

--- a/version/version.go
+++ b/version/version.go
@@ -2,15 +2,13 @@ package version
 
 import (
 	"fmt"
-
 	"io"
-
-	"github.com/pkg/errors"
 
 	"github.com/astronomer/astro-cli/deployment"
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/messages"
 	"github.com/astronomer/astro-cli/pkg/github"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -30,21 +28,7 @@ func PrintVersion(client *houston.Client, out io.Writer) error {
 	fmt.Fprintf(out, messages.CLI_CURR_VERSION+", ", version)
 	fmt.Fprintf(out, messages.CLI_CURR_COMMIT+"\n", gitCommit)
 
-	PrintServerVersion(client, out)
-
-	return nil
-}
-
-// PrintServerVersion outputs current server version
-func PrintServerVersion(client *houston.Client, out io.Writer) error {
-	appCfg, err := deployment.AppConfig(client)
-	if err != nil {
-		fmt.Fprintf(out, messages.HOUSTON_CURRENT_VERSION+"\n", "Please authenticate to a cluster to see server version")
-	}
-
-	if appCfg != nil {
-		fmt.Fprintf(out, messages.HOUSTON_CURRENT_VERSION+"\n", appCfg.Version)
-	}
+	printServerVersion(client, out)
 
 	return nil
 }
@@ -82,7 +66,7 @@ func CheckForUpdate(client *houston.Client, ghClient *github.Client, out io.Writ
 	fmt.Fprintf(out, messages.CLI_CURR_VERSION_DATE+"\n", currentTag, currentPub)
 	fmt.Fprintf(out, messages.CLI_LATEST_VERSION_DATE+"\n", latestTag, latestPub)
 
-	PrintServerVersion(client, out)
+	printServerVersion(client, out)
 
 	if latestTag > currentTag {
 		fmt.Fprintln(out, messages.CLI_UPGRADE_PROMPT)
@@ -99,4 +83,18 @@ func isValidVersion(version string) bool {
 		return false
 	}
 	return true
+}
+
+// printServerVersion outputs current server version
+func printServerVersion(client *houston.Client, out io.Writer) error {
+	appCfg, err := deployment.AppConfig(client)
+	if err != nil {
+		fmt.Fprintf(out, messages.HOUSTON_CURRENT_VERSION+"\n", "Please authenticate to a cluster to see server version")
+	}
+
+	if appCfg != nil {
+		fmt.Fprintf(out, messages.HOUSTON_CURRENT_VERSION+"\n", appCfg.Version)
+	}
+
+	return nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/pkg/errors"
+
 	"github.com/astronomer/astro-cli/deployment"
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/messages"
 	"github.com/astronomer/astro-cli/pkg/github"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -34,7 +35,7 @@ func PrintVersion(client *houston.Client, out io.Writer) error {
 }
 
 // CheckForUpdate checks current version against latest on github
-func CheckForUpdate(client *houston.Client, ghClient *github.Client, out io.Writer) error {
+func CheckForUpdate(client *houston.Client, ghc *github.Client, out io.Writer) error {
 	version := CurrVersion
 
 	if !isValidVersion(version) {
@@ -44,14 +45,14 @@ func CheckForUpdate(client *houston.Client, ghClient *github.Client, out io.Writ
 	}
 
 	// fetch latest cli version
-	latestTagResp, err := ghClient.RepoLatestRequest("astronomer", "astro-cli")
+	latestTagResp, err := ghc.RepoLatestRequest("astronomer", "astro-cli")
 	if err != nil {
 		fmt.Fprintln(out, err)
 		latestTagResp.TagName = messages.NA
 	}
 
 	// fetch meta data around current cli version
-	currentTagResp, err := ghClient.RepoTagRequest("astronomer", "astro-cli", string("v")+version)
+	currentTagResp, err := ghc.RepoTagRequest("astronomer", "astro-cli", string("v")+version)
 	if err != nil {
 		fmt.Fprintln(out, "Release info not found, please upgrade.")
 		fmt.Fprintln(out, messages.CLI_INSTALL_CMD)

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -88,7 +88,7 @@ func TestCheckForUpdateVersionMatch(t *testing.T) {
 			Header:     make(http.Header),
 		}
 	})
-	houston.NewHoustonClient(client)
+	houstonClient := houston.NewHoustonClient(client)
 
 	CurrVersion = "0.15.0"
 	okGitHubResponse := `{
@@ -107,8 +107,8 @@ func TestCheckForUpdateVersionMatch(t *testing.T) {
 	})
 	githubClient := github.NewGithubClient(gitHubClient)
 	output := new(strings.Builder)
-	CheckForUpdate(githubClient, output)
-	expected := "Astro CLI Version: v0.15.0 (2020.06.01)\nAstro CLI Latest: v0.15.0  (2020.06.01)\nYou are running the latest version.\n"
+	CheckForUpdate(houstonClient, githubClient, output)
+	expected := "Astro CLI Version: v0.15.0 (2020.06.01)\nAstro CLI Latest: v0.15.0 (2020.06.01)\nAstro Server Version: 0.13.0\nYou are running the latest version.\n"
 	actual := output.String()
 
 	assert.Equal(t, expected, actual)


### PR DESCRIPTION
## Description

`astro upgrade` should not require Houston context.

## 🎟 Issue(s)

Resolves astronomer/issues#1606

## 🧪 Functional Testing

1. You can test locally by build a local version that is the same as the latest:

Without authentication to a server:
```
$ ./astro upgrade
Astro CLI Version: v0.17.0 (2020.07.24)
Astro CLI Latest: v0.17.0  (2020.07.24)
Astro Server Version: Please authenticate to a cluster to see server version
You are running the latest version.
```

With server authentication:
```
./astro upgrade
Astro CLI Version: v0.17.0 (2020.07.24)
Astro CLI Latest: v0.17.0  (2020.07.24)
Astro Server Version: 0.18.0
You are running the latest version.
```

2. You can test locally by building a local version that using an outdated `CurrVersion`:


Without server authentication:
```
$ rm -rf ~/.astro
$ go build -o astro -ldflags "-X github.com/astronomer/astro-cli/version.CurrVersion=0.15.0  -X github.com/astronomer/astro-cli/version.CurrCommit=5ae31076d9f2dfc874c533e6c729e1fa7681b7f4" main.go
$./astro upgrade
Astro CLI Version: v0.15.0 (2020.06.01)
Astro CLI Latest: v0.17.0  (2020.07.24)
Astro Server Version: Please authenticate to a cluster to see server version
A newer version of the Astronomer CLI is available.
To upgrade to latest, run:
	$ curl -sL https://install.astronomer.io | sudo bash
OR for homebrew users:
	$ brew install astronomer/tap/astro
```

With server authentication:
```
$ ./astro upgrade
Astro CLI Version: v0.15.0 (2020.06.01)
Astro CLI Latest: v0.17.0  (2020.07.24)
Astro Server Version: 0.18.0
A newer version of the Astronomer CLI is available.
To upgrade to latest, run:
	$ curl -sL https://install.astronomer.io | sudo bash
OR for homebrew users:
	$ brew install astronomer/tap/astro
```




## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) 
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/astro-docs/)
