### PR TITLE
add ability to not fail when we are ahead of server version

### DIFF
--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -24,6 +24,19 @@ func newTableOut() *printutil.Table {
 	}
 }
 
+// AppVersion returns application version from houston-api
+func AppVersion(client *houston.Client) (*houston.AppConfig, error) {
+	req := houston.Request{
+		Query: houston.AppVersionRequest,
+	}
+	r, err := req.DoWithClient(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Data.GetAppConfig, nil
+}
+
 // AppConfig returns application config from houston-api
 func AppConfig(client *houston.Client) (*houston.AppConfig, error) {
 	req := houston.Request{

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -19,7 +19,7 @@ func TestAppVersion(t *testing.T) {
 		"data": {
 			"appConfig": {
 				"version": "0.15.1",
-				"baseDomain": "local.astronomer.io",
+				"baseDomain": "local.astronomer.io"
 			}
 		}
 }`

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -13,6 +13,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAppVersion(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+		"data": {
+			"appConfig": {
+				"version": "0.15.1",
+				"baseDomain": "local.astronomer.io",
+			}
+		}
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	config, err := AppVersion(api)
+	assert.NoError(t, err)
+	assert.Equal(t, config.Version, "0.15.1")
+	assert.Equal(t, config.BaseDomain, "local.astronomer.io")
+}
+
 func TestAppConfig(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -494,6 +494,14 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: Str
 			defaultAirflowImageTag
 		}
 	}`
+	AppVersionRequest = `
+	query AppConfig {
+		appConfig {
+			version
+			baseDomain
+		}
+	}
+	`
 	AppConfigRequest = `
 	query AppConfig {
 		appConfig {

--- a/version/validate_compatibility.go
+++ b/version/validate_compatibility.go
@@ -18,7 +18,7 @@ func ValidateCompatibility(client *houston.Client, out io.Writer, cliVer string,
 		return nil
 	}
 
-	serverCfg, err := deployment.AppConfig(client)
+	serverCfg, err := deployment.AppVersion(client)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fix:
```
Error: API error (400): {"errors":[{"message":"Cannot query field \"configureDagDeployment\" on type \"AppConfig\".","locations":[{"line":8,"column":4}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}},{"message":"Cannot query field \"nfsMountDagDeployment\" on type \"AppConfig\".","locations":[{"line":9,"column":4}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}]}
```
when astro-cli is ahead of server(platform) version

https://astronomer.slack.com/archives/C01QV8TKR2T/p1620084009061400