### PR TITLE
Use system environment variables when building docker-compose

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/messages"
 
+	composeInterp "github.com/compose-spec/compose-go/interpolation"
 	"github.com/compose-spec/compose-go/loader"
 	composeTypes "github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/config/configfile"
@@ -296,12 +297,14 @@ func createProject(projectName, airflowHome, envFile string, labels map[string]s
 
 	loaderOption := func(opts *loader.Options) {
 		opts.Name = projectName
+		opts.Interpolate = &composeInterp.Options{
+			LookupValue: os.LookupEnv,
+		}
 	}
 
 	project, err := loader.Load(composeTypes.ConfigDetails{
 		ConfigFiles: configs,
 		WorkingDir:  airflowHome,
-		Environment: map[string]string{},
 	}, loaderOption)
 
 	return project, err


### PR DESCRIPTION
## Description

Since version v0.27.2, host system environment variables are no longer able to be used in `docker-compose.override.yml` files for e.g. local development, this change passes along a pointer to the `compose-go` to use the system environment variables.

We have a local `docker-compose.override.yml` that tries to define volume which references a local path that includes an environment variable, like:

```
version: "2"
services:
  scheduler:
    volumes:
      - $HOME/myfile:/home/astro/myfile
 ```

As our team has gradually updated our `astro-cli` version, we noticed when running `astro dev` commands that we would get failures starting up because of a missing expected file and warnings that say `WARN[0000] The "HOME" variable is not set. Defaulting to a blank string.`

I believe the issue was introduced in the migration from `libcompose`, which handles parsing environment variables for you by default if you pass `Environment = nil`, and `compose-go`, which does not. Unfortunately I do not know go, but I managed to put this change together and it works locally. Please let me know if you have any pointers on how to add tests or make any further changes :) Thanks!

## 🎟 Issue(s)

Can't create issues on the repo externally.

## 🧪 Functional Testing

Create `docker-compose.override.yml` similar to above and try running `astro dev start` or `astro dev stop`

## 📸 Screenshots

<img width="882" alt="image" src="https://user-images.githubusercontent.com/5521150/152099035-a13978e8-cd3b-4de6-9a8c-a4a0383126a1.png">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
