### PR TITLE
Add triggerer replicas option to create/update cli

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -199,7 +199,7 @@ $ astro deployment update UUID label=Production-Airflow --dag-deployment-type=vo
 		cmd.Flags().StringVarP(&nfsLocation, "nfs-location", "n", "", "NFS Volume Mount, specified as: <IP>:/<path>. Input is automatically prepended with 'nfs://' - do not include.")
 	}
 	if deployment.CheckTriggererEnabled(client) {
-		cmd.Flags().IntVarP(&triggererReplicas, "triggerer-replicas", "t", 0, "Number of replicas to use for triggerer airflow componenet, valid 0-2")
+		cmd.Flags().IntVarP(&triggererReplicas, "triggerer-replicas", "t", 0, "Number of replicas to use for triggerer airflow component, valid 0-2")
 	}
 	cmd.Flags().StringVarP(&cloudRole, "cloud-role", "c", "", "Set cloud role to annotate service accounts in deployment")
 	return cmd

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -127,7 +127,7 @@ func newDeploymentCreateCmd(client *houston.Client, out io.Writer) *cobra.Comman
 		cmd.Flags().StringVarP(&nfsLocation, "nfs-location", "n", "", "NFS Volume Mount, specified as: <IP>:/<path>. Input is automatically prepended with 'nfs://' - do not include.")
 	}
 	if deployment.CheckTriggererEnabled(client) {
-		cmd.Flags().IntVarP(&triggererReplicas, "triggerer-replicas", "t", 0, "Number of replicas to use for triggerer airflow componenet, valid 0-2")
+		cmd.Flags().IntVarP(&triggererReplicas, "triggerer-replicas", "t", 0, "Number of replicas to use for triggerer airflow component, valid 0-2")
 	}
 	cmd.Flags().StringVarP(&executor, "executor", "e", "", "Add executor parameter: local, celery, or kubernetes")
 	cmd.Flags().StringVarP(&airflowVersion, "airflow-version", "a", "", "Add desired airflow version parameter: e.g: 1.10.5 or 1.10.7")

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -31,8 +31,8 @@ var (
 	releaseName           string
 	nfsLocation           string
 	dagDeploymentType     string
-
-	CreateExample = `
+	triggererReplicas     int
+	CreateExample         = `
 # Create new deployment with Celery executor (default: celery without params).
   $ astro deployment create new-deployment-name --executor=celery
 
@@ -126,6 +126,9 @@ func newDeploymentCreateCmd(client *houston.Client, out io.Writer) *cobra.Comman
 		cmd.Flags().StringVarP(&dagDeploymentType, "dag-deployment-type", "t", "", "DAG Deployment mechanism: image, volume")
 		cmd.Flags().StringVarP(&nfsLocation, "nfs-location", "n", "", "NFS Volume Mount, specified as: <IP>:/<path>. Input is automatically prepended with 'nfs://' - do not include.")
 	}
+	if deployment.CheckTriggererEnabled(client) {
+		cmd.Flags().IntVarP(&triggererReplicas, "triggerer-replicas", "t", 0, "Number of replicas to use for triggerer airflow componenet, valid 0-2")
+	}
 	cmd.Flags().StringVarP(&executor, "executor", "e", "", "Add executor parameter: local, celery, or kubernetes")
 	cmd.Flags().StringVarP(&airflowVersion, "airflow-version", "a", "", "Add desired airflow version parameter: e.g: 1.10.5 or 1.10.7")
 	cmd.Flags().StringVarP(&releaseName, "release-name", "r", "", "Set custom release-name if possible")
@@ -195,7 +198,9 @@ $ astro deployment update UUID label=Production-Airflow --dag-deployment-type=vo
 		cmd.Flags().StringVarP(&dagDeploymentType, "dag-deployment-type", "t", "", "DAG Deployment mechanism: image, volume")
 		cmd.Flags().StringVarP(&nfsLocation, "nfs-location", "n", "", "NFS Volume Mount, specified as: <IP>:/<path>. Input is automatically prepended with 'nfs://' - do not include.")
 	}
