### PR TITLE
Replaces the default astronomer image with 2.0.0-buster-onbuild

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-      - image: quay.io/astronomer/ap-houston-api:latest
+      - image: quay.io/astronomer/ap-houston-api:0.23.15
         name: houston
         entrypoint: "yarn start"
         environment:

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -291,7 +291,7 @@ func airflowInit(cmd *cobra.Command, args []string, client *houston.Client, out 
 	// }
 
 	if len(defaultImageTag) == 0 {
-		defaultImageTag = "latest-onbuild"
+		defaultImageTag = "2.0.0-buster-onbuild"
 		fmt.Printf("Initializing Airflow project\nNot connected to Astronomer, pulling Airflow development files from %s\n", defaultImageTag)
 	}
 

--- a/docker/parse_test.go
+++ b/docker/parse_test.go
@@ -13,23 +13,23 @@ func TestAllCmds(t *testing.T) {
 }
 
 func TestParseReaderParseError(t *testing.T) {
-	dockerfile := "FROM quay.io/astronomer/ap-airflow:latest-onbuild\nCMD [\"echo\", 1]"
+	dockerfile := "FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild\nCMD [\"echo\", 1]"
 	_, err := ParseReader(bytes.NewBufferString(dockerfile))
 	assert.IsType(t, ParseError{}, err)
 }
 
 func TestParseReader(t *testing.T) {
-	dockerfile := `FROM quay.io/astronomer/ap-airflow:latest-onbuild`
+	dockerfile := `FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild`
 	cmds, err := ParseReader(bytes.NewBufferString(dockerfile))
 	assert.Nil(t, err)
 	expected := []Command{
 		{
 			Cmd:       "from",
-			Original:  "FROM quay.io/astronomer/ap-airflow:latest-onbuild",
+			Original:  "FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild",
 			StartLine: 1,
 			EndLine:   1,
 			Flags:     []string{},
-			Value:     []string{"quay.io/astronomer/ap-airflow:latest-onbuild"},
+			Value:     []string{"quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild"},
 		},
 	}
 	assert.Equal(t, expected, cmds)
@@ -47,11 +47,11 @@ func TestParseFile(t *testing.T) {
 	expected := []Command{
 		{
 			Cmd:       "from",
-			Original:  "FROM quay.io/astronomer/ap-airflow:latest-onbuild",
+			Original:  "FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild",
 			StartLine: 1,
 			EndLine:   1,
 			Flags:     []string{},
-			Value:     []string{"quay.io/astronomer/ap-airflow:latest-onbuild"},
+			Value:     []string{"quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild"},
 		},
 	}
 	assert.Equal(t, expected, cmds)
@@ -61,14 +61,14 @@ func TestGetImageTagFromParsedFile(t *testing.T) {
 	cmds := []Command{
 		{
 			Cmd:       "from",
-			Original:  "FROM quay.io/astronomer/ap-airflow:latest-onbuild",
+			Original:  "FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild",
 			StartLine: 1,
 			EndLine:   1,
 			Flags:     []string{},
-			Value:     []string{"quay.io/astronomer/ap-airflow:latest-onbuild"},
+			Value:     []string{"quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild"},
 		},
 	}
 	image, tag := GetImageTagFromParsedFile(cmds)
 	assert.Equal(t, "quay.io/astronomer/ap-airflow", image)
-	assert.Equal(t, "latest-onbuild", tag)
+	assert.Equal(t, "2.0.0-buster-onbuild", tag)
 }

--- a/docker/testfiles/Dockerfile.ok
+++ b/docker/testfiles/Dockerfile.ok
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/ap-airflow:latest-onbuild
+FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild


### PR DESCRIPTION
The image with the tag "latest_onbuild" references image b17129847bec, which is an alpine image for Airflow 1.10.7. 

This image is broken. An error is received when the user attempts to rebuild (aka deploy their dags to Astronomer Platform). There is an issue to implement a proper fix (https://github.com/astronomer/issues/issues/2275), but until that can be done, this PR changes the default to a 2.0 on-build debian image. This ensures that users who are using Astro cli for the first time to create a new deployment project will start with a non-broken image, and hopefully have a smoother experience.

Resolves astronomer/issues#2660