### PR TITLE
replace pkg/errors with stdlib errors

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -12,7 +12,6 @@ import (
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 
 	semver "github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -36,12 +35,12 @@ func initDirs(root string, dirs []string) error {
 		// Move on if already exists
 		_, err := fileutil.Exists(fullpath)
 		if err != nil {
-			return errors.Wrapf(err, "failed to check existence of '%s'", fullpath)
+			return fmt.Errorf("failed to check existence of '%s': %w", fullpath, err)
 		}
 
 		// Create directory
 		if err := os.MkdirAll(fullpath, defaultDirPerm); err != nil {
-			return errors.Wrapf(err, "failed to create dir '%s'", dir)
+			return fmt.Errorf("failed to create dir '%s': %w", dir, err)
 		}
 	}
 
@@ -57,7 +56,7 @@ func initFiles(root string, files map[string]string) error {
 		// Move on if already exists
 		fileExist, err := fileutil.Exists(fullpath)
 		if err != nil {
-			return errors.Wrapf(err, "failed to check existence of '%s'", fullpath)
+			return fmt.Errorf("failed to check existence of '%s': %w", fullpath, err)
 		}
 
 		if fileExist {
@@ -66,7 +65,7 @@ func initFiles(root string, files map[string]string) error {
 
 		// Write files out
 		if err := fileutil.WriteStringToFile(fullpath, content); err != nil {
-			return errors.Wrapf(err, "failed to create file '%s'", fullpath)
+			return fmt.Errorf("failed to create file '%s': %w", fullpath, err)
 		}
 	}
 
@@ -97,12 +96,12 @@ func Init(path, airflowImageTag string) error {
 
 	// Initailize directories
 	if err := initDirs(path, dirs); err != nil {
-		return errors.Wrap(err, "failed to create project directories")
+		return fmt.Errorf("failed to create project directories: %w", err)
 	}
 
 	// Initialize files
 	if err := initFiles(path, files); err != nil {
-		return errors.Wrap(err, "failed to create project files")
+		return fmt.Errorf("failed to create project files: %w", err)
 	}
 
 	return nil
@@ -112,7 +111,7 @@ func ParseVersionFromDockerFile(airflowHome, dockerfile string) (uint64, error) 
 	// parse dockerfile
 	cmd, err := docker.ParseFile(filepath.Join(airflowHome, dockerfile))
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed to parse dockerfile: %s", filepath.Join(airflowHome, dockerfile))
+		return 0, fmt.Errorf("failed to parse dockerfile: %s: %w", filepath.Join(airflowHome, dockerfile), err)
 	}
 
 	_, airflowTag := docker.GetImageTagFromParsedFile(cmd)

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -42,7 +42,7 @@ func (d *DockerImage) Build(path string) error {
 	// Build image
 	err = dockerExec(nil, nil, "build", "-t", imageName, ".")
 	if err != nil {
-		return errors.Wrapf(err, "command 'docker build -t %s failed", d.imageName)
+		return fmt.Errorf("command 'docker build -t %s failed: %w", d.imageName, err)
 	}
 
 	return nil
@@ -54,7 +54,7 @@ func (d *DockerImage) Push(cloudDomain, token, remoteImageTag string) error {
 
 	err := dockerExec(nil, nil, "tag", imageName(d.imageName, "latest"), remoteImage)
 	if err != nil {
-		return errors.Wrapf(err, "command 'docker tag %s %s' failed", d.imageName, remoteImage)
+		return fmt.Errorf("command 'docker tag %s %s' failed: %w", d.imageName, remoteImage, err)
 	}
 
 	// Push image to registry
@@ -69,7 +69,7 @@ func (d *DockerImage) Push(cloudDomain, token, remoteImageTag string) error {
 	log.Debugf("Exec Push docker creds %v \n", authConfig)
 	if err != nil {
 		log.Debugf("Error reading credentials: %v", err)
-		return errors.Errorf("Error reading credentials: %v", err)
+		return fmt.Errorf("error reading credentials: %w", err)
 	}
 
 	ctx := context.Background()
@@ -101,7 +101,7 @@ func (d *DockerImage) Push(cloudDomain, token, remoteImageTag string) error {
 	// Delete the image tags we just generated
 	err = dockerExec(nil, nil, "rmi", remoteImage)
 	if err != nil {
-		return errors.Wrapf(err, "command 'docker rmi %s' failed", remoteImage)
+		return fmt.Errorf("command 'docker rmi %s' failed: %w", remoteImage, err)
 	}
 	return nil
 }
@@ -116,7 +116,7 @@ func (d *DockerImage) GetImageLabels() (map[string]string, error) {
 		return labels, err
 	}
 	if execErr := stderr.String(); execErr != "" {
-		return labels, errors.Wrap(errGetImageLabel, execErr)
+		return labels, fmt.Errorf("%s: %w", execErr, errGetImageLabel)
 	}
 	err = json.Unmarshal(stdout.Bytes(), &labels)
 	if err != nil {
@@ -129,7 +129,7 @@ func (d *DockerImage) GetImageLabels() (map[string]string, error) {
 func dockerExec(stdout, stderr io.Writer, args ...string) error {
 	_, lookErr := exec.LookPath(Docker)
 	if lookErr != nil {
-		return errors.Wrap(lookErr, "failed to find the docker binary")
+		return fmt.Errorf("failed to find the docker binary: %w", lookErr)
 	}
 
 	cmd := exec.Command(Docker, args...)
@@ -147,7 +147,7 @@ func dockerExec(stdout, stderr io.Writer, args ...string) error {
 	}
 
 	if cmdErr := cmd.Run(); cmdErr != nil {
-		return errors.Wrapf(cmdErr, "failed to execute cmd")
+		return fmt.Errorf("failed to execute cmd: %w", cmdErr)
 	}
 
 	return nil

--- a/airflow/docker_registry.go
+++ b/airflow/docker_registry.go
@@ -2,6 +2,7 @@ package airflow
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	cliconfig "github.com/docker/cli/cli/config"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/registry"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -43,7 +43,7 @@ func (d *DockerRegistry) Login(username, token string) error {
 	log.Debugf("docker creds %v \n", authConfig)
 	_, err = cli.RegistryLogin(ctx, *authConfig)
 	if err != nil {
-		return errors.Errorf("registry login error: %v", err)
+		return fmt.Errorf("registry login error: %w", err)
 	}
 
 	cliAuthConfig := cliTypes.AuthConfig(*authConfig)
@@ -56,7 +56,7 @@ func (d *DockerRegistry) Login(username, token string) error {
 	creds := configFile.GetCredentialsStore(serverAddress)
 
 	if err := creds.Store(cliAuthConfig); err != nil {
-		return errors.Errorf("Error saving credentials: %v", err)
+		return fmt.Errorf("error saving credentials: %w", err)
 	}
 	return nil
 }

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -3,6 +3,7 @@ package airflow
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -15,7 +16,6 @@ import (
 
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/airflow/podman_image.go
+++ b/airflow/podman_image.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/imagebuildah"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/pkg/errors"
 )
 
 type PodmanImage struct {
@@ -71,16 +70,16 @@ func (p *PodmanImage) Push(cloudDomain, token, remoteImageTag string) error {
 
 	err := p.podmanBind.Tag(p.conn, imageName(p.imageName, "latest"), remoteImageTag, fmt.Sprintf("%s/%s", registry, p.imageName), nil)
 	if err != nil {
-		return errors.Wrapf(err, "command 'podman tag %s %s' failed", p.imageName, remoteImage)
+		return fmt.Errorf("command 'podman tag %s %s' failed: %w", p.imageName, remoteImage, err)
 	}
 	options := new(podmanImages.PushOptions).WithIdentityToken(token)
 	if err := p.podmanBind.Push(p.conn, p.imageName, remoteImage, options); err != nil {
-		return errors.Wrapf(err, "Error pushing %s image to %s", p.imageName, registry)
+		return fmt.Errorf("error pushing %s image to %s: %w", p.imageName, registry, err)
 	}
 
 	err = p.podmanBind.Untag(p.conn, imageName(p.imageName, "latest"), remoteImageTag, fmt.Sprintf("%s/%s", registry, p.imageName), nil)
 	if err != nil {
-		return errors.Wrapf(err, "command 'podman untag %s' failed", remoteImage)
+		return fmt.Errorf("command 'podman untag %s' failed: %w", remoteImage, err)
 	}
 	return nil
 }

--- a/airflow/podman_image_test.go
+++ b/airflow/podman_image_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/astronomer/astro-cli/airflow/mocks"
-	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -25,19 +24,19 @@ func TestPodmanPushSuccess(t *testing.T) {
 func TestPodmanPushFailure(t *testing.T) {
 	bindMock := new(mocks.PodmanBind)
 	podmanImageMock := &PodmanImage{imageName: "test", podmanBind: bindMock, conn: context.TODO()}
-	bindMock.On("Tag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("some tag error")).Once()
+	bindMock.On("Tag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errPodman).Once()
 
 	err := podmanImageMock.Push("test.astro.io", "token", "2")
 	assert.Contains(t, err.Error(), "command 'podman tag test registry.test.astro.io/test/airflow:2' failed")
 
 	bindMock.On("Tag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	bindMock.On("Push", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("some image push error")).Once()
+	bindMock.On("Push", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything).Return(errPodman).Once()
 
 	err = podmanImageMock.Push("test.astro.io", "token", "2")
-	assert.Contains(t, err.Error(), "Error pushing test image to registry.test.astro.io")
+	assert.Contains(t, err.Error(), "error pushing test image to registry.test.astro.io")
 
 	bindMock.On("Push", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	bindMock.On("Untag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("some image untag error"))
+	bindMock.On("Untag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errPodman)
 
 	err = podmanImageMock.Push("test.astro.io", "token", "2")
 	assert.Contains(t, err.Error(), "command 'podman untag registry.test.astro.io/test/airflow:2' failed")

--- a/airflow/podman_registry_test.go
+++ b/airflow/podman_registry_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/astronomer/astro-cli/airflow/mocks"
-	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -23,8 +22,8 @@ func TestPodmanLoginSuccess(t *testing.T) {
 func TestPodmanLoginFailure(t *testing.T) {
 	bindMock := new(mocks.PodmanBind)
 	podmanRegistryMock := &PodmanRegistry{conn: context.TODO(), podmanBind: bindMock, registry: "test.astro.io"}
-	bindMock.On("Login", podmanRegistryMock.conn, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("some login error"))
+	bindMock.On("Login", podmanRegistryMock.conn, mock.Anything, mock.Anything, mock.Anything).Return(errPodman)
 
 	err := podmanRegistryMock.Login("user", "token")
-	assert.Contains(t, err.Error(), "some login error")
+	assert.Contains(t, err.Error(), "some podman error")
 }

--- a/airflow_versions/http_client.go
+++ b/airflow_versions/http_client.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/httputil"
-
-	"github.com/pkg/errors"
 )
 
 // Client containers the logger and HTTPClient used to communicate with the HoustonAPI
@@ -65,7 +63,7 @@ func (c *Client) Do(doOpts httputil.DoOptions) (*Response, error) {
 	decode := Response{}
 	err = json.NewDecoder(strings.NewReader(response.Body)).Decode(&decode)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("Failed to JSON decode %s response", url))
+		return nil, fmt.Errorf("failed to JSON decode %s response: %w", url, err)
 	}
 
 	return &decode, nil

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -12,9 +13,10 @@ import (
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/workspace"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
+
+var errOAuthDisabled = errors.New("cannot authenticate, oauth is disabled")
 
 // basicAuth handles authentication with the houston api
 func basicAuth(username, password string) (string, error) {
@@ -208,13 +210,13 @@ func getAuthToken(username, password string, authConfig *houston.AuthConfig, con
 		if len(authConfig.AuthProviders) > 0 {
 			token = oAuth(context.GetAppURL() + "/token")
 		} else {
-			return "", errors.New("cannot authenticate, oauth is disabled")
+			return "", errOAuthDisabled
 		}
 	} else {
 		if authConfig.LocalEnabled {
 			token, err = basicAuth(username, password)
 			if err != nil {
-				return "", errors.Wrap(err, "local auth login failed")
+				return "", fmt.Errorf("local auth login failed: %w", err)
 			}
 		} else {
 			fmt.Println(messages.HoustonBasicAuthDisabled)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -9,8 +10,6 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
-
-	"github.com/pkg/errors"
 )
 
 var tab = printutil.Table{
@@ -125,7 +124,7 @@ func getClusterSelection() (string, error) {
 	in := input.Text("\n> ")
 	i, err := strconv.ParseInt(in, 10, 64)
 	if err != nil {
-		return "", errors.Wrapf(err, "cannot parse %s to int", in)
+		return "", fmt.Errorf("cannot parse %s to int: %w", in, err)
 	}
 
 	return contexts[i-1], nil

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	testUtils "github.com/astronomer/astro-cli/pkg/testing"
-	"github.com/pkg/errors"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/astronomer/astro-cli/houston"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +55,7 @@ func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 func runCompletionBash(w io.Writer, cmd *cobra.Command) error {
 	err := cmd.Root().GenBashCompletion(w)
 	if err != nil {
-		return errors.Wrap(err, ErrGeneratingBash)
+		return fmt.Errorf("%s: %w", ErrGeneratingBash, err)
 	}
 	return nil
 }
@@ -63,7 +63,7 @@ func runCompletionBash(w io.Writer, cmd *cobra.Command) error {
 func runCompletionZsh(w io.Writer, cmd *cobra.Command) error {
 	err := cmd.Root().GenZshCompletion(w)
 	if err != nil {
-		return errors.Wrap(err, ErrGeneratingBash)
+		return fmt.Errorf("%s: %w", ErrGeneratingBash, err)
 	}
 	return nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,8 +10,13 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/messages"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+)
+
+var (
+	errMissingConfigPath = errors.New(messages.ErrMissingConfigPathKey)
+	errInvalidSetArgs    = errors.New(messages.ConfigInvalidSetArgs)
+	errInvalidConfigPath = errors.New(messages.ErrInvalidConfigPathKey)
 )
 
 var globalFlag bool
@@ -64,12 +70,12 @@ func ensureGlobalFlag(cmd *cobra.Command, args []string) {
 
 func configGet(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return errors.New(messages.ErrMissingConfigPathKey)
+		return errMissingConfigPath
 	}
 	// get config struct
 	cfg, ok := config.CFGStrMap[args[0]]
 	if !ok {
-		return errors.New(messages.ErrInvalidConfigPathKey)
+		return errInvalidConfigPath
 	}
 
 	// Silence Usage as we have now validated command input
@@ -86,14 +92,14 @@ func configGet(cmd *cobra.Command, args []string) error {
 
 func configSet(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 { // nolint:gomnd
-		return errors.New(messages.ConfigInvalidSetArgs)
+		return errInvalidSetArgs
 	}
 
 	// get config struct
 	cfg, ok := config.CFGStrMap[args[0]]
 
 	if !ok {
-		return errors.New(messages.ErrInvalidConfigPathKey)
+		return errInvalidConfigPath
 	}
 
 	// Silence Usage as we have now validated command input

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -8,9 +10,10 @@ import (
 	sa "github.com/astronomer/astro-cli/serviceaccount"
 	"github.com/astronomer/astro-cli/workspace"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
+
+var errUpdateWorkspaceInvalidArgs = errors.New("must specify a workspace ID and at least one attribute to update")
 
 var (
 	workspaceUpdateAttrs   = []string{"label"}
@@ -112,7 +115,7 @@ func newWorkspaceUpdateCmd(client *houston.Client, out io.Writer) *cobra.Command
 		Long:    "Update a Workspace name, as well as users and roles assigned to a Workspace",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) <= 1 {
-				return errors.New("must specify a workspace ID and at least one attribute to update")
+				return errUpdateWorkspaceInvalidArgs
 			}
 			return updateArgValidator(args[1:], workspaceUpdateAttrs)
 		},
@@ -300,11 +303,11 @@ func workspaceUpdate(cmd *cobra.Command, client *houston.Client, out io.Writer, 
 func workspaceUserAdd(cmd *cobra.Command, client *houston.Client, out io.Writer, args []string) error {
 	ws, err := coalesceWorkspace()
 	if err != nil {
-		return errors.Wrap(err, "failed to find a valid workspace")
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
 	}
 
 	if err := validateWorkspaceRole(workspaceRole); err != nil {
-		return errors.Wrap(err, "failed to find a valid role")
+		return fmt.Errorf("failed to find a valid role: %w", err)
 	}
 
 	// Silence Usage as we have now validated command input
@@ -315,11 +318,11 @@ func workspaceUserAdd(cmd *cobra.Command, client *houston.Client, out io.Writer,
 func workspaceUserUpdate(cmd *cobra.Command, client *houston.Client, out io.Writer, args []string) error {
 	ws, err := coalesceWorkspace()
 	if err != nil {
-		return errors.Wrap(err, "failed to find a valid workspace")
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
 	}
 
 	if err := validateWorkspaceRole(workspaceRole); err != nil {
-		return errors.Wrap(err, "failed to find a valid role")
+		return fmt.Errorf("failed to find a valid role: %w", err)
 	}
 
 	// Silence Usage as we have now validated command input
@@ -330,7 +333,7 @@ func workspaceUserUpdate(cmd *cobra.Command, client *houston.Client, out io.Writ
 func workspaceUserRm(cmd *cobra.Command, client *houston.Client, out io.Writer, args []string) error {
 	ws, err := coalesceWorkspace()
 	if err != nil {
-		return errors.Wrap(err, "failed to find a valid workspace")
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
 	}
 
 	// Silence Usage as we have now validated command input
@@ -355,18 +358,18 @@ func workspaceSwitch(cmd *cobra.Command, client *houston.Client, out io.Writer, 
 func workspaceUserList(_ *cobra.Command, client *houston.Client, out io.Writer, _ []string) error {
 	ws, err := coalesceWorkspace()
 	if err != nil {
-		return errors.Wrap(err, "failed to find a valid workspace")
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
 	}
 	return workspace.ListRoles(ws, client, out)
 }
 
 func workspaceSaCreate(cmd *cobra.Command, _ []string, client *houston.Client, out io.Writer) error {
 	if label == "" {
-		return errors.New("must provide a service-account label with the --label (-l) flag")
+		return errServiceAccountNotPresent
 	}
 
 	if err := validateRole(role); err != nil {
-		return errors.Wrap(err, "failed to find a valid role")
+		return fmt.Errorf("failed to find a valid role: %w", err)
 	}
 	fullRole := strings.Join([]string{"WORKSPACE", strings.ToUpper(role)}, "_")
 	// Silence Usage as we have now validated command input

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/astronomer/astro-cli/messages"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 )
@@ -169,15 +168,15 @@ func configExists(v *viper.Viper) bool {
 func CreateConfig(v *viper.Viper, path, file string) error {
 	err := os.MkdirAll(path, defaultDirPerm)
 	if err != nil {
-		return errors.Wrap(err, messages.ErrConfigDirCreation)
+		return fmt.Errorf("%s: %w", messages.ErrConfigDirCreation, err)
 	}
 
 	_, err = os.Create(file)
 	if err != nil {
-		return errors.Wrap(err, messages.ErrConfigFileCreation)
+		return fmt.Errorf("%s: %w", messages.ErrConfigFileCreation, err)
 	}
 	if err = os.Chmod(file, newFilePerm); err != nil {
-		return errors.Wrap(err, messages.ErrConfigFileCreation)
+		return fmt.Errorf("%s: %w", messages.ErrConfigFileCreation, err)
 	}
 
 	return saveConfig(v, file)
@@ -205,7 +204,7 @@ func IsProjectDir(path string) (bool, error) {
 func saveConfig(v *viper.Viper, file string) error {
 	err := v.WriteConfigAs(file)
 	if err != nil {
-		return errors.Wrap(err, messages.ErrSavingConfig)
+		return fmt.Errorf("%s: %w", messages.ErrSavingConfig, err)
 	}
 	return nil
 }

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,7 +18,6 @@ import (
 
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/fatih/camelcase"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	giturls "github.com/whilp/git-urls"
 )
@@ -33,6 +33,9 @@ var (
 	ErrKubernetesNamespaceNotAvailable = errors.New("no kubernetes namespaces are available")
 	ErrNumberOutOfRange                = errors.New("number is out of available range")
 	ErrMajorAirflowVersionUpgrade      = fmt.Errorf("Airflow 2.0 has breaking changes. To upgrade to Airflow 2.0, upgrade to %s first and make sure your DAGs and configs are 2.0 compatible", minAirflowVersion) //nolint:golint,stylecheck
+	errInvalidSSHKeyPath               = errors.New("wrong path specified, no file exists for ssh key")
+	errInvalidKnownHostsPath           = errors.New("wrong path specified, no file exists for known hosts")
+	errHostNotPresent                  = errors.New("git repository host not present in known hosts file")
 )
 
 type ErrParsingInt struct {
@@ -591,7 +594,7 @@ func readSSHKeyFile(sshFilePath string) (string, error) {
 	fd, err := os.Open(sshFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", errors.New("wrong path specified, no file exists for ssh key")
+			return "", errInvalidSSHKeyPath
 		}
 		return "", err
 	}
@@ -608,7 +611,7 @@ func readKnownHostsFile(filePath, repoHost string) (string, error) {
 	fd, err := os.Open(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", errors.New("wrong path specified, no file exists for known hosts")
+			return "", errInvalidKnownHostsPath
 		}
 		return "", err
 	}
@@ -624,10 +627,10 @@ func readKnownHostsFile(filePath, repoHost string) (string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return "", errors.Wrapf(err, "error reading known hosts file")
+		return "", fmt.Errorf("error reading known hosts file: %w", err)
 	}
 
-	return "", errors.New("git repository host not present in known hosts file")
+	return "", errHostNotPresent
 }
 
 func getURLHost(gitURL string) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cri-o/ocicni v0.2.1-0.20210621164014-d0acc7862283
 	github.com/docker/cli v20.10.7+incompatible
 	github.com/docker/compose/v2 v2.2.2
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v20.10.8+incompatible
 	github.com/fatih/camelcase v1.0.0
 	github.com/gorilla/websocket v1.4.2
@@ -20,7 +21,6 @@ require (
 	github.com/json-iterator/go v1.1.11
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.9.3
-	github.com/pkg/errors v0.9.1
 	github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0
@@ -70,7 +70,6 @@ require (
 	github.com/disiqueira/gotree/v3 v3.0.2 // indirect
 	github.com/distribution/distribution/v3 v3.0.0-20210316161203-a01c71e2477e // indirect
 	github.com/docker/buildx v0.5.2-0.20210422185057-908a856079fc // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
@@ -143,6 +142,7 @@ require (
 	github.com/openshift/imagebuilder v1.2.2-0.20210415181909-87f3e48c2656 // indirect
 	github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.10.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -2,13 +2,14 @@ package houston
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"strings"
 
 	"github.com/astronomer/astro-cli/cluster"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 
-	"github.com/pkg/errors"
 	newLogger "github.com/sirupsen/logrus"
 )
 
@@ -88,12 +89,12 @@ func (c *Client) Do(doOpts httputil.DoOptions) (*Response, error) {
 	decode := Response{}
 	err = json.NewDecoder(strings.NewReader(response.Body)).Decode(&decode)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to JSON decode Houston response")
+		return nil, fmt.Errorf("failed to JSON decode Houston response: %w", err)
 	}
 	newLogger.Debugf("Response Data: %v\n", string(body))
 	// Houston Specific Errors
 	if decode.Errors != nil {
-		err = errors.New(decode.Errors[0].Message)
+		err = fmt.Errorf("%s", decode.Errors[0].Message) //nolint:goerr113
 		if err.Error() == ErrInaptPermissions.Error() {
 			return nil, ErrVerboseInaptPermissions
 		}

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -1,12 +1,11 @@
 package fileutil
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -25,7 +24,7 @@ func Exists(path string) (bool, error) {
 	}
 
 	if !os.IsNotExist(err) {
-		return false, errors.Wrap(err, "cannot determine if path exists, error ambiguous")
+		return false, fmt.Errorf("cannot determine if path exists, error ambiguous: %w", err)
 	}
 
 	return false, nil

--- a/pkg/fileutil/paths.go
+++ b/pkg/fileutil/paths.go
@@ -1,6 +1,7 @@
 package fileutil
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -8,8 +9,9 @@ import (
 	"path/filepath"
 
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 )
+
+var errNotHomeDir = errors.New("current working directory is a home directory")
 
 // GetWorkingDir returns the current working directory
 func GetWorkingDir() (string, error) {
@@ -45,13 +47,13 @@ func FindDirInPath(search string) (string, error) {
 		}
 
 		if workingDir == homeDir {
-			return "", errors.New("current working directory is a home directory")
+			return "", errNotHomeDir
 		}
 
 		// Check if our file exists
 		exists, err := Exists(filepath.Join(workingDir, search))
 		if err != nil {
-			return "", errors.Wrapf(err, "failed to check existence of '%s'", filepath.Join(workingDir, search))
+			return "", fmt.Errorf("failed to check existence of '%s': %w", filepath.Join(workingDir, search), err)
 		}
 
 		// Return where we found it

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/astronomer/astro-cli/messages"
 	"github.com/astronomer/astro-cli/pkg/httputil"
-
-	"github.com/pkg/errors"
 )
 
 // RepoLatestResponse represents a tag info response from Github API
@@ -74,7 +72,7 @@ func (c *Client) RepoLatestRequest(orgName, repoName string) (*RepoLatestRespons
 	decode := RepoLatestResponse{}
 	err = json.NewDecoder(strings.NewReader(response.Body)).Decode(&decode)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf(messages.ErrGithubJSONMarshalling, url))
+		return nil, fmt.Errorf("%s: %w", fmt.Sprintf(messages.ErrGithubJSONMarshalling, url), err)
 	}
 	return &decode, nil
 }
@@ -91,7 +89,7 @@ func (c *Client) RepoTagRequest(orgName, repoName, tagName string) (*RepoLatestR
 	decode := RepoLatestResponse{}
 	err = json.NewDecoder(strings.NewReader(response.Body)).Decode(&decode)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf(messages.ErrGithubJSONMarshalling, url))
+		return nil, fmt.Errorf("%s: %w", fmt.Sprintf(messages.ErrGithubJSONMarshalling, url), err)
 	}
 	return &decode, nil
 }

--- a/pkg/httputil/http.go
+++ b/pkg/httputil/http.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httputil"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/shurcooL/go/ctxhttp"
 	log "github.com/sirupsen/logrus"
 )
@@ -75,7 +74,7 @@ func (c *HTTPClient) Do(method, path string, doOptions *DoOptions) (*http.Respon
 	resp, err := ctxhttp.Do(ctx, c.HTTPClient, req)
 	log.Debugf("Total time %v", time.Since(start))
 	if err != nil {
-		return nil, errors.Wrap(chooseError(ctx, err), "HTTP DO Failed")
+		return nil, fmt.Errorf("HTTP DO Failed: %w", chooseError(ctx, err))
 	}
 	debug(httputil.DumpResponse(resp, true))
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {

--- a/version/validate_compatibility.go
+++ b/version/validate_compatibility.go
@@ -9,7 +9,6 @@ import (
 	"github.com/astronomer/astro-cli/messages"
 
 	semver "github.com/Masterminds/semver/v3"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -52,7 +51,7 @@ func compareVersions(compareVer, currentVer string, out io.Writer) error {
 
 	switch {
 	case currMajor < compareMajor:
-		return errors.Errorf(messages.ErrNewMajorVersion, currentVer, compareVer)
+		return fmt.Errorf(messages.ErrNewMajorVersion, currentVer, compareVer) //nolint:goerr113
 	case currMinor < compareMinor:
 		fmt.Fprintf(out, messages.WarningNewMinorVersion, currentVer, compareVer)
 	case currMinor > compareMinor:

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -8,8 +9,6 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/messages"
 	"github.com/astronomer/astro-cli/pkg/github"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -17,13 +16,15 @@ var (
 	CurrCommit  string
 )
 
+var errInvalidCLIVersion = errors.New(messages.ErrInvalidCLIVersion)
+
 // PrintVersion outputs current cli version and git commit if exists
 func PrintVersion(client *houston.Client, out io.Writer) error {
 	version := CurrVersion
 	gitCommit := CurrCommit
 
 	if !isValidVersion(version) {
-		return errors.New(messages.ErrInvalidCLIVersion)
+		return errInvalidCLIVersion
 	}
 
 	fmt.Fprintf(out, messages.CLICurrVersion+", ", version)

--- a/workspace/user.go
+++ b/workspace/user.go
@@ -1,15 +1,16 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/printutil"
-
-	"github.com/pkg/errors"
 )
+
+var errUserNotInWorkspace = errors.New("the user you are trying to change is not part of this workspace")
 
 // Add a user to a workspace with specified role
 func Add(workspaceID, email, role string, client *houston.Client, out io.Writer) error {
@@ -108,7 +109,7 @@ func UpdateRole(workspaceID, email, role string, client *houston.Client, out io.
 	}
 	// check if rolebinding is an empty structure
 	if (rb == houston.RoleBindingWorkspace{}) {
-		return errors.New("the user you are trying to change is not part of this workspace")
+		return errUserNotInWorkspace
 	}
 
 	req := houston.Request{

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -9,9 +10,9 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
-
-	"github.com/pkg/errors"
 )
+
+var errWorkspaceContextNotSet = errors.New("current workspace context not set, you can switch to a workspace with \n\tastro workspace switch WORKSPACEID")
 
 func newTableOut() *printutil.Table {
 	return &printutil.Table{
@@ -113,7 +114,7 @@ func GetCurrentWorkspace() (string, error) {
 	}
 
 	if c.Workspace == "" {
-		return "", errors.New("current workspace context not set, you can switch to a workspace with \n\tastro workspace switch WORKSPACEID")
+		return "", errWorkspaceContextNotSet
 	}
 
 	return c.Workspace, nil
@@ -159,7 +160,7 @@ func getWorkspaceSelection(client *houston.Client, out io.Writer) (string, error
 	in := input.Text("\n> ")
 	i, err := strconv.ParseInt(in, 10, 64)
 	if err != nil {
-		return "", errors.Wrapf(err, "cannot parse %s to int", in)
+		return "", fmt.Errorf("cannot parse %s to int: %w", in, err)
 	}
 
 	return ws[i-1].ID, nil
@@ -183,7 +184,7 @@ func Switch(id string, client *houston.Client, out io.Writer) error {
 
 	_, err := req.DoWithClient(client)
 	if err != nil {
-		return errors.Wrap(err, "workspace id is not valid")
+		return fmt.Errorf("workspace id is not valid: %w", err)
 	}
 
 	c, err := config.GetCurrentContext()


### PR DESCRIPTION
## Description
Changes:
- Moved from pkg/errors to stdlib errors package as both are functionally almost the same with later being the only package which would receive new functional updates in future. Changes for this migration were:
  - Replace Wrap method with fmt.Errorf with %w formatting verb
  - As we moved away from pkg/errors, golinter was able to pick up more of err113 linting issues for moving the wrapped static errors from code logic to package level vars

## 🎟 Issue(s)

Related astronomer/issues#3965

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
