### PR TITLE
added missing verbosity flag logic

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -54,12 +54,12 @@ func newAirflowRootCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	cmd.AddCommand(
 		newAirflowInitCmd(client, out),
 		newAirflowDeployCmd(),
-		newAirflowStartCmd(),
-		newAirflowKillCmd(),
-		newAirflowLogsCmd(),
-		newAirflowStopCmd(),
-		newAirflowPSCmd(),
-		newAirflowRunCmd(),
+		newAirflowStartCmd(out),
+		newAirflowKillCmd(out),
+		newAirflowLogsCmd(out),
+		newAirflowStopCmd(out),
+		newAirflowPSCmd(out),
+		newAirflowRunCmd(out),
 	)
 	return cmd
 }
@@ -74,13 +74,13 @@ func newDevRootCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	cmd.AddCommand(
 		newAirflowInitCmd(client, out),
 		newAirflowDeployCmd(),
-		newAirflowStartCmd(),
-		newAirflowKillCmd(),
-		newAirflowLogsCmd(),
-		newAirflowStopCmd(),
-		newAirflowPSCmd(),
-		newAirflowRunCmd(),
-		newAirflowUpgradeCheckCmd(),
+		newAirflowStartCmd(out),
+		newAirflowKillCmd(out),
+		newAirflowLogsCmd(out),
+		newAirflowStopCmd(out),
+		newAirflowPSCmd(out),
+		newAirflowRunCmd(out),
+		newAirflowUpgradeCheckCmd(out),
 	)
 	return cmd
 }
@@ -93,7 +93,8 @@ func newAirflowInitCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return airflowInit(cmd, args, client, out)
@@ -124,7 +125,7 @@ func newAirflowDeployCmd() *cobra.Command {
 	return cmd
 }
 
