### PR TITLE
fixed update deployment response

### DIFF
--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -353,7 +353,11 @@ func Update(id, cloudRole string, args map[string]string, dagDeploymentType, nfs
 
 	d := r.Data.UpdateDeployment
 	tab := newTableOut()
-	tab.AddRow([]string{d.Label, d.ReleaseName, d.Version, d.ID, d.AirflowVersion}, false)
+	currentTag := d.DeploymentInfo.Current
+	if currentTag == "" {
+		currentTag = "?"
+	}
+	tab.AddRow([]string{d.Label, d.ReleaseName, d.Version, d.ID, currentTag, d.AirflowVersion}, false)
 	tab.SuccessMsg = "\n Successfully updated deployment"
 	tab.Print(out)
 

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -848,9 +848,6 @@ func TestUpdateTriggerer(t *testing.T) {
       "workspace": {
         "id": "ckbv7zvb100pe0760xp98qnh9"
       },
-	  "deployInfo":{
-		"current":"2.2.2-1"
-	  },
       "createdAt": "2020-06-25T20:09:38.341Z",
       "updatedAt": "2020-06-25T20:54:15.592Z"
     }
@@ -867,8 +864,8 @@ func TestUpdateTriggerer(t *testing.T) {
 	id := "ck1qg6whg001r08691y117hub"
 	role := "test-role"
 
-	expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG         AIRFLOW VERSION     
- test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c     2.2.2-1     2.2.2               
+	expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG     AIRFLOW VERSION     
+ test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c     ?       2.2.2               
 
  Successfully updated deployment
 `

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -764,9 +764,13 @@ func TestUpdate(t *testing.T) {
       "status": null,
       "type": "airflow",
       "version": "0.0.0",
+	  "airflowVersion": "2.2.2",
       "workspace": {
         "id": "ckbv7zvb100pe0760xp98qnh9"
       },
+	  "deployInfo":{
+		"current":"2.2.2-1"
+	  },
       "createdAt": "2020-06-25T20:09:38.341Z",
       "updatedAt": "2020-06-25T20:54:15.592Z"
     }
@@ -783,8 +787,8 @@ func TestUpdate(t *testing.T) {
 	id := "ck1qg6whg001r08691y117hub"
 	role := "test-role"
 
-	expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG     AIRFLOW VERSION     
- test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c             %!s(MISSING)
+	expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG         AIRFLOW VERSION     
+ test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c     2.2.2-1     2.2.2               
 
  Successfully updated deployment
 `
@@ -840,9 +844,13 @@ func TestUpdateTriggerer(t *testing.T) {
       "status": null,
       "type": "airflow",
       "version": "0.0.0",
+	  "airflowVersion": "2.2.2",
       "workspace": {
         "id": "ckbv7zvb100pe0760xp98qnh9"
       },
+	  "deployInfo":{
+		"current":"2.2.2-1"
+	  },
       "createdAt": "2020-06-25T20:09:38.341Z",
       "updatedAt": "2020-06-25T20:54:15.592Z"
     }
@@ -859,8 +867,8 @@ func TestUpdateTriggerer(t *testing.T) {
 	id := "ck1qg6whg001r08691y117hub"
 	role := "test-role"
 
-	expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG     AIRFLOW VERSION     
- test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c             %!s(MISSING)
+	expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG         AIRFLOW VERSION     
+ test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c     2.2.2-1     2.2.2               
 
  Successfully updated deployment
 `

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -143,6 +143,9 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $cloudRole: Str
 			workspace {
 				id
 			}
+			deployInfo {
+				current
+			}
 			createdAt
 			updatedAt
 		}


### PR DESCRIPTION
## Description
Changes:
- Fixed update deployment response by adding missing `Tag` field in the response and in houston request as well

## 🎟 Issue(s)

Related astronomer/issues#3921

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
