### PR TITLE
Add RBAC Deployment User

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -31,6 +31,10 @@ var (
 # Create new deployment with Kubernetes executor.
   $ astro deployment create new-deployment-name-k8s --executor=k8s
 `
+	deploymentUserCreateExample = `
+# Add a workspace user to a deployment with a particular role
+  $ astro deployment user add --deployment-id=xxxxx --role=DEPLOYMENT_ROLE <user-email-address>
+`
 	deploymentSaCreateExample = `
 # Create service-account
   $ astro deployment service-account create --deployment-id=xxxxx --label=my_label --role=ROLE
@@ -149,15 +153,16 @@ func newDeploymentUserRootCmd(client *houston.Client, out io.Writer) *cobra.Comm
 
 func newDeploymentUserAddCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "add EMAIL",
-		Short: "Add a user to a deployment",
-		Long:  "Add a user to a deployment",
-		Args:  cobra.ExactArgs(1),
+		Use:     "add EMAIL",
+		Short:   "Add a user to a deployment",
+		Long:    "Add a user to a deployment",
+		Args:    cobra.ExactArgs(1),
+		Example: deploymentUserCreateExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentUserAdd(cmd, client, out, args)
 		},
 	}
-	cmd.PersistentFlags().StringVar(&deploymentId, "deployment-id", "", "deployment assigned to deployment")
+	cmd.PersistentFlags().StringVar(&deploymentId, "deployment-id", "", "deployment assigned to user")
 	cmd.PersistentFlags().StringVar(&deploymentRole, "role", "DEPLOYMENT_VIEWER", "role assigned to user")
 	// TODO: add new deploymentRole and figure out role types "DEPLOYMENT_VIEWER", etc.
 	return cmd

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -144,3 +144,40 @@ func TestDeploymentSaCreateCommand(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOut, output)
 }
