### PR TITLE
added changes required to support Podman on RHEL

### DIFF
--- a/airflow/include/podconfigyml.go
+++ b/airflow/include/podconfigyml.go
@@ -75,6 +75,8 @@ spec:
       readOnlyRootFilesystem: false
       runAsGroup: 50000
       runAsUser: 50000
+      seLinuxOptions:
+        type: spc_t
     volumeMounts:
     - mountPath: /usr/local/airflow/dags
       name: airflow-dags-dir
@@ -138,6 +140,8 @@ spec:
       readOnlyRootFilesystem: false
       runAsGroup: 50000
       runAsUser: 50000
+      seLinuxOptions:
+        type: spc_t
     volumeMounts:
     - mountPath: /usr/local/airflow/dags
       name: airflow-dags-dir

--- a/airflow/mocks/PodmanBind.go
+++ b/airflow/mocks/PodmanBind.go
@@ -132,29 +132,6 @@ func (_m *PodmanBind) Kube(ctx context.Context, path string, options *play.KubeO
 	return r0, r1
 }
 
-// KubeDown provides a mock function with given fields: ctx, path
-func (_m *PodmanBind) KubeDown(ctx context.Context, path string) (*entities.PlayKubeReport, error) {
-	ret := _m.Called(ctx, path)
-
-	var r0 *entities.PlayKubeReport
-	if rf, ok := ret.Get(0).(func(context.Context, string) *entities.PlayKubeReport); ok {
-		r0 = rf(ctx, path)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*entities.PlayKubeReport)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, path)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // List provides a mock function with given fields: ctx, options
 func (_m *PodmanBind) List(ctx context.Context, options *containers.ListOptions) ([]entities.ListContainer, error) {
 	ret := _m.Called(ctx, options)
@@ -241,6 +218,29 @@ func (_m *PodmanBind) Push(ctx context.Context, source string, destination strin
 	}
 
 	return r0
+}
+
+// Remove provides a mock function with given fields: ctx, nameOrID, options
+func (_m *PodmanBind) Remove(ctx context.Context, nameOrID string, options *pods.RemoveOptions) (*entities.PodRmReport, error) {
+	ret := _m.Called(ctx, nameOrID, options)
+
+	var r0 *entities.PodRmReport
+	if rf, ok := ret.Get(0).(func(context.Context, string, *pods.RemoveOptions) *entities.PodRmReport); ok {
+		r0 = rf(ctx, nameOrID, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entities.PodRmReport)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, *pods.RemoveOptions) error); ok {
+		r1 = rf(ctx, nameOrID, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Start provides a mock function with given fields: ctx, nameOrID, options

--- a/airflow/podman_bindings.go
+++ b/airflow/podman_bindings.go
@@ -25,10 +25,10 @@ type PodmanBind interface {
 	List(ctx context.Context, options *containers.ListOptions) ([]entities.ListContainer, error)
 	Logs(ctx context.Context, nameOrID string, options *containers.LogOptions, stdoutChan, stderrChan chan string) error
 	Kube(ctx context.Context, path string, options *play.KubeOptions) (*entities.PlayKubeReport, error)
-	KubeDown(ctx context.Context, path string) (*entities.PlayKubeReport, error)
 	Stop(ctx context.Context, nameOrID string, options *pods.StopOptions) (*entities.PodStopReport, error)
 	Exists(ctx context.Context, nameOrID string, options *pods.ExistsOptions) (bool, error)
 	Start(ctx context.Context, nameOrID string, options *pods.StartOptions) (*entities.PodStartReport, error)
+	Remove(ctx context.Context, nameOrID string, options *pods.RemoveOptions) (*entities.PodRmReport, error)
 	// Methods to handle image operations
 	Build(ctx context.Context, containerFiles []string, options entities.BuildOptions) (*entities.BuildReport, error)
 	Tag(ctx context.Context, nameOrID, tag, repo string, options *images.TagOptions) error
@@ -76,6 +76,10 @@ func (p *PodmanBinder) Exists(ctx context.Context, nameOrID string, options *pod
 
 func (p *PodmanBinder) Start(ctx context.Context, nameOrID string, options *pods.StartOptions) (*entities.PodStartReport, error) {
 	return pods.Start(ctx, nameOrID, options)
+}
+
+func (p *PodmanBinder) Remove(ctx context.Context, nameOrID string, options *pods.RemoveOptions) (*entities.PodRmReport, error) {
+	return pods.Remove(ctx, nameOrID, options)
 }
 
 func (p *PodmanBinder) Build(ctx context.Context, containerFiles []string, options entities.BuildOptions) (*entities.BuildReport, error) { //nolint:gocritic

--- a/airflow/podman_image.go
+++ b/airflow/podman_image.go
@@ -54,6 +54,7 @@ func (p *PodmanImage) Build(path string) error {
 		Output:                  imageName(p.imageName, "latest"),
 		Quiet:                   false,
 		CommonBuildOpts:         &buildah.CommonBuildOptions{},
+		OutputFormat:            buildah.Dockerv2ImageManifest,
 	}
 	options := entities.BuildOptions{BuildOptions: buildahOpts}
 	_, err = p.podmanBind.Build(p.conn, []string{filepath.Join(projectDir, "Dockerfile")}, options)

--- a/airflow/podman_test.go
+++ b/airflow/podman_test.go
@@ -161,15 +161,15 @@ func TestPodmanKillSuccess(t *testing.T) {
 	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
 	config.InitConfig(fs)
 
-	mockResp := &entities.PlayKubeReport{
-		Pods:    []entities.PlayKubePod{{ID: "test-1", Containers: []string{"websever-id", "scheduler-id", "postgres-id"}}},
-		Volumes: []entities.PlayKubeVolume{{Name: "test-volume"}},
+	mockResp := &entities.PodRmReport{
+		Err: nil,
+		Id:  "testing",
 	}
 
 	bindMock := new(mocks.PodmanBind)
 	bindMock.On("NewConnection", mock.Anything, mock.Anything).Return(context.TODO(), nil)
 	podmanMock := &Podman{projectDir: "test", projectName: "test", envFile: ".env", podmanBind: bindMock, conn: context.TODO()}
-	bindMock.On("KubeDown", podmanMock.conn, mock.Anything).Return(mockResp, nil).Once()
+	bindMock.On("Remove", podmanMock.conn, mock.Anything, mock.Anything).Return(mockResp, nil).Once()
 
 	err := podmanMock.Kill()
 	assert.NoError(t, err)
@@ -184,7 +184,7 @@ func TestPodmanKillFailure(t *testing.T) {
 	bindMock := new(mocks.PodmanBind)
 	bindMock.On("NewConnection", mock.Anything, mock.Anything).Return(context.TODO(), nil)
 	podmanMock := &Podman{projectDir: "test", projectName: "test", envFile: ".env", podmanBind: bindMock, conn: context.TODO()}
-	bindMock.On("KubeDown", podmanMock.conn, mock.Anything).Return(&entities.PlayKubeReport{}, errPodman).Once()
+	bindMock.On("Remove", podmanMock.conn, mock.Anything, mock.Anything).Return(&entities.PodRmReport{}, errPodman).Once()
 
 	err := podmanMock.Kill()
 	assert.Contains(t, err.Error(), errPodman.Error())


### PR DESCRIPTION
## Description

Changes:
- disabled labels from volume mounting by adding `type: spc_t` for RHEL, as adding `:z` or `:Z` options to mountPath is not supported in non-SELinux based OS (Ubuntu, macOS)
- set built image format to `Dockerv2ImageManifest` which wasn't the default value at least in RHEL and is needed as per Houston logic in `astro deploy` logic
- had to move from `kube --down` to `pod rm` in order to kill local airflow dev setup, as kube down options is only present in 3.4.x and latest Podman version in RHEL is still 3.3.x
- updated podman mocks to include `pod rm` function

## 🎟 Issue(s)

Related astronomer/issues#3425

## 🧪 Functional Testing

Have tested these changes in RHEL with Podman versions 3.1.x, 3.2.x, 3.3.x, and also in Ubuntu & MacOS with additional Podman version 3.4.x.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
