### PR TITLE
Add feature Delete Deployment User Role

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -35,6 +35,10 @@ var (
 # Add a workspace user to a deployment with a particular role
   $ astro deployment user add --deployment-id=xxxxx --role=DEPLOYMENT_ROLE <user-email-address>
 `
+	deploymentUserDeleteExample = `
+# Delete user access to a deployment
+	$ astro deployment user delete --deployment-id=xxxxx <user-email-address>
+`
 	deploymentSaCreateExample = `
 # Create service-account
   $ astro deployment service-account create --deployment-id=xxxxx --label=my_label --role=ROLE
@@ -147,6 +151,7 @@ func newDeploymentUserRootCmd(client *houston.Client, out io.Writer) *cobra.Comm
 	}
 	cmd.AddCommand(
 		newDeploymentUserAddCmd(client, out),
+		newDeploymentUserDeleteCmd(client, out),
 	)
 	return cmd
 }
@@ -164,7 +169,21 @@ func newDeploymentUserAddCmd(client *houston.Client, out io.Writer) *cobra.Comma
 	}
 	cmd.PersistentFlags().StringVar(&deploymentId, "deployment-id", "", "deployment assigned to user")
 	cmd.PersistentFlags().StringVar(&deploymentRole, "role", "DEPLOYMENT_VIEWER", "role assigned to user")
-	// TODO: add new deploymentRole and figure out role types "DEPLOYMENT_VIEWER", etc.
+	return cmd
+}
+
+func newDeploymentUserDeleteCmd(client *houston.Client, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete EMAIL",
+		Short:   "Delete a user from a deployment",
+		Long:    "Delete a user from a deployment",
+		Args:    cobra.ExactArgs(1),
+		Example: deploymentUserDeleteExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentUserDelete(cmd, client, out, args)
+		},
+	}
+	cmd.PersistentFlags().StringVar(&deploymentId, "deployment-id", "", "deployment to remove user access")
 	return cmd
 }
 
