### PR TITLE
Use default as API Auth Backend

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -130,7 +130,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
       AIRFLOW__WEBSERVER__RBAC: "True"
-      AIRFLOW__API__AUTH_BACKEND: "airflow.api.auth.backend.basic_auth"
+      AIRFLOW__API__AUTH_BACKEND: "airflow.api.auth.backend.default"
     ports:
       - 8080:8080
     volumes:

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -80,7 +80,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
       AIRFLOW__WEBSERVER__RBAC: "True"
-      AIRFLOW__API__AUTH_BACKEND: "airflow.api.auth.backend.basic_auth"
+      AIRFLOW__API__AUTH_BACKEND: "airflow.api.auth.backend.default"
     ports:
       - {{ .AirflowWebserverPort }}:8080
     volumes:


### PR DESCRIPTION
The `basic_auth` backend is only available for 2.0. For local dev I think using `default` auth backend is OK