### PR TITLE
Run sync_perm / sync-perm command in Webserver

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -112,7 +112,7 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c '{ airflow create_user "$$@" || airflow users create "$$@"; } && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
+      bash -c '{ airflow create_user "$$@" || airflow users create "$$@"; } && { airflow sync_perm || airflow sync-perm; } && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -62,7 +62,7 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c '{ airflow create_user "$$@" || airflow users create "$$@"; } && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
+      bash -c '{ airflow create_user "$$@" || airflow users create "$$@"; } && { airflow sync_perm || airflow sync-perm; } && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:
       - airflow


### PR DESCRIPTION
After https://github.com/astronomer/ap-airflow/pull/146 and since we need to support CLI commands for <2.0 and >=2.0 the entrypoint does not sync-perm (https://github.com/astronomer/ap-airflow/pull/149) since the command run does not match to the condition. Hence lets run this command separately
