### PR TITLE
Add compare versions to astro upgrade

### DIFF
--- a/version/validate_compatibility.go
+++ b/version/validate_compatibility.go
@@ -32,12 +32,12 @@ func ValidateCompatibility(client *houston.Client, out io.Writer, cliVer string,
 
 // CompareVersions print warning message if astro-cli has a variation in the minor version.  Errors if major version is behind.
 func CompareVersions(compareVer string, currentVer string, out io.Writer) error {
-	semCompareVer, compareErr := parseVersion(compareVer)
+	semCompareVer, err := parseVersion(compareVer)
 	if compareErr != nil {
 		return compareErr
 	}
 
-	semCurrVer, currErr := parseVersion(currentVer)
+	semCurrVer, err := parseVersion(currentVer)
 	if currErr != nil {
 		return currErr
 	}

--- a/version/validate_compatibility.go
+++ b/version/validate_compatibility.go
@@ -24,22 +24,22 @@ func ValidateCompatibility(client *houston.Client, out io.Writer, cliVer string,
 	}
 	// Skip check if AppConfig is nil or is cv is empty
 	if serverCfg != nil && cliVer != "" {
-		return CompareVersions(serverCfg.Version, cliVer, out)
+		return compareVersions(serverCfg.Version, cliVer, out)
 	}
 
 	return nil
 }
 
-// CompareVersions print warning message if astro-cli has a variation in the minor version.  Errors if major version is behind.
-func CompareVersions(compareVer string, currentVer string, out io.Writer) error {
+// compareVersions print warning message if astro-cli has a variation in the minor version.  Errors if major version is behind.
+func compareVersions(compareVer string, currentVer string, out io.Writer) error {
 	semCompareVer, err := parseVersion(compareVer)
-	if compareErr != nil {
-		return compareErr
+	if err != nil {
+		return err
 	}
 
 	semCurrVer, err := parseVersion(currentVer)
-	if currErr != nil {
-		return currErr
+	if err != nil {
+		return err
 	}
 
 	currMajor := semCurrVer.Major()

--- a/version/validate_compatibility.go
+++ b/version/validate_compatibility.go
@@ -30,7 +30,7 @@ func ValidateCompatibility(client *houston.Client, out io.Writer, cliVer string,
 	return nil
 }
 
-// compareVersions print warning message if astro-cli has a variation in the minor version.  Errors if major version is behind.
+// compareVersions print warning message if astro-cli has a variation in the minor version. Errors if major version is behind.
 func compareVersions(compareVer string, currentVer string, out io.Writer) error {
 	semCompareVer, err := parseVersion(compareVer)
 	if err != nil {

--- a/version/validate_compatibility.go
+++ b/version/validate_compatibility.go
@@ -24,35 +24,36 @@ func ValidateCompatibility(client *houston.Client, out io.Writer, cliVer string,
 	}
 	// Skip check if AppConfig is nil or is cv is empty
 	if serverCfg != nil && cliVer != "" {
-		return compareVersions(serverCfg.Version, cliVer, out)
+		return CompareVersions(serverCfg.Version, cliVer, out)
 	}
 
 	return nil
 }
 
-func compareVersions(serverVer string, cliVer string, out io.Writer) error {
-	semVerServer, serverErr := parseVersion(serverVer)
-	if serverErr != nil {
-		return serverErr
+// CompareVersions print warning message if astro-cli has a variation in the minor version.  Errors if major version is behind.
+func CompareVersions(compareVer string, currentVer string, out io.Writer) error {
+	semCompareVer, compareErr := parseVersion(compareVer)
+	if compareErr != nil {
+		return compareErr
 	}
 
-	semVerCli, cliErr := parseVersion(cliVer)
-	if cliErr != nil {
-		return cliErr
+	semCurrVer, currErr := parseVersion(currentVer)
+	if currErr != nil {
+		return currErr
 	}
 
-	cliMajor := semVerCli.Major()
-	cliMinor := semVerCli.Minor()
+	currMajor := semCurrVer.Major()
+	currMinor := semCurrVer.Minor()
 
-	serverMajor := semVerServer.Major()
-	serverMinor := semVerServer.Minor()
+	compareMajor := semCompareVer.Major()
+	compareMinor := semCompareVer.Minor()
 
-	if cliMajor < serverMajor {
-		return errors.Errorf(messages.ERROR_NEW_MAJOR_VERSION, cliVer, serverVer)
-	} else if cliMinor < serverMinor {
-		fmt.Fprintf(out, messages.WARNING_NEW_MINOR_VERSION, cliVer, serverVer)
-	} else if cliMinor > serverMinor {
-		fmt.Fprintf(out, messages.WARNING_DOWNGRADE_VERSION, cliVer, serverVer)
+	if currMajor < compareMajor {
+		return errors.Errorf(messages.ERROR_NEW_MAJOR_VERSION, currentVer, compareVer)
+	} else if currMinor < compareMinor {
+		fmt.Fprintf(out, messages.WARNING_NEW_MINOR_VERSION, currentVer, compareVer)
+	} else if currMinor > compareMinor {
+		fmt.Fprintf(out, messages.WARNING_DOWNGRADE_VERSION, currentVer, compareVer)
 	}
 
 	return nil

--- a/version/validate_compatibility_test.go
+++ b/version/validate_compatibility_test.go
@@ -212,13 +212,13 @@ func TestValidateCompatibilityClientFailure(t *testing.T) {
 
 func TestCompareVersionsInvalidServerVer(t *testing.T) {
 	output := new(bytes.Buffer)
-	err := compareVersions("INVALID VERSION", "0.17.1", output)
+	err := CompareVersions("INVALID VERSION", "0.17.1", output)
 	assert.Error(t, err)
 }
 
 func TestCompareVersionsInvalidCliVer(t *testing.T) {
 	output := new(bytes.Buffer)
-	err := compareVersions("0.17.1", "INVALID VERSION", output)
+	err := CompareVersions("0.17.1", "INVALID VERSION", output)
 	assert.Error(t, err)
 }
 

--- a/version/validate_compatibility_test.go
+++ b/version/validate_compatibility_test.go
@@ -212,13 +212,13 @@ func TestValidateCompatibilityClientFailure(t *testing.T) {
 
 func TestCompareVersionsInvalidServerVer(t *testing.T) {
 	output := new(bytes.Buffer)
-	err := CompareVersions("INVALID VERSION", "0.17.1", output)
+	err := compareVersions("INVALID VERSION", "0.17.1", output)
 	assert.Error(t, err)
 }
 
 func TestCompareVersionsInvalidCliVer(t *testing.T) {
 	output := new(bytes.Buffer)
-	err := CompareVersions("0.17.1", "INVALID VERSION", output)
+	err := compareVersions("0.17.1", "INVALID VERSION", output)
 	assert.Error(t, err)
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -68,13 +68,7 @@ func CheckForUpdate(client *houston.Client, ghc *github.Client, out io.Writer) e
 	fmt.Fprintf(out, messages.CLI_LATEST_VERSION_DATE+"\n", latestTag, latestPub)
 
 	printServerVersion(client, out)
-
-	if latestTag > currentTag {
-		fmt.Fprintln(out, messages.CLI_UPGRADE_PROMPT)
-		fmt.Fprintln(out, messages.CLI_INSTALL_CMD)
-	} else {
-		fmt.Fprintln(out, messages.CLI_RUNNING_LATEST)
-	}
+	CompareVersions(latestTag, currentTag, out)
 
 	return nil
 }

--- a/version/version.go
+++ b/version/version.go
@@ -68,7 +68,7 @@ func CheckForUpdate(client *houston.Client, ghc *github.Client, out io.Writer) e
 	fmt.Fprintf(out, messages.CLI_LATEST_VERSION_DATE+"\n", latestTag, latestPub)
 
 	printServerVersion(client, out)
-	CompareVersions(latestTag, currentTag, out)
+	compareVersions(latestTag, currentTag, out)
 
 	return nil
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -108,7 +108,36 @@ func TestCheckForUpdateVersionMatch(t *testing.T) {
 	githubClient := github.NewGithubClient(gitHubClient)
 	output := new(strings.Builder)
 	CheckForUpdate(houstonClient, githubClient, output)
-	expected := "Astro CLI Version: v0.15.0 (2020.06.01)\nAstro CLI Latest: v0.15.0 (2020.06.01)\nAstro Server Version: 0.13.0\nYou are running the latest version.\n"
+	expected := "Astro CLI Version: v0.15.0 (2020.06.01)\nAstro CLI Latest: v0.15.0 (2020.06.01)\nAstro Server Version: 0.13.0\n"
+	actual := output.String()
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestPrintServerVersion(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+		"data": {
+			"appConfig": {
+				"version": "0.18.0",
+				"baseDomain": "local.astronomer.io",
+				"smtpConfigured": true,
+				"manualReleaseNames": false
+			}
+		}
+	}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	houstonClient := houston.NewHoustonClient(client)
+
+	output := new(strings.Builder)
+	printServerVersion(houstonClient, output)
+	expected := "Astro Server Version: 0.18.0\n"
 	actual := output.String()
 
 	assert.Equal(t, expected, actual)


### PR DESCRIPTION
## Description

astro upgrade is incorrectly indicating that it is the latest version when the current version is less than 0.10.0.  This PR corrects that issue and allows `astro version` and `astro upgrade` to use the same comparison function.

## 🎟 Issue(s)

Resolves astronomer/issues#1703

## 🧪 Functional Testing

Test 1:

1. Change the CLI Version in the make file to a valid older version (needs to be a real version hosted on github releases) example, `0.5.1`
2. Run `make build`
3. Run `./astro upgrade`
4. You should see the correct message about the version being behind

Test 2:
1. Change the CLI Version in the make file to a valid newer OR newest version (needs to be a real version hosted on github releases) example, `0.19.0`
2. Run `make build`
3. Run `./astro upgrade`
4. You should see the correct message about being on the latest version

## 📸 Screenshots

![Screen Shot 2020-08-27 at 11 01 57 AM](https://user-images.githubusercontent.com/749118/91459782-0d3a2500-e855-11ea-98c9-35e3b043189e.png)
![Screen Shot 2020-08-27 at 11 02 09 AM](https://user-images.githubusercontent.com/749118/91459785-0dd2bb80-e855-11ea-9cba-c1ef4911b5a6.png)
![Screen Shot 2020-08-27 at 11 03 22 AM](https://user-images.githubusercontent.com/749118/91459787-0dd2bb80-e855-11ea-9cfb-322ab32e6a7a.png)
![Screen Shot 2020-08-27 at 11 03 37 AM](https://user-images.githubusercontent.com/749118/91459788-0dd2bb80-e855-11ea-9218-9d4127b2f630.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/astro-docs/)
