### PR TITLE
fixing issues with golang sys in docker dependency

### DIFF
--- a/vendor/github.com/docker/docker/pkg/system/filesys_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/filesys_windows.go
@@ -11,7 +11,6 @@ import (
 	"time"
 	"unsafe"
 
-	winio "github.com/Microsoft/go-winio"
 	"golang.org/x/sys/windows"
 )
 
@@ -104,13 +103,13 @@ func mkdirall(path string, applyACL bool, sddl string) error {
 // and Local System.
 func mkdirWithACL(name string, sddl string) error {
 	sa := windows.SecurityAttributes{Length: 0}
-	sd, err := winio.SddlToSecurityDescriptor(sddl)
+	sd, err := windows.SecurityDescriptorFromString(sddl)
 	if err != nil {
 		return &os.PathError{Op: "mkdir", Path: name, Err: err}
 	}
 	sa.Length = uint32(unsafe.Sizeof(sa))
 	sa.InheritHandle = 1
-	sa.SecurityDescriptor = uintptr(unsafe.Pointer(&sd[0]))
+	sa.SecurityDescriptor = sd
 
 	namep, err := windows.UTF16PtrFromString(name)
 	if err != nil {


### PR DESCRIPTION
## Description
Fixed failing build on windows caused because of upgrade in golang/sys as we had included Podman dependency in our repo, can't backport to older sys as other dependency don't allow it, hence fixing it in docker dependency itself.

Build error: vendor/github.com/docker/docker/pkg/system/filesys_windows.go:113:24: cannot use uintptr(unsafe.Pointer(&sd[0])) (type uintptr) as type *"golang.org/x/sys/windows".SECURITY_DESCRIPTOR in assignment

Change reference: https://github.com/moby/moby/pull/40021/files#diff-31c7821daf0eebb430bf1ac78f405f70e92c63e39de3cb603982d4cd1986be75R103-R113

## 🎟 Issue(s)

Related astronomer/issues#3425

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
