### PR TITLE
Add AUR package to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ brew install astronomer/tap/astro
 ```
 curl -sSL https://install.astronomer.io | sudo bash -s
 ```
+#### For arch linux systems, via AUR
+
+There is an AUR package for astro-cli available [here](https://aur.archlinux.org/packages/astro-cli/).
+You can install it with an AUR helper like so:
+```
+yay -S astro-cli
+```
 
 ### Previous Versions
 


### PR DESCRIPTION
## Description
I added an aur package for installing astro-cli [here](https://aur.archlinux.org/packages/astro-cli/). I'm happy to pass ownership of this over to you if you'd like.

I'm not a fan of curl into sudo bash, and this allows the package to be managed by a package manager.

The full PKGBUILD is available here https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=astro-cli .

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
