### PR TITLE
moved goreleaser to go1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - commit-next-tag
   release:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.17
     working_directory: /go/src/github.com/astronomer/astro-cli
     steps:
       - checkout


### PR DESCRIPTION
## Description

Changes:
- Moved goreleaser to go1.17 as required golang version to build the repo after compose-go migration is 1.16


## 🎟 Issue(s)

Related astronomer/issues#3915

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
