### PR TITLE
Add support Mac with M1 chips

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ build:
   goarch:
     - 386
     - amd64
+    - arm64
   goarm:
     - 7
   flags:


### PR DESCRIPTION
https://github.com/astronomer/issues/issues/3323



practically works:
```
 astro-cli git:(add-support-for-m1-chips) ls -la dist
total 136976
drwxr-xr-x  23 andrii  staff      736 Dec 23 12:48 .
drwxr-xr-x  49 andrii  staff     1568 Dec 23 12:47 ..
-rw-r--r--   1 andrii  staff      251 Dec 23 12:47 CHANGELOG.md
-rw-------   1 andrii  staff     6487 Dec 23 12:48 artifacts.json
-rw-r--r--   1 andrii  staff     1635 Dec 23 12:48 astro.rb
-rw-r--r--   1 andrii  staff      819 Dec 23 12:48 astro_0.27.1-test_checksums.txt
-rw-r--r--   1 andrii  staff  8413825 Dec 23 12:48 astro_0.27.1-test_darwin_amd64.tar.gz
-rw-r--r--   1 andrii  staff  8355711 Dec 23 12:48 astro_0.27.1-test_darwin_arm64.tar.gz
-rw-r--r--   1 andrii  staff  7995075 Dec 23 12:48 astro_0.27.1-test_linux_386.tar.gz
-rw-r--r--   1 andrii  staff  8433290 Dec 23 12:48 astro_0.27.1-test_linux_amd64.tar.gz
-rw-r--r--   1 andrii  staff  7778279 Dec 23 12:48 astro_0.27.1-test_linux_arm64.tar.gz
-rw-r--r--   1 andrii  staff  8340536 Dec 23 12:48 astro_0.27.1-test_windows_386.zip
-rw-r--r--   1 andrii  staff  8552052 Dec 23 12:48 astro_0.27.1-test_windows_amd64.zip
-rw-r--r--   1 andrii  staff  7870530 Dec 23 12:48 astro_0.27.1-test_windows_arm64.zip
drwxr-xr-x   3 andrii  staff       96 Dec 23 12:48 astro_darwin_amd64
drwxr-xr-x   3 andrii  staff       96 Dec 23 12:48 astro_darwin_arm64
drwxr-xr-x   3 andrii  staff       96 Dec 23 12:48 astro_linux_386
drwxr-xr-x   3 andrii  staff       96 Dec 23 12:48 astro_linux_amd64
drwxr-xr-x   3 andrii  staff       96 Dec 23 12:48 astro_linux_arm64
drwxr-xr-x   3 andrii  staff       96 Dec 23 12:48 astro_windows_386
drwxr-xr-x   3 andrii  staff       96 Dec 23 12:48 astro_windows_amd64
drwxr-xr-x   3 andrii  staff       96 Dec 23 12:48 astro_windows_arm64
-rw-r--r--   1 andrii  staff     4213 Dec 23 12:47 config.yaml
```