### PR TITLE
Fix webserver command in docker-compose

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -112,7 +112,7 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c 'airflow create_user "$$@" && airflow webserver || airflow users create "$$@" && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
+      bash -c '{ airflow create_user "$$@" || airflow users create "$$@"; } && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -112,7 +112,7 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver
+      bash -c 'airflow create_user "$$@" && airflow webserver || airflow users create "$$@" && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -62,7 +62,7 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c 'airflow create_user "$$@" && airflow webserver || airflow users create "$$@" && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
+      bash -c '{ airflow create_user "$$@" || airflow users create "$$@"; } && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -62,7 +62,7 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c 'airflow create_user "$$@" || airflow users create "$$@"' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver
+      bash -c 'airflow create_user "$$@" && airflow webserver || airflow users create "$$@" && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:
       - airflow


### PR DESCRIPTION
When I built the CLI locally and tested it out, it failed with ` && airflow webserver` command not found error. 

After applying the patch in the PR it worked fine