### PR TITLE
fixed default airflow image tag behaviour

### DIFF
--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var tagOrder = []string{"buster-onbuild", "onbuild", "buster"}
+var tagPrefixOrder = []string{"buster-onbuild", "onbuild", "buster"}
 
 // GetDefaultImageTag returns default airflow image tag
 func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, error) {
@@ -17,11 +17,11 @@ func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, erro
 		return "", err
 	}
 
-	availableTag := []string{}
+	availableTags := []string{}
 	vs := make(AirflowVersions, len(resp.AvailableReleases))
 	for i, r := range resp.AvailableReleases {
 		if r.Version == airflowVersion {
-			availableTag = r.Tags
+			availableTags = r.Tags
 			break
 		}
 		v, err := NewAirflowVersion(r.Version, r.Tags)
@@ -34,22 +34,22 @@ func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, erro
 	if airflowVersion == "" && len(vs) != 0 {
 		sort.Sort(vs)
 		selectedVersion = vs[len(vs)-1]
-		availableTag = selectedVersion.tags
+		availableTags = selectedVersion.tags
 	} else {
-		selectedVersion, err = NewAirflowVersion(airflowVersion, availableTag)
+		selectedVersion, err = NewAirflowVersion(airflowVersion, availableTags)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	for tagIndex := range tagOrder {
-		for i := range availableTag {
-			if strings.HasPrefix(availableTag[i], selectedVersion.Coerce()) && strings.HasSuffix(availableTag[i], tagOrder[tagIndex]) {
-				return fmt.Sprintf("%s-%s", selectedVersion.Coerce(), tagOrder[tagIndex]), nil
+	for tagIndex := range tagPrefixOrder {
+		for idx := range availableTags {
+			if strings.HasPrefix(availableTags[idx], selectedVersion.Coerce()) && strings.HasSuffix(availableTags[idx], tagPrefixOrder[tagIndex]) {
+				return fmt.Sprintf("%s-%s", selectedVersion.Coerce(), tagPrefixOrder[tagIndex]), nil
 			}
 		}
 	}
 
-	// Case when airflowVersion requested is not present in certified astronomer endpoint, but is valid version as per Houston configuration
+	// case when airflowVersion requested is not present in certified astronomer endpoint, but is valid version as per Houston configuration
 	return airflowVersion, nil
 }

--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -3,6 +3,11 @@ package airflowversions
 import (
 	"fmt"
 	"sort"
+	"strings"
+)
+
+var (
+	tagOrder = []string{"buster-onbuild", "onbuild", "buster"}
 )
 
 // GetDefaultImageTag returns default airflow image tag
@@ -14,15 +19,32 @@ func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, erro
 		return "", err
 	}
 
+	availableTag := []string{}
 	vs := make(AirflowVersions, len(resp.AvailableReleases))
 	for i, r := range resp.AvailableReleases {
+		if r.Version == airflowVersion {
+			availableTag = r.Tags
+			break
+		}
 		v, err := NewAirflowVersion(r.Version, r.Tags)
 		if err == nil {
 			vs[i] = v
 		}
 	}
 
-	sort.Sort(vs)
-	maxAvailableVersion := vs[len(vs)-1]
-	return fmt.Sprintf("%s-buster-onbuild", maxAvailableVersion.Coerce()), nil
+	selectedVersion := &AirflowVersion{}
+	if len(availableTag) <= 0 || airflowVersion != "" {
+		sort.Sort(vs)
+		selectedVersion = vs[len(vs)-1]
+		availableTag = selectedVersion.tags
+	}
+
+	for i := range availableTag {
+		for tagIndex := range tagOrder {
+			if strings.HasPrefix(availableTag[i], selectedVersion.Coerce()) && strings.HasSuffix(availableTag[i], tagOrder[tagIndex]) {
+				return fmt.Sprintf("%s-%s", selectedVersion.Coerce(), tagOrder[tagIndex]), nil
+			}
+		}
+	}
+	return fmt.Sprintf("%s", selectedVersion.Coerce()), nil
 }

--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -6,9 +6,7 @@ import (
 	"strings"
 )
 
-var (
-	tagOrder = []string{"buster-onbuild", "onbuild", "buster"}
-)
+var tagOrder = []string{"buster-onbuild", "onbuild", "buster"}
 
 // GetDefaultImageTag returns default airflow image tag
 func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, error) {
@@ -32,19 +30,26 @@ func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, erro
 		}
 	}
 
