### PR TITLE
fix go releaser issue

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ build:
     - 7
   ldflags: -s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }} -X github.com/astronomer/astro-cli/version.CurrCommit={{ .Commit }}
 brews:
-  - github:
+  - tap:
       owner: astronomer
       name: homebrew-tap
     folder: Formula


### PR DESCRIPTION
## Description

Go releaser brew config has replaced its github attribute with a tap attribute see (https://goreleaser.com/deprecations/#brewsgithub)
