### PR TITLE
Shorten list of recommended tags/images in CLI to 1 AC version #2166

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -614,7 +614,7 @@ func Deploy(path, name, wsId string, prompt bool) error {
 	}
 
 	if config.CFG.ShowWarnings.GetBool() && !diResp.Data.DeploymentConfig.IsValidTag(tag) {
-		validTags := strings.Join(diResp.Data.DeploymentConfig.GetValidTags(), ", ")
+		validTags := strings.Join(diResp.Data.DeploymentConfig.GetValidTags(tag), ", ")
 		i, _ := input.InputConfirm(fmt.Sprintf(messages.WARNING_INVALID_IMAGE_TAG, tag, validTags))
 		if !i {
 			fmt.Println("Cancelling deploy...")
@@ -658,7 +658,7 @@ func Deploy(path, name, wsId string, prompt bool) error {
 func validImageRepo(image string) bool {
 	validDockerfileBaseImages := map[string]bool{
 		"quay.io/astronomer/ap-airflow": true,
-		"astronomerinc/ap-airflow": true,
+		"astronomerinc/ap-airflow":      true,
 	}
 	result, ok := validDockerfileBaseImages[image]
 	if !ok {

--- a/houston/types.go
+++ b/houston/types.go
@@ -1,5 +1,11 @@
 package houston
 
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver"
+)
+
 // Response wraps all houston response structs used for json marashalling
 type Response struct {
 	Data struct {
@@ -231,15 +237,20 @@ type DeploymentConfig struct {
 	AirflowVersions        []string       `json:"airflowVersions"`
 }
 
-func (config *DeploymentConfig) GetValidTags() (tags []string) {
+func (config *DeploymentConfig) GetValidTags(tag string) (tags []string) {
 	for _, image := range config.AirflowImages {
-		tags = append(tags, image.Tag)
+		tagVersion := coerce(tag)
+		imageTagVersion := coerce(image.Version)
+		// i = 1 means version greater than
+		if i := imageTagVersion.Compare(tagVersion); i >= 0 {
+			tags = append(tags, image.Tag)
+		}
 	}
 	return
 }
 
 func (config *DeploymentConfig) IsValidTag(tag string) bool {
-	for _, validTag := range config.GetValidTags() {
+	for _, validTag := range config.GetValidTags(tag) {
 		if tag == validTag {
 			return true
 		}
@@ -253,4 +264,17 @@ type AppConfig struct {
 	BaseDomain         string `json:"baseDomain"`
 	SmtpConfigured     bool   `json:"smtpConfigured"`
 	ManualReleaseNames bool   `json:"manualReleaseNames"`
+}
+
+// coerce a string into SemVer if possible
+func coerce(version string) *semver.Version {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		fmt.Println(err)
+	}
+	coerceVer, err := semver.NewVersion(fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch()))
+	if err != nil {
+		fmt.Println(err)
+	}
+	return coerceVer
 }

--- a/houston/types_test.go
+++ b/houston/types_test.go
@@ -1,0 +1,75 @@
+package houston
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetValidTagsSimpleSemVer(t *testing.T) {
+	dCfg := DeploymentConfig{
+		AirflowImages: []AirflowImage{
+			{Tag: "1.10.5-11-alpine3.10-onbuild", Version: "1.10.5-11"},
+			{Tag: "1.10.5-11-buster-onbuild", Version: "1.10.5-11"},
+			{Tag: "1.10.5-11-alpine3.10", Version: "1.10.5-11"},
+			{Tag: "1.10.5-11-buster", Version: "1.10.5-11"},
+			{Tag: "1.10.5-buster-onbuild", Version: "1.10.5"},
+			{Tag: "1.10.5-alpine3.10", Version: "1.10.5"},
+			{Tag: "1.10.5-buster", Version: "1.10.5"},
+			{Tag: "1.10.5-alpine3.10-onbuild", Version: "1.10.5"},
+			{Tag: "1.10.7-7-buster-onbuild", Version: "1.10.7-7"},
+			{Tag: "1.10.7-7-alpine3.10", Version: "1.10.7-7"},
+			{Tag: "1.10.7-7-buster", Version: "1.10.7-7"},
+			{Tag: "1.10.7-7-alpine3.10-onbuild", Version: "1.10.7-7"},
+			{Tag: "1.10.7-8-alpine3.10-onbuild", Version: "1.10.7-8"},
+			{Tag: "1.10.7-8-buster-onbuild", Version: "1.10.7-8"},
+			{Tag: "1.10.7-8-alpine3.10", Version: "1.10.7-8"},
+			{Tag: "1.10.7-8-buster", Version: "1.10.7-8"},
+		},
+	}
+	validTags := dCfg.GetValidTags("1.10.7")
+	expectedTags := []string{
+		"1.10.7-7-buster-onbuild",
+		"1.10.7-7-alpine3.10",
+		"1.10.7-7-buster",
+		"1.10.7-7-alpine3.10-onbuild",
+		"1.10.7-8-alpine3.10-onbuild",
+		"1.10.7-8-buster-onbuild",
+		"1.10.7-8-alpine3.10",
+		"1.10.7-8-buster"}
+	assert.Equal(t, expectedTags, validTags)
+}
+
+func TestGetValidTagsWithPreReleaseTag(t *testing.T) {
+	dCfg := DeploymentConfig{
+		AirflowImages: []AirflowImage{
+			{Tag: "1.10.5-11-alpine3.10-onbuild", Version: "1.10.5-11"},
+			{Tag: "1.10.5-11-buster-onbuild", Version: "1.10.5-11"},
+			{Tag: "1.10.5-11-alpine3.10", Version: "1.10.5-11"},
+			{Tag: "1.10.5-11-buster", Version: "1.10.5-11"},
+			{Tag: "1.10.5-buster-onbuild", Version: "1.10.5"},
+			{Tag: "1.10.5-alpine3.10", Version: "1.10.5"},
+			{Tag: "1.10.5-buster", Version: "1.10.5"},
+			{Tag: "1.10.5-alpine3.10-onbuild", Version: "1.10.5"},
+			{Tag: "1.10.7-7-buster-onbuild", Version: "1.10.7-7"},
+			{Tag: "1.10.7-7-alpine3.10", Version: "1.10.7-7"},
+			{Tag: "1.10.7-7-buster", Version: "1.10.7-7"},
+			{Tag: "1.10.7-7-alpine3.10-onbuild", Version: "1.10.7-7"},
+			{Tag: "1.10.7-8-alpine3.10-onbuild", Version: "1.10.7-8"},
+			{Tag: "1.10.7-8-buster-onbuild", Version: "1.10.7-8"},
+			{Tag: "1.10.7-8-alpine3.10", Version: "1.10.7-8"},
+			{Tag: "1.10.7-8-buster", Version: "1.10.7-8"},
+			{Tag: "1.10.12-buster", Version: "1.10.12"},
+			{Tag: "1.10.12-buster-onbuild", Version: "1.10.12"},
+			{Tag: "1.10.12-1-buster-onbuild", Version: "1.10.12-1"},
+		},
+	}
+	validTags := dCfg.GetValidTags("1.10.12-1-alpine3.10")
+	expectedTags := []string{"1.10.12-buster", "1.10.12-buster-onbuild", "1.10.12-1-buster-onbuild"}
+	assert.Equal(t, expectedTags, validTags)
+}
+
+func Test_coerce(t *testing.T) {
+	assert.Equal(t, "1.10.5", coerce("1.10.5-11-alpine3.10-onbuild").String())
+	assert.Equal(t, "1.10.5", coerce("1.10.5").String())
+	assert.Equal(t, "1.10.12", coerce("1.10.12-buster").String())
+}


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/2166

## 🧪 Functional Testing

practically LGTM:
```

➜  t_20201116_182629 astro-cli deploy
Authenticated to staging.astronomer.io

Select which airflow deployment you want to deploy to:
 #     LABEL              DEPLOYMENT NAME                 WORKSPACE     DEPLOYMENT ID
 1     k8s-1-10-12        explosive-instrument-2281       w1            ckhchzf22134861pjz6mskxr88
 2     celery-1-10-7      interstellar-cosmology-0863     w1            ckhchzthh141961pj6t6s4qdmh
 3     celery-1-10-10     extragalactic-perigee-2526      w1            ckhci022b139361pi042w9hr71
 4     celery-1-10-12     nebular-phase-0366              w1            ckhci09o6143071pj6li9nqx9n
 5     local-1-10-10      magnificent-corona-3536         w1            ckhci0sp6132401plrhhoi2b3x
 6     local-1-10-12      geocentric-waning-7948          w1            ckhci113u138811pjz1ybdgetb

> 1
Deploying: explosive-instrument-2281
explosive-instrument-2281/airflow
Building image...
WARNING! You are about to push an image using the '1.10.12' tag. This is not recommended.
Please use one of the following tags: 1.10.12-1-alpine3.10-onbuild, 1.10.12-1-buster-onbuild, 1.10.12-1-buster, 1.10.12-1-alpine3.10, 1.10.12-alpine3.10-onbuild, 1.10.12-buster-onbuild, 1.10.12-alpine3.10, 1.10.12-buster.
Are you sure you want to continue? (y/n)
```
