### PR TITLE
Point README instructions to most recent CLI Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl -sSL https://install.astronomer.io | sudo bash -s
 
 #### Via `Homebrew`
 
-To install a specific version Astro CLI use @major.minor.patch for example, to install v0.13.1 run:
+To install a specific version Astro CLI use @major.minor.patch. For example, to install v0.13.1 run:
 
 ```sh
 brew install astronomer/tap/astro@0.13.1
@@ -83,15 +83,15 @@ curl -sSL https://install.astronomer.io | sudo bash -s -- v0.7.5
 
 > Note: Make sure you have Windows 10 and Docker installed
 
-1. Download latest release of astro-cli using this [astro_0.13.1_windows_386.zip](https://github.com/astronomer/astro-cli/releases/download/v0.13.1/astro_0.13.1_windows_386.zip)
-2. Extract `astro_0.13.1_windows_386.zip` and copy `astro.exe` somewhere in your `%PATH%`
-3. Open cmd or PowerShell console and run:
+1. Download latest release of astro-cli on [this page](https://github.com/astronomer/astro-cli/releases/)
+2. Extract the file ending in `windows_386.zip` and copy `astro.exe` somewhere in your `%PATH%`
+3. Open cmd or PowerShell console and run the `astro version` command. Your output should look something like this:
 
-```
-C:\Windows\system32>astro version
-Astro CLI Version: 0.13.1
-Git Commit: 829e4702ca36dd725f1a98d82b6fdf889e5f4dc3
-```
+    ```
+    C:\Windows\system32>astro version
+    Astro CLI Version: 0.13.1
+    Git Commit: 829e4702ca36dd725f1a98d82b6fdf889e5f4dc3
+    ```
 
 #### Troubleshooting
 


### PR DESCRIPTION
Our Windows CLI instructions didn't point to the right place for getting the latest version of the CLI. This has caused problems as seen in Forum posts and support tickets.

## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Resolves astronomer/issues#XXXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
