### PR TITLE
fix get selection airflow version

### DIFF
--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -2,10 +2,11 @@ package deployment
 
 import (
 	"fmt"
-	"github.com/Masterminds/semver"
 	"io"
 	"sort"
 	"strconv"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -292,12 +293,16 @@ func getAirflowVersionSelection(deploymentId string, client *houston.Client, out
 	}
 	t.GetUserInput = true
 
+	var filteredVersions []string
+
 	for _, v := range airflowVersions {
 		vv, _ := semver.NewVersion(v)
 		// false means no colors
 		if currentAirflowVersion.LessThan(vv) {
+			filteredVersions = append(filteredVersions, v)
 			t.AddRow([]string{v}, false)
 		}
+
 	}
 
 	t.Print(out)
@@ -308,9 +313,8 @@ func getAirflowVersionSelection(deploymentId string, client *houston.Client, out
 		10,
 		64,
 	)
-	return airflowVersions[i-1], nil
+	return filteredVersions[i-1], nil
 }
-
 
 func getDeployment(deploymentId string, client *houston.Client) (*houston.Deployment, error) {
 	vars := map[string]interface{}{"id": deploymentId}

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -506,7 +506,7 @@ func Test_getAirflowVersionSelection(t *testing.T) {
 	buf := new(bytes.Buffer)
 
 	// mock os.Stdin
-	input := []byte("3")
+	input := []byte("2")
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Description

related https://github.com/astronomer/issues/issues/1741

fix issue (found during demo):
```
1     1.10.10
2     1.10.12

> 1
 NAME       DEPLOYMENT NAME          ASTRO       DEPLOYMENT ID                 AIRFLOW VERSION
 demo-1     blazing-kinetic-3888     v0.17.1     ckh3og6pn04841qdpv8xugrzr     1.10.7

The upgrade from Airflow 1.10.7 to 1.10.7 has been started. To complete this process, add an Airflow 1.10.7 image to your Dockerfile and deploy to Astronomer.

```

practically LGTM:
```
astro deployment airflow upgrade --deployment-id=ckh3sbgnx27471pgiccasavne
#     AIRFLOW VERSION
1     1.10.10
2     1.10.12

> 2
 NAME       DEPLOYMENT NAME                    ASTRO       DEPLOYMENT ID                 AIRFLOW VERSION
 demo-2     ultraviolet-radioactivity-3900     v0.17.1     ckh3sbgnx27471pgiccasavne     1.10.7

The upgrade from Airflow 1.10.7 to 1.10.12 has been started. To complete this process, add an Airflow 1.10.12 image to your Dockerfile and deploy to Astronomer.
To cancel, run:
 $ astro deployment airflow upgrade --cancel

(base) ➜  astro-cli git:(hotfix-get-selection-airflow-version) ✗ go run main.go deployment airflow upgrade --deployment-id=ckh3sbgnx27471pgiccasavne
#     AIRFLOW VERSION
1     1.10.10
2     1.10.12

> 1
 NAME       DEPLOYMENT NAME                    ASTRO       DEPLOYMENT ID                 AIRFLOW VERSION
 demo-2     ultraviolet-radioactivity-3900     v0.17.1     ckh3sbgnx27471pgiccasavne     1.10.7

T
```