### PR TITLE
Update RegistryAuthFail message

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -171,7 +171,7 @@ func Login(domain string, oAuthOnly bool, username, password string, client *hou
 
 	err = registryAuth()
 	if err != nil {
-		fmt.Printf(messages.REGISTRY_AUTH_FAIL)
+		fmt.Printf(messages.RegistryAuthFail)
 	}
 
 	return nil

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -64,7 +64,7 @@ var (
 	INPUT_OAUTH_TOKEN = "oAuth Token: "
 
 	REGISTRY_AUTH_SUCCESS        = "Successfully authenticated to %s\n"
-	REGISTRY_AUTH_FAIL           = "Failed to authenticate to the registry, this can occur when registry is offline. Until authenticated you will not be able to push new images to your Airflow clusters\n"
+	RegistryAuthFail             = "\nFailed to authenticate to the registry, do you have docker running?\nThis error can occur when docker is not running or the registry is offline.\nUntil authenticated you will not be able to push new images to your Airflow clusters\n"
 	REGISTRY_UNCOMMITTED_CHANGES = "Project directory has uncommmited changes, use `astro deploy [releaseName] -f` to force deploy."
 
 	SETTINGS_PATH = "Error looking for settings.yaml"

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -64,7 +64,7 @@ var (
 	INPUT_OAUTH_TOKEN = "oAuth Token: "
 
 	REGISTRY_AUTH_SUCCESS        = "Successfully authenticated to %s\n"
-	RegistryAuthFail             = "\nFailed to authenticate to the registry, do you have docker running?\nThis error can occur when docker is not running or the registry is offline.\nUntil authenticated you will not be able to push new images to your Airflow clusters.\n"
+	RegistryAuthFail             = "\nFailed to authenticate to the registry. Do you have Docker running?\nYou will not be able to push new images to your Airflow Deployment unless Docker is running.\nIf Docker is running and you are seeing this message, the registry is down or cannot be reached.\n"
 	REGISTRY_UNCOMMITTED_CHANGES = "Project directory has uncommmited changes, use `astro deploy [releaseName] -f` to force deploy."
 
 	SETTINGS_PATH = "Error looking for settings.yaml"

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -64,7 +64,7 @@ var (
 	INPUT_OAUTH_TOKEN = "oAuth Token: "
 
 	REGISTRY_AUTH_SUCCESS        = "Successfully authenticated to %s\n"
-	RegistryAuthFail             = "\nFailed to authenticate to the registry, do you have docker running?\nThis error can occur when docker is not running or the registry is offline.\nUntil authenticated you will not be able to push new images to your Airflow clusters\n"
+	RegistryAuthFail             = "\nFailed to authenticate to the registry, do you have docker running?\nThis error can occur when docker is not running or the registry is offline.\nUntil authenticated you will not be able to push new images to your Airflow clusters.\n"
 	REGISTRY_UNCOMMITTED_CHANGES = "Project directory has uncommmited changes, use `astro deploy [releaseName] -f` to force deploy."
 
 	SETTINGS_PATH = "Error looking for settings.yaml"


### PR DESCRIPTION
## Description

Right now, if you run `astro auth login` without the local Docker daemon running, you get an error suggesting that the registry is offline:

```
Failed to authenticate to the registry, this can occur when registry is offline. Until authenticated you will not be able to push new images to your Airflow clusters
```

The intent in this PR is to update the error message as a quick fix until we can get better error handling in place.

The new error message is:

```

Failed to authenticate to the registry. Do you have Docker running?
You will not be able to push new images to your Airflow Deployment unless Docker is running.
If Docker is running and you are seeing this message, the registry is down or cannot be reached.
```

## 🎟 Issue(s)

Resolves astronomer/issues#1372

## 🧪 Functional Testing

Turn off docker locally and try to log into a remote cluster.

## 📸 Screenshots

```
$ astroDev auth login gcp0001.us-east4.astronomer.io
 CLUSTER                             WORKSPACE
 gcp0001.us-east4.astronomer.io      ckgld7mpx232391pjhgju22nm8

 Switched cluster
Username (leave blank for oAuth):

Please visit the following URL, authenticate and paste token in next prompt

https://app.gcp0001.us-east4.astronomer.io/token

oAuth Token: eyJhbGciOiJ...{AuthTokenRemoved}
Default "Testing" (ckgld7mpx232391pjhgju22nm8) workspace found, setting default workspace.

Failed to authenticate to the registry, do you have docker running?
This error can occur when docker is not running or the registry is offline.
Until authenticated you will not be able to push new images to your Airflow clusters
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