+
+func TestDeploymentUserAddCommand(t *testing.T) {
+	testUtil.InitTestConfig()
+	expectedOut := ` DEPLOYMENT NAME              DEPLOYMENT ID                 USER                        ROLE                  
+ prehistoric-gravity-9229     ckggvxkw112212kc9ebv8vu6p     somebody@astronomer.com     DEPLOYMENT_VIEWER     
+
+ Successfully added somebody@astronomer.com as a DEPLOYMENT_VIEWER
+`
+	okResponse := `{
+		"data": {
+			"deploymentAddUserRole": {
+				"id": "ckggzqj5f4157qtc9lescmehm",
+				"user": {
+					"username": "somebody@astronomer.com"
+				},
+				"role": "DEPLOYMENT_VIEWER",
+				"deployment": {
+					"id": "ckggvxkw112212kc9ebv8vu6p",
+					"releaseName": "prehistoric-gravity-9229"
+				}
+			}
+		}
+	}`
+
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(strings.NewReader(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	_, output, err := executeCommandC(api, "deployment", "user", "add", "--deployment-id=ckggvxkw112212kc9ebv8vu6p", "somebody@astronomer.com")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOut, output)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,10 +10,11 @@ import (
 )
 
 var (
-	workspaceId   string
-	workspaceRole string
-	role          string
-	skipVerCheck  bool
+	workspaceId    string
+	workspaceRole  string
+	deploymentRole string
+	role           string
+	skipVerCheck   bool
 )
 
 // NewRootCmd adds all of the primary commands for the cli

--- a/cmd/validation.go
+++ b/cmd/validation.go
@@ -81,7 +81,7 @@ func validateWorkspaceRole(role string) error {
 }
 
 func validateDeploymentRole(role string) error {
-	validRoles := []string{houston.DEPLOYMENT_ADMIN, houston.DEPLOYMENT_EDITOR, houston.DEPLOYMENT_VIEWER}
+	validRoles := []string{houston.DeploymentAdmin, houston.DeploymentEditor, houston.DeploymentViewer}
 
 	for _, validRole := range validRoles {
 		if role == validRole {

--- a/cmd/validation.go
+++ b/cmd/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/workspace"
 
 	"github.com/pkg/errors"
@@ -70,6 +71,17 @@ func coalesceWorkspace() (string, error) {
 
 func validateWorkspaceRole(role string) error {
 	validRoles := []string{"WORKSPACE_ADMIN", "WORKSPACE_EDITOR", "WORKSPACE_VIEWER"}
+
+	for _, validRole := range validRoles {
+		if role == validRole {
+			return nil
+		}
+	}
+	return errors.Errorf("please use one of: %s", strings.Join(validRoles, ", "))
+}
+
+func validateDeploymentRole(role string) error {
+	validRoles := []string{houston.DEPLOYMENT_ADMIN, houston.DEPLOYMENT_EDITOR, houston.DEPLOYMENT_VIEWER}
 
 	for _, validRole := range validRoles {
 		if role == validRole {

--- a/deployment/user.go
+++ b/deployment/user.go
@@ -1,0 +1,41 @@
+package deployment
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/printutil"
+)
+
+// Add a user to a deployment with specified role
+func Add(deploymentId string, email string, role string, client *houston.Client, out io.Writer) error {
+	req := houston.Request{
+		Query: houston.DeploymentUserAddRequest,
+		Variables: map[string]interface{}{
+			"email":        email,
+			"deploymentId": deploymentId,
+			"role":         role,
+		},
+	}
+
+	r, err := req.DoWithClient(client)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	d := r.Data.AddDeploymentUser
+	header := []string{"DEPLOYMENT NAME", "DEPLOYMENT ID", "USER", "ROLE"}
+
+	tab := printutil.Table{
+		Padding:        []int{44, 50},
+		DynamicPadding: true,
+		Header:         header,
+	}
+
+	tab.AddRow([]string{d.Deployment.ReleaseName, d.Deployment.Id, d.User.Username, d.Role}, false)
+	tab.SuccessMsg = fmt.Sprintf("\n Successfully added %s as a %s", email, role)
+	tab.Print(out)
+
+	return nil
+}

--- a/deployment/user_test.go
+++ b/deployment/user_test.go
@@ -63,11 +63,7 @@ func TestAdd(t *testing.T) {
 					"exception": {
 						"message": "A duplicate role binding already exists",
 						"stacktrace": [
-							"UserInputError: A duplicate role binding already exists",
-							"    at deploymentAddUserRole (/Users/adamvandover/Documents/GitHub/houston-api/src/resolvers/mutation/deployment-add-user-role/index.js:69:11)",
-							"    at runMicrotasks (<anonymous>)",
-							"    at processTicksAndRejections (internal/process/task_queues.js:97:5)",
-							"    at middleware (/Users/adamvandover/Documents/GitHub/houston-api/node_modules/graphql-shield/src/generator.ts:70:16)"
+							"UserInputError: A duplicate role binding already exists"
 						]
 					}
 				}

--- a/deployment/user_test.go
+++ b/deployment/user_test.go
@@ -1,0 +1,98 @@
+package deployment
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/astronomer/astro-cli/houston"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+		"data": {
+			"deploymentAddUserRole": {
+				"id": "ckggzqj5f4157qtc9lescmehm",
+				"user": {
+					"username": "somebody@astronomer.com"
+				},
+				"role": "DEPLOYMENT_ADMIN",
+				"deployment": {
+					"releaseName": "prehistoric-gravity-9229"
+				}
+			}
+		}
+	}
+`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	deploymentId := "ckggzqj5f4157qtc9lescmehm"
+	email := "somebody@astronomer.com"
+	role := "DEPLOYMENT_ADMIN"
+
+	buf := new(bytes.Buffer)
+	err := Add(deploymentId, email, role, api, buf)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Successfully added somebody@astronomer.com as a DEPLOYMENT_ADMIN")
+
+	errResponse := `{
+		"errors": [
+			{
+				"message": "A duplicate role binding already exists",
+				"locations": [
+					{
+						"line": 2,
+						"column": 3
+					}
+				],
+				"path": [
+					"deploymentAddUserRole"
+				],
+				"extensions": {
+					"code": "BAD_USER_INPUT",
+					"exception": {
+						"message": "A duplicate role binding already exists",
+						"stacktrace": [
+							"UserInputError: A duplicate role binding already exists",
+							"    at deploymentAddUserRole (/Users/adamvandover/Documents/GitHub/houston-api/src/resolvers/mutation/deployment-add-user-role/index.js:69:11)",
+							"    at runMicrotasks (<anonymous>)",
+							"    at processTicksAndRejections (internal/process/task_queues.js:97:5)",
+							"    at middleware (/Users/adamvandover/Documents/GitHub/houston-api/node_modules/graphql-shield/src/generator.ts:70:16)"
+						]
+					}
+				}
+			}
+		],
+		"data": {
+			"deploymentAddUserRole": null
+		}
+	}
+	`
+
+	client = testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(errResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api = houston.NewHoustonClient(client)
+	deploymentId = "ckggzqj5f4157qtc9lescmehm"
+	email = "somebody@astronomer.com"
+	role = "DEPLOYMENT_ADMIN"
+
+	buf = new(bytes.Buffer)
+	err = Add(deploymentId, email, role, api, buf)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "A duplicate role binding already exists")
+}

--- a/houston/constants.go
+++ b/houston/constants.go
@@ -3,7 +3,7 @@ package houston
 // Houston Constants
 const (
 	// Deployment Level Role Based Access
-	DEPLOYMENT_ADMIN  = "DEPLOYMENT_ADMIN"
-	DEPLOYMENT_EDITOR = "DEPLOYMENT_EDITOR"
-	DEPLOYMENT_VIEWER = "DEPLOYMENT_VIEWER"
+	DeploymentAdmin  = "DEPLOYMENT_ADMIN"
+	DeploymentEditor = "DEPLOYMENT_EDITOR"
+	DeploymentViewer = "DEPLOYMENT_VIEWER"
 )

--- a/houston/constants.go
+++ b/houston/constants.go
@@ -1,0 +1,9 @@
+package houston
+
+// Houston Constants
+const (
+	// Deployment Level Role Based Access
+	DEPLOYMENT_ADMIN  = "DEPLOYMENT_ADMIN"
+	DEPLOYMENT_EDITOR = "DEPLOYMENT_EDITOR"
+	DEPLOYMENT_VIEWER = "DEPLOYMENT_VIEWER"
+)

--- a/houston/mutations.go
+++ b/houston/mutations.go
@@ -1,5 +1,6 @@
 package houston
 
+// TODO: @adam2k Reorganize based on this issue - https://github.com/astronomer/issues/issues/1991
 var (
 	// DeploymentUserAddRequest Mutation for AddDeploymentUser
 	DeploymentUserAddRequest = `

--- a/houston/mutations.go
+++ b/houston/mutations.go
@@ -1,0 +1,30 @@
+package houston
+
+var (
+	// DeploymentUserAddRequest Mutation for AddDeploymentUser
+	DeploymentUserAddRequest = `
+	mutation AddDeploymentUser(
+		$userId: Uuid
+		$email: String!
+		$deploymentId: Uuid!
+		$role: Role!
+	) {
+		deploymentAddUserRole(
+			userUuid: $userId
+			email: $email
+			deploymentUuid: $deploymentId
+			role: $role
+		) {
+			id
+			user {
+				username
+			}
+			role
+			deployment {
+				id
+				releaseName
+			}
+		}
+	}
+	`
+)

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -1,5 +1,6 @@
 package houston
 
+// TODO: @adam2k Reorganize based on this issue - https://github.com/astronomer/issues/issues/1991
 var (
 	AuthConfigGetRequest = `
 	query GetAuthConfig($redirect: String) {

--- a/houston/types.go
+++ b/houston/types.go
@@ -3,6 +3,7 @@ package houston
 // Response wraps all houston response structs used for json marashalling
 type Response struct {
 	Data struct {
+		AddDeploymentUser              *RoleBinding              `json:"deploymentAddUserRole,omitempty"`
 		AddWorkspaceUser               *Workspace                `json:"workspaceAddUser,omitempty"`
 		RemoveWorkspaceUser            *Workspace                `json:"workspaceRemoveUser,omitempty"`
 		CreateDeployment               *Deployment               `json:"createDeployment,omitempty"`
@@ -178,6 +179,7 @@ type RoleBinding struct {
 		Id       string `json:"id"`
 		Username string `json:"username"`
 	} `json:"user"`
+	Deployment Deployment `json:"deployment"`
 }
 
 // Workspace contains all components of an Astronomer Workspace


### PR DESCRIPTION
## Description

This PR is in support of astronomer/issues#1763 to allow for adding workspace users to with appropriate roles to a created deployment.  This PR only includes the `Add` action.  There will be follow up PRs for `delete` and `update` with appropriate mutations and addtional tests. 

## 🎟 Issue(s)

Resolves astronomer/issues#1763

## 🧪 Functional Testing

1. `make build` after checking out this branch.
2. Checkout Houston API Branch `1762-deployment-add-user-role`
3. Switch/Create a workspace and add a user to the workspace
4. Run following command: `./astro deployment user add --deployment-id=ckggvxkw112212kc9ebv8vu6p somebody@astronomer.com`

You should see a success message.

5. Try to run the same command and you should see an appropriate error message


## 📸 Screenshots

![Screen Shot 2020-10-19 at 5 14 52 PM](https://user-images.githubusercontent.com/749118/96512541-a4f13980-122e-11eb-8fd2-3ef48d4909bc.png)
![Screen Shot 2020-10-19 at 5 13 06 PM](https://user-images.githubusercontent.com/749118/96512347-5cd21700-122e-11eb-8ba3-e3b309187d5e.png)
![Screen Shot 2020-10-20 at 11 15 11 AM](https://user-images.githubusercontent.com/749118/96606701-90ac4b80-12c5-11eb-8112-58c2ef3270db.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
