### PR TITLE
add afero.fs as an argument to fileutil.Exists

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -36,7 +36,7 @@ func initDirs(root string, dirs []string) error {
 		fullpath := filepath.Join(root, dir)
 
 		// Move on if already exists
-		_, err := fileutil.Exists(fullpath)
+		_, err := fileutil.Exists(fullpath, nil)
 		if err != nil {
 			return fmt.Errorf("failed to check existence of '%s': %w", fullpath, err)
 		}
@@ -57,7 +57,7 @@ func initFiles(root string, files map[string]string) error {
 		fullpath := filepath.Join(root, file)
 
 		// Move on if already exists
-		fileExist, err := fileutil.Exists(fullpath)
+		fileExist, err := fileutil.Exists(fullpath, nil)
 		if err != nil {
 			return fmt.Errorf("failed to check existence of '%s': %w", fullpath, err)
 		}

--- a/airflow/airflow_test.go
+++ b/airflow/airflow_test.go
@@ -88,7 +88,7 @@ func TestInit(t *testing.T) {
 		"dags/example-dag.py",
 	}
 	for _, file := range expectedFiles {
-		exist, err := fileutil.Exists(filepath.Join(tmpDir, file), fs)
+		exist, err := fileutil.Exists(filepath.Join(tmpDir, file), nil) // passing afero.Fs as nil since none of the files in expectedFiles are created using fs
 		assert.NoError(t, err)
 		assert.True(t, exist)
 	}

--- a/airflow/airflow_test.go
+++ b/airflow/airflow_test.go
@@ -26,7 +26,7 @@ func TestInitDirs(t *testing.T) {
 	err = initDirs(tmpDir, dirs)
 	assert.NoError(t, err)
 
-	exist, err := fileutil.Exists(filepath.Join(tmpDir, "dags"))
+	exist, err := fileutil.Exists(filepath.Join(tmpDir, "dags"), nil)
 
 	assert.NoError(t, err)
 	assert.True(t, exist)
@@ -57,7 +57,7 @@ func TestInitFiles(t *testing.T) {
 	err = initFiles(tmpDir, files)
 	assert.NoError(t, err)
 
-	exist, err := fileutil.Exists(filepath.Join(tmpDir, "requirements.txt"))
+	exist, err := fileutil.Exists(filepath.Join(tmpDir, "requirements.txt"), nil)
 
 	assert.NoError(t, err)
 	assert.True(t, exist)
@@ -88,7 +88,7 @@ func TestInit(t *testing.T) {
 		"dags/example-dag.py",
 	}
 	for _, file := range expectedFiles {
-		exist, err := fileutil.Exists(filepath.Join(tmpDir, file))
+		exist, err := fileutil.Exists(filepath.Join(tmpDir, file), fs)
 		assert.NoError(t, err)
 		assert.True(t, exist)
 	}

--- a/airflow/container.go
+++ b/airflow/container.go
@@ -184,7 +184,7 @@ func getFmtEnvFile(envFile string, containerEngine Container) (string, error) {
 		return "", nil
 	}
 
-	envExists, err := fileutil.Exists(envFile)
+	envExists, err := fileutil.Exists(envFile, nil)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", fmt.Sprintf(messages.EnvPath, envFile), err)
 	}

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -266,7 +266,7 @@ func ensureProjectDir(cmd *cobra.Command, args []string) error {
 
 	projectConfigFile := filepath.Join(config.WorkingPath, config.ConfigDir, config.ConfigFileNameWithExt)
 
-	configExists, err := fileutil.Exists(projectConfigFile)
+	configExists, err := fileutil.Exists(projectConfigFile, nil)
 	if err != nil {
 		return fmt.Errorf("failed to check existence of '%s': %w", projectConfigFile, err)
 	}
@@ -362,7 +362,7 @@ func airflowStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fileState, err := fileutil.Exists("airflow_settings.yaml")
+	fileState, err := fileutil.Exists("airflow_settings.yaml", nil)
 	if err != nil {
 		return fmt.Errorf("%s: %w", messages.SettingsPath, err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -96,7 +96,7 @@ func initHome(fs afero.Fs) {
 	}
 
 	// If home config does not exist, create it
-	homeConfigExists, _ := fileutil.Exists(HomeConfigFile)
+	homeConfigExists, _ := fileutil.Exists(HomeConfigFile, fs)
 
 	if !homeConfigExists {
 		err := CreateConfig(viperHome, HomeConfigPath, HomeConfigFile)
@@ -129,7 +129,7 @@ func initProject(fs afero.Fs) {
 	workingConfigFile := filepath.Join(workingConfigPath, ConfigFileNameWithExt)
 
 	// If path is empty or config file does not exist, just return
-	workingConfigExists, _ := fileutil.Exists(workingConfigFile)
+	workingConfigExists, _ := fileutil.Exists(workingConfigFile, fs)
 	if workingConfigPath == "" || workingConfigPath == HomeConfigPath || !workingConfigExists {
 		return
 	}
@@ -197,7 +197,7 @@ func IsProjectDir(path string) (bool, error) {
 		return false, nil
 	}
 
-	return fileutil.Exists(configFile)
+	return fileutil.Exists(configFile, nil)
 }
 
 // saveConfig will save the config to a file

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -14,7 +14,7 @@ const (
 	defaultFilePerm os.FileMode = 0777
 )
 
-// Exists returns a boolean indicating if the given path already exists
+// Exists returns a boolean indicating if the given path already exists in fs or os in case fs is nil
 func Exists(path string, fs afero.Fs) (bool, error) {
 	if path == "" {
 		return false, nil

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -1,0 +1,93 @@
+package fileutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExists(t *testing.T) {
+	filePath := "test.yaml"
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, filePath, []byte(`test`), 0777)
+	tempFile, _ := os.CreateTemp("", "test.yaml")
+	defer os.Remove(tempFile.Name())
+	type args struct {
+		path string
+		fs   afero.Fs
+	}
+	tests := []struct {
+		name         string
+		args         args
+		expectedResp bool
+		errResp      string
+	}{
+		{
+			name: "file exists in fs",
+			args: args{
+				path: filePath,
+				fs:   fs,
+			},
+			expectedResp: true,
+			errResp:      "",
+		},
+		{
+			name: "file does not exists in fs",
+			args: args{
+				path: "test_not_exists.yaml",
+				fs:   fs,
+			},
+			expectedResp: false,
+			errResp:      "",
+		},
+		{
+			name: "return with an error when fs is not nil",
+			args: args{
+				path: "\000x", // invalid file name
+				fs:   fs,
+			},
+			expectedResp: false,
+			errResp:      "cannot determine if path exists, error ambiguous:",
+		},
+		{
+			name: "file exists in os",
+			args: args{
+				path: tempFile.Name(),
+				fs:   nil,
+			},
+			expectedResp: true,
+			errResp:      "",
+		},
+
+		{
+			name: "file doesnot exists in os",
+			args: args{
+				path: "test_not_exists.yaml",
+				fs:   nil,
+			},
+			expectedResp: false,
+			errResp:      "",
+		},
+		{
+			name: "return with an error when fs is nil",
+			args: args{
+				path: "\000x", // invalid file name
+				fs:   nil,
+			},
+			expectedResp: false,
+			errResp:      "cannot determine if path exists, error ambiguous:",
+		},
+	}
+
+	for _, tt := range tests {
+		actualResp, actualErr := Exists(tt.args.path, tt.args.fs)
+		if tt.errResp != "" && actualErr != nil {
+			assert.Contains(t, actualErr.Error(), tt.errResp)
+		} else {
+			assert.NoError(t, actualErr)
+		}
+		assert.Equal(t, tt.expectedResp, actualResp)
+	}
+}

--- a/pkg/fileutil/paths.go
+++ b/pkg/fileutil/paths.go
@@ -51,7 +51,7 @@ func FindDirInPath(search string) (string, error) {
 		}
 
 		// Check if our file exists
-		exists, err := Exists(filepath.Join(workingDir, search))
+		exists, err := Exists(filepath.Join(workingDir, search), nil)
 		if err != nil {
 			return "", fmt.Errorf("failed to check existence of '%s': %w", filepath.Join(workingDir, search), err)
 		}


### PR DESCRIPTION
## Description
Changes:
- Added `afero.FS`interface as an argument to `fileutil.Exists` method, to cover cases where file is created in-memory in some of the test cases and have to be checked in the in-memory fs created.

## 🎟 Issue(s)

Related astronomer/issues#4187

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
