### PR TITLE
add kubernetes in help text for executor options

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -112,7 +112,7 @@ func newDeploymentCreateCmd(client *houston.Client, out io.Writer) *cobra.Comman
 			return deploymentCreate(cmd, args, client, out)
 		},
 	}
-	cmd.Flags().StringVarP(&executor, "executor", "e", "", "Add executor parameter: local or celery")
+	cmd.Flags().StringVarP(&executor, "executor", "e", "", "Add executor parameter: local, celery, or kubernetes")
 	cmd.Flags().StringVarP(&airflowVersion, "airflow-version", "a", "", "Add desired airflow version parameter: e.g: 1.10.5 or 1.10.7")
 	cmd.Flags().StringVarP(&releaseName, "release-name", "r", "", "Set custom release-name if possible")
 	cmd.Flags().StringVarP(&cloudRole, "cloud-role", "c", "", "Set cloud role to annotate service accounts in deployment")


### PR DESCRIPTION
## Description

Small Doc-only fix, to add `kubernetes` as an option in the help text for available executors for creating a deployment.
Previously:
<img width="885" alt="Screen Shot 2021-04-08 at 11 34 43 AM" src="https://user-images.githubusercontent.com/80706212/114055129-7a3b8180-985e-11eb-8ff3-63ddf8d5528d.png">

## 🎟 Issue(s)

No issue was created 

## 🧪 Functional Testing

This is a doc-only fix, no testing should be required.

## 📸 Screenshots

No screenshots are available to verify the fix (I'm not sure how to build and test a local version of the cli yet)

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
