### PR TITLE
add missed out new line char in deployment link log

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -142,7 +142,7 @@ services:
       - airflow_logs:/usr/local/airflow/logs
     healthcheck:
       test: curl --fail http://webserver:8080/health || exit 1
-      interval: 2s
+      interval: 10s
       retries: 50
       start_period: 10s
       timeout: 10s

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -99,7 +99,7 @@ services:
       - airflow_logs:/usr/local/airflow/logs
     healthcheck:
       test: curl --fail http://webserver:8080/health || exit 1
-      interval: 2s
+      interval: 10s
       retries: 50
       start_period: 10s
       timeout: 10s

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -197,7 +197,7 @@ func deployAirflow(path, name, wsID string, prompt bool) error {
 	}
 
 	deploymentLink := buildAstroUIDeploymentLink(name, wsID)
-	fmt.Printf("Successfully pushed Docker image to Astronomer registry, it can take a few minutes to update the deployment with the new image. Navigate to the Astronomer UI to confirm the state of your deployment (%s).", deploymentLink)
+	fmt.Printf("Successfully pushed Docker image to Astronomer registry, it can take a few minutes to update the deployment with the new image. Navigate to the Astronomer UI to confirm the state of your deployment (%s).\n", deploymentLink)
 
 	return nil
 }


### PR DESCRIPTION
## Description
Changes:
- Added the missed out new line character in the new deployment link which is part `astro deploy` output
- Kept the health check in docker webserver same as that of podman webserver

## 🎟 Issue(s)

Related astronomer/issues#4219

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