@@ -309,6 +328,17 @@ func deploymentUserAdd(cmd *cobra.Command, client *houston.Client, out io.Writer
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 	return deployment.Add(deploymentId, args[0], deploymentRole, client, out)
+}
+
+func deploymentUserDelete(cmd *cobra.Command, client *houston.Client, out io.Writer, args []string) error {
+	_, err := coalesceWorkspace()
+	if err != nil {
+		return errors.Wrap(err, "failed to find a valid workspace")
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+	return deployment.DeleteUser(deploymentId, args[0], client, out)
 }
 
 func deploymentSaCreate(cmd *cobra.Command, args []string, client *houston.Client, out io.Writer) error {

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -181,3 +181,40 @@ func TestDeploymentUserAddCommand(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOut, output)
 }
+
+func TestDeploymentUserDeleteCommand(t *testing.T) {
+	testUtil.InitTestConfig()
+	expectedOut := ` DEPLOYMENT ID                 USER                        ROLE                  
+ ckggvxkw112212kc9ebv8vu6p     somebody@astronomer.com     DEPLOYMENT_VIEWER     
+
+ Successfully removed the DEPLOYMENT_VIEWER role for somebody@astronomer.com from deployment ckggvxkw112212kc9ebv8vu6p
+`
+	okResponse := `{
+		"data": {
+			"deploymentRemoveUserRole": {
+				"id": "ckggzqj5f4157qtc9lescmehm",
+				"user": {
+					"username": "somebody@astronomer.com"
+				},
+				"role": "DEPLOYMENT_VIEWER",
+				"deployment": {
+					"id": "ckggvxkw112212kc9ebv8vu6p",
+					"releaseName": "prehistoric-gravity-9229"
+				}
+			}
+		}
+	}`
+
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(strings.NewReader(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	_, output, err := executeCommandC(api, "deployment", "user", "delete", "--deployment-id=ckggvxkw112212kc9ebv8vu6p", "somebody@astronomer.com")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOut, output)
+}

--- a/deployment/user.go
+++ b/deployment/user.go
@@ -39,3 +39,34 @@ func Add(deploymentId string, email string, role string, client *houston.Client,
 
 	return nil
 }
+
+// DeleteUser removes user access for a deployment
+func DeleteUser(deploymentId string, email string, client *houston.Client, out io.Writer) error {
+	req := houston.Request{
+		Query: houston.DeploymentUserDeleteRequest,
+		Variables: map[string]interface{}{
+			"email":        email,
+			"deploymentId": deploymentId,
+		},
+	}
+
+	r, err := req.DoWithClient(client)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	d := r.Data.DeleteDeploymentUser
+	header := []string{"DEPLOYMENT ID", "USER", "ROLE"}
+
+	tab := printutil.Table{
+		Padding:        []int{44, 50},
+		DynamicPadding: true,
+		Header:         header,
+	}
+
+	tab.AddRow([]string{deploymentId, email, d.Role}, false)
+	tab.SuccessMsg = fmt.Sprintf("\n Successfully removed the %s role for %s from deployment %s", d.Role, email, deploymentId)
+	tab.Print(out)
+
+	return nil
+}

--- a/houston/mutations.go
+++ b/houston/mutations.go
@@ -5,15 +5,15 @@ var (
 	// DeploymentUserAddRequest Mutation for AddDeploymentUser
 	DeploymentUserAddRequest = `
 	mutation AddDeploymentUser(
-		$userId: Uuid
+		$userId: Id
 		$email: String!
-		$deploymentId: Uuid!
+		$deploymentId: Id!
 		$role: Role!
 	) {
 		deploymentAddUserRole(
-			userUuid: $userId
+			userId: $userId
 			email: $email
-			deploymentUuid: $deploymentId
+			deploymentId: $deploymentId
 			role: $role
 		) {
 			id
@@ -25,6 +25,24 @@ var (
 				id
 				releaseName
 			}
+		}
+	}
+	`
+
+	// DeploymentUserDeleteRequest Mutation for AddDeploymentUser
+	DeploymentUserDeleteRequest = `
+	mutation DeleteDeploymentUser(
+		$userId: Id
+		$email: String!
+		$deploymentId: Id!
+	) {
+		deploymentRemoveUserRole(
+			userId: $userId
+			email: $email
+			deploymentId: $deploymentId
+		) {
+			id
+			role
 		}
 	}
 	`

--- a/houston/types.go
+++ b/houston/types.go
@@ -4,6 +4,7 @@ package houston
 type Response struct {
 	Data struct {
 		AddDeploymentUser              *RoleBinding              `json:"deploymentAddUserRole,omitempty"`
+		DeleteDeploymentUser           *RoleBinding              `json:"deploymentRemoveUserRole,omitempty"`
 		AddWorkspaceUser               *Workspace                `json:"workspaceAddUser,omitempty"`
 		RemoveWorkspaceUser            *Workspace                `json:"workspaceRemoveUser,omitempty"`
 		CreateDeployment               *Deployment               `json:"createDeployment,omitempty"`


### PR DESCRIPTION
## Description

Allow users to delete the deployment user role after a user is added to a deployment.

## 🎟 Issue(s)

Resolves astronomer/issues#763

## 🧪 Functional Testing

1. make build after checking out this branch.
2. Checkout Houston API Branch `1762-deployment-remove-user-role` (there is a bug fix that needs to go in and it is commented here: https://github.com/astronomer/houston-api/pull/526#discussion_r510923551 )
3. Switch/Create a workspace and add a user to the workspace
4. Run following command: ./astro deployment user add --deployment-id={YOUR_DEPLOYMENT_ID} somebody@astronomer.com
5. Run the update command: ./astro deployment user delete --deployment-id={YOUR_DEPLOYMENT_ID} somebody@astronomer.com

You should see a success message for steps 4 and 5.

## 📸 Screenshots

![Screen Shot 2020-10-23 at 10 51 37 AM](https://user-images.githubusercontent.com/749118/97026556-87bab480-1527-11eb-806f-eeab83073b1d.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
