### PR TITLE
added dial timeout to houston client

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -2,6 +2,7 @@ package airflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/messages"
-	"github.com/pkg/errors"
 
 	composeInterp "github.com/compose-spec/compose-go/interpolation"
 	"github.com/compose-spec/compose-go/loader"
@@ -114,7 +114,7 @@ func (d *DockerCompose) Start(dockerfile string) error {
 
 	err = d.webserverHealthCheck()
 	if err != nil {
-		return errors.Wrap(err, messages.ErrContainerRecreate)
+		return fmt.Errorf("%s: %w", messages.ErrContainerRecreate, err)
 	}
 
 	parts := strings.Split(config.CFG.WebserverPort.GetString(), ":")

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ var (
 		SchedulerContainerName: newCfg("scheduler.container_name", "scheduler"),
 		WebserverContainerName: newCfg("webserver.container_name", "webserver"),
 		TriggererContainerName: newCfg("triggerer.container_name", "triggerer"),
+		HoustonDialTimeout:     newCfg("houston.dial_timeout", "10"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/types.go
+++ b/config/types.go
@@ -41,6 +41,7 @@ type cfgs struct {
 	SchedulerContainerName cfg
 	WebserverContainerName cfg
 	TriggererContainerName cfg
+	HoustonDialTimeout     cfg
 }
 
 // Creates a new cfg struct
@@ -84,6 +85,14 @@ func (c cfg) GetBool() bool {
 		return viperProject.GetBool(c.Path)
 	}
 	return viperHome.GetBool(c.Path)
+}
+
+// GetBool will return the integer value of requested config, check working dir and fallback to home
+func (c cfg) GetInt() int {
+	if configExists(viperProject) && viperProject.IsSet(c.Path) {
+		return viperProject.GetInt(c.Path)
+	}
+	return viperHome.GetInt(c.Path)
 }
 
 // GetProjectString will return a project config

--- a/main.go
+++ b/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/astronomer/astro-cli/cmd"
 	"github.com/astronomer/astro-cli/config"
@@ -18,8 +20,15 @@ func main() {
 	config.InitConfig(fs)
 	httpClient := httputil.NewHTTPClient()
 	// configure http transport
+	dialTimeout := config.CFG.HoustonDialTimeout.GetInt()
 	// #nosec
-	httpClient.HTTPClient.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: config.CFG.SkipVerifyTLS.GetBool()}}
+	httpClient.HTTPClient.Transport = &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: time.Duration(dialTimeout) * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: time.Duration(dialTimeout) * time.Second,
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: config.CFG.SkipVerifyTLS.GetBool()},
+	}
 	houstonClient := houston.NewClient(httpClient)
 	// setup log level before we start command since we will miss the feature flag checks other wise
 	if err := cmd.SetUpLogs(os.Stdout, config.CFG.Verbosity.GetString()); err != nil {


### PR DESCRIPTION
## Description
Changes:
- Added dial timeout to Houston client, for cases when Houston is down, then user don't have to wait for minutes for dial timeout error. The default value for the dial timeout error has been kept to 10 seconds and user can configure it via `houston.dial_timeout` key
- Moved from `pkg/errors` to `errors` in `airflow/docker.go` which would have been introduced because of a separate PR https://github.com/astronomer/astro-cli/pull/486 was being developed at the same time we were moving away from `pkg/errors`

## 🎟 Issue(s)

Related astronomer/issues#4064

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
