### PR TITLE
fix worker component name

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -136,7 +136,7 @@ func schedulerRemoteLogs(cmd *cobra.Command, args []string) error {
 
 func workersRemoteLogs(cmd *cobra.Command, args []string) error {
 	if follow {
-		return logs.SubscribeDeploymentLog(args[0], "workers", search, since)
+		return logs.SubscribeDeploymentLog(args[0], "worker", search, since)
 	}
-	return logs.DeploymentLog(args[0], "workers", search, since)
+	return logs.DeploymentLog(args[0], "worker", search, since)
 }


### PR DESCRIPTION
## Description

Changes:
- Fixed component name passed to Houston for fetching worker logs from `workers` => `worker`

## 🎟 Issue(s)

Related astronomer/issues#3684

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
