### PR TITLE
fixed volume and postgres container naming convention in docker compose

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -140,7 +140,7 @@ func generateConfig(projectName, airflowHome, envFile string, imageLabels map[st
 		AirflowWebserverPort:   config.CFG.WebserverPort.GetString(),
 		AirflowEnvFile:         envFile,
 		MountLabel:             "z",
-		ProjectName:            projectName,
+		ProjectName:            sanitizeRepoName(projectName),
 		TriggererEnabled:       triggererEnabled,
 		SchedulerContainerName: config.CFG.SchedulerContainerName.GetString(),
 		WebserverContainerName: config.CFG.WebserverContainerName.GetString(),

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -55,12 +55,15 @@ networks:
 volumes:
   postgres_data:
     driver: local
+    name: test-project-name_postgres_data
   airflow_logs:
     driver: local
+    name: test-project-name_airflow_logs
 
 services:
   postgres:
     image: postgres:12.2
+    container_name: test-project-name-postgres
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -13,12 +13,15 @@ networks:
 volumes:
   postgres_data:
     driver: local
+    name: {{ .ProjectName }}_postgres_data
   airflow_logs:
     driver: local
+    name: {{ .ProjectName }}_airflow_logs
 
 services:
   postgres:
     image: postgres:12.2
+    container_name: {{ .ProjectName }}-postgres
     restart: unless-stopped
     networks:
       - airflow


### PR DESCRIPTION
## Description
Changes:
- Fixed volume & postgres container naming for docker and pod naming in case of podman for cases when project directory doesn't contain lowercase alphabet or number as prefix, i.e. starts with `.` or any other special characters


## 🎟 Issue(s)

Related astronomer/issues#3749

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
