### PR TITLE
fix: cannot use syscall.Stdin (type syscall.Handle) as type int in argument to terminal.ReadPassword

### DIFF
--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -23,7 +23,7 @@ func Text(promptText string) string {
 // Password requests a users passord, does not print out what they entered, and returns it
 func Password(promptText string) (string, error) {
 	fmt.Print(promptText)
-	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin)) // nolint: unconvert
 	if err != nil {
 		return "", err
 	}

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -23,7 +23,7 @@ func Text(promptText string) string {
 // Password requests a users passord, does not print out what they entered, and returns it
 func Password(promptText string) (string, error) {
 	fmt.Print(promptText)
-	bytePassword, err := terminal.ReadPassword(syscall.Stdin)
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
fix https://app.circleci.com/pipelines/github/astronomer/astro-cli/798/workflows/06126152-9324-40cb-9174-f4a84bc78e32/jobs/1162