### PR TITLE
Fix: astro deploy PANIC (user's Dockerfile FROM statement not using a semver image)

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -222,7 +222,13 @@ func buildPushDockerImage(c config.Context, name, path, nextTag, cloudDomain str
 
 	if config.CFG.ShowWarnings.GetBool() && !deploymentConfig.IsValidTag(tag) {
 		validTags := strings.Join(deploymentConfig.GetValidTags(tag), ", ")
-		i, _ := input.Confirm(fmt.Sprintf(messages.WarningInvalidNameTag, tag, validTags))
+
+		msg := fmt.Sprintf(messages.WarningInvalidNameTag, tag, validTags)
+		if validTags == "" {
+			msg = fmt.Sprintf(messages.WarningInvalidNameTagEmptyRecommendations, tag)
+		}
+
+		i, _ := input.Confirm(msg)
 		if !i {
 			fmt.Println("Canceling deploy...")
 			os.Exit(1)

--- a/houston/types.go
+++ b/houston/types.go
@@ -317,7 +317,7 @@ func coerce(version string) (*semver.Version, error) {
 	}
 	coerceVer, err := semver.NewVersion(fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch()))
 	if err != nil {
-		fmt.Println(err)
+		return nil, err
 	}
 	return coerceVer, nil
 }

--- a/houston/types.go
+++ b/houston/types.go
@@ -257,9 +257,18 @@ type DeploymentConfig struct {
 }
 
 func (config *DeploymentConfig) GetValidTags(tag string) (tags []string) {
+	tagVersion, err := coerce(tag)
+	// if tag doesn't follow the semver standard return empty array
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	for _, image := range config.AirflowImages {
-		tagVersion := coerce(tag)
-		imageTagVersion := coerce(image.Version)
+		imageTagVersion, err := coerce(image.Version)
+		if err != nil {
+			continue
+		}
 		// i = 1 means version greater than
 		if i := imageTagVersion.Compare(tagVersion); i >= 0 {
 			tags = append(tags, image.Tag)
@@ -301,14 +310,14 @@ type FeatureFlags struct {
 }
 
 // coerce a string into SemVer if possible
-func coerce(version string) *semver.Version {
+func coerce(version string) (*semver.Version, error) {
 	v, err := semver.NewVersion(version)
 	if err != nil {
-		fmt.Println(err)
+		return nil, err
 	}
 	coerceVer, err := semver.NewVersion(fmt.Sprintf("%d.%d.%d", v.Major(), v.Minor(), v.Patch()))
 	if err != nil {
 		fmt.Println(err)
 	}
-	return coerceVer
+	return coerceVer, nil
 }

--- a/houston/types_test.go
+++ b/houston/types_test.go
@@ -27,51 +27,77 @@ func TestGetValidTagsSimpleSemVer(t *testing.T) {
 			{Tag: "1.10.7-8-buster", Version: "1.10.7-8"},
 		},
 	}
-	validTags := dCfg.GetValidTags("1.10.7")
-	expectedTags := []string{
-		"1.10.7-7-buster-onbuild",
-		"1.10.7-7-alpine3.10",
-		"1.10.7-7-buster",
-		"1.10.7-7-alpine3.10-onbuild",
-		"1.10.7-8-alpine3.10-onbuild",
-		"1.10.7-8-buster-onbuild",
-		"1.10.7-8-alpine3.10",
-		"1.10.7-8-buster",
-	}
-	assert.Equal(t, expectedTags, validTags)
-}
 
-func TestGetValidTagsWithPreReleaseTag(t *testing.T) {
-	dCfg := DeploymentConfig{
-		AirflowImages: []AirflowImage{
-			{Tag: "1.10.5-11-alpine3.10-onbuild", Version: "1.10.5-11"},
-			{Tag: "1.10.5-11-buster-onbuild", Version: "1.10.5-11"},
-			{Tag: "1.10.5-11-alpine3.10", Version: "1.10.5-11"},
-			{Tag: "1.10.5-11-buster", Version: "1.10.5-11"},
-			{Tag: "1.10.5-buster-onbuild", Version: "1.10.5"},
-			{Tag: "1.10.5-alpine3.10", Version: "1.10.5"},
-			{Tag: "1.10.5-buster", Version: "1.10.5"},
-			{Tag: "1.10.5-alpine3.10-onbuild", Version: "1.10.5"},
-			{Tag: "1.10.7-7-buster-onbuild", Version: "1.10.7-7"},
-			{Tag: "1.10.7-7-alpine3.10", Version: "1.10.7-7"},
-			{Tag: "1.10.7-7-buster", Version: "1.10.7-7"},
-			{Tag: "1.10.7-7-alpine3.10-onbuild", Version: "1.10.7-7"},
-			{Tag: "1.10.7-8-alpine3.10-onbuild", Version: "1.10.7-8"},
-			{Tag: "1.10.7-8-buster-onbuild", Version: "1.10.7-8"},
-			{Tag: "1.10.7-8-alpine3.10", Version: "1.10.7-8"},
-			{Tag: "1.10.7-8-buster", Version: "1.10.7-8"},
-			{Tag: "1.10.12-buster", Version: "1.10.12"},
-			{Tag: "1.10.12-buster-onbuild", Version: "1.10.12"},
-			{Tag: "1.10.12-1-buster-onbuild", Version: "1.10.12-1"},
-		},
-	}
-	validTags := dCfg.GetValidTags("1.10.12-1-alpine3.10")
-	expectedTags := []string{"1.10.12-buster", "1.10.12-buster-onbuild", "1.10.12-1-buster-onbuild"}
-	assert.Equal(t, expectedTags, validTags)
+	t.Run("tag uses semver", func(t *testing.T) {
+		validTags := dCfg.GetValidTags("1.10.7")
+		expectedTags := []string{
+			"1.10.7-7-buster-onbuild",
+			"1.10.7-7-alpine3.10",
+			"1.10.7-7-buster",
+			"1.10.7-7-alpine3.10-onbuild",
+			"1.10.7-8-alpine3.10-onbuild",
+			"1.10.7-8-buster-onbuild",
+			"1.10.7-8-alpine3.10",
+			"1.10.7-8-buster",
+		}
+		assert.Equal(t, expectedTags, validTags)
+	})
+
+	t.Run("tag does not use semver", func(t *testing.T) {
+		validTags := dCfg.GetValidTags("buster-1.10.2")
+		assert.Equal(t, 0, len(validTags))
+	})
+
+	t.Run("get valid tag with pre-release tag", func(t *testing.T) {
+		dCfg = DeploymentConfig{
+			AirflowImages: []AirflowImage{
+				{Tag: "1.10.5-11-alpine3.10-onbuild", Version: "1.10.5-11"},
+				{Tag: "1.10.5-11-buster-onbuild", Version: "1.10.5-11"},
+				{Tag: "1.10.5-11-alpine3.10", Version: "1.10.5-11"},
+				{Tag: "1.10.5-11-buster", Version: "1.10.5-11"},
+				{Tag: "1.10.5-buster-onbuild", Version: "1.10.5"},
+				{Tag: "1.10.5-alpine3.10", Version: "1.10.5"},
+				{Tag: "1.10.5-buster", Version: "1.10.5"},
+				{Tag: "1.10.5-alpine3.10-onbuild", Version: "1.10.5"},
+				{Tag: "1.10.7-7-buster-onbuild", Version: "1.10.7-7"},
+				{Tag: "1.10.7-7-alpine3.10", Version: "1.10.7-7"},
+				{Tag: "1.10.7-7-buster", Version: "1.10.7-7"},
+				{Tag: "1.10.7-7-alpine3.10-onbuild", Version: "1.10.7-7"},
+				{Tag: "1.10.7-8-alpine3.10-onbuild", Version: "1.10.7-8"},
+				{Tag: "1.10.7-8-buster-onbuild", Version: "1.10.7-8"},
+				{Tag: "1.10.7-8-alpine3.10", Version: "1.10.7-8"},
+				{Tag: "1.10.7-8-buster", Version: "1.10.7-8"},
+				{Tag: "1.10.12-buster", Version: "1.10.12"},
+				{Tag: "1.10.12-buster-onbuild", Version: "1.10.12"},
+				{Tag: "1.10.12-1-buster-onbuild", Version: "1.10.12-1"},
+			},
+		}
+
+		validTags := dCfg.GetValidTags("1.10.12-1-alpine3.10")
+		expectedTags := []string{"1.10.12-buster", "1.10.12-buster-onbuild", "1.10.12-1-buster-onbuild"}
+		assert.Equal(t, expectedTags, validTags)
+	})
 }
 
 func Test_coerce(t *testing.T) {
-	assert.Equal(t, "1.10.5", coerce("1.10.5-11-alpine3.10-onbuild").String())
-	assert.Equal(t, "1.10.5", coerce("1.10.5").String())
-	assert.Equal(t, "1.10.12", coerce("1.10.12-buster").String())
+	tests := []struct {
+		tag             string
+		expectedVersion string
+		expectError     bool
+	}{
+		{tag: "1.10.5-11-alpine3.10-onbuild", expectedVersion: "1.10.5", expectError: false},
+		{tag: "1.10.5", expectedVersion: "1.10.5", expectError: false},
+		{tag: "1.10.12-buster", expectedVersion: "1.10.12", expectError: false},
+		{tag: "buster", expectedVersion: "", expectError: true},
+	}
+
+	for _, tt := range tests {
+		test, err := coerce(tt.tag)
+		if tt.expectError {
+			assert.Error(t, err)
+		} else {
+			assert.Equal(t, tt.expectedVersion, test.String())
+			assert.NoError(t, err)
+		}
+	}
 }

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -77,10 +77,11 @@ var (
 
 	SettingsPath = "Error looking for settings.yaml"
 
-	NA                       = "N/A"
-	ValidDockerfileBaseImage = "quay.io/astronomer/ap-airflow"
-	WarningDowngradeVersion  = "Your Astro CLI Version (%s) is ahead of the server version (%s).\nConsider downgrading your Astro CLI to match. See https://www.astronomer.io/docs/cli-quickstart for more information.\n"
-	WarningInvalidImageName  = "WARNING! The image in your Dockerfile is pulling from '%s', which is not supported. We strongly recommend that you use Astronomer Certified images that pull from 'astronomerinc/ap-airflow' or 'quay.io/astronomer/ap-airflow'. If you're running a custom image, you can override this. Are you sure you want to continue?\n"
-	WarningInvalidNameTag    = "WARNING! You are about to push an image using the '%s' tag. This is not recommended.\nPlease use one of the following tags: %s.\nAre you sure you want to continue?"
-	WarningNewMinorVersion   = "A new minor version of Astro CLI is available. Your version is %s and %s is the latest.\nSee https://www.astronomer.io/docs/cli-quickstart for more information.\n"
+	NA                                        = "N/A"
+	ValidDockerfileBaseImage                  = "quay.io/astronomer/ap-airflow"
+	WarningDowngradeVersion                   = "Your Astro CLI Version (%s) is ahead of the server version (%s).\nConsider downgrading your Astro CLI to match. See https://www.astronomer.io/docs/cli-quickstart for more information.\n"
+	WarningInvalidImageName                   = "WARNING! The image in your Dockerfile is pulling from '%s', which is not supported. We strongly recommend that you use Astronomer Certified images that pull from 'astronomerinc/ap-airflow' or 'quay.io/astronomer/ap-airflow'. If you're running a custom image, you can override this. Are you sure you want to continue?\n"
+	WarningInvalidNameTag                     = "WARNING! You are about to push an image using the '%s' tag. This is not recommended.\nPlease use one of the following tags: %s.\nAre you sure you want to continue?"
+	WarningInvalidNameTagEmptyRecommendations = "WARNING! You are about to push an image using the '%s' tag. This is not recommended.\nAre you sure you want to continue?"
+	WarningNewMinorVersion                    = "A new minor version of Astro CLI is available. Your version is %s and %s is the latest.\nSee https://www.astronomer.io/docs/cli-quickstart for more information.\n"
 )


### PR DESCRIPTION
## Description

Fix a bug where the `astro deploy` command PANICS when a user deploys an airflow project in which his Dockerfile extends a base image not using the `SemVer standard`.

For example, if we had the following Dockerfile in the airflow projects:
```Dockerfile
FROM quay.io/danielhoherd/scratch:ap-airflow
```
`quay.io/danielhoherd/scratch:ap-airflow` does not use the semver standard (`quay.io/danielhoherd/scratch:1.1.0-ap-airflow`).

In this pull request, I fix the panic and allow users to still deploy their projects.

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/4218

## 🧪 Functional Testing

- Create a new astronomer airflow project using `astro dev init`
- Edit the generated Dockerfile's content with the following:
```Dockerfile
FROM quay.io/danielhoherd/scratch:ap-airflow
```
- Run `astro deploy`, the command should prompt a warning message, and after you confirm, the deployment is shipped properly.

## 📸 Screenshots

```bash
A new minor version of Astro CLI is available. Your version is 0.25.0 and 0.26.3 is the latest.
See https://www.astronomer.io/docs/cli-quickstart for more information.
Authenticated to staging.astronomer.io

Select which airflow deployment you want to deploy to:
 #     LABEL                       DEPLOYMENT NAME             WORKSPACE        DEPLOYMENT ID
 1     antoine-demo-deployment     combusting-cluster-8779     antoine-demo     ckz70qvrp157296rff91jyoe6c

> 1
Deploying: combusting-cluster-8779
Building image...
WARNING! The image in your Dockerfile is pulling from 'quay.io/danielhoherd/scratch', which is not supported. We strongly recommend that you use Astronomer Certified images that pull from 'astronomerinc/ap-airflow' or 'quay.io/astronomer/ap-airflow'. If you're running a custom image, you can override this. Are you sure you want to continue?
 (y/n) y
Invalid Semantic Version
Invalid Semantic Version
WARNING! You are about to push an image using the 'ap-airflow' tag. This is not recommended.
Are you sure you want to continue? (y/n) y
[+] Building 35.0s (5/5) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                        0.0s
 => => transferring dockerfile: 88B                                                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                                                           0.0s
 => => transferring context: 34B                                                                                                                                                                            0.0s
 => [internal] load metadata for quay.io/danielhoherd/scratch:ap-airflow                                                                                                                                    1.3s
 => [1/1] FROM quay.io/danielhoherd/scratch:ap-airflow@sha256:72d70b2618afe861a4254012a92582713c7c0ea5f1f24ddc43b1b1977ea3beef                                                                             33.5s
 => => resolve quay.io/danielhoherd/scratch:ap-airflow@sha256:72d70b2618afe861a4254012a92582713c7c0ea5f1f24ddc43b1b1977ea3beef                                                                              0.0s
 => => sha256:72d70b2618afe861a4254012a92582713c7c0ea5f1f24ddc43b1b1977ea3beef 4.71kB / 4.71kB                                                                                                              0.0s
 => => sha256:6f348b71cd8dbff4053ba556d694ee33d7d93e572c3bcf70e317abb057738bcf 18.67kB / 18.67kB                                                                                                            0.0s
 => => sha256:3a2ae6a8a46fffa233f21b45018452da63383a6721967f9f2a76298e2853c7a5 238B / 238B                                                                                                                  0.5s
 => => sha256:ec43610c2a1767b740611ac899c14dc53b841ba847cd8304eee84bfd10096cb8 11.03MB / 11.03MB                                                                                                            1.1s
 => => sha256:5c69ac0246d0815a09c65c7b9a19e8a486a5ba057aed0c83bce1794bdd856f67 1.08MB / 1.08MB                                                                                                              0.2s
 => => extracting sha256:5c69ac0246d0815a09c65c7b9a19e8a486a5ba057aed0c83bce1794bdd856f67                                                                                                                   0.2s
 => => sha256:078e1103ffcc0cb3a883b9b6ae03e39b9cf0faf28f754bf6ef0d504a1c4cf182 2.64MB / 2.64MB                                                                                                              0.8s
 => => sha256:514a15d97a4b34623e8bc2bfe90362056eb7bc2ca3e18449b3445906b2f48f5c 11.22MB / 11.22MB                                                                                                            2.4s
 => => sha256:69ca1dd45292ad3bce6f526ce53a3a0ef7aaac07101ee9695150cfc59a10d862 2.31MB / 2.31MB                                                                                                              2.1s
 => => sha256:ec8f1bc53ee93b9e044a72a3edfcc463a19927f8e95b0149e9542565cb207ecf 19.73kB / 19.73kB                                                                                                            1.7s
 => => extracting sha256:ec43610c2a1767b740611ac899c14dc53b841ba847cd8304eee84bfd10096cb8                                                                                                                   0.7s
 => => sha256:1d48e9e554c70a5661fa74faf267e7786f39be83de8ddee6e7b5b40753092b66 361B / 361B                                                                                                                  2.3s
 => => extracting sha256:3a2ae6a8a46fffa233f21b45018452da63383a6721967f9f2a76298e2853c7a5                                                                                                                   0.0s
 => => extracting sha256:078e1103ffcc0cb3a883b9b6ae03e39b9cf0faf28f754bf6ef0d504a1c4cf182                                                                                                                   0.4s
 => => sha256:ac833a5fb4774c17d62ad5c4a253e896e4faaf4a61b2ef3086184f6842a6e548 206.71MB / 206.71MB                                                                                                         13.7s
 => => sha256:b0da82b8f05448047ed73d7073417385ad3bde684376ec40a644876c8a6f3d28 42.10kB / 42.10kB                                                                                                            3.0s
 => => sha256:2e1b2e31571cde37d6b5817ab2f15b752f4058f05faa7e3996e268d6b7849bb6 228B / 228B                                                                                                                  3.3s
 => => extracting sha256:514a15d97a4b34623e8bc2bfe90362056eb7bc2ca3e18449b3445906b2f48f5c                                                                                                                   0.7s
 => => sha256:5dfbf2caa222a2b8eb347448ee535c98588ed0340d2f31097c926c05b8a917b1 314B / 314B                                                                                                                  3.6s
 => => extracting sha256:69ca1dd45292ad3bce6f526ce53a3a0ef7aaac07101ee9695150cfc59a10d862                                                                                                                   0.3s
 => => sha256:efd74c1bfb4cb18a17f7382f92954617df77d039748c3017407a0bdec336112f 5.42kB / 5.42kB                                                                                                              3.8s
 => => extracting sha256:ec8f1bc53ee93b9e044a72a3edfcc463a19927f8e95b0149e9542565cb207ecf                                                                                                                   0.2s
 => => sha256:e27f2d9dc0b0c779eeca986fc7b5ef00c6c6099aa36f2aa6daa6fc8e0438ce9c 16.57kB / 16.57kB                                                                                                            4.2s
 => => extracting sha256:1d48e9e554c70a5661fa74faf267e7786f39be83de8ddee6e7b5b40753092b66                                                                                                                   0.0s
 => => sha256:7edbceb046b87652a906c9afd8dffae57aad1c84b25882f1d0fb0a9f98149d74 205B / 205B                                                                                                                  4.7s
 => => sha256:f684c12b0029efd9120ec9bf0a79df19e00115e57e295ed5037cfcb46e42b6d3 1.84kB / 1.84kB                                                                                                              4.8s
 => => sha256:7fb68b5d034be8d493afd254ca6f18bf6f885de126c0912917d64125f9769994 509B / 509B                                                                                                                  5.2s
 => => sha256:8a9097e672afed5ea84b52093ff91525604b97b855869bf5c7f31b61fcf9f2b3 943.35kB / 943.35kB                                                                                                          5.9s
 => => sha256:1fe05676f9eb46c9799337e3de940234e3ee9a6b132c3339d4cb10f5ac339189 92B / 92B                                                                                                                    5.8s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                                                                                                                    6.3s
 => => extracting sha256:ac833a5fb4774c17d62ad5c4a253e896e4faaf4a61b2ef3086184f6842a6e548                                                                                                                  16.6s
 => => extracting sha256:b0da82b8f05448047ed73d7073417385ad3bde684376ec40a644876c8a6f3d28                                                                                                                   0.1s
 => => extracting sha256:2e1b2e31571cde37d6b5817ab2f15b752f4058f05faa7e3996e268d6b7849bb6                                                                                                                   0.0s
 => => extracting sha256:5dfbf2caa222a2b8eb347448ee535c98588ed0340d2f31097c926c05b8a917b1                                                                                                                   0.0s
 => => extracting sha256:efd74c1bfb4cb18a17f7382f92954617df77d039748c3017407a0bdec336112f                                                                                                                   0.0s
 => => extracting sha256:e27f2d9dc0b0c779eeca986fc7b5ef00c6c6099aa36f2aa6daa6fc8e0438ce9c                                                                                                                   0.0s
 => => extracting sha256:7edbceb046b87652a906c9afd8dffae57aad1c84b25882f1d0fb0a9f98149d74                                                                                                                   0.0s
 => => extracting sha256:f684c12b0029efd9120ec9bf0a79df19e00115e57e295ed5037cfcb46e42b6d3                                                                                                                   0.0s
 => => extracting sha256:7fb68b5d034be8d493afd254ca6f18bf6f885de126c0912917d64125f9769994                                                                                                                   0.0s
 => => extracting sha256:8a9097e672afed5ea84b52093ff91525604b97b855869bf5c7f31b61fcf9f2b3                                                                                                                   0.1s
 => => extracting sha256:1fe05676f9eb46c9799337e3de940234e3ee9a6b132c3339d4cb10f5ac339189                                                                                                                   0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                                                                                                                   0.0s
 => exporting to image                                                                                                                                                                                      0.0s
 => => exporting layers                                                                                                                                                                                     0.0s
 => => writing image sha256:6f348b71cd8dbff4053ba556d694ee33d7d93e572c3bcf70e317abb057738bcf                                                                                                                0.0s
 => => naming to docker.io/combusting-cluster-8779/airflow:latest                                                                                                                                           0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
Pushing image to Astronomer registry
The push refers to repository [registry.staging.astronomer.io/combusting-cluster-8779/airflow]
5f70bf18a086: Pushed
9fecff210e7d: Pushed
61e1ace9051e: Pushed
44d4e41686cf: Pushed
aeda4ca617cb: Pushed
1700af2c8d27: Pushed
4be7643eca93: Pushed
3f3c7eb681da: Pushed
dc4b55daef11: Pushed
ae4ac620c5ef: Pushed
bda309d32cab: Pushed
a54e71dbd957: Pushed
1207c8596bbd: Pushed
22cf73e20451: Pushed
dd5c1f268d22: Pushed
3e27d8025be6: Pushed
bd2446141b44: Pushed
fa5abdc28024: Pushed
65bc0c77c48f: Pushed
32034715e5d4: Pushed
7d0ebbe3f5d2: Pushed
deploy-2: digest: sha256:72d70b2618afe861a4254012a92582713c7c0ea5f1f24ddc43b1b1977ea3beef size: 4707
Untagged: registry.staging.astronomer.io/combusting-cluster-8779/airflow:deploy-2
Untagged: registry.staging.astronomer.io/combusting-cluster-8779/airflow@sha256:72d70b2618afe861a4254012a92582713c7c0ea5f1f24ddc43b1b1977ea3beef
Successfully pushed Docker image to Astronomer registry, it can take a few minutes to update the deployment with the new image. Navigate to the Astronomer UI to confirm the state of your deployment (https://app.staging.astronomer.io/w/ckz70q12q136036qhz7qx0sn3u/d/combusting-cluster-8779).
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
