### PR TITLE
Use astro robot account to tag releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,6 @@ commands:
           name: Tag the Git commit
           command: |
             set -xe
-            git remote rm origin
-            git remote add origin git@github.com:${GIT_ORG}/${CIRCLE_PROJECT_REPONAME}.git
+            git remote set-url origin "https://astro-astronomer:${GITHUB_TOKEN}@github.com/${GIT_ORG}/${CIRCLE_PROJECT_REPONAME}.git"
             git tag $NEXT_TAG
             git push origin $NEXT_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ workflows:
             branches:
               only: '/release-.*/'
       - new-tag:
+          context:
+            - github-repo
           requires:
             - approve-release
           filters:
@@ -118,6 +120,6 @@ commands:
           command: |
             set -xe
             git remote rm origin
-            git remote add origin https://sjmiller609:${GITHUB_TOKEN}@github.com/${GIT_ORG}/${CIRCLE_PROJECT_REPONAME}.git
+            git remote add origin git@github.com:${GIT_ORG}/${CIRCLE_PROJECT_REPONAME}.git
             git tag $NEXT_TAG
             git push origin $NEXT_TAG


### PR DESCRIPTION
## Description

This repo was set up to tag releases using sjmiller609's GITHUB_TOKEN. This PR changes that to use the astro robot account which has a token set up in a CircleCI variable context. This is related to astronomer/issues#2255

## 🧪 Functional Testing

This change is difficult to test because it relates to releases. I ssh'd into the running CI job and did some iterating, verifying that the new credentials have the ability to push to astro-cli.