### PR TITLE
Feature/debug

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -171,6 +171,10 @@ func Login(domain string, oAuthOnly bool, username, password string, client *hou
 
 	err = registryAuth()
 	if err != nil {
+		if config.CFG.Debug.GetBool() {
+			fmt.Printf("DEBUG: There was an error: %s", err.Error())
+		}
+
 		fmt.Printf(messages.RegistryAuthFail)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ var (
 		ShowWarnings:       newCfg("show_warnings", "true"),
 		AirflowReleasesURL: newCfg("airflow_releases_url", "https://updates.astronomer.io/astronomer-certified"),
 		SkipVerifyTLS:      newCfg("skip_verify_tls", "false"),
+		Debug:              newCfg("debug", "false"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/types.go
+++ b/config/types.go
@@ -28,6 +28,7 @@ type cfgs struct {
 	ShowWarnings       cfg
 	AirflowReleasesURL cfg
 	SkipVerifyTLS      cfg
+	Debug              cfg
 }
 
 // Creates a new cfg struct

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/semver"
 
+	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
@@ -108,6 +109,7 @@ func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDepl
 		if err != nil {
 			return err
 		}
+
 		vars["namespace"] = namespace
 	}
 
@@ -189,6 +191,9 @@ func Delete(id string, hardDelete bool, client *houston.Client, out io.Writer) e
 
 // list all available namespaces
 func getDeploymentSelectionNamespaces(client *houston.Client, out io.Writer) (string, error) {
+	if config.CFG.Debug.GetBool() {
+		fmt.Println("checking namespaces available for platform")
+	}
 	tab := namespacesTableOut()
 	tab.GetUserInput = true
 

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -74,6 +74,9 @@ func (c *Client) Do(doOpts httputil.DoOptions) (*Response, error) {
 		fmt.Printf("DEBUG: Request Data: %v\n", doOpts.Data)
 	}
 	if err != nil {
+		if config.CFG.Debug.GetBool() {
+			fmt.Printf("DEBUG: ERROR in HTTP request: %s", err.Error())
+		}
 		return nil, err
 	}
 	defer httpResponse.Body.Close()

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -2,16 +2,19 @@ package houston
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"strings"
 
 	"github.com/astronomer/astro-cli/cluster"
+	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/pkg/errors"
 )
 
 var PermissionsError = errors.New("You do not have the appropriate permissions for that")
 var PermissionsErrorVerbose = errors.New("You do not have the appropriate permissions for that: Your token has expired. Please log in again.")
+var debug = true
 
 // Client containers the logger and HTTPClient used to communicate with the HoustonAPI
 type Client struct {
@@ -66,6 +69,10 @@ func (c *Client) Do(doOpts httputil.DoOptions) (*Response, error) {
 
 	var response httputil.HTTPResponse
 	httpResponse, err := c.HTTPClient.Do("POST", cl.GetAPIURL(), &doOpts)
+	if config.CFG.Debug.GetBool() {
+		fmt.Printf("DEBUG: This is the url %s \n", cl.GetAPIURL())
+		fmt.Printf("DEBUG: doOpts.Data: %v\n", doOpts.Data)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -71,7 +71,7 @@ func (c *Client) Do(doOpts httputil.DoOptions) (*Response, error) {
 	httpResponse, err := c.HTTPClient.Do("POST", cl.GetAPIURL(), &doOpts)
 	if config.CFG.Debug.GetBool() {
 		fmt.Printf("DEBUG: This is the url %s \n", cl.GetAPIURL())
-		fmt.Printf("DEBUG: doOpts.Data: %v\n", doOpts.Data)
+		fmt.Printf("DEBUG: Request Data: %v\n", doOpts.Data)
 	}
 	if err != nil {
 		return nil, err

--- a/version/validate_compatibility.go
+++ b/version/validate_compatibility.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/deployment"
 	"github.com/pkg/errors"
 
@@ -16,6 +17,9 @@ import (
 func ValidateCompatibility(client *houston.Client, out io.Writer, cliVer string, skipVerCheck bool) error {
 	if skipVerCheck {
 		return nil
+	}
+	if config.CFG.Debug.GetBool() {
+		fmt.Println("checking if astro-cli version is not compatible with platform")
 	}
 
 	serverCfg, err := deployment.AppVersion(client)


### PR DESCRIPTION
## Description

> A very basic debuging mode, you need to add debug: true to config for it to work. It will print out the query that it is doing, where and the params

## 🎟 Issue(s)

Related astronomer/issues#3328

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

```
./astro
DEBUG: This is the url http://localhost:8871/v1 
DEBUG: Request Data: &{
        query AppConfig {
                appConfig {
                        version
                        baseDomain
                        smtpConfigured
                        manualReleaseNames
                        configureDagDeployment
                        nfsMountDagDeployment
                        preCreatedNamespaces
                }
        } map[]}
DEBUG: This is the url http://localhost:8871/v1 
DEBUG: Request Data: &{
        query AppConfig {
                appConfig {
                        version
                        baseDomain
                        smtpConfigured
                        manualReleaseNames
                        configureDagDeployment
                        nfsMountDagDeployment
                        preCreatedNamespaces
                }
        } map[]}
DEBUG: This is the url http://localhost:8871/v1 
DEBUG: Request Data: &{
        query AppConfig {
                appConfig {
                        version
                        baseDomain
                        smtpConfigured
                        manualReleaseNames
                        configureDagDeployment
                        nfsMountDagDeployment
                        preCreatedNamespaces
                }
        } map[]}
astro is a command line interface for working with the Astronomer Platform.

Usage:
  astro [command]

Available Commands:
  auth            Authenticate with an Astronomer Cluster
  cluster         Manage Astronomer Clusters
  completion      Generate autocompletions script for the specified shell (bash or zsh)
  config          Manage project configuration
  deploy          Deploy an Airflow project
  deployment      Manage Astronomer Deployments
  dev             Manage Airflow projects
  help            Help about any command
  upgrade         Check for newer version of Astronomer CLI
  user            Manage Astronomer user
  version         astro CLI version
  workspace       Manage Astronomer Workspaces

Flags:
  -h, --help                 help for astro
      --skip-version-check   skip version compatibility check

Use "astro [command] --help" for more information about a command.
```

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
