### PR TITLE
Fix broken link in `airflow.settings.yaml` file

### DIFF
--- a/airflow/include/settingsyml.go
+++ b/airflow/include/settingsyml.go
@@ -4,13 +4,12 @@ import "strings"
 
 // Settingsyml is the settings template
 var Settingsyml = strings.TrimSpace(`
-# This feature is in Beta.
 
 # Please report any bugs to support@astronomer.io
 
 # NOTE: If putting a dict in conn_extra, please wrap in single quotes.
 
-# More details you can find https://github.com/astronomer/docs/blob/main/v0.10/cli-airflow-configuration.md
+# For more information, refer to our docs: https://www.astronomer.io/docs/cloud/stable/develop/customize-image#configure-airflowsettingsyaml
 
 airflow:
   connections:

--- a/airflow/include/settingsyml.go
+++ b/airflow/include/settingsyml.go
@@ -5,11 +5,11 @@ import "strings"
 // Settingsyml is the settings template
 var Settingsyml = strings.TrimSpace(`
 
-# Please report any bugs to support@astronomer.io
-
+# This file allows you to configure Airflow Connections, Pools, and Variables in a single place for local development only.
 # NOTE: If putting a dict in conn_extra, please wrap in single quotes.
 
 # For more information, refer to our docs: https://www.astronomer.io/docs/cloud/stable/develop/customize-image#configure-airflowsettingsyaml
+# For issues or questions, reach out to support@astronomer.io
 
 airflow:
   connections:


### PR DESCRIPTION
## Description

This is a hotfix PR does a few small things:

1. Fixes the broken link in the `airflow_settings.yaml` file that is automatically generated when a user runs `$ astro dev init` via the Astronomer CLI.
2. Removes the `## This feature is in Beta` comment (that has been there for 2+ years...)
3.  Adds improved copy that better informs the user on what this file should be used for

Old link: https://github.com/astronomer/docs/blob/main/v0.10/cli-airflow-configuration.md
New Link: https://www.astronomer.io/docs/cloud/stable/develop/customize-image#configure-airflowsettingsyaml

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/2850

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)

@vishwas-astro @andriisoldatenko This felt like an easy fix so I gave it a shot 😊  Let me know if I missed anything or if you have feedback on the copy here.