### PR TITLE
fixed the import reference

### DIFF
--- a/airflow_versions/airflow_versions_test.go
+++ b/airflow_versions/airflow_versions_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Masterminds/semver"
+	semver "github.com/Masterminds/semver/v3"
 )
 
 func TestGetDefaultImageTag(t *testing.T) {


### PR DESCRIPTION
## Description

Missed out merging last week main changes in podman branch, since there was no active development on podman branch as well.

## 🎟 Issue(s)

Related astronomer/issues#XXXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
