### PR TITLE
fixed repo name prefix as per docker naming standards

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/astronomer/astro-cli/airflow/include"
 	"github.com/astronomer/astro-cli/config"
@@ -20,6 +21,8 @@ const (
 	defaultAirflowVersion = uint64(0x1) //nolint:gomnd
 	componentName         = "airflow"
 )
+
+var repoNameSanitizeRegexp = regexp.MustCompile(`^[^a-z0-9]*`) // must not start with anything except lowercase letter or number
 
 func initDirs(root string, dirs []string) error {
 	// Create the dirs
@@ -121,10 +124,15 @@ func ParseVersionFromDockerFile(airflowHome, dockerfile string) (uint64, error) 
 
 // repositoryName creates an airflow repository name
 func repositoryName(name string) string {
-	return fmt.Sprintf("%s/%s", name, componentName)
+	return fmt.Sprintf("%s/%s", sanitizeRepoName(name), componentName)
 }
 
 // imageName creates an airflow image name
 func imageName(name, tag string) string {
 	return fmt.Sprintf("%s:%s", repositoryName(name), tag)
+}
+
+// sanitizeRepoName updates the repoName to be compatible with docker image naming convention
+func sanitizeRepoName(repoName string) string {
+	return repoNameSanitizeRegexp.ReplaceAllString(repoName, "")
 }

--- a/airflow/airflow_test.go
+++ b/airflow/airflow_test.go
@@ -153,3 +153,41 @@ func Test_airflowVersionFromDockerFile(t *testing.T) {
 		})
 	}
 }
+
+func Test_repositoryName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		expectedResult string
+	}{
+		{
+			name:           "repo name with alphanumeric only",
+			args:           args{name: "testing123"},
+			expectedResult: "testing123/airflow",
+		},
+		{
+			name:           "repo name starting with alphanumeric",
+			args:           args{name: "testing-123_test"},
+			expectedResult: "testing-123_test/airflow",
+		},
+		{
+			name:           "repo name starting with dot",
+			args:           args{name: ".testing-123_test"},
+			expectedResult: "testing-123_test/airflow",
+		},
+		{
+			name:           "repo name starting with underscore",
+			args:           args{name: "_testing-123_test"},
+			expectedResult: "testing-123_test/airflow",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := repositoryName(tt.args.name)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Changes:
- Fixed the repo name prefix to be inline with docker naming standards, which expects the image name to start with either lowercase letter or a number.

## 🎟 Issue(s)

Related astronomer/issues#3749

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
