### PR TITLE
Fixed image parsing logic

### DIFF
--- a/docker/parse.go
+++ b/docker/parse.go
@@ -118,11 +118,10 @@ func parseImageName(imageName string) (baseImage, tag string) {
 	if ok {
 		baseImage = parsedName.Name()
 	}
+	tag = "latest"
 	parsedTag, ok := ref.(reference.Tagged)
 	if ok {
 		tag = parsedTag.Tag()
-	} else {
-		tag = "latest"
 	}
 	return baseImage, tag
 }

--- a/docker/parse_test.go
+++ b/docker/parse_test.go
@@ -72,3 +72,23 @@ func TestGetImageTagFromParsedFile(t *testing.T) {
 	assert.Equal(t, "quay.io/astronomer/ap-airflow", image)
 	assert.Equal(t, "2.0.0-buster-onbuild", tag)
 }
+
+func TestParseImageName(t *testing.T) {
+	tests := []struct {
+		imageName         string
+		expectedBaseImage string
+		expectedTag       string
+	}{
+		{imageName: "localhost:5000/airflow:latest", expectedBaseImage: "localhost:5000/airflow", expectedTag: "latest"},
+		{imageName: "localhost/airflow:1.2.0", expectedBaseImage: "localhost/airflow", expectedTag: "1.2.0"},
+		{imageName: "quay.io:5000/airflow", expectedBaseImage: "quay.io:5000/airflow", expectedTag: "latest"},
+		{imageName: "airflow:latest", expectedBaseImage: "airflow", expectedTag: "latest"},
+		{imageName: "airflow", expectedBaseImage: "airflow", expectedTag: "latest"},
+	}
+
+	for _, tt := range tests {
+		baseImage, tag := parseImageName(tt.imageName)
+		assert.Equal(t, tt.expectedBaseImage, baseImage)
+		assert.Equal(t, tt.expectedTag, tag)
+	}
+}


### PR DESCRIPTION
## Description

Changes:
- Fixed logic with parsing image name from Dockerfile to fix issues with ports being in hostname, panic when no tag is present.

## 🎟 Issue(s)

Related astronomer/issues#926
Related astronomer/issues#3473
Related astronomer/issues#3605

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
