### PR TITLE
added extra 'remote' tag in windows build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,28 +7,47 @@ release:
   # If set to auto, will mark the release as not ready for production
   # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
   prerelease: true
-build:
-  main: main.go
-  binary: astro
-  env:
-    - CGO_ENABLED=0
-  goos:
-    - linux
-    - darwin
-    - windows
-  goarch:
-    - 386
-    - amd64
-    - arm64
-  goarm:
-    - 7
-  flags:
-    - -mod=vendor
-  ldflags: -s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }} -X github.com/astronomer/astro-cli/version.CurrCommit={{ .Commit }}
-  tags:
-    - containers_image_openpgp
-    - exclude_graphdriver_btrfs
-    - exclude_graphdriver_devicemapper
+builds:
+  - main: main.go
+    binary: astro
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm64
+    goarm:
+      - 7
+    flags:
+      - -mod=vendor
+    ldflags: -s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }} -X github.com/astronomer/astro-cli/version.CurrCommit={{ .Commit }}
+    tags:
+      - containers_image_openpgp
+      - exclude_graphdriver_btrfs
+      - exclude_graphdriver_devicemapper
+  - id: astro-windows
+    main: main.go
+    binary: astro
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+    goarch:
+      - 386
+      - amd64
+    goarm:
+      - 7
+    flags:
+      - -mod=vendor
+    ldflags: -s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }} -X github.com/astronomer/astro-cli/version.CurrCommit={{ .Commit }}
+    tags:
+      - containers_image_openpgp
+      - exclude_graphdriver_btrfs
+      - exclude_graphdriver_devicemapper
+      - remote
 brews:
   - tap:
       owner: astronomer


### PR DESCRIPTION
## Description
Fix:
- Added `remote` tag in windows build to make sure we pass through validations for windows OS ([since they are not windows safe](https://github.com/containers/common/issues/165)). 
Reference:
File which is used to build without `remote` flag: https://github.com/containers/common/blob/main/pkg/config/config_local.go
File which will be used to build with `remote` flag:
https://github.com/containers/common/blob/main/pkg/config/config_remote.go

The change will only ensure that we pass through config validation in astro-cli at runtime.

`.\astro` represents 0.27.1 release `.\astro.exe` represents the build with the fix

![Screenshot 2022-01-06 233601](https://user-images.githubusercontent.com/92356010/148429921-de48f5f7-aa62-4781-ab41-2204022340ee.png)

![Screenshot 2022-01-06 233636](https://user-images.githubusercontent.com/92356010/148429932-508bb834-99bf-4c2b-81cd-7f7eb6c7e50f.png)

## 🎟 Issue(s)

Related astronomer/issues#4006

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
