### PR TITLE
Add triggerer to astro dev

### DIFF
--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -93,4 +93,32 @@ services:
       - {{ .AirflowHome }}/include:/usr/local/airflow/include:{{ .MountLabel }}
       - airflow_logs:/usr/local/airflow/logs
     {{ .AirflowEnvFile }}
+{{if .TriggererEnabled}}
+  triggerer:
+    image: {{ .AirflowImage }}
+    command: >
+      bash -c "(airflow upgradedb || airflow db upgrade) && airflow triggerer"
+    restart: unless-stopped
+    networks:
+      - airflow
+    user: {{ .AirflowUser }}
+    labels:
+      io.astronomer.docker: "true"
+      io.astronomer.docker.cli: "true"
+      io.astronomer.docker.component: "airflow-triggerer"
+    depends_on:
+      - postgres
+    environment:
+      AIRFLOW__CORE__EXECUTOR: LocalExecutor
+      AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@{{ .PostgresHost }}:5432
+      AIRFLOW__CORE__LOAD_EXAMPLES: "False"
+      AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+      AIRFLOW__WEBSERVER__RBAC: "True"
+    volumes:
+      - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:{{ .MountLabel }}
+      - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:{{ .MountLabel }}
+      - {{ .AirflowHome }}/include:/usr/local/airflow/include:{{ .MountLabel }}
+      - airflow_logs:/usr/local/airflow/logs
+    {{ .AirflowEnvFile }}
+{{end}}
 `)


### PR DESCRIPTION
resolves https://github.com/astronomer/issues/issues/3682#event-5605643776

> Enable triggerer only if airflow >= 2.2.0

**TODO:**

- [ ] add tests
- [ ] update logs flags
- [x] astro dev ps

```
astro-cli dev ps
Name                                    State           Ports
t202111112132512d0e5f_scheduler_1       Up 11 minutes
t202111112132512d0e5f_triggerer_1       Up 11 minutes
t202111112132512d0e5f_webserver_1       Up 11 minutes   0.0.0.0:8080->8080/tcp, :::8080->8080/tcp
t202111112132512d0e5f_postgres_1        Up 11 minutes   0.0.0.0:5432->5432/tcp, :::5432->5432/tcp
```

- [x] astro dev start
