### PR TITLE
added mod flag to pick dependency from vendor

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,8 @@ build:
     - amd64
   goarm:
     - 7
+  flags:
+    - -mod=vendor
   ldflags: -s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }} -X github.com/astronomer/astro-cli/version.CurrCommit={{ .Commit }}
   tags:
     - containers_image_openpgp


### PR DESCRIPTION
## Description

Changes:
- added -mod=vendor flag to goreleaser as it is running on 1.13 version
Context:
```
-mod mode
                module download mode to use: readonly, vendor, or mod.
                By default, if a vendor directory is present and the go version in go.mod
                is 1.14 or higher, the go command acts as if -mod=vendor were set.
                Otherwise, the go command acts as if -mod=readonly were set.
                See https://golang.org/ref/mod#build-commands for details.
```

## 🎟 Issue(s)

Related astronomer/issues#XXXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
