### PR TITLE
Add missing datbase_url env var for houston

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           PRISMA__DEBUG: "false"
           ORBIT__PORT: "8080"
           DATABASE__CONNECTION: "postgres://postgres:postgres@postgres:5432/postgres"
+          DATABASE_URL: "postgres://postgres:postgres@postgres:5432/postgres?schema=houston%24default"
           PUBLIC_SIGNUPS: "true"
           EMAIL_CONFIRMATION: "false"
           EMAIL__ENABLED: "false"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           PRISMA__DEBUG: "false"
           ORBIT__PORT: "8080"
           DATABASE__CONNECTION: "postgres://postgres:postgres@postgres:5432/postgres"
-          DATABASE_URL: "postgres://postgres:postgres@postgres:5432/postgres?schema=houston%24default"
+          DATABASE_URL: "postgres://postgres:postgres@postgres:5432/postgres"
           PUBLIC_SIGNUPS: "true"
           EMAIL_CONFIRMATION: "false"
           EMAIL__ENABLED: "false"


### PR DESCRIPTION
## Description

Add missing database url to circle ci config for Houston's Prisma 2 schema connection.

## 🎟 Issue(s)

Resolves astronomer/issues#XXXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
