### PR TITLE
To enable (NamespaceFreeformEntry) pre-deployment webhook, no longer need to check/enable ManualNamespaceNames

### DIFF
--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -158,7 +158,7 @@ func CheckTriggererEnabled(client *houston.Client) bool {
 func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDeploymentType, nfsLocation, gitRepoURL, gitRevision, gitBranchName, gitDAGDir, sshKey, knownHosts string, gitSyncInterval, triggererReplicas int, client *houston.Client, out io.Writer) error {
 	vars := map[string]interface{}{"label": label, "workspaceId": ws, "executor": executor, "cloudRole": cloudRole}
 
-	if CheckPreCreateNamespaceDeployment(client) && !CheckNamespaceFreeformEntryDeployment(client) {
+	if CheckPreCreateNamespaceDeployment(client) {
 		namespace, err := getDeploymentSelectionNamespaces(client, out)
 		if err != nil {
 			return err
@@ -166,7 +166,7 @@ func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDepl
 		vars["namespace"] = namespace
 	}
 
-	if CheckNamespaceFreeformEntryDeployment(client) && CheckPreCreateNamespaceDeployment(client) {
+	if CheckNamespaceFreeformEntryDeployment(client) {
 		namespace, err := getDeploymentNamespaceName()
 		if err != nil {
 			return err

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -1620,7 +1620,7 @@ func TestCreateWithFreeFormNamespaceDeployment(t *testing.T) {
       "hardDeleteDeployment": true,
       "manualNamespaceNames": true,
 	  "featureFlags": {
-		"manualNamespaceNames": true,
+		"manualNamespaceNames": false,
 		"namespaceFreeformEntry": true
 	  }
     },
@@ -1716,7 +1716,7 @@ func TestCreateWithFreeFormNamespaceDeploymentError(t *testing.T) {
       "hardDeleteDeployment": true,
       "manualNamespaceNames": true,
 	  "featureFlags": {
-		"manualNamespaceNames": true,
+		"manualNamespaceNames": false,
 		"namespaceFreeformEntry": true
 	  }
     },


### PR DESCRIPTION

## Description

> To enable (NamespaceFreeformEntry) pre-deployment webhook, no longer need to check/enable ManualNamespaceNames

## 🎟 Issue(s)

Related astronomer/issues#4132

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
