### PR TITLE
Switch docker hub references to quay.io

### DIFF
--- a/airflow/include/dockerfile.go
+++ b/airflow/include/dockerfile.go
@@ -4,5 +4,5 @@ import "strings"
 
 // Dockerfile is the Dockerfile template
 var Dockerfile = strings.TrimSpace(`
-FROM astronomerinc/ap-airflow:%s
+FROM quay.io/astronomer/ap-airflow:%s
 `)

--- a/docker/parse_test.go
+++ b/docker/parse_test.go
@@ -13,23 +13,23 @@ func TestAllCmds(t *testing.T) {
 }
 
 func TestParseReaderParseError(t *testing.T) {
-	dockerfile := "FROM astronomerinc/ap-airflow:latest-onbuild\nCMD [\"echo\", 1]"
+	dockerfile := "FROM quay.io/astronomer/ap-airflow:latest-onbuild\nCMD [\"echo\", 1]"
 	_, err := ParseReader(bytes.NewBufferString(dockerfile))
 	assert.IsType(t, ParseError{}, err)
 }
 
 func TestParseReader(t *testing.T) {
-	dockerfile := `FROM astronomerinc/ap-airflow:latest-onbuild`
+	dockerfile := `FROM quay.io/astronomer/ap-airflow:latest-onbuild`
 	cmds, err := ParseReader(bytes.NewBufferString(dockerfile))
 	assert.Nil(t, err)
 	expected := []Command{
 		{
 			Cmd:       "from",
-			Original:  "FROM astronomerinc/ap-airflow:latest-onbuild",
+			Original:  "FROM quay.io/astronomer/ap-airflow:latest-onbuild",
 			StartLine: 1,
 			EndLine:   1,
 			Flags:     []string{},
-			Value:     []string{"astronomerinc/ap-airflow:latest-onbuild"},
+			Value:     []string{"quay.io/astronomer/ap-airflow:latest-onbuild"},
 		},
 	}
 	assert.Equal(t, expected, cmds)
@@ -47,11 +47,11 @@ func TestParseFile(t *testing.T) {
 	expected := []Command{
 		{
 			Cmd:       "from",
-			Original:  "FROM astronomerinc/ap-airflow:latest-onbuild",
+			Original:  "FROM quay.io/astronomer/ap-airflow:latest-onbuild",
 			StartLine: 1,
 			EndLine:   1,
 			Flags:     []string{},
-			Value:     []string{"astronomerinc/ap-airflow:latest-onbuild"},
+			Value:     []string{"quay.io/astronomer/ap-airflow:latest-onbuild"},
 		},
 	}
 	assert.Equal(t, expected, cmds)
@@ -61,14 +61,14 @@ func TestGetImageTagFromParsedFile(t *testing.T) {
 	cmds := []Command{
 		{
 			Cmd:       "from",
-			Original:  "FROM astronomerinc/ap-airflow:latest-onbuild",
+			Original:  "FROM quay.io/astronomer/ap-airflow:latest-onbuild",
 			StartLine: 1,
 			EndLine:   1,
 			Flags:     []string{},
-			Value:     []string{"astronomerinc/ap-airflow:latest-onbuild"},
+			Value:     []string{"quay.io/astronomer/ap-airflow:latest-onbuild"},
 		},
 	}
 	image, tag := GetImageTagFromParsedFile(cmds)
-	assert.Equal(t, "astronomerinc/ap-airflow", image)
+	assert.Equal(t, "quay.io/astronomer/ap-airflow", image)
 	assert.Equal(t, "latest-onbuild", tag)
 }

--- a/docker/testfiles/Dockerfile.ok
+++ b/docker/testfiles/Dockerfile.ok
@@ -1,1 +1,1 @@
-FROM astronomerinc/ap-airflow:latest-onbuild
+FROM quay.io/astronomer/ap-airflow:latest-onbuild

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -72,7 +72,7 @@ var (
 	SETTINGS_PATH = "Error looking for settings.yaml"
 
 	NA                          = "N/A"
-	VALID_DOCKERFILE_BASE_IMAGE = "astronomerinc/ap-airflow"
+	VALID_DOCKERFILE_BASE_IMAGE = "quay.io/astronomer/ap-airflow"
 
 	WARNING_DOWNGRADE_VERSION  = "Your Astro CLI Version (%s) is ahead of the server version (%s).\nConsider downgrading your Astro CLI to match. See https://www.astronomer.io/docs/cli-quickstart for more information.\n"
 	WARNING_INVALID_IMAGE_NAME = "WARNING! You are using an invalid image name '%s' in your Dockerfile, please use %s. Are you sure you want to continue?\n"


### PR DESCRIPTION
## Description

In all our repos, all docker hub references are being switched to quay.io references.

## 🎟 Issue(s)

Relates to astronomer/issues#1355