### PR TITLE
Add deployment user list

### DIFF
--- a/houston/constants.go
+++ b/houston/constants.go
@@ -3,6 +3,7 @@ package houston
 // Houston Constants
 const (
 	// Deployment Level Role Based Access
+	DeploymentRole   = "DEPLOYMENT"
 	DeploymentAdmin  = "DEPLOYMENT_ADMIN"
 	DeploymentEditor = "DEPLOYMENT_EDITOR"
 	DeploymentViewer = "DEPLOYMENT_VIEWER"

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -233,6 +233,25 @@ var (
          }
     }`
 
+	// DeploymentUserListRequest return the users for a specific deployment by ID
+	DeploymentUserListRequest = `
+	query deploymentUsers(
+    $deploymentId: Id!
+    $user: UserSearch
+  ) {
+    deploymentUsers(
+      deploymentId: $deploymentId
+      user: $user
+    ) {
+      id
+      fullName
+      username
+      roleBindings {
+        role
+      }
+    }
+  }`
+
 	ServiceAccountsGetRequest = `
 	query GetServiceAccount(
 		$serviceAccountId: Uuid

--- a/houston/types.go
+++ b/houston/types.go
@@ -6,6 +6,7 @@ type Response struct {
 		AddDeploymentUser              *RoleBinding              `json:"deploymentAddUserRole,omitempty"`
 		DeleteDeploymentUser           *RoleBinding              `json:"deploymentRemoveUserRole,omitempty"`
 		UpdateDeploymentUser           *RoleBinding              `json:"deploymentUpdateUserRole,omitempty"`
+		DeploymentUserList             []DeploymentUser          `json:"deploymentUsers,omitempty"`
 		AddWorkspaceUser               *Workspace                `json:"workspaceAddUser,omitempty"`
 		RemoveWorkspaceUser            *Workspace                `json:"workspaceRemoveUser,omitempty"`
 		CreateDeployment               *Deployment               `json:"createDeployment,omitempty"`
@@ -135,6 +136,15 @@ type WorkspaceServiceAccount struct {
 	CreatedAt     string `json:"createdAt"`
 	UpdatedAt     string `json:"updatedAt"`
 	Active        bool   `json:"active"`
+}
+
+// DeploymentUser defines a structure of RBAC deployment users
+type DeploymentUser struct {
+	Id           string        `json:"id"`
+	Emails       []Email       `json:"emails"`
+	FullName     string        `json:"fullName"`
+	Username     string        `json:"username"`
+	RoleBindings []RoleBinding `json:"roleBindings"`
 }
 
 // DeploymentServiceAccount defines a structure of a DeploymentServiceAccountResponse object

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -58,6 +58,8 @@ var (
 	HOUSTON_SELECT_DEPLOYMENT_PROMPT = "Select which airflow deployment you want to deploy to:"
 	HOUSTON_OAUTH_REDIRECT           = "Please visit the following URL, authenticate and paste token in next prompt\n"
 	HOUSTON_INVALID_DEPLOYMENT_KEY   = "Invalid deployment selection\n"
+	// TODO: @adam2k remove this message once the Houston API work is completed that will surface a similar error message
+	HoustonInvalidDeploymentUsers = "No users were found for this deployment.  Check the deploymentId and try again.\n"
 
 	INPUT_PASSWORD    = "Password: "
 	INPUT_USERNAME    = "Username (leave blank for oAuth): "


### PR DESCRIPTION
## Description

Allow for `astro deployment user list <deployment-id>` so users can see who has access to a particular deployment.

## 🎟 Issue(s)

Resolves astronomer/issues#1763

## 🧪 Functional Testing

1. This works by checking out `Houston API` - `main` branch now.
2. Create a workspace & deployment
3. Add user(s) to the workspace and then to the deployment:
```
$ astro workspace user add <user_email>
$ astro deployment user add <user_email> --deployment-id=<deployment-id>
```
4. `astro deployment user list FAKE_DEPLOYMENT_ID` 
5. You should see an error message: `No users were found for this deployment.  Check the deploymentId and try again.`
6. Now use the real deployment ID
7. You should see results like:

```
 USER ID                       NAME              EMAIL                     ROLE
 ckgqw2k2600081qc90nbamgno     Adam Vandover     adam@astronomer.io        DEPLOYMENT_ADMIN
 ckgqyufp813838oc9cj8u5jtr     Adam Vandover     avandover@gmail.com       DEPLOYMENT_EDITOR
 ckgr08ay936788oc9asik4wqs     Vandover Ada      avandover+1@gmail.com     DEPLOYMENT_VIEWER
```

## 📸 Screenshots

![Screen Shot 2020-10-27 at 12 40 20 PM](https://user-images.githubusercontent.com/749118/97333167-9ec41400-1851-11eb-9288-a88031c9b815.png)
![Screen Shot 2020-10-27 at 12 40 28 PM](https://user-images.githubusercontent.com/749118/97333170-9ec41400-1851-11eb-912b-18585756657f.png)

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
