### PR TITLE
fixed postgres host for docker airflow setup

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -83,7 +83,7 @@ services:
       - postgres
     environment:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
-      AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://postgres:postgres@0.0.0.0:5432
+      AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://postgres:postgres@postgres:5432
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
     volumes:
@@ -115,7 +115,7 @@ services:
       - postgres
     environment:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
-      AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://postgres:postgres@0.0.0.0:5432
+      AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://postgres:postgres@postgres:5432
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
       AIRFLOW__WEBSERVER__RBAC: "True"

--- a/airflow/include/podconfigyml.go
+++ b/airflow/include/podconfigyml.go
@@ -56,7 +56,7 @@ spec:
     - name: AIRFLOW_HOME
       value: /usr/local/airflow
     - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
-      value: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@{{ .PostgresHost }}:5432
+      value: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@localhost:5432
     - name: AIRFLOW__CORE__LOAD_EXAMPLES
       value: "False"
     - name: ASTRONOMER_USER
@@ -125,7 +125,7 @@ spec:
     - name: AIRFLOW__CORE__FERNET_KEY
       value: d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw=
     - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
-      value: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@{{ .PostgresHost }}:5432
+      value: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@localhost:5432
     - name: AIRFLOW_SNOWFLAKE_PARTNER
       value: ASTRONOMER
     - name: AIRFLOW__CORE__LOAD_EXAMPLES

--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ var (
 		LocalOrbit:          newCfg("local.orbit", ""),
 		PostgresUser:        newCfg("postgres.user", "postgres"),
 		PostgresPassword:    newCfg("postgres.password", "postgres"),
-		PostgresHost:        newCfg("postgres.host", "0.0.0.0"),
+		PostgresHost:        newCfg("postgres.host", "postgres"),
 		PostgresPort:        newCfg("postgres.port", "5432"),
 		ProjectDeployment:   newCfg("project.deployment", ""),
 		ProjectName:         newCfg("project.name", ""),


### PR DESCRIPTION
## Description

Changes:
- Moved the default value for `postgres.host` back to `postgres`
- Pointed postgres host in webserver & scheduler of Podman containers to `localhost`, as there is no need for postgres.host since all containers run in the same pod.

## 🎟 Issue(s)

Related astronomer/issues#3929

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
