### PR TITLE
Update airflow dev init message

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -274,7 +274,7 @@ func airflowInit(cmd *cobra.Command, args []string, client *houston.Client, out 
 
 	if len(defaultImageTag) == 0 {
 		defaultImageTag = "latest-onbuild"
-		fmt.Printf("Failed to get list of supported tags from Astonomer, falling back to %s\n", defaultImageTag)
+		fmt.Printf("Initializing Airflow project\nNot connected to Astronomer, pulling Airflow development files from %s\n", defaultImageTag)
 	}
 
 	emtpyDir := fileutil.IsEmptyDir(config.WorkingPath)


### PR DESCRIPTION
## Description

Update the message for `astro dev init` to be more informative and less of an error message.

## 🎟 Issue(s)

Resolves astronomer/issues#1075

## 🧪 Functional Testing

Run `astro dev init` without any auth with Astronomer

## 📸 Screenshots

![Screen Shot 2020-08-27 at 9 38 38 AM](https://user-images.githubusercontent.com/749118/91450223-14a80100-e84a-11ea-9298-c5becb383340.png)
![dev init authed](https://user-images.githubusercontent.com/749118/91450245-196cb500-e84a-11ea-8890-7d36af8fe366.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/astro-docs/)