-	selectedVersion := &AirflowVersion{}
-	if len(availableTag) <= 0 || airflowVersion != "" {
+	var selectedVersion *AirflowVersion
+	if airflowVersion == "" && len(vs) != 0 {
 		sort.Sort(vs)
 		selectedVersion = vs[len(vs)-1]
 		availableTag = selectedVersion.tags
+	} else {
+		selectedVersion, err = NewAirflowVersion(airflowVersion, availableTag)
+		if err != nil {
+			return "", err
+		}
 	}
 
-	for i := range availableTag {
-		for tagIndex := range tagOrder {
+	for tagIndex := range tagOrder {
+		for i := range availableTag {
 			if strings.HasPrefix(availableTag[i], selectedVersion.Coerce()) && strings.HasSuffix(availableTag[i], tagOrder[tagIndex]) {
 				return fmt.Sprintf("%s-%s", selectedVersion.Coerce(), tagOrder[tagIndex]), nil
 			}
 		}
 	}
-	return fmt.Sprintf("%s", selectedVersion.Coerce()), nil
+
+	// Case when airflowVersion requested is not present in certified astronomer endpoint, but is valid version as per Houston configuration
+	return airflowVersion, nil
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowversions.Client, houstonClient *houston.Client, out io.Writer) (string, error) {
+func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowversions.Client, houstonClient *houston.Client, _ io.Writer) (string, error) {
 	r := houston.Request{
 		Query: houston.DeploymentInfoRequest,
 	}
@@ -24,10 +24,10 @@ func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowver
 		}
 	} else if airflowVersion != "" {
 		switch t := err; t {
-		default:
-			return "", err
 		case houston.ErrVerboseInaptPermissions:
 			return "", errors.New("the --airflow-version flag is not supported if you're not authenticated to Astronomer. Please authenticate and try again")
+		default:
+			return "", err
 		}
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 	"strings"
 
@@ -12,8 +11,6 @@ import (
 )
 
 func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowversions.Client, houstonClient *houston.Client, out io.Writer) (string, error) {
-	defaultImageTag, _ := airflowversions.GetDefaultImageTag(httpClient, "")
-
 	r := houston.Request{
 		Query: houston.DeploymentInfoRequest,
 	}
@@ -25,11 +22,6 @@ func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowver
 		if airflowVersion != "" && !acceptableVersion(airflowVersion, acceptableAirflowVersions) {
 			return "", errors.Errorf(messages.ErrInvalidAirflowVersion, strings.Join(acceptableAirflowVersions, ", "))
 		}
-		if airflowVersion == "" {
-			defaultImageTag = ""
-		} else {
-			defaultImageTag = fmt.Sprintf("%s-buster-onbuild", airflowVersion)
-		}
 	} else if airflowVersion != "" {
 		switch t := err; t {
 		default:
@@ -39,9 +31,10 @@ func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowver
 		}
 	}
 
+	defaultImageTag, _ := airflowversions.GetDefaultImageTag(httpClient, airflowVersion)
+
 	if defaultImageTag == "" {
 		defaultImageTag = "2.0.0-buster-onbuild"
-		fmt.Fprintf(out, "Initializing Airflow project\nNot connected to Astronomer, pulling Airflow development files from %s\n", defaultImageTag)
 	}
 	return defaultImageTag, nil
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowversions.Client, houstonClient *houston.Client, _ io.Writer) (string, error) {
+func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowversions.Client, houstonClient *houston.Client, out io.Writer) (string, error) {
 	r := houston.Request{
 		Query: houston.DeploymentInfoRequest,
 	}
@@ -35,6 +36,7 @@ func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowver
 
 	if defaultImageTag == "" {
 		defaultImageTag = "2.0.0-buster-onbuild"
+		fmt.Fprintf(out, "Initializing Airflow project, pulling Airflow development files from %s\n", defaultImageTag)
 	}
 	return defaultImageTag, nil
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -78,11 +78,75 @@ func Test_prepareDefaultAirflowImageTag(t *testing.T) {
 		expectedImageTag string
 		expectedError    string
 	}{
-		{airflowVersion: "1.10.14", expectedImageTag: "1.10.14-buster-onbuild", expectedError: ""},
-		{airflowVersion: "1.10.15", expectedImageTag: "1.10.15-buster-onbuild", expectedError: ""},
-		{airflowVersion: "", expectedImageTag: "2.0.0-buster-onbuild", expectedError: ""},
-		{airflowVersion: "2.0.2", expectedImageTag: "2.0.2-buster-onbuild", expectedError: ""},
+		{airflowVersion: "1.10.14", expectedImageTag: "1.10.14", expectedError: ""},
+		{airflowVersion: "1.10.15", expectedImageTag: "1.10.15", expectedError: ""},
+		{airflowVersion: "", expectedImageTag: "1.10.5-buster-onbuild", expectedError: ""},
+		{airflowVersion: "2.0.2", expectedImageTag: "2.0.2", expectedError: ""},
 		{airflowVersion: "9.9.9", expectedImageTag: "", expectedError: "Unsupported Airflow Version specified. Please choose from: 2.1.0, 2.0.2, 2.0.0, 1.10.15, 1.10.14, 1.10.12, 1.10.10, 1.10.7, 1.10.5 \n"},
+	}
+	for _, tt := range myTests {
+		defaultTag, err := prepareDefaultAirflowImageTag(tt.airflowVersion, httpClient, api, output)
+		if tt.expectedError != "" {
+			assert.EqualError(t, err, tt.expectedError)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, tt.expectedImageTag, defaultTag)
+	}
+}
+
+func Test_fallbackDefaultAirflowImageTag(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	// prepare fake response from updates.astronomer.io
+	okResponse := `{
+  "version": "1.0",
+  "available_releases": []
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	httpClient := airflowversions.NewClient(client)
+
+	// prepare fake response from houston
+	ok := `{
+	"data": {
+		"deploymentConfig": {
+				"airflowVersions": [
+					"2.1.0",
+					"2.0.2",
+					"2.0.0",
+					"1.10.15",
+					"1.10.14",
+					"1.10.12",
+					"1.10.10",
+					"1.10.7",
+					"1.10.5"
+				]
+			}
+		}
+	}`
+	houstonClient := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(ok)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(houstonClient)
+
+	output := new(bytes.Buffer)
+
+	myTests := []struct {
+		airflowVersion   string
+		expectedImageTag string
+		expectedError    string
+	}{
+		{airflowVersion: "", expectedImageTag: "2.0.0-buster-onbuild", expectedError: ""},
 	}
 	for _, tt := range myTests {
 		defaultTag, err := prepareDefaultAirflowImageTag(tt.airflowVersion, httpClient, api, output)


### PR DESCRIPTION
## Description

Updated behavior of selecting default airflow image and its corresponding tag, will rely on the tags returned from astronomer-certified endpoint rather than hardcoding it in code

## 🎟 Issue(s)

Related astronomer/issues#3748

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