-func newAirflowStartCmd() *cobra.Command {
+func newAirflowStartCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start an Airflow cluster locally using docker-compose",
@@ -132,7 +133,8 @@ func newAirflowStartCmd() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowStart,
@@ -141,14 +143,15 @@ func newAirflowStartCmd() *cobra.Command {
 	return cmd
 }
 
-func newAirflowKillCmd() *cobra.Command {
+func newAirflowKillCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kill",
 		Short: "Kill a locally running Airflow cluster",
 		Long:  "Kill a locally running Airflow cluster",
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowKill,
@@ -156,14 +159,15 @@ func newAirflowKillCmd() *cobra.Command {
 	return cmd
 }
 
-func newAirflowLogsCmd() *cobra.Command {
+func newAirflowLogsCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs",
 		Short: "Output logs for a locally running Airflow cluster",
 		Long:  "Output logs for a locally running Airflow cluster",
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowLogs,
@@ -174,14 +178,15 @@ func newAirflowLogsCmd() *cobra.Command {
 	return cmd
 }
 
-func newAirflowStopCmd() *cobra.Command {
+func newAirflowStopCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stop",
 		Short: "Stop a locally running Airflow cluster",
 		Long:  "Stop a locally running Airflow cluster",
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowStop,
@@ -189,14 +194,15 @@ func newAirflowStopCmd() *cobra.Command {
 	return cmd
 }
 
-func newAirflowPSCmd() *cobra.Command {
+func newAirflowPSCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ps",
 		Short: "List locally running Airflow containers",
 		Long:  "List locally running Airflow containers",
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		PreRunE: ensureProjectDir,
 		RunE:    airflowPS,
@@ -204,14 +210,15 @@ func newAirflowPSCmd() *cobra.Command {
 	return cmd
 }
 
-func newAirflowRunCmd() *cobra.Command {
+func newAirflowRunCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run a command inside locally running Airflow webserver",
 		Long:  "Run a command inside locally running Airflow webserver",
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		PreRunE:            ensureProjectDir,
 		RunE:               airflowRun,
@@ -221,14 +228,15 @@ func newAirflowRunCmd() *cobra.Command {
 	return cmd
 }
 
-func newAirflowUpgradeCheckCmd() *cobra.Command {
+func newAirflowUpgradeCheckCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade-check",
 		Short: "List DAG and config-level changes required to upgrade to Airflow 2.0",
 		Long:  "List DAG and config-level changes required to upgrade to Airflow 2.0",
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		PreRunE:            ensureProjectDir,
 		RunE:               airflowUpgradeCheck,

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -51,37 +51,37 @@ func TestNewAirflowInitCmd(t *testing.T) {
 }
 
 func TestNewAirflowStartCmd(t *testing.T) {
-	cmd := newAirflowStartCmd()
+	cmd := newAirflowStartCmd(os.Stdout)
 	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
 func TestNewAirflowKillCmd(t *testing.T) {
-	cmd := newAirflowKillCmd()
+	cmd := newAirflowKillCmd(os.Stdout)
 	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
 func TestNewAirflowLogsCmd(t *testing.T) {
-	cmd := newAirflowLogsCmd()
+	cmd := newAirflowLogsCmd(os.Stdout)
 	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
 func TestNewAirflowStopCmd(t *testing.T) {
-	cmd := newAirflowStopCmd()
+	cmd := newAirflowStopCmd(os.Stdout)
 	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
 func TestNewAirflowPSCmd(t *testing.T) {
-	cmd := newAirflowPSCmd()
+	cmd := newAirflowPSCmd(os.Stdout)
 	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
 func TestNewAirflowRunCmd(t *testing.T) {
-	cmd := newAirflowRunCmd()
+	cmd := newAirflowRunCmd(os.Stdout)
 	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
 func TestNewAirflowUpgradeCheckCmd(t *testing.T) {
-	cmd := newAirflowUpgradeCheckCmd()
+	cmd := newAirflowUpgradeCheckCmd(os.Stdout)
 	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
@@ -97,7 +97,7 @@ func TestAirflowKillSuccess(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowKillCmd()
+	cmd := newAirflowKillCmd(os.Stdout)
 	err := airflowKill(cmd, []string{})
 	assert.NoError(t, err)
 	mockContainer.AssertExpectations(t)
@@ -115,7 +115,7 @@ func TestAirflowKillFailure(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowKillCmd()
+	cmd := newAirflowKillCmd(os.Stdout)
 	err := airflowKill(cmd, []string{})
 	assert.Error(t, err, errSomeContainerIssue.Error())
 	mockContainer.AssertExpectations(t)
@@ -133,7 +133,7 @@ func TestAirflowLogsSuccess(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowLogsCmd()
+	cmd := newAirflowLogsCmd(os.Stdout)
 	cmd.Flags().Set("scheduler", "true")
 	cmd.Flags().Set("webserver", "true")
 	err := airflowLogs(cmd, []string{})
@@ -153,7 +153,7 @@ func TestAirflowLogsFailure(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowLogsCmd()
+	cmd := newAirflowLogsCmd(os.Stdout)
 	err := airflowLogs(cmd, []string{})
 	assert.Error(t, err, errSomeContainerIssue.Error())
 	mockContainer.AssertExpectations(t)
@@ -171,7 +171,7 @@ func TestAirflowStopSuccess(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowStopCmd()
+	cmd := newAirflowStopCmd(os.Stdout)
 	err := airflowStop(cmd, []string{})
 	assert.NoError(t, err)
 	mockContainer.AssertExpectations(t)
@@ -189,7 +189,7 @@ func TestAirflowStopFailure(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowStopCmd()
+	cmd := newAirflowStopCmd(os.Stdout)
 	err := airflowStop(cmd, []string{})
 	assert.Error(t, err, errSomeContainerIssue.Error())
 	mockContainer.AssertExpectations(t)
@@ -207,7 +207,7 @@ func TestAirflowPSSuccess(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowPSCmd()
+	cmd := newAirflowPSCmd(os.Stdout)
 	err := airflowPS(cmd, []string{})
 	assert.NoError(t, err)
 	mockContainer.AssertExpectations(t)
@@ -225,7 +225,7 @@ func TestAirflowPSFailure(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowPSCmd()
+	cmd := newAirflowPSCmd(os.Stdout)
 	err := airflowPS(cmd, []string{})
 	assert.Error(t, err, errSomeContainerIssue.Error())
 	mockContainer.AssertExpectations(t)
@@ -243,7 +243,7 @@ func TestAirflowRunSuccess(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowRunCmd()
+	cmd := newAirflowRunCmd(os.Stdout)
 	err := airflowRun(cmd, []string{})
 	assert.NoError(t, err)
 	mockContainer.AssertExpectations(t)
@@ -261,7 +261,7 @@ func TestAirflowRunFailure(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowRunCmd()
+	cmd := newAirflowRunCmd(os.Stdout)
 	err := airflowRun(cmd, []string{})
 	assert.Error(t, err, errSomeContainerIssue.Error())
 	mockContainer.AssertExpectations(t)
@@ -279,7 +279,7 @@ func TestAirflowUpgradeCheckSuccess(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowUpgradeCheckCmd()
+	cmd := newAirflowUpgradeCheckCmd(os.Stdout)
 	err := airflowUpgradeCheck(cmd, []string{})
 	assert.NoError(t, err)
 	mockContainer.AssertExpectations(t)
@@ -297,7 +297,7 @@ func TestAirflowUpgradeCheckFailure(t *testing.T) {
 		return mockContainer, nil
 	}
 
-	cmd := newAirflowUpgradeCheckCmd()
+	cmd := newAirflowUpgradeCheckCmd(os.Stdout)
 	err := airflowUpgradeCheck(cmd, []string{})
 	assert.Error(t, err, errSomeContainerIssue.Error())
 	mockContainer.AssertExpectations(t)

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -19,7 +19,8 @@ func newAuthRootCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		Use:   "auth",
 		Short: "Authenticate with an Astronomer Cluster",

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,7 +18,8 @@ func newVersionCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Long:  "The astro-cli semantic version and git commit tied to that release.",
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return printVersion(client, cmd, out, args)
@@ -34,7 +35,8 @@ func newUpgradeCheckCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		Long:  "Check for newer version of Astronomer CLI",
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			err := SetUpLogs(out, verboseLevel)
+			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return upgradeCheck(client, cmd, out, args)


### PR DESCRIPTION
## Description

Changes:
- Added missed out verbosity flag logic from few the commands because of how we handle version check logic via PersistentPreRunE.

## 🎟 Issue(s)

Related astronomer/issues#3856

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
