### PR TITLE
fixed global config set command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,49 +12,46 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var globalFlag bool
+
 func newConfigRootCmd(_ *houston.Client, out io.Writer) *cobra.Command {
-	var globalFlag bool
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage project configuration",
 		Long:  "Manage project configuration",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			ensureGlobalFlag(cmd, args, globalFlag)
+			ensureGlobalFlag(cmd, args)
 		},
 	}
 	cmd.PersistentFlags().BoolVarP(&globalFlag, "global", "g", false, "view or modify global config")
 	cmd.AddCommand(
-		newConfigGetCmd(out, globalFlag),
-		newConfigSetCmd(out, globalFlag),
+		newConfigGetCmd(out),
+		newConfigSetCmd(out),
 	)
 	return cmd
 }
 
-func newConfigGetCmd(_ io.Writer, globalFlag bool) *cobra.Command {
+func newConfigGetCmd(_ io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get project configuration",
 		Long:  "Get project configuration",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return configGet(cmd, args, globalFlag)
-		},
+		RunE:  configGet,
 	}
 	return cmd
 }
 
-func newConfigSetCmd(_ io.Writer, globalFlag bool) *cobra.Command {
+func newConfigSetCmd(_ io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set",
 		Short: "Set project configuration",
 		Long:  "Set project configuration",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return configSet(cmd, args, globalFlag)
-		},
+		RunE:  configSet,
 	}
 	return cmd
 }
 
-func ensureGlobalFlag(cmd *cobra.Command, args []string, globalFlag bool) {
+func ensureGlobalFlag(cmd *cobra.Command, args []string) {
 	isProjectDir, _ := config.IsProjectDir(config.WorkingPath)
 
 	if !isProjectDir && !globalFlag {
@@ -64,7 +61,7 @@ func ensureGlobalFlag(cmd *cobra.Command, args []string, globalFlag bool) {
 	}
 }
 
-func configGet(cmd *cobra.Command, args []string, globalFlag bool) error {
+func configGet(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New(messages.ErrMissingConfigPathKey)
 	}
@@ -86,7 +83,7 @@ func configGet(cmd *cobra.Command, args []string, globalFlag bool) error {
 	return nil
 }
 
-func configSet(cmd *cobra.Command, args []string, globalFlag bool) error {
+func configSet(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 { // nolint:gomnd
 		return errors.New(messages.ConfigInvalidSetArgs)
 	}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -34,8 +34,8 @@ func TestConfigSetCommandFailure(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestConfigSetCommandFailurePrjConfig(t *testing.T) {
+func TestConfigSetCommandSuccess(t *testing.T) {
 	testUtil.InitTestConfig()
 	_, err := executeCommand("config", "set", "-g", "project.name", "testing")
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description
Changes:
- Fixed global config flag used in set & get commands
- Fixed `TestConfigSetCommandFailurePrjConfig` test case, as the actual code implementation does not feature having a configuration with just local scope

## 🎟 Issue(s)

Related astronomer/issues#3821

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
