### PR TITLE
Validate email

### DIFF
--- a/user/user.go
+++ b/user/user.go
@@ -57,7 +57,8 @@ func Create(email string, password string, client *houston.Client, out io.Writer
 
 // IsValidEmail checks if the email provided is valid
 func IsValidEmail(email string) bool {
-	emailRegex := regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+	exp := "^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+	emailRegex := regexp.MustCompile(exp)
 	minLen := 3
 	maxLen := 254
 

--- a/user/user.go
+++ b/user/user.go
@@ -4,16 +4,24 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"regexp"
+	"strings"
 
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/input"
 )
 
 // Create verifies input before sending a CreateUser API call to houston
-func Create(email, password string, client *houston.Client, out io.Writer) error {
+func Create(email string, password string, client *houston.Client, out io.Writer) error {
 	if len(email) == 0 {
 		email = input.InputText("Email: ")
 	}
+
+	if !IsValidEmail(email) {
+		return errors.New(email + " is an invalid email address")
+	}
+
 	if password == "" {
 		inputPassword, _ := input.InputPassword("Password: ")
 		inputPassword2, _ := input.InputPassword("Re-enter Password: ")
@@ -45,4 +53,24 @@ func Create(email, password string, client *houston.Client, out io.Writer) error
 	_, err = fmt.Fprintln(out, fmt.Sprintf(msg, email, loginMsg))
 
 	return err
+}
+
+// IsValidEmail checks if the email provided is valid
+func IsValidEmail(email string) bool {
+	emailRegex := regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+	minLen := 3
+	maxLen := 254
+
+	if len(email) < minLen && len(email) > maxLen {
+		return false
+	}
+	if !emailRegex.MatchString(email) {
+		return false
+	}
+	parts := strings.Split(email, "@")
+	mx, err := net.LookupMX(parts[1])
+	if err != nil || len(mx) == 0 {
+		return false
+	}
+	return true
 }

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -1,0 +1,15 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidEmail(t *testing.T) {
+	email := "steve@apple.com"
+	actual := IsValidEmail(email)
+	expected := true
+
+	assert.Equal(t, actual, expected)
+}

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -1,15 +1,50 @@
 package user
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIsValidEmail(t *testing.T) {
+	// Test a valid email
 	email := "steve@apple.com"
 	actual := IsValidEmail(email)
 	expected := true
+
+	assert.Equal(t, actual, expected)
+
+	// Test a invalid email that is too long
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789@."
+	sb := make([]byte, 256)
+	for i := range sb {
+		sb[i] = chars[rand.Intn(len(chars))]
+	}
+	email = string(sb)
+	actual = IsValidEmail(email)
+	expected = false
+
+	assert.Equal(t, actual, expected)
+
+	// Test a invalid email that is too short
+	email = "abc"
+	actual = IsValidEmail(email)
+	expected = false
+
+	assert.Equal(t, actual, expected)
+
+	// Test a invalid email
+	email = "this@isnotanemail"
+	actual = IsValidEmail(email)
+	expected = false
+
+	assert.Equal(t, actual, expected)
+
+	// Test real address without MX records
+	email = "testing@test.com"
+	actual = IsValidEmail(email)
+	expected = false
 
 	assert.Equal(t, actual, expected)
 }

--- a/workspace/user.go
+++ b/workspace/user.go
@@ -4,15 +4,22 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/pkg/errors"
+
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/printutil"
+	"github.com/astronomer/astro-cli/user"
 )
 
 // Add a user to a workspace with specified role
-func Add(workspaceId, email, role string, client *houston.Client, out io.Writer) error {
+func Add(workspaceID string, email, role string, client *houston.Client, out io.Writer) error {
+	if !user.IsValidEmail(email) {
+		return errors.New(email + " is an invalid email address")
+	}
+
 	req := houston.Request{
 		Query:     houston.WorkspaceUserAddRequest,
-		Variables: map[string]interface{}{"workspaceId": workspaceId, "email": email, "role": role},
+		Variables: map[string]interface{}{"workspaceId": workspaceID, "email": email, "role": role},
 	}
 
 	r, err := req.DoWithClient(client)
@@ -35,10 +42,10 @@ func Add(workspaceId, email, role string, client *houston.Client, out io.Writer)
 }
 
 // Remove a user from a workspace
-func Remove(workspaceId, userId string, client *houston.Client, out io.Writer) error {
+func Remove(workspaceID, userID string, client *houston.Client, out io.Writer) error {
 	req := houston.Request{
 		Query:     houston.WorkspaceUserRemoveRequest,
-		Variables: map[string]interface{}{"workspaceId": workspaceId, "userId": userId},
+		Variables: map[string]interface{}{"workspaceId": workspaceID, "userId": userID},
 	}
 
 	r, err := req.DoWithClient(client)
@@ -52,17 +59,17 @@ func Remove(workspaceId, userId string, client *houston.Client, out io.Writer) e
 		Header:  []string{"NAME", "WORKSPACE ID", "USER_ID"},
 	}
 
-	utab.AddRow([]string{w.Label, w.Id, userId}, false)
+	utab.AddRow([]string{w.Label, w.Id, userID}, false)
 	utab.SuccessMsg = "Successfully removed user from workspace"
 	utab.Print(out)
 	return nil
 }
 
 // ListRoles print users and roles from a workspace
-func ListRoles(workspaceId string, client *houston.Client, out io.Writer) error {
+func ListRoles(workspaceID string, client *houston.Client, out io.Writer) error {
 	req := houston.Request{
 		Query:     houston.WorkspacesGetRequest,
-		Variables: map[string]interface{}{"workspaceId": workspaceId},
+		Variables: map[string]interface{}{"workspaceId": workspaceID},
 	}
 	r, err := req.DoWithClient(client)
 
@@ -85,11 +92,11 @@ func ListRoles(workspaceId string, client *houston.Client, out io.Writer) error 
 	return nil
 }
 
-// Update workspace user role
-func UpdateRole(workspaceId, email, role string, client *houston.Client, out io.Writer) error {
+// UpdateRole workspace user role
+func UpdateRole(workspaceID string, email string, role string, client *houston.Client, out io.Writer) error {
 	req := houston.Request{
 		Query:     houston.WorkspaceUserUpdateRequest,
-		Variables: map[string]interface{}{"workspaceUuid": workspaceId, "email": email, "role": role},
+		Variables: map[string]interface{}{"workspaceUuid": workspaceID, "email": email, "role": role},
 	}
 	r, err := req.DoWithClient(client)
 

--- a/workspace/user_test.go
+++ b/workspace/user_test.go
@@ -2,12 +2,14 @@ package workspace
 
 import (
 	"bytes"
-	"github.com/astronomer/astro-cli/houston"
-	testUtil "github.com/astronomer/astro-cli/pkg/testing"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/astro-cli/houston"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
 func TestAdd(t *testing.T) {
@@ -24,14 +26,14 @@ func TestAdd(t *testing.T) {
 	api := houston.NewHoustonClient(client)
 	id := "ck1qg6whg001r08691y117hub"
 	role := "test-role"
-	email := "andrii@test.com"
+	email := "andrii@apple.com"
 
 	buf := new(bytes.Buffer)
 	err := Add(id, email, role, api, buf)
 	assert.NoError(t, err)
-	expected := ` NAME     WORKSPACE ID                  EMAIL               ROLE          
-          ckc0eir8e01gj07608ajmvia1     andrii@test.com     test-role     
-Successfully added andrii@test.com to 
+	expected := ` NAME     WORKSPACE ID                  EMAIL                ROLE          
+          ckc0eir8e01gj07608ajmvia1     andrii@apple.com     test-role     
+Successfully added andrii@apple.com to 
 `
 	assert.Equal(t, buf.String(), expected)
 }
@@ -49,7 +51,7 @@ func TestAddError(t *testing.T) {
 	api := houston.NewHoustonClient(client)
 	id := "ck1qg6whg001r08691y117hub"
 	role := "test-role"
-	email := "andrii@test.com"
+	email := "andrii@apple.com"
 
 	buf := new(bytes.Buffer)
 	err := Add(id, email, role, api, buf)
@@ -93,7 +95,7 @@ func TestRemoveError(t *testing.T) {
 	})
 	api := houston.NewHoustonClient(client)
 	id := "ck1qg6whg001r08691y117hub"
-	email := "andrii@test.com"
+	email := "andrii@apple.com"
 
 	buf := new(bytes.Buffer)
 	err := Remove(id, email, api, buf)
@@ -188,12 +190,12 @@ func TestUpdateRole(t *testing.T) {
 	api := houston.NewHoustonClient(client)
 	id := "ck1qg6whg001r08691y117hub"
 	role := "test-role"
-	email := "andrii@test.com"
+	email := "andrii@apple.com"
 
 	buf := new(bytes.Buffer)
 	err := UpdateRole(id, role, email, api, buf)
 	assert.NoError(t, err)
-	expected := `Role has been changed from andrii@test.com to WORKSPACE_VIEWER for user test-role`
+	expected := `Role has been changed from andrii@apple.com to WORKSPACE_VIEWER for user test-role`
 	assert.Equal(t, buf.String(), expected)
 }
 
@@ -208,7 +210,7 @@ func TestUpdateRoleError(t *testing.T) {
 	api := houston.NewHoustonClient(client)
 	id := "ck1qg6whg001r08691y117hub"
 	role := "test-role"
-	email := "andrii@test.com"
+	email := "andrii@apple.com"
 
 	buf := new(bytes.Buffer)
 	err := UpdateRole(id, role, email, api, buf)


### PR DESCRIPTION
## Description

Client side test for email address validation.  Another PR for Houston API could also validate the email address using similar logic.

## 🎟 Issue(s)

Resolves astronomer/issues#1630

## 🧪 Functional Testing

Creates a user: `./astro workspace user add steve@apple.com`
Should fail: `./astro workspace user add steve@test.com`
Fails: `./astro workspace user add steve@notAnAddress`
Fails: `./astro workspace user add notAnEmail`

## 📸 Screenshots

N/A

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/astro-docs/)
