### PR TITLE
Feature/pre created namespaces

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -165,7 +165,7 @@ func newDeploymentListCmd(client *houston.Client, out io.Writer) *cobra.Command 
 }
 
 func newDeploymentUpdateCmd(client *houston.Client, out io.Writer) *cobra.Command {
-	example := ` 
+	example := `
 # update labels and description for given deployment
 $ astro deployment update UUID label=Production-Airflow description=example version=v1.0.0`
 	updateExampleDagDeployment := `
@@ -378,7 +378,6 @@ func newDeploymentAirflowUpgradeCmd(client *houston.Client, out io.Writer) *cobr
 	cmd.MarkFlagRequired("deployment-id")
 	return cmd
 }
-
 
 func deploymentCreate(cmd *cobra.Command, args []string, client *houston.Client, out io.Writer) error {
 	ws, err := coalesceWorkspace()

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -379,6 +379,7 @@ func newDeploymentAirflowUpgradeCmd(client *houston.Client, out io.Writer) *cobr
 	return cmd
 }
 
+
 func deploymentCreate(cmd *cobra.Command, args []string, client *houston.Client, out io.Writer) error {
 	ws, err := coalesceWorkspace()
 	if err != nil {

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -88,7 +88,7 @@ func CheckPreCreateNamespaceDeployment(client *houston.Client) bool {
 	if err != nil {
 		return false
 	}
-	return appConfig.PreCreatedNamespaces
+	return appConfig.ManualNamespaceNames
 }
 
 // Create airflow deployment

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -99,7 +99,6 @@ func CheckPreCreateNamespaceDeployment(client *houston.Client) bool {
 	return appConfig.PreCreatedNamespaces
 }
 
-
 // Create airflow deployment
 func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDeploymentType, nfsLocation string, client *houston.Client, out io.Writer) error {
 	vars := map[string]interface{}{"label": label, "workspaceId": ws, "executor": executor, "cloudRole": cloudRole}
@@ -107,7 +106,7 @@ func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDepl
 	if CheckPreCreateNamespaceDeployment(client) {
 		namespace, err := getDeploymentSelectionNamespaces(client, out)
 		if err != nil {
-		 	return err
+			return err
 		}
 		vars["namespace"] = namespace
 	}
@@ -187,6 +186,7 @@ func Delete(id string, hardDelete bool, client *houston.Client, out io.Writer) e
 
 	return nil
 }
+
 // list all available namespaces
 func getDeploymentSelectionNamespaces(client *houston.Client, out io.Writer) (string, error) {
 	tab := namespacesTableOut()
@@ -202,6 +202,10 @@ func getDeploymentSelectionNamespaces(client *houston.Client, out io.Writer) (st
 	}
 
 	names := r.Data.GetDeploymentNamespaces
+
+	if len(names) == 0 {
+		return "", errors.New("no namespaces are available")
+	}
 
 	for _, namespace := range names {
 		name := namespace.Name
@@ -224,6 +228,7 @@ func getDeploymentSelectionNamespaces(client *houston.Client, out io.Writer) (st
 
 	return names[i-1].Name, nil
 }
+
 // List all airflow deployments
 func List(ws string, all bool, client *houston.Client, out io.Writer) error {
 	var deployments []houston.Deployment

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -223,7 +223,9 @@ func getDeploymentSelectionNamespaces(client *houston.Client, out io.Writer) (st
 	if err != nil {
 		return "", fmt.Errorf("cannot parse %s to int", in)
 	}
-
+	if i > int64(len(names)) {
+		return "", errors.New("Number is out of available range")
+	}
 	return names[i-1].Name, nil
 }
 

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -28,7 +28,7 @@ func namespacesTableOut() *printutil.Table {
 	return &printutil.Table{
 		Padding:        []int{30},
 		DynamicPadding: true,
-		Header:         []string{"AVAILABLE NAMESPACES"},
+		Header:         []string{"AVAILABLE KUBERNETES NAMESPACES"},
 	}
 }
 
@@ -204,7 +204,7 @@ func getDeploymentSelectionNamespaces(client *houston.Client, out io.Writer) (st
 	names := r.Data.GetDeploymentNamespaces
 
 	if len(names) == 0 {
-		return "", errors.New("no namespaces are available")
+		return "", errors.New("no kubernetes namespaces are available")
 	}
 
 	for _, namespace := range names {

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -24,14 +24,6 @@ func newTableOut() *printutil.Table {
 	}
 }
 
-func namespacesTableOut() *printutil.Table {
-	return &printutil.Table{
-		Padding:        []int{30},
-		DynamicPadding: true,
-		Header:         []string{"AVAILABLE KUBERNETES NAMESPACES"},
-	}
-}
-
 // AppVersion returns application version from houston-api
 func AppVersion(client *houston.Client) (*houston.AppConfig, error) {
 	req := houston.Request{
@@ -189,7 +181,13 @@ func Delete(id string, hardDelete bool, client *houston.Client, out io.Writer) e
 
 // list all available namespaces
 func getDeploymentSelectionNamespaces(client *houston.Client, out io.Writer) (string, error) {
-	tab := namespacesTableOut()
+
+	tab := &printutil.Table{
+		Padding:        []int{30},
+		DynamicPadding: true,
+		Header:         []string{"AVAILABLE KUBERNETES NAMESPACES"},
+	}
+
 	tab.GetUserInput = true
 
 	req := houston.Request{

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -28,7 +28,7 @@ func namespacesTableOut() *printutil.Table {
 	return &printutil.Table{
 		Padding:        []int{30},
 		DynamicPadding: true,
-		Header:         []string{"NAME"},
+		Header:         []string{"AVAILABLE NAMESPACES"},
 	}
 }
 

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -148,7 +148,7 @@ func TestCreate(t *testing.T) {
 				"smtpConfigured": true,
 				"manualReleaseNames": false,
 				"hardDeleteDeployment": true,
-				"preCreatedNamespaces": false
+				"manualNamespaceNames": false
 			},
 			    "createDeployment": {
 			"id": "ckbv818oa00r107606ywhoqtw",
@@ -214,7 +214,7 @@ func TestCreateWithNFSLocation(t *testing.T) {
 				"smtpConfigured": true,
 				"manualReleaseNames": false,
 				"hardDeleteDeployment": true,
-				"preCreatedNamespaces": false
+				"manualNamespaceNames": false
 			},
     "createDeployment": {
 			"id": "ckbv818oa00r107606ywhoqtw",
@@ -280,7 +280,7 @@ func TestCreateWithPreCreateNamespaceDeployment(t *testing.T) {
 				"smtpConfigured": true,
 				"manualReleaseNames": false,
 				"hardDeleteDeployment": true,
-				"preCreatedNamespaces": true
+				"manualNamespaceNames": true
 			},
 			"availableNamespaces": [
 				{
@@ -1069,7 +1069,7 @@ func TestCheckPreCreateNamespacesDeployment(t *testing.T) {
       "smtpConfigured": true,
       "manualReleaseNames": false,
       "hardDeleteDeployment": true,
-      "preCreatedNamespaces": true
+      "manualNamespaceNames": true
     }
   }
 }

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -1010,9 +1010,9 @@ func TestGetDeploymentSelectionNamespaces(t *testing.T) {
 
 	name, err := getDeploymentSelectionNamespaces(api, buf)
 	assert.NoError(t, err)
-	expected := `#     AVAILABLE NAMESPACES     
-1     test1                    
-2     test2                    
+	expected := `#     AVAILABLE KUBERNETES NAMESPACES     
+1     test1                               
+2     test2                               
 `
 	assert.Equal(t, expected, buf.String())
 	assert.Equal(t, "test1", name)
@@ -1047,7 +1047,7 @@ func TestGetDeploymentSelectionNamespacesNoNamespaces(t *testing.T) {
 	name, err := getDeploymentSelectionNamespaces(api, buf)
 	expected := ``
 	assert.Equal(t, expected, name)
-	assert.EqualError(t, err, "no namespaces are available")
+	assert.EqualError(t, err, "no kubernetes namespaces are available")
 }
 
 func TestGetDeploymentSelectionNamespacesError(t *testing.T) {

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -1010,9 +1010,9 @@ func TestGetDeploymentSelectionNamespaces(t *testing.T) {
 
 	name, err := getDeploymentSelectionNamespaces(api, buf)
 	assert.NoError(t, err)
-	expected := `#     NAME      
-1     test1     
-2     test2     
+	expected := `#     AVAILABLE NAMESPACES     
+1     test1                    
+2     test2                    
 `
 	assert.Equal(t, expected, buf.String())
 	assert.Equal(t, "test1", name)

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -274,26 +274,26 @@ func TestCreateWithPreCreateNamespaceDeployment(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
   "data": {
-			"appConfig": {
-				"version": "0.15.1",
-				"baseDomain": "local.astronomer.io",
-				"smtpConfigured": true,
-				"manualReleaseNames": false,
-				"hardDeleteDeployment": true,
-				"manualNamespaceNames": true
-			},
-			"availableNamespaces": [
-				{
-				  "name": "test1"
-				},
-				{
-				  "name": "test2"
-				}
-			      ],
+    "appConfig": {
+      "version": "0.15.1",
+      "baseDomain": "local.astronomer.io",
+      "smtpConfigured": true,
+      "manualReleaseNames": false,
+      "hardDeleteDeployment": true,
+      "manualNamespaceNames": true
+    },
+    "availableNamespaces": [
+      {
+        "name": "test1"
+      },
+      {
+        "name": "test2"
+      }
+    ],
     "createDeployment": {
-			"id": "ckbv818oa00r107606ywhoqtw",
-			"executor": "CeleryExecutor",
-			"urls": [
+      "id": "ckbv818oa00r107606ywhoqtw",
+      "executor": "CeleryExecutor",
+      "urls": [
         {
           "type": "airflow",
           "url": "https://deployments.local.astronomer.io/boreal-penumbra-1102/airflow"

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -361,6 +361,96 @@ func TestCreateWithPreCreateNamespaceDeployment(t *testing.T) {
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
 
+func TestCreateWithPreCreateNamespaceDeploymentError(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+    "appConfig": {
+      "version": "0.15.1",
+      "baseDomain": "local.astronomer.io",
+      "smtpConfigured": true,
+      "manualReleaseNames": false,
+      "hardDeleteDeployment": true,
+      "manualNamespaceNames": true
+    },
+    "availableNamespaces": [
+      {
+        "name": "test1"
+      },
+      {
+        "name": "test2"
+      }
+    ],
+    "createDeployment": {
+      "id": "ckbv818oa00r107606ywhoqtw",
+      "executor": "CeleryExecutor",
+      "urls": [
+        {
+          "type": "airflow",
+          "url": "https://deployments.local.astronomer.io/boreal-penumbra-1102/airflow"
+        },
+        {
+          "type": "flower",
+          "url": "https://deployments.local.astronomer.io/boreal-penumbra-1102/flower"
+        }
+      ],
+      "properties": {
+        "component_version": "0.0.0",
+        "alert_emails": []
+      },
+      "description": "",
+      "label": "test2",
+      "releaseName": "boreal-penumbra-1102",
+      "status": null,
+      "type": "airflow",
+      "version": "0.0.0",
+      "workspace": {
+        "id": "ckbv7zvb100pe0760xp98qnh9",
+        "label": "w1"
+      },
+      "createdAt": "2020-06-25T20:10:33.898Z",
+      "updatedAt": "2020-06-25T20:10:33.898Z"
+    }
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	label := "label"
+	ws := "ck1qg6whg001r08691y117hub"
+	releaseName := ""
+	role := "test-role"
+	executor := "CeleryExecutor"
+	airflowVersion := "1.10.5"
+	dagDeploymentType := "volume"
+	nfsLocation := "test:/test"
+	buf := new(bytes.Buffer)
+
+	// mock os.Stdin
+	input := []byte("5")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = w.Write(input)
+	if err != nil {
+		t.Error(err)
+	}
+	w.Close()
+	stdin := os.Stdin
+	// Restore stdin right after the test.
+	defer func() { os.Stdin = stdin }()
+	os.Stdin = r
+
+	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, api, buf)
+	assert.EqualError(t, err, "Number is out of available range")
+}
+
 func TestCreateHoustonError(t *testing.T) {
 	testUtil.InitTestConfig()
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
@@ -1041,6 +1131,52 @@ func TestGetDeploymentSelectionNamespacesNoNamespaces(t *testing.T) {
 	expected := ``
 	assert.Equal(t, expected, name)
 	assert.EqualError(t, err, "no kubernetes namespaces are available")
+}
+
+func TestGetDeploymentSelectionNamespacesParseError(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+    "appConfig": {
+      "version": "0.15.1",
+      "baseDomain": "local.astronomer.io",
+      "smtpConfigured": true,
+      "manualReleaseNames": false,
+      "hardDeleteDeployment": true
+    },
+    "availableNamespaces": [ { "name": "test1" }, { "name": "test2" } ]
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	buf := new(bytes.Buffer)
+
+	// mock os.Stdin
+	input := []byte("test")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = w.Write(input)
+	if err != nil {
+		t.Error(err)
+	}
+	w.Close()
+	stdin := os.Stdin
+	// Restore stdin right after the test.
+	defer func() { os.Stdin = stdin }()
+	os.Stdin = r
+
+	name, err := getDeploymentSelectionNamespaces(api, buf)
+	assert.Equal(t, "", name)
+	assert.EqualError(t, err, "cannot parse test to int")
 }
 
 func TestGetDeploymentSelectionNamespacesError(t *testing.T) {

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -924,15 +924,15 @@ func TestCheckNFSMountDagDeploymentSuccess(t *testing.T) {
 func TestCheckHardDeleteDeployment(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
-		"data": {
-			"appConfig": {
-				"version": "0.15.1",
-				"baseDomain": "local.astronomer.io",
-				"smtpConfigured": true,
-				"manualReleaseNames": false,
-				"hardDeleteDeployment": true
-			}
-		}
+  "data": {
+    "appConfig": {
+      "version": "0.15.1",
+      "baseDomain": "local.astronomer.io",
+      "smtpConfigured": true,
+      "manualReleaseNames": false,
+      "hardDeleteDeployment": true
+    }
+  }
 }`
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
@@ -963,23 +963,16 @@ func TestCheckHardDeleteDeploymentError(t *testing.T) {
 func TestGetDeploymentSelectionNamespaces(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
-		"data": {
-			"appConfig": {
-				"version": "0.15.1",
-				"baseDomain": "local.astronomer.io",
-				"smtpConfigured": true,
-				"manualReleaseNames": false,
-				"hardDeleteDeployment": true
-			},
-			"availableNamespaces": [
-				{
-				  "name": "test1"
-				},
-				{
-				  "name": "test2"
-				}
-			      ]
-		}
+  "data": {
+    "appConfig": {
+      "version": "0.15.1",
+      "baseDomain": "local.astronomer.io",
+      "smtpConfigured": true,
+      "manualReleaseNames": false,
+      "hardDeleteDeployment": true
+    },
+    "availableNamespaces": [ { "name": "test1" }, { "name": "test2" } ]
+  }
 }`
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
@@ -1022,18 +1015,18 @@ func TestGetDeploymentSelectionNamespaces(t *testing.T) {
 func TestGetDeploymentSelectionNamespacesNoNamespaces(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
-		"data": {
-			"appConfig": {
-				"version": "0.15.1",
-				"baseDomain": "local.astronomer.io",
-				"smtpConfigured": true,
-				"manualReleaseNames": false,
-				"hardDeleteDeployment": true
-			},
-			"availableNamespaces": [
-			      ]
-		}
-}`
+  "data": {
+    "appConfig": {
+      "version": "0.15.1",
+      "baseDomain": "local.astronomer.io",
+      "smtpConfigured": true,
+      "manualReleaseNames": false,
+      "hardDeleteDeployment": true
+    },
+    "availableNamespaces" : []
+  }
+}
+`
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,
@@ -1069,17 +1062,18 @@ func TestGetDeploymentSelectionNamespacesError(t *testing.T) {
 func TestCheckPreCreateNamespacesDeployment(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
-		"data": {
-			"appConfig": {
-				"version": "0.15.1",
-				"baseDomain": "local.astronomer.io",
-				"smtpConfigured": true,
-				"manualReleaseNames": false,
-				"hardDeleteDeployment": true,
-				"preCreatedNamespaces": true
-			}
-		}
-}`
+  "data": {
+    "appConfig": {
+      "version": "0.15.1",
+      "baseDomain": "local.astronomer.io",
+      "smtpConfigured": true,
+      "manualReleaseNames": false,
+      "hardDeleteDeployment": true,
+      "preCreatedNamespaces": true
+    }
+  }
+}
+`
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,
@@ -1089,6 +1083,6 @@ func TestCheckPreCreateNamespacesDeployment(t *testing.T) {
 	})
 	api := houston.NewHoustonClient(client)
 
-	hardDelete := CheckPreCreateNamespaceDeployment(api)
-	assert.Equal(t, true, hardDelete)
+	usesPreCreateNamespace := CheckPreCreateNamespaceDeployment(api)
+	assert.Equal(t, true, usesPreCreateNamespace)
 }

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -142,7 +142,15 @@ func TestCreate(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
   "data": {
-    "createDeployment": {
+			"appConfig": {
+				"version": "0.15.1",
+				"baseDomain": "local.astronomer.io",
+				"smtpConfigured": true,
+				"manualReleaseNames": false,
+				"hardDeleteDeployment": true,
+				"PreCreatedNamespaces": false
+			},
+			    "createDeployment": {
 			"id": "ckbv818oa00r107606ywhoqtw",
 			"executor": "CeleryExecutor",
 			"urls": [
@@ -200,6 +208,14 @@ func TestCreateWithNFSLocation(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
   "data": {
+			"appConfig": {
+				"version": "0.15.1",
+				"baseDomain": "local.astronomer.io",
+				"smtpConfigured": true,
+				"manualReleaseNames": false,
+				"hardDeleteDeployment": true,
+				"PreCreatedNamespaces": false
+			},
     "createDeployment": {
 			"id": "ckbv818oa00r107606ywhoqtw",
 			"executor": "CeleryExecutor",
@@ -253,6 +269,99 @@ func TestCreateWithNFSLocation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
+
+func TestCreateWithPreCreateNamespaceDeployment(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+			"appConfig": {
+				"version": "0.15.1",
+				"baseDomain": "local.astronomer.io",
+				"smtpConfigured": true,
+				"manualReleaseNames": false,
+				"hardDeleteDeployment": true,
+				"PreCreatedNamespaces": true
+			},
+			"availableNamespaces": [
+				{
+				  "name": "test1"
+				},
+				{
+				  "name": "test2"
+				}
+			      ],
+    "createDeployment": {
+			"id": "ckbv818oa00r107606ywhoqtw",
+			"executor": "CeleryExecutor",
+			"urls": [
+        {
+          "type": "airflow",
+          "url": "https://deployments.local.astronomer.io/boreal-penumbra-1102/airflow"
+        },
+        {
+          "type": "flower",
+          "url": "https://deployments.local.astronomer.io/boreal-penumbra-1102/flower"
+        }
+      ],
+      "properties": {
+        "component_version": "0.0.0",
+        "alert_emails": []
+      },
+      "description": "",
+      "label": "test2",
+      "releaseName": "boreal-penumbra-1102",
+      "status": null,
+      "type": "airflow",
+      "version": "0.0.0",
+      "workspace": {
+        "id": "ckbv7zvb100pe0760xp98qnh9",
+        "label": "w1"
+      },
+      "createdAt": "2020-06-25T20:10:33.898Z",
+      "updatedAt": "2020-06-25T20:10:33.898Z"
+    }
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	label := "label"
+	ws := "ck1qg6whg001r08691y117hub"
+	releaseName := ""
+	role := "test-role"
+	executor := "CeleryExecutor"
+	airflowVersion := "1.10.5"
+	dagDeploymentType := "volume"
+	nfsLocation := "test:/test"
+	buf := new(bytes.Buffer)
+
+	// mock os.Stdin
+	input := []byte("1")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = w.Write(input)
+	if err != nil {
+		t.Error(err)
+	}
+	w.Close()
+	stdin := os.Stdin
+	// Restore stdin right after the test.
+	defer func() { os.Stdin = stdin }()
+	os.Stdin = r
+
+
+	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, api, buf)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
+}
+
 
 func TestCreateHoustonError(t *testing.T) {
 	testUtil.InitTestConfig()
@@ -852,3 +961,108 @@ func TestCheckHardDeleteDeploymentError(t *testing.T) {
 	api := houston.NewHoustonClient(client)
 	assert.Equal(t, false, CheckHardDeleteDeployment(api))
 }
+
+func TestGetDeploymentSelectionNamespaces(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+		"data": {
+			"appConfig": {
+				"version": "0.15.1",
+				"baseDomain": "local.astronomer.io",
+				"smtpConfigured": true,
+				"manualReleaseNames": false,
+				"hardDeleteDeployment": true
+			},
+			"availableNamespaces": [
+				{
+				  "name": "test1"
+				},
+				{
+				  "name": "test2"
+				}
+			      ]
+		}
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	buf := new(bytes.Buffer)
+
+	// mock os.Stdin
+	input := []byte("1")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = w.Write(input)
+	if err != nil {
+		t.Error(err)
+	}
+	w.Close()
+	stdin := os.Stdin
+	// Restore stdin right after the test.
+	defer func() { os.Stdin = stdin }()
+	os.Stdin = r
+
+
+	name, err := getDeploymentSelectionNamespaces(api, buf)
+	assert.NoError(t, err)
+	expected := `#     NAME      
+1     test1     
+2     test2     
+`
+	assert.Equal(t, expected, buf.String())
+	assert.Equal(t, "test1", name)
+
+}
+
+func TestGetDeploymentSelectionNamespacesError(t *testing.T) {
+	testUtil.InitTestConfig()
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 500,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`Internal Server Error`)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	buf := new(bytes.Buffer)
+	name, err := getDeploymentSelectionNamespaces(api, buf)
+	assert.Equal(t, "", name);
+	assert.EqualError(t, err, "API error (500): Internal Server Error")
+}
+
+func TestCheckPreCreateNamespacesDeployment(t *testing.T){
+	testUtil.InitTestConfig()
+	okResponse := `{
+		"data": {
+			"appConfig": {
+				"version": "0.15.1",
+				"baseDomain": "local.astronomer.io",
+				"smtpConfigured": true,
+				"manualReleaseNames": false,
+				"hardDeleteDeployment": true,
+				"PreCreatedNamespaces": true
+			}
+		}
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	hardDelete := CheckPreCreateNamespaceDeployment(api)
+	assert.Equal(t, true, hardDelete)
+}
+
+

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -356,12 +356,10 @@ func TestCreateWithPreCreateNamespaceDeployment(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-
 	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, api, buf)
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
-
 
 func TestCreateHoustonError(t *testing.T) {
 	testUtil.InitTestConfig()
@@ -1010,7 +1008,6 @@ func TestGetDeploymentSelectionNamespaces(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-
 	name, err := getDeploymentSelectionNamespaces(api, buf)
 	assert.NoError(t, err)
 	expected := `#     NAME      
@@ -1020,6 +1017,37 @@ func TestGetDeploymentSelectionNamespaces(t *testing.T) {
 	assert.Equal(t, expected, buf.String())
 	assert.Equal(t, "test1", name)
 
+}
+
+func TestGetDeploymentSelectionNamespacesNoNamespaces(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+		"data": {
+			"appConfig": {
+				"version": "0.15.1",
+				"baseDomain": "local.astronomer.io",
+				"smtpConfigured": true,
+				"manualReleaseNames": false,
+				"hardDeleteDeployment": true
+			},
+			"availableNamespaces": [
+			      ]
+		}
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	buf := new(bytes.Buffer)
+	name, err := getDeploymentSelectionNamespaces(api, buf)
+	expected := ``
+	assert.Equal(t, expected, name)
+	assert.EqualError(t, err, "no namespaces are available")
 }
 
 func TestGetDeploymentSelectionNamespacesError(t *testing.T) {
@@ -1034,11 +1062,11 @@ func TestGetDeploymentSelectionNamespacesError(t *testing.T) {
 	api := houston.NewHoustonClient(client)
 	buf := new(bytes.Buffer)
 	name, err := getDeploymentSelectionNamespaces(api, buf)
-	assert.Equal(t, "", name);
+	assert.Equal(t, "", name)
 	assert.EqualError(t, err, "API error (500): Internal Server Error")
 }
 
-func TestCheckPreCreateNamespacesDeployment(t *testing.T){
+func TestCheckPreCreateNamespacesDeployment(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
 		"data": {
@@ -1064,5 +1092,3 @@ func TestCheckPreCreateNamespacesDeployment(t *testing.T){
 	hardDelete := CheckPreCreateNamespaceDeployment(api)
 	assert.Equal(t, true, hardDelete)
 }
-
-

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -148,7 +148,7 @@ func TestCreate(t *testing.T) {
 				"smtpConfigured": true,
 				"manualReleaseNames": false,
 				"hardDeleteDeployment": true,
-				"PreCreatedNamespaces": false
+				"preCreatedNamespaces": false
 			},
 			    "createDeployment": {
 			"id": "ckbv818oa00r107606ywhoqtw",
@@ -214,7 +214,7 @@ func TestCreateWithNFSLocation(t *testing.T) {
 				"smtpConfigured": true,
 				"manualReleaseNames": false,
 				"hardDeleteDeployment": true,
-				"PreCreatedNamespaces": false
+				"preCreatedNamespaces": false
 			},
     "createDeployment": {
 			"id": "ckbv818oa00r107606ywhoqtw",
@@ -280,7 +280,7 @@ func TestCreateWithPreCreateNamespaceDeployment(t *testing.T) {
 				"smtpConfigured": true,
 				"manualReleaseNames": false,
 				"hardDeleteDeployment": true,
-				"PreCreatedNamespaces": true
+				"preCreatedNamespaces": true
 			},
 			"availableNamespaces": [
 				{
@@ -1076,7 +1076,7 @@ func TestCheckPreCreateNamespacesDeployment(t *testing.T) {
 				"smtpConfigured": true,
 				"manualReleaseNames": false,
 				"hardDeleteDeployment": true,
-				"PreCreatedNamespaces": true
+				"preCreatedNamespaces": true
 			}
 		}
 }`

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -555,7 +555,7 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: Str
 			manualReleaseNames
 			configureDagDeployment
 			nfsMountDagDeployment
-			preCreatedNamespaces
+			manualNamespaceNames
 		}
 	}`
 )

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -24,6 +24,7 @@ var (
 		$workspaceId: Uuid!
 		$executor: ExecutorType!
 		$airflowVersion: String
+		$namespace: String
 		$config: JSON
 		$cloudRole: String
 		$dagDeployment: DagDeployment
@@ -35,6 +36,7 @@ var (
 			releaseName: $releaseName
 			executor: $executor
 		        airflowVersion: $airflowVersion
+			namespace: $namespace
 			config: $config
 			cloudRole: $cloudRole
 			dagDeployment: $dagDeployment

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -105,9 +105,8 @@ var (
 	}`
 
 	AvailableNamespacesGetRequest = `
-	query availableNamespaces() {
-		availableNamespaces(
-		) {
+	query availableNamespaces {
+		availableNamespaces{
 			name
 		}
 	}`

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -104,6 +104,15 @@ var (
 		}
 	}`
 
+	AvailableNamespacesGetRequest = `
+	query availableNamespaces() {
+		availableNamespaces(
+		) {
+			name
+		}
+	}`
+
+
 	DeploymentGetRequest = `
 	query GetDeployment(
 		$id: String!

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -112,7 +112,6 @@ var (
 		}
 	}`
 
-
 	DeploymentGetRequest = `
 	query GetDeployment(
 		$id: String!
@@ -557,6 +556,7 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: Str
 			manualReleaseNames
 			configureDagDeployment
 			nfsMountDagDeployment
+			preCreatedNamespaces
 		}
 	}`
 )

--- a/houston/types.go
+++ b/houston/types.go
@@ -40,12 +40,12 @@ type Response struct {
 		WorkspaceUpdateUserRole        string                    `json:"workspaceUpdateUserRole,omitempty"`
 		WorkspaceGetUser               WorkspaceUserRoleBindings `json:"workspaceUser,omitempty"`
 		DeploymentConfig               DeploymentConfig          `json:"deploymentConfig,omitempty"`
-		GetDeploymentNamespaces        []Namespace        	 `json:"availableNamespaces,omitempty"`
+		GetDeploymentNamespaces        []Namespace               `json:"availableNamespaces,omitempty"`
 	} `json:"data"`
 	Errors []Error `json:"errors,omitempty"`
 }
 type Namespace struct {
-	Name        string `json:"name"`
+	Name string `json:"name"`
 }
 type AuthProvider struct {
 	Name        string `json:"name"`

--- a/houston/types.go
+++ b/houston/types.go
@@ -40,10 +40,13 @@ type Response struct {
 		WorkspaceUpdateUserRole        string                    `json:"workspaceUpdateUserRole,omitempty"`
 		WorkspaceGetUser               WorkspaceUserRoleBindings `json:"workspaceUser,omitempty"`
 		DeploymentConfig               DeploymentConfig          `json:"deploymentConfig,omitempty"`
+		GetDeploymentNamespaces        []Namespace        	 `json:"availableNamespaces,omitempty"`
 	} `json:"data"`
 	Errors []Error `json:"errors,omitempty"`
 }
-
+type Namespace struct {
+	Name        string `json:"name"`
+}
 type AuthProvider struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName"`
@@ -276,6 +279,7 @@ type AppConfig struct {
 	ConfigureDagDeployment bool   `json:"configureDagDeployment"`
 	NfsMountDagDeployment  bool   `json:"nfsMountDagDeployment"`
 	HardDeleteDeployment   bool   `json:"hardDeleteDeployment"`
+	PreCreatedNamespaces   bool   `json:"PreCreatedNamespaces"`
 }
 
 // coerce a string into SemVer if possible

--- a/houston/types.go
+++ b/houston/types.go
@@ -279,7 +279,7 @@ type AppConfig struct {
 	ConfigureDagDeployment bool   `json:"configureDagDeployment"`
 	NfsMountDagDeployment  bool   `json:"nfsMountDagDeployment"`
 	HardDeleteDeployment   bool   `json:"hardDeleteDeployment"`
-	PreCreatedNamespaces   bool   `json:"PreCreatedNamespaces"`
+	ManualNamespaceNames   bool   `json:"manualNamespaceNames"`
 }
 
 // coerce a string into SemVer if possible

--- a/workspace/user_test.go
+++ b/workspace/user_test.go
@@ -34,7 +34,7 @@ func TestAdd(t *testing.T) {
           ckc0eir8e01gj07608ajmvia1     andrii@test.com     test-role     
 Successfully added andrii@test.com to 
 `
-	assert.Equal(t, expected, buf.String() )
+	assert.Equal(t, expected, buf.String())
 }
 
 func TestAddError(t *testing.T) {
@@ -79,7 +79,7 @@ func TestRemove(t *testing.T) {
                                ckc0eir8e01gj07608ajmvia1                         ckc0eir8e01gj07608ajmvia1                         
 Successfully removed user from workspace
 `
-	assert.Equal(t, expected, buf.String() )
+	assert.Equal(t, expected, buf.String())
 }
 
 func TestRemoveError(t *testing.T) {
@@ -156,7 +156,7 @@ func TestListRoles(t *testing.T) {
 	expected := ` USERNAME                 ID                            ROLE                
  andrii@astronomer.io     ckbv7zpkh00og0760ki4mhl6r     WORKSPACE_ADMIN     
 `
-	assert.Equal(t, expected, buf.String() )
+	assert.Equal(t, expected, buf.String())
 }
 
 func TestListRolesError(t *testing.T) {


### PR DESCRIPTION
## Description

> Add pre-created namespaces feature to cli, if the flag is enabled when creating new deployment will ask which namespace you want to use

## 🎟 Issue(s)
### **This PR need to go first** https://github.com/astronomer/houston-api/pull/750
Related astronomer/issues#3335

## 🧪 Functional Testing

> make sure houston has the flag on and then run createDeployment should prompt from a list of namespaces defined

## 📸 Screenshots

```
./astro deployment create new-deployment-name4 --executor=celery --skip-version-check
#     AVAILABLE KUBERNETES NAMESPACES   
1     test1                    
2     test2                    

> 1
 NAME                     DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 TAG     AIRFLOW VERSION     
 new-deployment-name4     nebular-declination-2708     0.17.1     ckshyd0uq0824hc9hwutz8kbn     -       1.10.7-15           

 Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs 

 Airflow Dashboard: https://deployments.local.astronomer.io/nebular-declination-2708/airflow
 Flower Dashboard: https://deployments.local.astronomer.io/nebular-declination-2708/flower
```

```
 ./astro deployment create new-deployment-name4 --executor=celery --skip-version-check
Error: no kubernetes namespaces are available
```

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
