### PR TITLE
Fix deploy link to point to airflow UI instead of astro UI

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -20,8 +20,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const airflowURLType = "airflow"
-
 var (
 	errNoWorkspaceID             = errors.New("no workspace id provided")
 	errNoDomainSet               = errors.New("no domain set, re-authenticate")
@@ -265,7 +263,7 @@ func getAirflowUILink(deploymentID string) string {
 		return ""
 	}
 	for _, url := range resp.Urls {
-		if url.Type == airflowURLType {
+		if url.Type == houston.AirflowURLType {
 			return url.URL
 		}
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -20,6 +20,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const airflowURLType = "airflow"
+
 var (
 	errNoWorkspaceID             = errors.New("no workspace id provided")
 	errNoDomainSet               = errors.New("no domain set, re-authenticate")
@@ -164,10 +166,12 @@ func deployAirflow(path, name, wsID string, prompt bool) error {
 	}
 
 	nextTag := ""
+	deploymentID = ""
 	for i := range deployments {
 		deployment := deployments[i]
 		if deployment.ReleaseName == name {
 			nextTag = deployment.DeploymentInfo.NextCli
+			deploymentID = deployment.ID
 		}
 	}
 
@@ -179,7 +183,7 @@ func deployAirflow(path, name, wsID string, prompt bool) error {
 		return err
 	}
 
-	deploymentLink := buildAstroUIDeploymentLink(name, wsID)
+	deploymentLink := getAirflowUILink(deploymentID)
 	fmt.Printf("Successfully pushed Docker image to Astronomer registry, it can take a few minutes to update the deployment with the new image. Navigate to the Astronomer UI to confirm the state of your deployment (%s).\n", deploymentLink)
 
 	return nil
@@ -251,10 +255,19 @@ func validImageRepo(image string) bool {
 	return result
 }
 
-func buildAstroUIDeploymentLink(deploymentName, wsID string) string {
-	context, err := config.GetCurrentContext()
-	if err != nil {
+func getAirflowUILink(deploymentID string) string {
+	if deploymentID == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s://app.%s/w/%s/d/%s", config.CFG.CloudAPIProtocol.GetString(), context.Domain, wsID, deploymentName)
+
+	resp, err := houstonClient.GetDeployment(deploymentID)
+	if err != nil || resp == nil {
+		return ""
+	}
+	for _, url := range resp.Urls {
+		if url.Type == airflowURLType {
+			return url.URL
+		}
+	}
+	return ""
 }

--- a/houston/constants.go
+++ b/houston/constants.go
@@ -7,4 +7,6 @@ const (
 	DeploymentAdmin  = "DEPLOYMENT_ADMIN"
 	DeploymentEditor = "DEPLOYMENT_EDITOR"
 	DeploymentViewer = "DEPLOYMENT_VIEWER"
+
+	AirflowURLType = "airflow"
 )

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -127,6 +127,10 @@ var (
 			id
 			airflowVersion
 			desiredAirflowVersion
+			urls {
+				type
+				url
+			}
 		}
 	}`
 


### PR DESCRIPTION
## Description
Changes:
- Fixed the UI link in `astro deploy` output to point to airflow UI instead of astro UI

## 🎟 Issue(s)

Related astronomer/issues#3826

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
