### PR TITLE
Update deployment user role

### DIFF
--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -218,3 +218,36 @@ func TestDeploymentUserDeleteCommand(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOut, output)
 }
+
+func TestDeploymentUserUpdateCommand(t *testing.T) {
+	testUtil.InitTestConfig()
+	expectedOut := `Successfully updated somebody@astronomer.com to a DEPLOYMENT_ADMIN`
+	okResponse := `{
+		"data": {
+			"deploymentUpdateUserRole": {
+				"id": "ckggzqj5f4157qtc9lescmehm",
+				"user": {
+					"username": "somebody@astronomer.com"
+				},
+				"role": "DEPLOYMENT_ADMIN",
+				"deployment": {
+					"id": "ckggvxkw112212kc9ebv8vu6p",
+					"releaseName": "prehistoric-gravity-9229"
+				}
+			}
+		}
+	}`
+
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(strings.NewReader(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	_, output, err := executeCommandC(api, "deployment", "user", "update", "--deployment-id=ckggvxkw112212kc9ebv8vu6p", "--role=DEPLOYMENT_ADMIN", "somebody@astronomer.com")
+	assert.NoError(t, err)
+	assert.Contains(t, output, expectedOut)
+}

--- a/deployment/user.go
+++ b/deployment/user.go
@@ -8,6 +8,15 @@ import (
 	"github.com/astronomer/astro-cli/pkg/printutil"
 )
 
+var (
+	header = []string{"DEPLOYMENT NAME", "DEPLOYMENT ID", "USER", "ROLE"}
+	tab    = printutil.Table{
+		Padding:        []int{44, 50},
+		DynamicPadding: true,
+		Header:         header,
+	}
+)
+
 // Add a user to a deployment with specified role
 func Add(deploymentId string, email string, role string, client *houston.Client, out io.Writer) error {
 	req := houston.Request{
@@ -21,20 +30,36 @@ func Add(deploymentId string, email string, role string, client *houston.Client,
 
 	r, err := req.DoWithClient(client)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	d := r.Data.AddDeploymentUser
-	header := []string{"DEPLOYMENT NAME", "DEPLOYMENT ID", "USER", "ROLE"}
-
-	tab := printutil.Table{
-		Padding:        []int{44, 50},
-		DynamicPadding: true,
-		Header:         header,
-	}
 
 	tab.AddRow([]string{d.Deployment.ReleaseName, d.Deployment.Id, d.User.Username, d.Role}, false)
 	tab.SuccessMsg = fmt.Sprintf("\n Successfully added %s as a %s", email, role)
+	tab.Print(out)
+
+	return nil
+}
+
+// UpdateUser updates a user's deployment role
+func UpdateUser(deploymentId string, email string, role string, client *houston.Client, out io.Writer) error {
+	req := houston.Request{
+		Query: houston.DeploymentUserUpdateRequest,
+		Variables: map[string]interface{}{
+			"email":        email,
+			"deploymentId": deploymentId,
+			"role":         role,
+		},
+	}
+
+	r, err := req.DoWithClient(client)
+	if err != nil {
+		return err
+	}
+	d := r.Data.UpdateDeploymentUser
+
+	tab.AddRow([]string{d.Deployment.ReleaseName, d.Deployment.Id, d.User.Username, d.Role}, false)
+	tab.SuccessMsg = fmt.Sprintf("\n Successfully updated %s to a %s", email, role)
 	tab.Print(out)
 
 	return nil

--- a/houston/mutations.go
+++ b/houston/mutations.go
@@ -46,4 +46,31 @@ var (
 		}
 	}
 	`
+
+	// DeploymentUserUpdateRequest Mutation for UpdateDeploymentUser
+	DeploymentUserUpdateRequest = `
+	mutation UpdateDeploymentUser(
+		$userId: Id
+		$email: String!
+		$deploymentId: Id!
+		$role: Role!
+	) {
+		deploymentUpdateUserRole(
+			userId: $userId
+			email: $email
+			deploymentId: $deploymentId
+			role: $role
+		) {
+			id
+			user {
+				username
+			}
+			role
+			deployment {
+				id
+				releaseName
+			}
+		}
+	}
+	`
 )

--- a/houston/types.go
+++ b/houston/types.go
@@ -5,6 +5,7 @@ type Response struct {
 	Data struct {
 		AddDeploymentUser              *RoleBinding              `json:"deploymentAddUserRole,omitempty"`
 		DeleteDeploymentUser           *RoleBinding              `json:"deploymentRemoveUserRole,omitempty"`
+		UpdateDeploymentUser           *RoleBinding              `json:"deploymentUpdateUserRole,omitempty"`
 		AddWorkspaceUser               *Workspace                `json:"workspaceAddUser,omitempty"`
 		RemoveWorkspaceUser            *Workspace                `json:"workspaceRemoveUser,omitempty"`
 		CreateDeployment               *Deployment               `json:"createDeployment,omitempty"`


### PR DESCRIPTION
## Description

Allow users to update the deployment user role after a user is added to a deployment.

## 🎟 Issue(s)

Resolves astronomer/issues#1763

## 🧪 Functional Testing

1. make build after checking out this branch.
2. Checkout Houston API Branch `1762-deployment-update-user-role`
3. Switch/Create a workspace and add a user to the workspace
4. Run following command: ./astro deployment user add --deployment-id={YOUR_DEPLOYMENT_ID} somebody@astronomer.com
5. Run the update command: ./astro deployment user update --deployment-id={YOUR_DEPLOYMENT_ID} --role=DEPLOYMENT_EDITOR somebody@astronomer.com

You should see a success message for steps 4 and 5.

The user role should have changed from the default `DEPLOYMENT_VIEWER` to `DEPLOYMENT_EDITOR`.


## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
