### PR TITLE
Add support for Airflow 2.0

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -112,7 +112,7 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
+      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -112,7 +112,7 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c 'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
+      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -68,7 +68,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:10.1-alpine
+    image: postgres:12.2
     restart: unless-stopped
     networks:
       - airflow
@@ -86,7 +86,7 @@ services:
   scheduler:
     image: test-project-name/airflow:latest
     command: >
-      bash -c "airflow upgradedb && airflow scheduler"
+      bash -c "(airflow upgradedb || airflow db upgrade) && airflow scheduler"
     restart: unless-stopped
     networks:
       - airflow
@@ -112,7 +112,9 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c "airflow create_user -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
+      bash -c
+      'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com
+       -f admin -l user -p admin && airflow webserver"
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -112,7 +112,7 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
+      bash -c 'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -112,9 +112,7 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c
-      'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com
-       -f admin -l user -p admin && airflow webserver"
+      bash -c 'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -62,7 +62,7 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
+      bash -c 'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -62,7 +62,7 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c 'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
+      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -62,7 +62,7 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
+      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -18,7 +18,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:10.1-alpine
+    image: postgres:12.2
     restart: unless-stopped
     networks:
       - airflow
@@ -36,7 +36,7 @@ services:
   scheduler:
     image: {{ .AirflowImage }}
     command: >
-      bash -c "airflow upgradedb && airflow scheduler"
+      bash -c "(airflow upgradedb || airflow db upgrade) && airflow scheduler"
     restart: unless-stopped
     networks:
       - airflow
@@ -62,7 +62,9 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c "airflow create_user -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
+      bash -c
+      'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com
+       -f admin -l user -p admin && airflow webserver"
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -62,9 +62,7 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c
-      'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com
-       -f admin -l user -p admin && airflow webserver"
+      bash -c 'airflow create_user "$@" || airflow users create "$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
     restart: unless-stopped
     networks:
       - airflow


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

This PR adds support for running 2.0 and keeps backwards-compatibility will 1.10.x versions

## 🎟 Issue(s)

Resolves astronomer/issues#XXXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
