### PR TITLE
Add airflow 2.0 min requirements

### DIFF
--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -341,7 +341,7 @@ func getDeployment(deploymentId string, client *houston.Client) (*houston.Deploy
 }
 
 func meetsAirflowUpgradeReqs(airflowVersion string, desiredAirflowVersion string) error {
-	upgradeVersion := strconv.FormatUint(settings.NewAirflowVersion, 10)
+	upgradeVersion := strconv.FormatUint(settings.AirflowVersionTwo, 10)
 	minRequiredVersion := "1.10.14"
 	airflowUpgradeVersion, err := semver.NewVersion(upgradeVersion)
 	if err != nil {

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -476,7 +476,6 @@ func Test_getDeploymentError(t *testing.T) {
 }
 
 func Test_getAirflowVersionSelection(t *testing.T) {
-	deploymentId := "ckggzqj5f4157qtc9lescmehm"
 	testUtil.InitTestConfig()
 	okResponse := `{"data": {
 					"deployment": {
@@ -521,7 +520,7 @@ func Test_getAirflowVersionSelection(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-	airflowVersion, err := getAirflowVersionSelection(deploymentId, api, buf)
+	airflowVersion, err := getAirflowVersionSelection("1.10.7", api, buf)
 	assert.NoError(t, err)
 	assert.Equal(t, airflowVersion, "1.10.12")
 }
@@ -541,4 +540,20 @@ func Test_getAirflowVersionSelectionError(t *testing.T) {
 	airflowVersion, err := getAirflowVersionSelection(deploymentId, api, buf)
 	assert.Error(t, err, "API error (500):")
 	assert.Equal(t, airflowVersion, "")
+}
+
+func Test_meetsAirflowUpgradeReqs(t *testing.T) {
+	airflowVersion := "1.10.12"
+	desiredAirflowVersion := "2.0.0"
+	err := meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion)
+	assert.Error(t, err)
+
+	airflowVersion = "1.10.14"
+	err = meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion)
+	assert.NoError(t, err)
+
+	airflowVersion = "1.10.7"
+	desiredAirflowVersion = "1.10.10"
+	err = meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion)
+	assert.NoError(t, err)
 }

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -32,7 +32,7 @@ var (
 	settings Config
 
 	// Version 2.0.0
-	newAirflowVersion uint64 = 2
+	NewAirflowVersion uint64 = 2
 )
 
 // ConfigSettings is the main builder of the settings package
@@ -80,7 +80,7 @@ func AddVariables(id string, version uint64) {
 			if objectValidator(0, variable.VariableValue) {
 
 				baseCmd := "airflow variables "
-				if version >= newAirflowVersion {
+				if version >= NewAirflowVersion {
 					baseCmd += "set %s " // Airflow 2.0.0 command
 				} else {
 					baseCmd += "-s %s " // Airflow 1.0.0 command

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -32,7 +32,7 @@ var (
 	settings Config
 
 	// Version 2.0.0
-	NewAirflowVersion uint64 = 2
+	AirflowVersionTwo uint64 = 2
 )
 
 // ConfigSettings is the main builder of the settings package
@@ -80,7 +80,7 @@ func AddVariables(id string, version uint64) {
 			if objectValidator(0, variable.VariableValue) {
 
 				baseCmd := "airflow variables "
-				if version >= NewAirflowVersion {
+				if version >= AirflowVersionTwo {
 					baseCmd += "set %s " // Airflow 2.0.0 command
 				} else {
 					baseCmd += "-s %s " // Airflow 1.0.0 command


### PR DESCRIPTION
## Description

Make sure that an Airflow deployment is using version `1.10.14` before allowing the upgrade to `2.0.x`

## 🎟 Issue(s)

Resolves astronomer/issues#2289

## 🧪 Functional Testing

It's possible to test this change locally.

1. Make build with a valid version number in the Makefile
2. Start up Houston API and Astro UI
3. Create a new deployment with a version prior to `1.10.14`.  (I was testing with `1.10.12`) 
4. Make sure you have Airflow 2.0 added into your database in the `AirflowRelease` table.  If not, manually add it (you can copy and existing deployment and change the version number for testing purposes)
5. Attempt to upgrade the airflow deployment to 2.0 (see the screen shots below).
6.  Make sure you see an error message.
7. After getting the error message, update your deployment Airflow version to `1.10.14` and attempt to upgrade again.  You should now see the success message.

## 📸 Screenshots

![Screen Shot 2020-12-07 at 12 16 01 PM](https://user-images.githubusercontent.com/749118/101385180-6a4c6a80-3889-11eb-8471-2f9a24a10101.png)
![Screen Shot 2020-12-07 at 12 16 23 PM](https://user-images.githubusercontent.com/749118/101385181-6ae50100-3889-11eb-994d-c51e9eb6f7af.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
