### PR TITLE
Fixed logic to get the Airflow UI link from houston

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -60,7 +60,7 @@ func newAirflowRootCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newAirflowInitCmd(client, out),
-		newAirflowDeployCmd(),
+		newAirflowDeployCmd(client),
 		newAirflowStartCmd(out),
 		newAirflowKillCmd(out),
 		newAirflowLogsCmd(out),
@@ -80,7 +80,7 @@ func newDevRootCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newAirflowInitCmd(client, out),
-		newAirflowDeployCmd(),
+		newAirflowDeployCmd(client),
 		newAirflowStartCmd(out),
 		newAirflowKillCmd(out),
 		newAirflowLogsCmd(out),
@@ -112,8 +112,8 @@ func newAirflowInitCmd(client *houston.Client, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func newAirflowDeployCmd() *cobra.Command {
-	deployCmd := newDeployCmd()
+func newAirflowDeployCmd(client *houston.Client) *cobra.Command {
+	deployCmd := newDeployCmd(client)
 	cmd := &cobra.Command{
 		Use:     "deploy DEPLOYMENT",
 		Short:   "Deploy an Airflow project",

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -20,6 +20,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const airflowURLType = "airflow"
+
 var (
 	errNoWorkspaceID             = errors.New("no workspace id provided")
 	errNoDomainSet               = errors.New("no domain set, re-authenticate")
@@ -300,6 +302,10 @@ func validImageRepo(image string) bool {
 }
 
 func getAirflowUILink(deploymentID string, client *houston.Client) string {
+	if deploymentID == "" {
+		return ""
+	}
+
 	vars := map[string]interface{}{"id": deploymentID}
 
 	req := houston.Request{
@@ -312,7 +318,7 @@ func getAirflowUILink(deploymentID string, client *houston.Client) string {
 		return ""
 	}
 	for _, url := range resp.Data.GetDeployment.Urls {
-		if url.Type == "airflow" {
+		if url.Type == airflowURLType {
 			return url.URL
 		}
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -60,14 +60,16 @@ Menu will be presented if you do not specify a deployment name:
   $ astro deploy
 `
 
-func newDeployCmd() *cobra.Command {
+func newDeployCmd(client *houston.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "deploy DEPLOYMENT",
 		Short:   "Deploy an Airflow project",
 		Long:    "Deploy an Airflow project to an Astronomer Cluster",
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: ensureProjectDir,
-		RunE:    deploy,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploy(cmd, args, client)
+		},
 		Example: deployExample,
 		Aliases: []string{"airflow deploy"},
 	}
@@ -78,7 +80,7 @@ func newDeployCmd() *cobra.Command {
 	return cmd
 }
 
-func deploy(cmd *cobra.Command, args []string) error {
+func deploy(cmd *cobra.Command, args []string, client *houston.Client) error {
 	ws, err := coalesceWorkspace()
 	if err != nil {
 		return fmt.Errorf("failed to find a valid workspace: %w", err)
@@ -107,10 +109,10 @@ func deploy(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	return deployAirflow(config.WorkingPath, releaseName, ws, forcePrompt)
+	return deployAirflow(config.WorkingPath, releaseName, ws, forcePrompt, client)
 }
 
-func deployAirflow(path, name, wsID string, prompt bool) error {
+func deployAirflow(path, name, wsID string, prompt bool, client *houston.Client) error {
 	if wsID == "" {
 		return errNoWorkspaceID
 	}
@@ -181,10 +183,12 @@ func deployAirflow(path, name, wsID string, prompt bool) error {
 	}
 
 	nextTag := ""
+	deploymentID := ""
 	for i := range deployments {
 		deployment := deployments[i]
 		if deployment.ReleaseName == name {
 			nextTag = deployment.DeploymentInfo.NextCli
+			deploymentID = deployment.ID
 		}
 	}
 
@@ -196,7 +200,7 @@ func deployAirflow(path, name, wsID string, prompt bool) error {
 		return err
 	}
 
-	deploymentLink := buildAstroUIDeploymentLink(name, wsID)
+	deploymentLink := getAirflowUILink(deploymentID, client)
 	fmt.Printf("Successfully pushed Docker image to Astronomer registry, it can take a few minutes to update the deployment with the new image. Navigate to the Astronomer UI to confirm the state of your deployment (%s).\n", deploymentLink)
 
 	return nil
@@ -295,10 +299,22 @@ func validImageRepo(image string) bool {
 	return result
 }
 
-func buildAstroUIDeploymentLink(deploymentName, wsID string) string {
-	context, err := config.GetCurrentContext()
+func getAirflowUILink(deploymentID string, client *houston.Client) string {
+	vars := map[string]interface{}{"id": deploymentID}
+
+	req := houston.Request{
+		Query:     houston.DeploymentGetRequest,
+		Variables: vars,
+	}
+
+	resp, err := req.DoWithClient(client)
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("%s://app.%s/w/%s/d/%s", config.CFG.CloudAPIProtocol.GetString(), context.Domain, wsID, deploymentName)
+	for _, url := range resp.Data.GetDeployment.Urls {
+		if url.Type == "airflow" {
+			return url.URL
+		}
+	}
+	return ""
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,7 @@ func NewRootCmd(client *houston.Client, out io.Writer) *cobra.Command {
 		newCompletionCmd(client, out),
 		newConfigRootCmd(client, out),
 		newDeploymentRootCmd(client, out),
-		newDeployCmd(),
+		newDeployCmd(client),
 		newSaRootCmd(client, out),
 		// TODO: remove newAirflowRootCmd, after 1.0 we have only devRootCmd
 		newAirflowRootCmd(client, out),

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -127,6 +127,10 @@ var (
 			id
 			airflowVersion
 			desiredAirflowVersion
+			urls {
+				type
+				url
+			}
 		}
 	}`
 


### PR DESCRIPTION
## Description
Changes:
- Fixed the UI link in astro deploy output to point to airflow UI instead of astro UI

## 🎟 Issue(s)

Related astronomer/issues#3826

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
