### PR TITLE
change the order in which requests are called for workspace update role

### DIFF
--- a/workspace/user.go
+++ b/workspace/user.go
@@ -89,16 +89,6 @@ func ListRoles(workspaceId string, client *houston.Client, out io.Writer) error 
 
 // Update workspace user role
 func UpdateRole(workspaceId, email, role string, client *houston.Client, out io.Writer) error {
-	req := houston.Request{
-		Query:     houston.WorkspaceUserUpdateRequest,
-		Variables: map[string]interface{}{"workspaceUuid": workspaceId, "email": email, "role": role},
-	}
-	r, err := req.DoWithClient(client)
-
-	if err != nil {
-		return err
-	}
-	newRole := r.Data.WorkspaceUpdateUserRole
 	// get user you are updating to show role from before change
 	roles, err := getUserRole(workspaceId, email, client, out)
 
@@ -117,6 +107,17 @@ func UpdateRole(workspaceId, email, role string, client *houston.Client, out io.
 	if (rb == houston.RoleBindingWorkspace{}) {
 		return errors.New("The user you are trying to change is not part of this workspace")
 	}
+
+	req := houston.Request{
+		Query:     houston.WorkspaceUserUpdateRequest,
+		Variables: map[string]interface{}{"workspaceUuid": workspaceId, "email": email, "role": role},
+	}
+	r, err := req.DoWithClient(client)
+
+	if err != nil {
+		return err
+	}
+	newRole := r.Data.WorkspaceUpdateUserRole
 
 	fmt.Fprintf(out, "Role has been changed from %s to %s for user %s", rb.Role, newRole, email)
 	return nil


### PR DESCRIPTION
## Description

> change the order in which requests are called for workspace update role. I accidently was calling the getUserRole after it was updated instead of before. I had tested it locally but I gess there were async problems that cause it to show up the correct information and testing works just that its per request.

## 🎟 Issue(s)

Related astronomer/issues#3258

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

```
/astro workspace user update --role=WORKSPACE_VIEWER nic+viewer@astronomer.io --skip-version-check
Role has been changed from WORKSPACE_EDITOR to WORKSPACE_VIEWER for user nic+viewer@astronomer.io%                                                                                                 

./astro workspace user update --role=WORKSPACE_ADMIN nic+viewer@astronomer.io --skip-version-check
Role has been changed from WORKSPACE_VIEWER to WORKSPACE_ADMIN for user nic+viewer@astronomer.io%                                                                                                  

./astro workspace user update --role=WORKSPACE_EDITOR nic+viewer@astronomer.io --skip-version-check
Role has been changed from WORKSPACE_ADMIN to WORKSPACE_EDITOR for user nic+viewer@astronomer.io%                                                                                                  

./astro workspace user update --role=WORKSPACE_VIEWER nic+viewer@astronomer.io --skip-version-check
Role has been changed from WORKSPACE_EDITOR to WORKSPACE_VIEWER for user nic+viewer@astronomer.io%  
```

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
