### PR TITLE
added command to fetch triggerer logs

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -24,7 +24,7 @@ const (
 	airflowVersionLabelName        = "io.astronomer.docker.airflow.version"
 	triggererAllowedAirflowVersion = "2.2.0"
 
-	webserverHealthCheckInterval = 5 * time.Second
+	webserverHealthCheckInterval = 10 * time.Second
 )
 
 var repoNameSanitizeRegexp = regexp.MustCompile(`^[^a-z0-9]*`) // must not start with anything except lowercase letter or number

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -35,7 +35,7 @@ const (
 	// Docker is the docker command.
 	Docker = "docker"
 
-	healthCheckBreakPoint = 25 // Maximum number of tries to wait for health check to pass
+	healthCheckBreakPoint = 100 // Maximum number of events to wait for health check to pass
 	healthyProjectStatus  = "health_status: healthy"
 	execDieStatus         = "exec_die"
 )

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -112,7 +112,7 @@ func newDeploymentRootCmd(client *houston.Client, out io.Writer) *cobra.Command 
 		newDeploymentListCmd(client, out),
 		newDeploymentUpdateCmd(client, out),
 		newDeploymentDeleteCmd(client, out),
-		newLogsCmd(),
+		newLogsCmd(client),
 		newDeploymentSaRootCmd(client, out),
 		newDeploymentUserRootCmd(client, out),
 		newDeploymentAirflowRootCmd(client, out),

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,16 +1,55 @@
 package cmd
 
 import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
 	"testing"
 
+	"github.com/astronomer/astro-cli/houston"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeploymentLogsRootCommand(t *testing.T) {
+func TestDeploymentLogsRootCommandTriggererEnabled(t *testing.T) {
 	testUtil.InitTestConfig()
-	output, err := executeCommand("deployment", "logs")
+	okResponse := `{
+		"data": {
+		  "appConfig": {"triggererEnabled": true, "featureFlags": { "triggererEnabled": true}}
+		}
+	  }`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	output, err := executeCommandC(api, "deployment", "logs")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "astro deployment logs")
+	assert.Contains(t, output, "triggerer")
+}
+
+func TestDeploymentLogsRootCommandTriggererDisabled(t *testing.T) {
+	testUtil.InitTestConfig()
+	okResponse := `{
+		"data": {
+		  "appConfig": {"triggererEnabled": false, "featureFlags": { "triggererEnabled": false}}
+		}
+	  }`
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	api := houston.NewHoustonClient(client)
+	output, err := executeCommandC(api, "deployment", "logs")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "astro deployment logs")
+	assert.NotContains(t, output, "triggerer")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,7 @@ func NewRootCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		newSaRootCmd(client, out),
 		// TODO: remove newAirflowRootCmd, after 1.0 we have only devRootCmd
 		newAirflowRootCmd(client, out),
-		newLogsDeprecatedCmd(),
+		newLogsDeprecatedCmd(client),
 	)
 	return rootCmd
 }


### PR DESCRIPTION
## Description
Changes:
- Added command `astro deployment logs triggerer` to fetch Airflow triggerer logs, command will only be visible if the feature flag is set.
- Consolidate `webserverRemoteLogs`, `schedulerRemoteLogs` & `workerRemoteLogs` into a single `fetchRemoteLogs` method.

## 🎟 Issue(s)

Related astronomer/issues#3807

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
