### PR TITLE
Added ServiceAccount in workspace rolebinding response and showing it…

### DIFF
--- a/houston/queries.go
+++ b/houston/queries.go
@@ -401,6 +401,10 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: Str
                   id
                   username
         		}
+				serviceAccount {
+					id
+					label
+				}
       		}
 		}
 	}`

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -396,16 +396,16 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: Str
 			createdAt
 			updatedAt
 			roleBindings {
-        		role
-  				user {
-                  id
-                  username
-        		}
+				role
+				user {
+					id
+					username
+				}
 				serviceAccount {
 					id
 					label
 				}
-      		}
+			}
 		}
 	}`
 

--- a/houston/types.go
+++ b/houston/types.go
@@ -217,6 +217,10 @@ type RoleBinding struct {
 		ID       string `json:"id"`
 		Username string `json:"username"`
 	} `json:"user"`
+	ServiceAccount struct {
+		ID	string	`json:"id"`
+		Label	string	`json:"label"`
+	} `json:"serviceAccount"`
 	Deployment Deployment `json:"deployment"`
 }
 

--- a/houston/types.go
+++ b/houston/types.go
@@ -218,7 +218,7 @@ type RoleBinding struct {
 		Username string `json:"username"`
 	} `json:"user"`
 	ServiceAccount WorkspaceServiceAccount `json:"serviceAccount"`
-	Deployment     Deployment               `json:"deployment"`
+	Deployment     Deployment              `json:"deployment"`
 }
 
 // Workspace contains all components of an Astronomer Workspace

--- a/houston/types.go
+++ b/houston/types.go
@@ -217,11 +217,8 @@ type RoleBinding struct {
 		ID       string `json:"id"`
 		Username string `json:"username"`
 	} `json:"user"`
-	ServiceAccount struct {
-		ID	string	`json:"id"`
-		Label	string	`json:"label"`
-	} `json:"serviceAccount"`
-	Deployment Deployment `json:"deployment"`
+	ServiceAccount *WorkspaceServiceAccount `json:"serviceAccount"`
+	Deployment     Deployment               `json:"deployment"`
 }
 
 // Workspace contains all components of an Astronomer Workspace

--- a/houston/types.go
+++ b/houston/types.go
@@ -217,7 +217,7 @@ type RoleBinding struct {
 		ID       string `json:"id"`
 		Username string `json:"username"`
 	} `json:"user"`
-	ServiceAccount *WorkspaceServiceAccount `json:"serviceAccount"`
+	ServiceAccount WorkspaceServiceAccount `json:"serviceAccount"`
 	Deployment     Deployment               `json:"deployment"`
 }
 

--- a/workspace/user.go
+++ b/workspace/user.go
@@ -81,7 +81,7 @@ func ListRoles(workspaceID string, client *houston.Client, out io.Writer) error 
 	for i := range workspace.RoleBindings {
 		role := workspace.RoleBindings[i]
 		var color bool
-		if len(role.User.Username) != 0 {
+		if role.User.Username != "" {
 			tab.AddRow([]string{role.User.Username, role.User.ID, role.Role}, color)
 		} else {
 			tab.AddRow([]string{role.ServiceAccount.Label, role.ServiceAccount.ID, role.Role}, color)

--- a/workspace/user.go
+++ b/workspace/user.go
@@ -81,9 +81,12 @@ func ListRoles(workspaceID string, client *houston.Client, out io.Writer) error 
 	for i := range workspace.RoleBindings {
 		role := workspace.RoleBindings[i]
 		var color bool
-		tab.AddRow([]string{role.User.Username, role.User.ID, role.Role}, color)
+		if len(role.User.Username) != 0 {
+			tab.AddRow([]string{role.User.Username, role.User.ID, role.Role}, color)
+		} else {
+			tab.AddRow([]string{role.ServiceAccount.Label, role.ServiceAccount.ID, role.Role}, color)
+		}
 	}
-
 	tab.Print(out)
 	return nil
 }

--- a/workspace/user_test.go
+++ b/workspace/user_test.go
@@ -160,6 +160,73 @@ func TestListRoles(t *testing.T) {
 	assert.Equal(t, expected, buf.String())
 }
 
+func TestListRolesWithServiceAccounts(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+  "data": {
+    "workspaces": [
+      {
+        "id": "ckbv7zvb100pe0760xp98qnh9",
+        "label": "w1",
+        "description": "",
+        "createdAt": "2020-06-25T20:09:29.917Z",
+        "updatedAt": "2020-06-25T20:09:29.917Z",
+        "roleBindings": [
+          {
+            "role": "WORKSPACE_ADMIN",
+            "user": {
+              "id": "ckbv7zpkh00og0760ki4mhl6r",
+              "username": "andrii@astronomer.io"
+            }
+          },
+		  {
+            "role": "WORKSPACE_ADMIN",
+            "serviceAccount": {
+              "id": "ckxaolfky0822zsvcrgts3c6a",
+              "label": "WA1"
+            }
+          }
+        ]
+      },
+      {
+        "id": "ckbv8pwbq00wk0760us7ktcgd",
+        "label": "wwww",
+        "description": "",
+        "createdAt": "2020-06-25T20:29:44.294Z",
+        "updatedAt": "2020-06-25T20:29:44.294Z",
+        "roleBindings": [
+          {
+            "role": "WORKSPACE_ADMIN",
+            "user": {
+              "id": "ckbv7zpkh00og0760ki4mhl6r",
+              "username": "andriiii@astronomer.io"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	wsID := "ck1qg6whg001r08691y117hub"
+
+	buf := new(bytes.Buffer)
+	err := ListRoles(wsID, api, buf)
+	assert.NoError(t, err)
+	expected := ` USERNAME                 ID                            ROLE                
+ andrii@astronomer.io     ckbv7zpkh00og0760ki4mhl6r     WORKSPACE_ADMIN     
+ WA1                      ckxaolfky0822zsvcrgts3c6a     WORKSPACE_ADMIN     
+`
+	assert.Equal(t, expected, buf.String())
+}
+
 func TestListRolesError(t *testing.T) {
 	testUtil.InitTestConfig()
 


### PR DESCRIPTION
… in user list command

## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related astronomer/issues#3631

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.
Tested the user list command on my local machine

## 📸 Screenshots
<img width="1489" alt="Screenshot 2021-12-18 at 5 54 29 PM" src="https://user-images.githubusercontent.com/95576577/146640909-d2c884b6-f59b-4f14-8391-689fcb14ba8d.png">

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