-
+	if deployment.CheckTriggererEnabled(client) {
+		cmd.Flags().IntVarP(&triggererReplicas, "triggerer-replicas", "t", 0, "Number of replicas to use for triggerer airflow componenet, valid 0-2")
+	}
 	cmd.Flags().StringVarP(&cloudRole, "cloud-role", "c", "", "Set cloud role to annotate service accounts in deployment")
 	return cmd
 }
@@ -407,7 +412,7 @@ func deploymentCreate(cmd *cobra.Command, args []string, client *houston.Client,
 			return err
 		}
 	}
-	return deployment.Create(args[0], ws, releaseName, cloudRole, executorType, airflowVersion, dagDeploymentType, nfsLocation, client, out)
+	return deployment.Create(args[0], ws, releaseName, cloudRole, executorType, airflowVersion, dagDeploymentType, nfsLocation, triggererReplicas, client, out)
 }
 
 func deploymentDelete(cmd *cobra.Command, args []string, client *houston.Client, out io.Writer) error {
@@ -458,7 +463,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 			return err
 		}
 	}
-	return deployment.Update(args[0], cloudRole, argsMap, dagDeploymentType, nfsLocation, client, out)
+	return deployment.Update(args[0], cloudRole, argsMap, dagDeploymentType, nfsLocation, triggererReplicas, client, out)
 }
 
 func deploymentUserList(cmd *cobra.Command, client *houston.Client, out io.Writer, args []string) error {

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -100,6 +100,164 @@ func TestDeploymentCreateCommandNfsMountDisabled(t *testing.T) {
 	}
 }
 
