### PR TITLE
Astro deployment airflow upgrade no op 3055

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.25.2] - 2021-06-23
+- Add error message for airflow upgrade no-op #3055 (#417)
 
 ## [0.23.1] - 2020-11-25
 

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -485,16 +485,22 @@ func TestDeploymentAirflowUpgradeCommand(t *testing.T) {
 	testUtil.InitTestConfig()
 	expectedOut := `The upgrade from Airflow 1.10.5 to 1.10.10 has been started. To complete this process, add an Airflow 1.10.10 image to your Dockerfile and deploy to Astronomer.`
 
-	okResponse := `{"data": {
-					"appConfig": {"nfsMountDagDeployment": false},
-					"updateDeploymentAirflow": {
-						"id": "ckggzqj5f4157qtc9lescmehm",
-						"label": "test",
-						"airflowVersion": "1.10.5",
-						"desiredAirflowVersion": "1.10.10"
-					}
-				}
-			}`
+	okResponse := `{
+  "data": {
+    "appConfig": {"nfsMountDagDeployment": false},
+    "deployment": {
+	  "id": "ckggzqj5f4157qtc9lescmehm",
+	  "airflowVersion": "1.10.5",
+	  "desiredAirflowVersion": "1.10.10"
+	  },
+	  "updateDeploymentAirflow": {
+	  "id": "ckggzqj5f4157qtc9lescmehm",
+	  "label": "test",
+	  "airflowVersion": "1.10.5",
+	  "desiredAirflowVersion": "1.10.10"
+	  }
+    }
+  }`
 
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
@@ -514,16 +520,17 @@ func TestDeploymentAirflowUpgradeCancelCommand(t *testing.T) {
 	testUtil.InitTestConfig()
 	expectedOut := `Airflow upgrade process has been successfully canceled. Your Deployment was not interrupted and you are still running Airflow 1.10.5.`
 
-	okResponse := `{"data": {
-                                        "appConfig": {"nfsMountDagDeployment": false},
-					"deployment": {
-						"id": "ckggzqj5f4157qtc9lescmehm",
-						"label": "test",
-						"airflowVersion": "1.10.5",
-						"desiredAirflowVersion": "1.10.10"
-					}
-				}
-			}`
+	okResponse := `{
+  "data": {
+    "appConfig": {"nfsMountDagDeployment": false},
+    "deployment": {
+	  "id": "ckggzqj5f4157qtc9lescmehm",
+	  "label": "test",
+	  "airflowVersion": "1.10.5",
+	  "desiredAirflowVersion": "1.10.10"
+    }
+  }
+}`
 
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -245,7 +245,6 @@ func AirflowUpgrade(id, desiredAirflowVersion string, client *houston.Client, ou
 		}
 		desiredAirflowVersion = selectedVersion
 	}
-
 	err = meetsAirflowUpgradeReqs(deployment.AirflowVersion, desiredAirflowVersion)
 	if err != nil {
 		return err
@@ -385,19 +384,26 @@ func meetsAirflowUpgradeReqs(airflowVersion string, desiredAirflowVersion string
 		return err
 	}
 
+	currentVersion, err := semver.NewVersion(airflowVersion)
+	if err != nil {
+		return err
+	}
+
+	if currentVersion.Compare(desiredVersion) == 0 {
+		errorMessage := fmt.Sprintf("Error: You tried to set --desired-airflow-version to %s, but this Airflow Deployment "+
+			"is already running %s. Please indicate a higher version of Airflow and try again.", desiredVersion, currentVersion)
+		return errors.New(errorMessage)
+	}
+
 	if airflowUpgradeVersion.Compare(desiredVersion) < 1 {
 		minUpgrade, err := semver.NewVersion(minRequiredVersion)
 		if err != nil {
 			return err
 		}
 
-		currentVersion, err := semver.NewVersion(airflowVersion)
-		if err != nil {
-			return err
-		}
-
 		if currentVersion.Compare(minUpgrade) < 0 {
-			errorMessage := fmt.Sprintf("Airflow 2.0 has breaking changes. To upgrade to Airflow 2.0, upgrade to %s first and make sure your DAGs and configs are 2.0 compatible", minRequiredVersion)
+			errorMessage := fmt.Sprintf("Airflow 2.0 has breaking changes. To upgrade to Airflow 2.0, upgrade to %s first "+
+				"and make sure your DAGs and configs are 2.0 compatible.", minRequiredVersion)
 			return errors.New(errorMessage)
 		}
 	}

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -427,15 +427,21 @@ func TestUpdateError(t *testing.T) {
 
 func TestAirflowUpgrade(t *testing.T) {
 	testUtil.InitTestConfig()
-	okResponse := `{"data": {
-					"updateDeploymentAirflow": {
-						"id": "ckggzqj5f4157qtc9lescmehm",
-						"label": "test",
-						"airflowVersion": "1.10.5",
-						"desiredAirflowVersion": "1.10.10"
-					}
-				}
-			}`
+	okResponse := `{
+  "data": {
+    "deployment": {
+      "id": "ckbv818oa00r107606ywhoqtw",
+	  "airflowVersion": "1.10.5",
+	  "desiredAirflowVersion": "1.10.10"
+    },
+    "updateDeploymentAirflow": {
+	  "id": "ckbv818oa00r107606ywhoqtw",
+	  "label": "test",
+	  "airflowVersion": "1.10.5",
+	  "desiredAirflowVersion": "1.10.10"
+      }
+    }
+  }`
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,
@@ -451,7 +457,7 @@ func TestAirflowUpgrade(t *testing.T) {
 	err := AirflowUpgrade(deploymentId, desiredAirflowVersion, api, buf)
 	assert.NoError(t, err)
 	expected := ` NAME     DEPLOYMENT NAME     ASTRO     DEPLOYMENT ID                 AIRFLOW VERSION     
- test                         v         ckggzqj5f4157qtc9lescmehm     1.10.5              
+ test                         v         ckbv818oa00r107606ywhoqtw     1.10.5              
 
 The upgrade from Airflow 1.10.5 to 1.10.10 has been started. To complete this process, add an Airflow 1.10.10 image to your Dockerfile and deploy to Astronomer.
 To cancel, run: 
@@ -485,15 +491,16 @@ func TestAirflowUpgradeCancel(t *testing.T) {
 	testUtil.InitTestConfig()
 	deploymentId := "ckggzqj5f4157qtc9lescmehm"
 
-	okResponse := `{"data": {
-					"deployment": {
-						"id": "ckggzqj5f4157qtc9lescmehm",
-						"label": "test",
-						"airflowVersion": "1.10.5",
-						"desiredAirflowVersion": "1.10.10"
-					}
-				}
-			}`
+	okResponse := `{
+  "data": {
+    "deployment": {
+	  "id": "ckggzqj5f4157qtc9lescmehm",
+      "label": "test",
+      "airflowVersion": "1.10.5",
+	  "desiredAirflowVersion": "1.10.10"
+      }
+    }
+  }`
 
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
@@ -529,17 +536,89 @@ func TestAirflowUpgradeCancelError(t *testing.T) {
 	assert.Error(t, err, "API error (500):")
 }
 
+func TestAirflowUpgradeEmptyDesiredVersion(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+    "deployment": {
+	  "id": "ckbv818oa00r107606ywhoqtw",
+	  "airflowVersion": "1.10.5",
+	  "desiredAirflowVersion": "1.10.10"
+	  },
+	  "updateDeploymentAirflow": {
+	  "id": "ckbv818oa00r107606ywhoqtw",
+	  "label": "test",
+	  "airflowVersion": "1.10.5",
+	  "desiredAirflowVersion": "1.10.10"
+	  },
+	  "deploymentConfig": {
+	  "airflowVersions": [
+	  "1.10.7",
+	  "1.10.10",
+	  "1.10.12"
+	  ]}
+      }
+    }
+  }`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	deploymentId := "ckggzqj5f4157qtc9lescmehm"
+	desiredAirflowVersion := ""
+
+	// mock os.Stdin for when prompted by getAirflowVersionSelection()
+	input := []byte("2")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = w.Write(input)
+	if err != nil {
+		t.Error(err)
+	}
+	w.Close()
+	stdin := os.Stdin
+	// Restore stdin right after the test.
+	defer func() { os.Stdin = stdin }()
+	os.Stdin = r
+
+	buf := new(bytes.Buffer)
+	err = AirflowUpgrade(deploymentId, desiredAirflowVersion, api, buf)
+	t.Log(buf.String()) // Log the buffer so that this test is recognized by go test
+
+	assert.NoError(t, err)
+	expected := `#     AIRFLOW VERSION     
+1     1.10.7              
+2     1.10.10             
+3     1.10.12             
+ NAME     DEPLOYMENT NAME     ASTRO     DEPLOYMENT ID                 AIRFLOW VERSION     
+ test                         v         ckbv818oa00r107606ywhoqtw     1.10.5              
+
+The upgrade from Airflow 1.10.5 to 1.10.10 has been started. To complete this process, add an Airflow 1.10.10 image to your Dockerfile and deploy to Astronomer.
+To cancel, run: 
+ $ astro deployment airflow upgrade --cancel
+
+`
+	assert.Equal(t, buf.String(), expected)
+}
+
 func Test_getDeployment(t *testing.T) {
 	testUtil.InitTestConfig()
-	okResponse := `{"data": {
-					"deployment": {
-						"id": "ckggzqj5f4157qtc9lescmehm",
-						"label": "test",
-						"airflowVersion": "1.10.5",
-						"desiredAirflowVersion": "1.10.10"
-					}
-				}
-			}`
+	okResponse := `{
+  "data": {
+    "deployment": {
+	  "id": "ckggzqj5f4157qtc9lescmehm",
+	  "label": "test",
+	  "airflowVersion": "1.10.5",
+	  "desiredAirflowVersion": "1.10.10"
+	  }
+	}
+  }`
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,
@@ -569,28 +648,28 @@ func Test_getDeploymentError(t *testing.T) {
 	deploymentId := "ckbv818oa00r107606ywhoqtw"
 
 	_, err := getDeployment(deploymentId, api)
-	assert.Error(t, err, "tes")
+	assert.Error(t, err, "test")
 }
 
 func Test_getAirflowVersionSelection(t *testing.T) {
 	testUtil.InitTestConfig()
-	okResponse := `{"data": {
-					"deployment": {
-						"id": "ckggzqj5f4157qtc9lescmehm",
-						"label": "test",
-						"airflowVersion": "1.10.7",
-						"desiredAirflowVersion": "1.10.10"
-					},
-					"deploymentConfig": {
-							"airflowVersions": [
-							  "1.10.7",
-							  "1.10.10",
-							  "1.10.12"
-							]
-						}
-					}
-				}
-			}`
+	okResponse := `{
+  "data": {
+    "deployment": {
+	  "id": "ckggzqj5f4157qtc9lescmehm",
+	  "label": "test",
+	  "airflowVersion": "1.10.7",
+	  "desiredAirflowVersion": "1.10.10"
+	  },
+    "deploymentConfig": {
+	  "airflowVersions": [
+        "1.10.7",
+        "1.10.10",
+        "1.10.12"
+        ]}
+	  }
+	}
+  }`
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,
@@ -618,6 +697,7 @@ func Test_getAirflowVersionSelection(t *testing.T) {
 	os.Stdin = r
 
 	airflowVersion, err := getAirflowVersionSelection("1.10.7", api, buf)
+	t.Log(buf.String()) // Log the buffer so that this test is recognized by go test
 	assert.NoError(t, err)
 	assert.Equal(t, airflowVersion, "1.10.12")
 }
@@ -644,6 +724,14 @@ func Test_meetsAirflowUpgradeReqs(t *testing.T) {
 	desiredAirflowVersion := "2.0.0"
 	err := meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion)
 	assert.Error(t, err)
+	assert.EqualError(t, err, "Airflow 2.0 has breaking changes. To upgrade to Airflow 2.0, upgrade to 1.10.14 "+
+		"first and make sure your DAGs and configs are 2.0 compatible.")
+
+	airflowVersion = "2.0.0"
+	err = meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Error: You tried to set --desired-airflow-version to 2.0.0, but this Airflow Deployment "+
+		"is already running 2.0.0. Please indicate a higher version of Airflow and try again.")
 
 	airflowVersion = "1.10.14"
 	err = meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion)
@@ -653,6 +741,18 @@ func Test_meetsAirflowUpgradeReqs(t *testing.T) {
 	desiredAirflowVersion = "1.10.10"
 	err = meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion)
 	assert.NoError(t, err)
+
+	airflowVersion = "-1.10.12"
+	desiredAirflowVersion = "2.0.0"
+	err = meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Invalid Semantic Version")
+
+	airflowVersion = "1.10.12"
+	desiredAirflowVersion = "-2.0.0"
+	err = meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Invalid Semantic Version")
 }
 
 func TestCheckNFSMountDagDeploymentError(t *testing.T) {
@@ -671,16 +771,16 @@ func TestCheckNFSMountDagDeploymentError(t *testing.T) {
 func TestCheckNFSMountDagDeploymentSuccess(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
-		"data": {
-			"appConfig": {
-				"version": "0.15.1",
-				"baseDomain": "local.astronomer.io",
-				"smtpConfigured": true,
-				"manualReleaseNames": false,
-                                "nfsMountDagDeployment": true
-			}
-		}
-}`
+  "data": {
+    "appConfig": {
+	  "version": "0.15.1",
+	  "baseDomain": "local.astronomer.io",
+	  "smtpConfigured": true,
+	  "manualReleaseNames": false,
+	  "nfsMountDagDeployment": true
+      }
+    }
+  }`
 
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{


### PR DESCRIPTION
## Description
Provides an error message with more context to the user when they attempt to upgrade to the version of airflow they're currently running. 

To do the above I ended up moving a small amount of code that I don't think was covered by unit tests. So I updated / added unit tests as well. 

**Update:** Took a closer look and fixed some test data. The change below was totally unnecessary.
~NOTE: I'm not 100% sure that this is the change I want to make here to satisfy the tests:~
![image](https://user-images.githubusercontent.com/18646772/123868968-41eb9280-d8e5-11eb-9e78-5de9281487f5.png)

~However the applicable test was mocked with an 'updateDeploymentAirflow' object returned from the API and on line 266 of deployment.go we're trying to access r.Data.UpdateDeploymentAirflow, so I'm flipping a coin 😄~

## 🎟 Issue(s)

Resolves astronomer/issues#3055

## 🧪 Functional Testing
make test

## 📸 Screenshots
N/A

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
