### PR TITLE
Use Constant Instead of String

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -163,8 +163,8 @@ func newDeploymentUserAddCmd(client *houston.Client, out io.Writer) *cobra.Comma
 		},
 	}
 	cmd.PersistentFlags().StringVar(&deploymentId, "deployment-id", "", "deployment assigned to user")
-	cmd.PersistentFlags().StringVar(&deploymentRole, "role", "DEPLOYMENT_VIEWER", "role assigned to user")
-	// TODO: add new deploymentRole and figure out role types "DEPLOYMENT_VIEWER", etc.
+	cmd.PersistentFlags().StringVar(&deploymentRole, "role", houston.DeploymentViewer, "role assigned to user")
+
 	return cmd
 }
 

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -169,7 +169,6 @@ func newDeploymentUserAddCmd(client *houston.Client, out io.Writer) *cobra.Comma
 	}
 	cmd.PersistentFlags().StringVar(&deploymentId, "deployment-id", "", "deployment assigned to user")
 	cmd.PersistentFlags().StringVar(&deploymentRole, "role", houston.DeploymentViewer, "role assigned to user")
-
 	return cmd
 }
 

--- a/houston/mutations.go
+++ b/houston/mutations.go
@@ -5,15 +5,15 @@ var (
 	// DeploymentUserAddRequest Mutation for AddDeploymentUser
 	DeploymentUserAddRequest = `
 	mutation AddDeploymentUser(
-		$userId: Uuid
+		$userId: Id
 		$email: String!
-		$deploymentId: Uuid!
+		$deploymentId: Id!
 		$role: Role!
 	) {
 		deploymentAddUserRole(
-			userUuid: $userId
+			userId: $userId
 			email: $email
-			deploymentUuid: $deploymentId
+			deploymentId: $deploymentId
 			role: $role
 		) {
 			id


### PR DESCRIPTION
## Description

The `DEPLOYMENT_VIEWER` hard coded string value can be replaced with the constant value.

## 🎟 Issue(s)

Resolves astronomer/issues#1763

## 🧪 Functional Testing

The steps are the same as the original PR: https://github.com/astronomer/astro-cli/pull/365

## 📸 Screenshots

See https://github.com/astronomer/astro-cli/pull/365

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