+func TestDeploymentCreateCommandTriggererDisabled(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+    "appConfig": {"triggererEnabled": false},
+    "createDeployment": {
+      "airflowVersion": "2.2.0",
+      "config": {
+        "dagDeployment": {
+          "nfsLocation": "",
+          "type": "image"
+        },
+        "executor": "CeleryExecutor"
+      },
+      "createdAt": "2021-04-26T20:03:36.262Z",
+      "dagDeployment": {
+        "nfsLocation": "",
+        "type": "image"
+      },
+      "description": "",
+      "desiredAirflowVersion": "2.2.0",
+      "id": "cknz133ra49758zr9w34b87ua",
+      "label": "test",
+      "properties": {
+        "alert_emails": [
+          "andrii@astronomer.io"
+        ],
+        "component_version": "2.0.0"
+      },
+      "releaseName": "accurate-radioactivity-8677",
+      "status": null,
+      "type": "airflow",
+      "updatedAt": "2021-04-26T20:03:36.262Z",
+      "urls": [
+        {
+          "type": "airflow",
+          "url": "https://deployments.local.astronomer.io/accurate-radioactivity-8677/airflow"
+        },
+        {
+          "type": "flower",
+          "url": "https://deployments.local.astronomer.io/accurate-radioactivity-8677/flower"
+        }
+      ],
+      "version": "0.15.6",
+      "workspace": {
+        "id": "ckn4phn1k0104v5xtrer5lpli",
+        "label": "w1"
+      }
+    }
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	myTests := []struct {
+		cmdArgs        []string
+		expectedOutput string
+		expectedError  string
+	}{
+		{cmdArgs: []string{"deployment", "create", "new-deployment-name", "--executor=celery", "--triggerer-replicas=1"}, expectedOutput: "", expectedError: "unknown flag: --triggerer-replicas"},
+		{cmdArgs: []string{"deployment", "create", "new-deployment-name", "--executor=celery"}, expectedOutput: "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs", expectedError: ""},
+	}
+	for _, tt := range myTests {
+		_, output, err := executeCommandC(api, tt.cmdArgs...)
+		if tt.expectedError != "" {
+			assert.EqualError(t, err, tt.expectedError)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Contains(t, output, tt.expectedOutput)
+	}
+}
+
+func TestDeploymentCreateCommandTriggererEnabled(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+    "appConfig": {"triggererEnabled": true},
+    "createDeployment": {
+      "airflowVersion": "2.0.0",
+      "config": {
+        "dagDeployment": {
+          "nfsLocation": "",
+          "type": "image"
+        },
+        "executor": "CeleryExecutor"
+      },
+      "createdAt": "2021-04-26T20:03:36.262Z",
+      "dagDeployment": {
+        "nfsLocation": "",
+        "type": "image"
+      },
+      "description": "",
+      "desiredAirflowVersion": "2.0.0",
+      "id": "cknz133ra49758zr9w34b87ua",
+      "label": "test",
+      "properties": {
+        "alert_emails": [
+          "andrii@astronomer.io"
+        ],
+        "component_version": "2.0.0"
+      },
+      "releaseName": "accurate-radioactivity-8677",
+      "status": null,
+      "type": "airflow",
+      "updatedAt": "2021-04-26T20:03:36.262Z",
+      "urls": [
+        {
+          "type": "airflow",
+          "url": "https://deployments.local.astronomer.io/accurate-radioactivity-8677/airflow"
+        },
+        {
+          "type": "flower",
+          "url": "https://deployments.local.astronomer.io/accurate-radioactivity-8677/flower"
+        }
+      ],
+      "version": "0.15.6",
+      "workspace": {
+        "id": "ckn4phn1k0104v5xtrer5lpli",
+        "label": "w1"
+      }
+    }
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	myTests := []struct {
+		cmdArgs        []string
+		expectedOutput string
+		expectedError  string
+	}{
+		{cmdArgs: []string{"deployment", "create", "new-deployment-name", "--executor=celery", "--triggerer-replicas=1"}, expectedOutput: "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs", expectedError: ""},
+		{cmdArgs: []string{"deployment", "create", "new-deployment-name", "--executor=celery", "-t=1"}, expectedOutput: "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs", expectedError: ""},
+	}
+	for _, tt := range myTests {
+		_, output, err := executeCommandC(api, tt.cmdArgs...)
+		if tt.expectedError != "" {
+			assert.EqualError(t, err, tt.expectedError)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Contains(t, output, tt.expectedOutput)
+	}
+}
+
 func TestDeploymentCreateCommandNfsMountEnabled(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -337,7 +337,69 @@ func TestDeploymentCreateCommandNfsMountEnabled(t *testing.T) {
 		assert.Contains(t, output, tt.expectedOutput)
 	}
 }
+func TestDeploymentUpdateTriggererEnabledCommand(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+    "appConfig": {"triggererEnabled": true},
+    "updateDeployment": {
+      "createdAt": "2021-04-23T14:29:28.497Z",
+      "dagDeployment": {
+        "nfsLocation": "test:/test",
+        "type": "volume"
+      },
+      "description": "",
+      "id": "cknuetusw0018yqxto2jzxjqq",
+      "label": "test_dima22asdasd",
+      "releaseName": "amateur-instrument-9515",
+      "status": null,
+      "type": "airflow",
+      "updatedAt": "2021-04-26T21:42:35.361Z",
+      "urls": [
+        {
+          "type": "airflow",
+          "url": "https://deployments.local.astronomer.io/amateur-instrument-9515/airflow"
+        },
+        {
+          "type": "flower",
+          "url": "https://deployments.local.astronomer.io/amateur-instrument-9515/flower"
+        }
+      ],
+      "version": "0.15.6",
+      "workspace": {
+        "id": "ckn4phn1k0104v5xtrer5lpli"
+      }
+    }
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
 
+	myTests := []struct {
+		cmdArgs        []string
+		expectedOutput string
+		expectedError  string
+	}{
+		{cmdArgs: []string{"deployment", "update", "cknrml96n02523xr97ygj95n5", "label=test22222", "--triggerer-replicas=1"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
+		{cmdArgs: []string{"deployment", "update", "cknrml96n02523xr97ygj95n5", "label=test22222", "--t=1"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
+		{cmdArgs: []string{"deployment", "update", "cknrml96n02523xr97ygj95n5", "label=test22222"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
+	}
+	for _, tt := range myTests {
+		_, output, err := executeCommandC(api, tt.cmdArgs...)
+		if tt.expectedError != "" {
+			assert.EqualError(t, err, tt.expectedError)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Contains(t, output, tt.expectedOutput)
+	}
+}
 func TestDeploymentUpdateCommand(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -387,7 +387,7 @@ func TestDeploymentUpdateTriggererEnabledCommand(t *testing.T) {
 		expectedError  string
 	}{
 		{cmdArgs: []string{"deployment", "update", "cknrml96n02523xr97ygj95n5", "label=test22222", "--triggerer-replicas=1"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
-		{cmdArgs: []string{"deployment", "update", "cknrml96n02523xr97ygj95n5", "label=test22222", "--t=1"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
+		{cmdArgs: []string{"deployment", "update", "cknrml96n02523xr97ygj95n5", "label=test22222", "-t=1"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
 		{cmdArgs: []string{"deployment", "update", "cknrml96n02523xr97ygj95n5", "label=test22222"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
 	}
 	for _, tt := range myTests {

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -97,6 +97,15 @@ func CheckPreCreateNamespaceDeployment(client *houston.Client) bool {
 	return appConfig.ManualNamespaceNames
 }
 
+func CheckTriggererEnabled(client *houston.Client) bool {
+	logrus.Debug("Checking for triggerer flag")
+	appConfig, err := AppConfig(client)
+	if err != nil {
+		return false
+	}
+	return appConfig.TriggererEnabled
+}
+
 // Create airflow deployment
 func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDeploymentType, nfsLocation string, client *houston.Client, out io.Writer) error {
 	vars := map[string]interface{}{"label": label, "workspaceId": ws, "executor": executor, "cloudRole": cloudRole}

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -107,7 +107,7 @@ func CheckTriggererEnabled(client *houston.Client) bool {
 }
 
 // Create airflow deployment
-func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDeploymentType, nfsLocation string, client *houston.Client, out io.Writer) error {
+func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDeploymentType, nfsLocation string, triggererReplicas int, client *houston.Client, out io.Writer) error {
 	vars := map[string]interface{}{"label": label, "workspaceId": ws, "executor": executor, "cloudRole": cloudRole}
 
 	if CheckPreCreateNamespaceDeployment(client) {
@@ -128,6 +128,10 @@ func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDepl
 
 	if dagDeploymentType == "volume" && nfsLocation != "" {
 		vars["dagDeployment"] = map[string]string{"nfsLocation": nfsLocation, "type": dagDeploymentType}
+	}
+
+	if CheckTriggererEnabled(client) {
+		vars["triggererReplicas"] = triggererReplicas
 	}
 	req := houston.Request{
 		Query:     houston.DeploymentCreateRequest,
@@ -291,7 +295,7 @@ func List(ws string, all bool, client *houston.Client, out io.Writer) error {
 }
 
 // Update an airflow deployment
-func Update(id, cloudRole string, args map[string]string, dagDeploymentType, nfsLocation string, client *houston.Client, out io.Writer) error {
+func Update(id, cloudRole string, args map[string]string, dagDeploymentType, nfsLocation string, triggererReplicas int, client *houston.Client, out io.Writer) error {
 	vars := map[string]interface{}{"deploymentId": id, "payload": args, "cloudRole": cloudRole}
 
 	// sync with commander only when we have cloudRole
@@ -301,6 +305,10 @@ func Update(id, cloudRole string, args map[string]string, dagDeploymentType, nfs
 
 	if dagDeploymentType != "" {
 		vars["dagDeployment"] = map[string]string{"nfsLocation": nfsLocation, "type": dagDeploymentType}
+	}
+
+	if CheckTriggererEnabled(client) {
+		vars["triggererReplicas"] = triggererReplicas
 	}
 
 	req := houston.Request{

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -1239,7 +1239,7 @@ func TestCheckTriggererEnabledError(t *testing.T) {
 		}
 	})
 	api := houston.NewHoustonClient(client)
-	assert.Equal(t, false, CheckHardDeleteDeployment(api))
+	assert.Equal(t, false, CheckTriggererEnabled(api))
 }
 func TestGetDeploymentSelectionNamespaces(t *testing.T) {
 	testUtil.InitTestConfig()

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -1225,8 +1225,8 @@ func TestCheckTriggererEnabled(t *testing.T) {
 	})
 	api := houston.NewHoustonClient(client)
 
-	hardDelete := CheckTriggererEnabled(api)
-	assert.Equal(t, true, hardDelete)
+	triggererEnabled := CheckTriggererEnabled(api)
+	assert.Equal(t, true, triggererEnabled)
 }
 
 func TestCheckTriggererEnabledError(t *testing.T) {

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -204,6 +204,73 @@ func TestCreate(t *testing.T) {
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
 
+func TestCreateTriggererEnabled(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+			"appConfig": {
+				"version": "0.15.1",
+				"baseDomain": "local.astronomer.io",
+				"smtpConfigured": true,
+				"manualReleaseNames": false,
+				"hardDeleteDeployment": true,
+				"manualNamespaceNames": false,
+				"triggererEnabled": true
+			},
+			    "createDeployment": {
+			"id": "ckbv818oa00r107606ywhoqtw",
+			"executor": "CeleryExecutor",
+			"urls": [
+        {
+          "type": "airflow",
+          "url": "https://deployments.local.astronomer.io/boreal-penumbra-1102/airflow"
+        },
+        {
+          "type": "flower",
+          "url": "https://deployments.local.astronomer.io/boreal-penumbra-1102/flower"
+        }
+      ],
+      "properties": {
+        "component_version": "0.0.0",
+        "alert_emails": []
+      },
+      "description": "",
+      "label": "test2",
+      "releaseName": "boreal-penumbra-1102",
+      "status": null,
+      "type": "airflow",
+      "version": "0.0.0",
+      "workspace": {
+        "id": "ckbv7zvb100pe0760xp98qnh9",
+        "label": "w1"
+      },
+      "createdAt": "2020-06-25T20:10:33.898Z",
+      "updatedAt": "2020-06-25T20:10:33.898Z"
+    }
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	label := "label"
+	ws := "ck1qg6whg001r08691y117hub"
+	releaseName := ""
+	role := "test-role"
+	executor := "CeleryExecutor"
+	airflowVersion := "1.10.5"
+	dagDeploymentType := "image"
+	nfsLocation := ""
+	buf := new(bytes.Buffer)
+	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 1, api, buf)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
+}
+
 func TestCreateWithNFSLocation(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
@@ -626,6 +693,82 @@ func TestUpdate(t *testing.T) {
 	for _, tt := range myTests {
 		buf := new(bytes.Buffer)
 		err := Update(id, role, tt.deploymentConfig, tt.dagDeploymentType, "", 0, api, buf)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, buf.String())
+	}
+}
+
+func TestUpdateTriggerer(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+  "appConfig": {
+    "version": "0.15.1",
+     "baseDomain": "local.astronomer.io",
+     "smtpConfigured": true, 
+     "manualReleaseNames": false,
+     "hardDeleteDeployment": true,
+     "manualNamespaceNames": true,
+     "triggererEnabled": true
+	},
+    "updateDeployment": {
+			"id": "ckbv801t300qh0760pck7ea0c",
+			"executor": "CeleryExecutor",
+			"urls": [
+        {
+          "type": "airflow",
+          "url": "https://deployments.local.astronomer.io/burning-terrestrial-5940/airflow"
+        },
+        {
+          "type": "flower",
+          "url": "https://deployments.local.astronomer.io/burning-terrestrial-5940/flower"
+        }
+      ],
+      "properties": {
+        "component_version": "0.0.0",
+        "alert_emails": []
+      },
+      "description": "",
+      "label": "test123",
+      "releaseName": "burning-terrestrial-5940",
+      "status": null,
+      "type": "airflow",
+      "version": "0.0.0",
+      "workspace": {
+        "id": "ckbv7zvb100pe0760xp98qnh9"
+      },
+      "createdAt": "2020-06-25T20:09:38.341Z",
+      "updatedAt": "2020-06-25T20:54:15.592Z"
+    }
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	id := "ck1qg6whg001r08691y117hub"
+	role := "test-role"
+
+	expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG     AIRFLOW VERSION     
+ test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c             %!s(MISSING)
+
+ Successfully updated deployment
+`
+	myTests := []struct {
+		deploymentConfig  map[string]string
+		dagDeploymentType string
+		expectedOutput    string
+	}{
+		{deploymentConfig: map[string]string{"executor": "CeleryExecutor"}, dagDeploymentType: "", expectedOutput: expected},
+		{deploymentConfig: map[string]string{"executor": "CeleryExecutor"}, dagDeploymentType: "image", expectedOutput: expected},
+	}
+	for _, tt := range myTests {
+		buf := new(bytes.Buffer)
+		err := Update(id, role, tt.deploymentConfig, tt.dagDeploymentType, "", 1, api, buf)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, buf.String())
 	}
@@ -1059,6 +1202,45 @@ func TestCheckHardDeleteDeploymentError(t *testing.T) {
 	assert.Equal(t, false, CheckHardDeleteDeployment(api))
 }
 
+func TestCheckTriggererEnabled(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+    "appConfig": {
+      "version": "0.15.1",
+      "baseDomain": "local.astronomer.io",
+      "smtpConfigured": true,
+      "manualReleaseNames": false,
+      "hardDeleteDeployment": true,
+      "triggererEnabled": true
+    }
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+
+	hardDelete := CheckTriggererEnabled(api)
+	assert.Equal(t, true, hardDelete)
+}
+
+func TestCheckTriggererEnabledError(t *testing.T) {
+	testUtil.InitTestConfig()
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 500,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(``)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	assert.Equal(t, false, CheckHardDeleteDeployment(api))
+}
 func TestGetDeploymentSelectionNamespaces(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -199,7 +199,7 @@ func TestCreate(t *testing.T) {
 	dagDeploymentType := "image"
 	nfsLocation := ""
 	buf := new(bytes.Buffer)
-	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, api, buf)
+	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
@@ -265,7 +265,7 @@ func TestCreateWithNFSLocation(t *testing.T) {
 	dagDeploymentType := "volume"
 	nfsLocation := "test:/test"
 	buf := new(bytes.Buffer)
-	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, api, buf)
+	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
@@ -356,7 +356,7 @@ func TestCreateWithPreCreateNamespaceDeployment(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, api, buf)
+	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
@@ -447,7 +447,7 @@ func TestCreateWithPreCreateNamespaceDeploymentError(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, api, buf)
+	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
 	assert.EqualError(t, err, "Number is out of available range")
 }
 
@@ -470,7 +470,7 @@ func TestCreateHoustonError(t *testing.T) {
 	dagDeploymentType := "image"
 	nfsLocation := ""
 	buf := new(bytes.Buffer)
-	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, api, buf)
+	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
 	assert.EqualError(t, err, "API error (500): Internal Server Error")
 }
 
@@ -559,6 +559,15 @@ func TestUpdate(t *testing.T) {
 	testUtil.InitTestConfig()
 	okResponse := `{
   "data": {
+  "appConfig": {
+    "version": "0.15.1",
+     "baseDomain": "local.astronomer.io",
+     "smtpConfigured": true, 
+     "manualReleaseNames": false,
+     "hardDeleteDeployment": true,
+     "manualNamespaceNames": true,
+     "triggererEnabled": false
+	},
     "updateDeployment": {
 			"id": "ckbv801t300qh0760pck7ea0c",
 			"executor": "CeleryExecutor",
@@ -616,7 +625,7 @@ func TestUpdate(t *testing.T) {
 	}
 	for _, tt := range myTests {
 		buf := new(bytes.Buffer)
-		err := Update(id, role, tt.deploymentConfig, tt.dagDeploymentType, "", api, buf)
+		err := Update(id, role, tt.deploymentConfig, tt.dagDeploymentType, "", 0, api, buf)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, buf.String())
 	}
@@ -638,7 +647,7 @@ func TestUpdateError(t *testing.T) {
 	deploymentConfig["executor"] = "CeleryExecutor"
 
 	buf := new(bytes.Buffer)
-	err := Update(id, role, deploymentConfig, "", "", api, buf)
+	err := Update(id, role, deploymentConfig, "", "", 0, api, buf)
 
 	assert.EqualError(t, err, "API error (500): Internal Server Error")
 }

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -198,8 +198,9 @@ func TestCreate(t *testing.T) {
 	airflowVersion := "1.10.5"
 	dagDeploymentType := "image"
 	nfsLocation := ""
+	triggerReplicas := 0
 	buf := new(bytes.Buffer)
-	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
+	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, triggerReplicas, api, buf)
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
@@ -265,8 +266,9 @@ func TestCreateTriggererEnabled(t *testing.T) {
 	airflowVersion := "1.10.5"
 	dagDeploymentType := "image"
 	nfsLocation := ""
+	triggerReplicas := 1
 	buf := new(bytes.Buffer)
-	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 1, api, buf)
+	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, triggerReplicas, api, buf)
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
@@ -331,8 +333,9 @@ func TestCreateWithNFSLocation(t *testing.T) {
 	airflowVersion := "1.10.5"
 	dagDeploymentType := "volume"
 	nfsLocation := "test:/test"
+	triggerReplicas := 0
 	buf := new(bytes.Buffer)
-	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
+	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, triggerReplicas, api, buf)
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
@@ -405,6 +408,7 @@ func TestCreateWithPreCreateNamespaceDeployment(t *testing.T) {
 	airflowVersion := "1.10.5"
 	dagDeploymentType := "volume"
 	nfsLocation := "test:/test"
+	triggerReplicas := 0
 	buf := new(bytes.Buffer)
 
 	// mock os.Stdin
@@ -423,7 +427,7 @@ func TestCreateWithPreCreateNamespaceDeployment(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
+	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, triggerReplicas, api, buf)
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 }
@@ -496,6 +500,7 @@ func TestCreateWithPreCreateNamespaceDeploymentError(t *testing.T) {
 	airflowVersion := "1.10.5"
 	dagDeploymentType := "volume"
 	nfsLocation := "test:/test"
+	triggerReplicas := 0
 	buf := new(bytes.Buffer)
 
 	// mock os.Stdin
@@ -514,7 +519,7 @@ func TestCreateWithPreCreateNamespaceDeploymentError(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
+	err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, triggerReplicas, api, buf)
 	assert.EqualError(t, err, "Number is out of available range")
 }
 
@@ -536,8 +541,9 @@ func TestCreateHoustonError(t *testing.T) {
 	airflowVersion := "1.10.5"
 	dagDeploymentType := "image"
 	nfsLocation := ""
+	triggerReplicas := 0
 	buf := new(bytes.Buffer)
-	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, 0, api, buf)
+	err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, triggerReplicas, api, buf)
 	assert.EqualError(t, err, "API error (500): Internal Server Error")
 }
 

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -559,6 +559,7 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: Str
 			nfsMountDagDeployment
 			manualNamespaceNames
 			hardDeleteDeployment
+			triggererEnabled
 		}
 	}`
 )

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -28,6 +28,7 @@ var (
 		$config: JSON
 		$cloudRole: String
 		$dagDeployment: DagDeployment
+		$triggererReplicas: Int
 	) {
 		createDeployment(
 			label: $label
@@ -40,6 +41,9 @@ var (
 			config: $config
 			cloudRole: $cloudRole
 			dagDeployment: $dagDeployment
+			triggerer: {
+				replicas: $triggererReplicas
+			}
 		) {
 			id
 			type
@@ -127,8 +131,8 @@ var (
 	}`
 
 	DeploymentUpdateRequest = `
-mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: String, $dagDeployment: DagDeployment) {
-		updateDeployment(deploymentUuid: $deploymentId, payload: $payload, cloudRole: $cloudRole, dagDeployment: $dagDeployment) {
+mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: String, $dagDeployment: DagDeployment, $triggererReplicas: Int) {
+		updateDeployment(deploymentUuid: $deploymentId, payload: $payload, cloudRole: $cloudRole, dagDeployment: $dagDeployment, triggerer:{ replicas: $triggererReplicas }) {
 			id
 			type
 			label

--- a/houston/types.go
+++ b/houston/types.go
@@ -280,6 +280,7 @@ type AppConfig struct {
 	NfsMountDagDeployment  bool   `json:"nfsMountDagDeployment"`
 	HardDeleteDeployment   bool   `json:"hardDeleteDeployment"`
 	ManualNamespaceNames   bool   `json:"manualNamespaceNames"`
+	TriggererEnabled       bool   `json:"triggererEnabled"`
 }
 
 // coerce a string into SemVer if possible


### PR DESCRIPTION
## Description

> adds triggerer-replicas option to create/update cli 

## 🎟 Issue(s)

Related astronomer/issues#3467

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

```
Usage:
  astro deployment create DEPLOYMENT [flags]

Aliases:
  create, cr

Examples:

# Create new deployment with Celery executor (default: celery without params).
  $ astro deployment create new-deployment-name --executor=celery

# Create new deployment with Local executor.
  $ astro deployment create new-deployment-name-local --executor=local

# Create new deployment with Kubernetes executor.
  $ astro deployment create new-deployment-name-k8s --executor=k8s

# Create new deployment with Kubernetes executor.
  $ astro deployment create my-new-deployment --executor=k8s --airflow-version=1.10.10


Flags:
  -a, --airflow-version string   Add desired airflow version parameter: e.g: 1.10.5 or 1.10.7
  -c, --cloud-role string        Set cloud role to annotate service accounts in deployment
  -e, --executor string          Add executor parameter: local, celery, or kubernetes
  -h, --help                     help for create
  -r, --release-name string      Set custom release-name if possible
  -t, --triggerer-replicas int   Number of replicas to use for triggerer airflow componenet, valid 0-2

Global Flags:
      --skip-version-check    skip version compatibility check
      --verbosity string      Log level (debug, info, warn, error, fatal, panic (default "warning")
      --workspace-id string   workspace assigned to deployment
```
create:
```
 ./astro deployment create my-new-deploymen3 --executor=k8s --airflow-version=2.2.0 -t 1 --skip-version-check
 NAME                  DEPLOYMENT NAME      ASTRO      DEPLOYMENT ID                 TAG     AIRFLOW VERSION     
 my-new-deploymen3     boreal-axis-1138     0.17.1     cktxdvi9s0213jvy2c7sr1izl     -       2.2.0               

 Successfully created deployment with Kubernetes executor. Deployment can be accessed at the following URLs 

 Airflow Dashboard: https://deployments.local.astronomer.io/boreal-axis-1138/airflow
```


update:
```
./astro deployment update "cktx613az02573ny28m4khroe" label="my-new-deployment-update" -t=0 --skip-version-check
 NAME                         DEPLOYMENT NAME        ASTRO      DEPLOYMENT ID                 TAG       AIRFLOW VERSION     
 my-new-deployment-update     empty-perigee-5436     0.17.1     cktx613az02573ny28m4khroe     2.2.0     %!s(MISSING)

 Successfully updated deployment
```

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
