### PR TITLE
astro workspace user update command giving wrong before role

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## 🎟 Issue(s)
 
-Resolves astronomer/issues#XXXX
+Related astronomer/issues#XXXX
 
 ## 🧪 Functional Testing
 

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -534,7 +534,7 @@ func TestDeploymentSAGetCommand(t *testing.T) {
     ]
   }
 }`
-client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,
 			Body:       ioutil.NopCloser(strings.NewReader(okResponse)),
@@ -611,7 +611,6 @@ func TestDeploymentDeleteHardResponseNo(t *testing.T) {
 		}
 	})
 	api := houston.NewHoustonClient(client)
-
 
 	// mock os.Stdin
 	input := []byte("n")

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -118,7 +118,6 @@ func TestWorkspaceSAGetCommand(t *testing.T) {
   }
 }`
 
-
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -449,6 +449,21 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: Str
         )
 	}`
 
+	WorkspaceGetUserRequest = `
+	query workspaceGetUser($workspaceUuid: Uuid!, $email: String!) {
+		workspaceUser(
+        	workspaceUuid: $workspaceUuid
+                user: { email: $email }
+        ) {
+		roleBindings {
+		  workspace{
+			id
+		  }
+		  role
+		}
+	}
+	}`
+
 	WorkspaceUserRemoveRequest = `
 	mutation RemoveWorkspaceUser(
 		$workspaceId: Uuid!

--- a/houston/types.go
+++ b/houston/types.go
@@ -38,6 +38,7 @@ type Response struct {
 		UpdateWorkspace                *Workspace                `json:"updateWorkspace,omitempty"`
 		DeploymentLog                  []DeploymentLog           `json:"logs,omitempty"`
 		WorkspaceUpdateUserRole        string                    `json:"workspaceUpdateUserRole,omitempty"`
+		WorkspaceGetUser               WorkspaceUserRoleBindings `json:"workspaceUser,omitempty"`
 		DeploymentConfig               DeploymentConfig          `json:"deploymentConfig,omitempty"`
 	} `json:"data"`
 	Errors []Error `json:"errors,omitempty"`
@@ -192,6 +193,15 @@ type User struct {
 	// created at
 	// updated at
 	// profile
+}
+type RoleBindingWorkspace struct {
+	Role      string `json:"role"`
+	Workspace struct {
+		Id string `json:"id"`
+	} `json:"workspace"`
+}
+type WorkspaceUserRoleBindings struct {
+	RoleBindings []RoleBindingWorkspace `json:"roleBindings"`
 }
 
 type RoleBinding struct {

--- a/workspace/user.go
+++ b/workspace/user.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/printutil"
@@ -107,7 +108,7 @@ func UpdateRole(workspaceId, email, role string, client *houston.Client, out io.
 
 	var rb houston.RoleBindingWorkspace
 	for _, val := range roles.RoleBindings {
-		if val.Workspace.Id == workspaceId {
+		if val.Workspace.Id == workspaceId && strings.Contains(val.Role, "WORKSPACE") {
 			rb = val
 			break
 		}

--- a/workspace/user_test.go
+++ b/workspace/user_test.go
@@ -216,7 +216,7 @@ func TestUpdateRoleNoAccessDeploymentOnly(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	err := UpdateRole(id, role, email, api, buf)
-	assert.Equal(t, err.Error(), "The user you are trying to change is not part of this workspace")
+	assert.Equal(t, "The user you are trying to change is not part of this workspace", err.Error())
 }
 func TestUpdateRoleNoAccess(t *testing.T) {
 	testUtil.InitTestConfig()
@@ -235,7 +235,8 @@ func TestUpdateRoleNoAccess(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	err := UpdateRole(id, role, email, api, buf)
-	assert.Equal(t, err.Error(), "The user you are trying to change is not part of this workspace")
+	assert.Equal(t, "The user you are trying to change is not part of this workspace", err.Error())
+
 }
 
 func TestUpdateRoleError(t *testing.T) {
@@ -274,7 +275,7 @@ func TestGetUserRole(t *testing.T) {
 	buf := new(bytes.Buffer)
 	userRoleBinding, err := getUserRole(id, email, api, buf)
 	assert.NoError(t, err)
-	assert.Equal(t, len(userRoleBinding.RoleBindings), 4)
+	assert.Equal(t, 4, len(userRoleBinding.RoleBindings))
 }
 
 func TestGetUserRoleError(t *testing.T) {

--- a/workspace/user_test.go
+++ b/workspace/user_test.go
@@ -199,6 +199,26 @@ func TestUpdateRole(t *testing.T) {
 	assert.Equal(t, buf.String(), expected)
 }
 
+func TestUpdateRoleNoAccess(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{"data":{"workspaceUpdateUserRole":"WORKSPACE_ADMIN", "workspaceUser":{"roleBindings":[]}}}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	id := "ckoixo6o501496qemiwsja1tl"
+	role := "test-role"
+	email := "andrii@test.com"
+
+	buf := new(bytes.Buffer)
+	err := UpdateRole(id, role, email, api, buf)
+	assert.Equal(t, err.Error(), "The user you are trying to change is not part of this workspace")
+}
+
 func TestUpdateRoleError(t *testing.T) {
 	testUtil.InitTestConfig()
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {

--- a/workspace/user_test.go
+++ b/workspace/user_test.go
@@ -34,7 +34,7 @@ func TestAdd(t *testing.T) {
           ckc0eir8e01gj07608ajmvia1     andrii@test.com     test-role     
 Successfully added andrii@test.com to 
 `
-	assert.Equal(t, buf.String(), expected)
+	assert.Equal(t, expected, buf.String() )
 }
 
 func TestAddError(t *testing.T) {
@@ -79,7 +79,7 @@ func TestRemove(t *testing.T) {
                                ckc0eir8e01gj07608ajmvia1                         ckc0eir8e01gj07608ajmvia1                         
 Successfully removed user from workspace
 `
-	assert.Equal(t, buf.String(), expected)
+	assert.Equal(t, expected, buf.String() )
 }
 
 func TestRemoveError(t *testing.T) {
@@ -156,7 +156,7 @@ func TestListRoles(t *testing.T) {
 	expected := ` USERNAME                 ID                            ROLE                
  andrii@astronomer.io     ckbv7zpkh00og0760ki4mhl6r     WORKSPACE_ADMIN     
 `
-	assert.Equal(t, buf.String(), expected)
+	assert.Equal(t, expected, buf.String() )
 }
 
 func TestListRolesError(t *testing.T) {
@@ -196,7 +196,7 @@ func TestUpdateRole(t *testing.T) {
 	err := UpdateRole(id, role, email, api, buf)
 	assert.NoError(t, err)
 	expected := `Role has been changed from WORKSPACE_VIEWER to WORKSPACE_ADMIN for user test-role`
-	assert.Equal(t, buf.String(), expected)
+	assert.Equal(t, expected, buf.String())
 }
 
 func TestUpdateRoleNoAccessDeploymentOnly(t *testing.T) {

--- a/workspace/user_test.go
+++ b/workspace/user_test.go
@@ -199,6 +199,25 @@ func TestUpdateRole(t *testing.T) {
 	assert.Equal(t, buf.String(), expected)
 }
 
+func TestUpdateRoleNoAccessDeploymentOnly(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{"data":{"workspaceUpdateUserRole":"WORKSPACE_ADMIN", "workspaceUser":{"roleBindings":[{"workspace":{"id":"ckg6sfddu30911pc0n1o0e97e"},"role":"DEPLOYMENT_VIEWER"}]}}}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	id := "ckg6sfddu30911pc0n1o0e97e"
+	role := "test-role"
+	email := "andrii@test.com"
+
+	buf := new(bytes.Buffer)
+	err := UpdateRole(id, role, email, api, buf)
+	assert.Equal(t, err.Error(), "The user you are trying to change is not part of this workspace")
+}
 func TestUpdateRoleNoAccess(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{"data":{"workspaceUpdateUserRole":"WORKSPACE_ADMIN", "workspaceUser":{"roleBindings":[]}}}`


### PR DESCRIPTION
## Description

> astro workspace user update command giving wrong role for what the user used to have, it was repeating the same role twice. I added a request to retrieve the previous role so now it correctly says 
`Role has been changed from WORKSPACE_VIEWER to WORKSPACE_ADMIN for user test-role`

## 🎟 Issue(s)

Related astronomer/issues#3258

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

```
./astro workspace user update --role=WORKSPACE_VIEWER nic+viewer@astronomer.io --skip-version-check
Role has been changed from WORKSPACE_VIEWER to WORKSPACE_VIEWER for user nic+viewer@astronomer.io%   
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
