### PR TITLE
fixed URL validation for update deployment

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -485,7 +485,7 @@ func deploymentCreate(cmd *cobra.Command, args []string, client *houston.Client,
 
 	// we should validate only in case when this feature has been enabled
 	if nfsMountDAGDeploymentEnabled || gitSyncDAGDeploymentEnabled {
-		err = validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL)
+		err = validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL, false)
 		if err != nil {
 			return err
 		}
@@ -546,7 +546,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 
 	// we should validate only in case when this feature has been enabled
 	if nfsMountDAGDeploymentEnabled || gitSyncDAGDeploymentEnabled {
-		err = validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL)
+		err = validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL, true)
 		if err != nil {
 			return err
 		}

--- a/cmd/validation.go
+++ b/cmd/validation.go
@@ -133,25 +133,26 @@ func validateRole(role string) error {
 	return errors.Errorf("please use one of: %s", strings.Join(validRoles, ", "))
 }
 
-func validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL string) error {
+func validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL string, acceptEmptyArgs bool) error {
 	if dagDeploymentType != imageDeploymentType && dagDeploymentType != volumeDeploymentType && dagDeploymentType != gitSyncDeploymentType && dagDeploymentType != "" {
 		return errors.New("please specify the correct DAG deployment type, one of the following: image, volume, git_sync")
 	}
 	if dagDeploymentType == volumeDeploymentType && nfsLocation == "" {
 		return errors.New("please specify the nfs location via --nfs-location flag")
 	}
-	if dagDeploymentType == gitSyncDeploymentType && !validURL(gitRepoURL) {
+	if dagDeploymentType == gitSyncDeploymentType && !validURL(gitRepoURL, acceptEmptyArgs) {
 		return errors.New("please specify a valid git repository URL via --git-repository-url")
 	}
 	return nil
 }
 
 // validURL will validate whether the URL's scheme is a known Git transport
-func validURL(gitURL string) bool {
-	if gitURL == "" {
+func validURL(gitURL string, acceptEmptyURL bool) bool {
+	if !acceptEmptyURL && gitURL == "" {
 		return false
+	} else if acceptEmptyURL && gitURL == "" {
+		return true
 	}
-
 	u, err := giturls.Parse(gitURL)
 	if err != nil {
 		return false

--- a/cmd/validation_test.go
+++ b/cmd/validation_test.go
@@ -24,6 +24,7 @@ func TestValidateValidRole(t *testing.T) {
 func TestValidateDagDeploymentArgs(t *testing.T) {
 	myTests := []struct {
 		dagDeploymentType, nfsLocation, gitRepoURL string
+		acceptEmptyArgs                            bool
 		expectedOutput                             string
 		expectedError                              error
 	}{
@@ -35,10 +36,11 @@ func TestValidateDagDeploymentArgs(t *testing.T) {
 		{dagDeploymentType: "git_sync", gitRepoURL: "ssh://login@server.com:8080/~/private-airflow-dags-test.git", expectedError: nil},
 		{dagDeploymentType: "git_sync", gitRepoURL: "user@server.com:path/to/repo.git", expectedError: nil},
 		{dagDeploymentType: "git_sync", gitRepoURL: "git://server.com/~user/path/to/repo.git/", expectedError: nil},
+		{dagDeploymentType: "git_sync", gitRepoURL: "", acceptEmptyArgs: true, expectedError: nil},
 	}
 
 	for _, tt := range myTests {
-		actualError := validateDagDeploymentArgs(tt.dagDeploymentType, tt.nfsLocation, tt.gitRepoURL)
+		actualError := validateDagDeploymentArgs(tt.dagDeploymentType, tt.nfsLocation, tt.gitRepoURL, tt.acceptEmptyArgs)
 		assert.NoError(t, actualError, "optional message here")
 	}
 }
@@ -46,6 +48,7 @@ func TestValidateDagDeploymentArgs(t *testing.T) {
 func TestValidateDagDeploymentArgsErrors(t *testing.T) {
 	myTests := []struct {
 		dagDeploymentType, nfsLocation, gitRepoURL string
+		acceptEmptyArgs                            bool
 		expectedOutput                             string
 		expectedError                              string
 	}{
@@ -58,7 +61,7 @@ func TestValidateDagDeploymentArgsErrors(t *testing.T) {
 	}
 
 	for _, tt := range myTests {
-		actualError := validateDagDeploymentArgs(tt.dagDeploymentType, tt.nfsLocation, tt.gitRepoURL)
+		actualError := validateDagDeploymentArgs(tt.dagDeploymentType, tt.nfsLocation, tt.gitRepoURL, tt.acceptEmptyArgs)
 		if tt.expectedError != "" {
 			assert.EqualError(t, actualError, tt.expectedError, "optional message here")
 		} else {


### PR DESCRIPTION
## Description

> Fixed the validation logic to allow empty git URL in case it's been called from the update deployment command

## 🎟 Issue(s)

Related astronomer/issues#3780

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
