### PR TITLE
Make API auth_backend compatible to 1.10.x and 2.0

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -113,7 +113,7 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c 'if [[ -z "$$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $$(airflow version | tail -1) =~ "2."[0-9]+\.[0.9]+.* ]];
+      bash -c 'if [[ -z "$$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $$(pip show -f apache-airflow | grep basic_auth.py) ]];
         then export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.basic_auth ;
         else export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.default ; fi &&
         { airflow create_user "$$@" || airflow users create "$$@" ; } &&

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -113,7 +113,12 @@ services:
   webserver:
     image: test-project-name/airflow:latest
     command: >
-      bash -c '{ airflow create_user "$$@" || airflow users create "$$@"; } && { airflow sync_perm || airflow sync-perm; } && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
+      bash -c 'if [[ -z "$$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $$(airflow version | tail -1) =~ "2."[0-9]+\.[0.9]+.* ]];
+        then export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.basic_auth ;
+        else export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.default ; fi &&
+        { airflow create_user "$$@" || airflow users create "$$@" ; } &&
+        { airflow sync_perm || airflow sync-perm ;} &&
+        airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:
       - airflow
@@ -131,7 +136,6 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
       AIRFLOW__WEBSERVER__RBAC: "True"
-      AIRFLOW__API__AUTH_BACKEND: "airflow.api.auth.backend.basic_auth"
     ports:
       - 8080:8080
     volumes:

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -62,7 +62,7 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c 'if [[ -z "$$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $$(airflow version | tail -1) =~ "2."[0-9]+\.[0.9]+.* ]];
+      bash -c 'if [[ -z "$$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $$(pip show -f apache-airflow | grep basic_auth.py) ]];
         then export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.basic_auth ;
         else export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.default ; fi &&
         { airflow create_user "$$@" || airflow users create "$$@" ; } &&

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -62,7 +62,12 @@ services:
   webserver:
     image: {{ .AirflowImage }}
     command: >
-      bash -c '{ airflow create_user "$$@" || airflow users create "$$@"; } && { airflow sync_perm || airflow sync-perm; } && airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
+      bash -c 'if [[ -z "$$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $$(airflow version | tail -1) =~ "2."[0-9]+\.[0.9]+.* ]];
+        then export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.basic_auth ;
+        else export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.default ; fi &&
+        { airflow create_user "$$@" || airflow users create "$$@" ; } &&
+        { airflow sync_perm || airflow sync-perm ;} &&
+        airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:
       - airflow
@@ -80,7 +85,6 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
       AIRFLOW__WEBSERVER__RBAC: "True"
-      AIRFLOW__API__AUTH_BACKEND: "airflow.api.auth.backend.basic_auth"
     ports:
       - {{ .AirflowWebserverPort }}:8080
     volumes:


### PR DESCRIPTION
This commit does the following:

- uses `airflow.api.auth.backend.basic_auth` for Airflow >= 2.0
- uses `airflow.api.auth.backend.default` for Airflow <2
- allow overriding API auth backend by setting `AIRFLOW__API__AUTH_BACKEND` in Dockerfile or `.env`

I have tested this with the following Docker files:


```dockerfile
FROM quay.io/astronomer/ap-airflow-dev:2.0.0-buster-onbuild-26413
ENV AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True
```

![image](https://user-images.githubusercontent.com/8811558/101268502-8a7e0b80-375b-11eb-9afa-63efddd952b9.png)


```dockerfile
FROM quay.io/astronomer/ap-airflow:1.10.12-2-buster-onbuild
ENV AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True
```

![image](https://user-images.githubusercontent.com/8811558/101268496-805c0d00-375b-11eb-8e55-871d891fa5bc.png)


```dockerfile
FROM astronomerio/ap-airflow:1.10.12-buster-onbuild-23518
ENV AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True
```

and by overriding the value

```dockerfile
FROM quay.io/astronomer/ap-airflow-dev:2.0.0-buster-onbuild-26413

ENV AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True
ENV AIRFLOW__API__AUTH_BACKEND="airflow.api.auth.backend.default"
```