### PR TITLE
Feature/homebrew trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,12 +44,27 @@ jobs:
       - run:
           name: goreleaser
           command: curl -sL https://git.io/goreleaser | bash
+  release-homebrew:
+    docker:
+      - image: circleci/golang:1.13
+    working_directory: /go/src/github.com/astronomer/astro-cli
+    steps:
+      - checkout
+      - run:
+          name: goreleaser
+          command: curl -sL https://git.io/goreleaser | bash -s -- --config=.goreleaser-release.yml
+
 workflows:
   version: 2.1
   build-images:
     jobs:
       - test
       - approve-release:
+          type: approval
+          filters:
+            branches:
+              only: "/release-.*/"
+      - approve-real-release:
           type: approval
           filters:
             branches:
@@ -63,6 +78,17 @@ workflows:
             branches:
               only: "/release-.*/"
       - release:
+          context:
+            - github-repo
+          # Only run this job on git tag pushes
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+      - release-homebrew:
+          requires:
+            - approve-real-release
           context:
             - github-repo
           # Only run this job on git tag pushes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,9 @@ workflows:
           filters:
             branches:
               only: "/release-.*/"
+          requires:
+            - approve-pre-release
+            - new-tag
       - new-tag:
           context:
             - github-repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - commit-next-tag
-  release:
+  pre-release:
     docker:
       - image: circleci/golang:1.13
     working_directory: /go/src/github.com/astronomer/astro-cli
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: goreleaser
           command: curl -sL https://git.io/goreleaser | bash
-  release-homebrew:
+  release:
     docker:
       - image: circleci/golang:1.13
     working_directory: /go/src/github.com/astronomer/astro-cli
@@ -59,12 +59,12 @@ workflows:
   build-images:
     jobs:
       - test
-      - approve-release:
+      - approve-pre-release:
           type: approval
           filters:
             branches:
               only: "/release-.*/"
-      - approve-real-release:
+      - approve-release:
           type: approval
           filters:
             branches:
@@ -73,11 +73,11 @@ workflows:
           context:
             - github-repo
           requires:
-            - approve-release
+            - approve-pre-release
           filters:
             branches:
               only: "/release-.*/"
-      - release:
+      - pre-release:
           context:
             - github-repo
           # Only run this job on git tag pushes
@@ -86,9 +86,9 @@ workflows:
               ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-      - release-homebrew:
+      - release:
           requires:
-            - approve-real-release
+            - approve-release
           context:
             - github-repo
           # Only run this job on git tag pushes

--- a/.goreleaser-release.yml
+++ b/.goreleaser-release.yml
@@ -1,0 +1,52 @@
+---
+project_name: astro
+release:
+  github:
+    owner: astronomer
+    name: astro-cli
+  # If set to auto, will mark the release as not ready for production
+  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  prerelease: false
+build:
+  main: main.go
+  binary: astro
+  env:
+    - CGO_ENABLED=0
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - 386
+    - amd64
+  goarm:
+    - 7
+  ldflags: -s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }} -X github.com/astronomer/astro-cli/version.CurrCommit={{ .Commit }}
+brews:
+  - tap:
+      owner: astronomer
+      name: homebrew-tap
+    folder: Formula
+    homepage: https://astronomer.io
+    description: To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API.
+    test: |
+      system "#{bin}/astro version"
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    files:
+      - licence*
+      - LICENCE*
+      - license*
+      - LICENSE*
+      - readme*
+      - README*
+      - changelog*
+      - CHANGELOG*
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'


### PR DESCRIPTION
## Description

> configuration to try to test creating a pre-release and release approval ci jobs that when we want to do a pre-release it will update it as such and then on release it will update pre-release to release and release to homebrew

## 🎟 Issue(s)

Related astronomer/issues#3480

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
