### PR TITLE
Add astro ui link to deploy command output

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -195,7 +195,9 @@ func deployAirflow(path, name, wsID string, prompt bool) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Successfully pushed Docker image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful.")
+
+	deploymentLink := buildAstroUIDeploymentLink(name, wsID)
+	fmt.Printf("Successfully pushed Docker image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful (%s).", deploymentLink)
 
 	return nil
 }
@@ -291,4 +293,12 @@ func validImageRepo(image string) bool {
 		return false
 	}
 	return result
+}
+
+func buildAstroUIDeploymentLink(deploymentName, wsID string) string {
+	context, err := config.GetCurrentContext()
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("https://app.%s/w/%s/d/%s", context.Domain, wsID, deploymentName)
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -197,7 +197,7 @@ func deployAirflow(path, name, wsID string, prompt bool) error {
 	}
 
 	deploymentLink := buildAstroUIDeploymentLink(name, wsID)
-	fmt.Printf("Successfully pushed Docker image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful (%s).", deploymentLink)
+	fmt.Printf("Successfully pushed Docker image to Astronomer registry, it can take a few minutes to update the deployment with the new image. Navigate to the Astronomer UI to confirm the state of your deployment (%s).", deploymentLink)
 
 	return nil
 }
@@ -300,5 +300,5 @@ func buildAstroUIDeploymentLink(deploymentName, wsID string) string {
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("https://app.%s/w/%s/d/%s", context.Domain, wsID, deploymentName)
+	return fmt.Sprintf("%s://app.%s/w/%s/d/%s", config.CFG.CloudAPIProtocol.GetString(), context.Domain, wsID, deploymentName)
 }

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/astronomer/astro-cli/airflow"
@@ -141,4 +142,15 @@ func TestBuildPushDockerImageFailure(t *testing.T) {
 	err = buildPushDockerImage(config.Context{}, "test", "./testfiles/", "test", "test")
 	assert.Error(t, err, errSomeContainerIssue.Error())
 	mockImageHandler.AssertExpectations(t)
+}
+
+func TestBuildAstroUIDeploymentLink(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configYaml := testUtil.NewTestConfig("docker")
+	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
+	config.InitConfig(fs)
+	houstonHost := testUtil.GetEnv("HOUSTON_HOST", "localhost")
+	expectedResult := fmt.Sprintf("https://app.%s/w/wsID1234/d/test", houstonHost)
+	actualResult := buildAstroUIDeploymentLink("test", "wsID1234")
+	assert.Equal(t, expectedResult, actualResult)
 }


### PR DESCRIPTION
## Description
Changes:
- Added astro UI's deployment page link at the end of `astro deploy` command output

## 🎟 Issue(s)

Related astronomer/issues#3826

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
