### PR TITLE
astro-cli should prompt the user for namespace name input when pre-deployment validation is configured

### DIFF
--- a/houston/types.go
+++ b/houston/types.go
@@ -290,11 +290,12 @@ type AppConfig struct {
 }
 
 type FeatureFlags struct {
-	NfsMountDagDeployment bool `json:"nfsMountDagDeployment"`
-	HardDeleteDeployment  bool `json:"hardDeleteDeployment"`
-	ManualNamespaceNames  bool `json:"manualNamespaceNames"`
-	TriggererEnabled      bool `json:"triggererEnabled"`
-	GitSyncEnabled        bool `json:"gitSyncDagDeployment"`
+	NfsMountDagDeployment  bool `json:"nfsMountDagDeployment"`
+	HardDeleteDeployment   bool `json:"hardDeleteDeployment"`
+	ManualNamespaceNames   bool `json:"manualNamespaceNames"`
+	TriggererEnabled       bool `json:"triggererEnabled"`
+	GitSyncEnabled         bool `json:"gitSyncDagDeployment"`
+	NamespaceFreeformEntry bool `json:"namespaceFreeformEntry"`
 }
 
 // coerce a string into SemVer if possible


### PR DESCRIPTION
## Description

> based on pre-deployment validation config, user should be prompted for k8 namespace name to be enter instead of select from available k8 namespaces

## 🎟 Issue(s)

Related astronomer/issues#4132

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
