### PR TITLE
fixed dag deployment type in update request

### DIFF
--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -29,6 +29,7 @@ var (
 
 	volumeDeploymentType  = "volume"
 	gitSyncDeploymentType = "git_sync"
+	imageDeploymentType   = "image"
 
 	ErrKubernetesNamespaceNotAvailable = errors.New("no kubernetes namespaces are available")
 	ErrNumberOutOfRange                = errors.New("number is out of available range")
@@ -476,12 +477,16 @@ func meetsAirflowUpgradeReqs(airflowVersion, desiredAirflowVersion string) error
 
 // addDagDeploymentArgs adds dag deployment argument to houston request map
 func addDagDeploymentArgs(vars map[string]interface{}, dagDeploymentType, nfsLocation, sshKey, knownHosts, gitRepoURL, gitRevision, gitBranchName, gitDAGDir string, gitSyncInterval int) error {
+	dagDeploymentConfig := map[string]interface{}{}
+	if dagDeploymentType != "" {
+		dagDeploymentConfig["type"] = dagDeploymentType
+	}
+
 	if dagDeploymentType == volumeDeploymentType && nfsLocation != "" {
-		vars["dagDeployment"] = map[string]string{"nfsLocation": nfsLocation, "type": dagDeploymentType}
+		dagDeploymentConfig["nfsLocation"] = nfsLocation
 	}
 
 	if dagDeploymentType == gitSyncDeploymentType {
-		dagDeploymentConfig := map[string]interface{}{"type": dagDeploymentType}
 		if sshKey != "" {
 			sshPubKey, err := readSSHKeyFile(sshKey)
 			if err != nil {
@@ -514,8 +519,8 @@ func addDagDeploymentArgs(vars map[string]interface{}, dagDeploymentType, nfsLoc
 			dagDeploymentConfig["dagDirectoryLocation"] = gitDAGDir
 		}
 		dagDeploymentConfig["syncInterval"] = gitSyncInterval
-		vars["dagDeployment"] = dagDeploymentConfig
 	}
+	vars["dagDeployment"] = dagDeploymentConfig
 	return nil
 }
 

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -1074,16 +1074,28 @@ func TestAddDagDeploymentArgs(t *testing.T) {
 		expectedError     string
 		expectedOutput    map[string]interface{}
 	}{
-		{dagDeploymentType: imageDeploymentType, expectedError: "", expectedOutput: map[string]interface{}{"dagDeployment": map[string]interface{}{"type": imageDeploymentType}}},
-		{dagDeploymentType: volumeDeploymentType, nfsLocation: "test", expectedError: "", expectedOutput: map[string]interface{}{"dagDeployment": map[string]interface{}{"type": volumeDeploymentType, "nfsLocation": "test"}}},
+		{
+			dagDeploymentType: imageDeploymentType,
+			expectedError:     "",
+			expectedOutput:    map[string]interface{}{"dagDeployment": map[string]interface{}{"type": imageDeploymentType}},
+		},
+		{
+			dagDeploymentType: volumeDeploymentType,
+			nfsLocation:       "test",
+			expectedError:     "",
+			expectedOutput:    map[string]interface{}{"dagDeployment": map[string]interface{}{"type": volumeDeploymentType, "nfsLocation": "test"}},
+		},
 		{
 			dagDeploymentType: gitSyncDeploymentType,
 			sshKey:            "../cmd/testfiles/ssh_key",
 			knownHosts:        "../cmd/testfiles/known_hosts",
 			gitRepoURL:        "https://github.com/neel-astro/private-airflow-dags-test",
-			gitRevision:       "test-revision", gitBranchName: "test-branch", gitDAGDir: "test-dags",
-			gitSyncInterval: 1, expectedError: "",
-			expectedOutput: map[string]interface{}{"dagDeployment": map[string]interface{}{"branchName": "test-branch", "dagDirectoryLocation": "test-dags", "knownHosts": "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRTest1ngUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvTestingTYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTestingFImWwoG6mbUoWf9nzpIoaSjB+weqqUTestingXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydTestingS5ap43JXiUFFAaQ==", "repositoryUrl": "https://github.com/neel-astro/private-airflow-dags-test", "rev": "test-revision", "sshKey": "Test_ssh_key_file_content\n", "syncInterval": 1, "type": gitSyncDeploymentType}},
+			gitRevision:       "test-revision",
+			gitBranchName:     "test-branch",
+			gitDAGDir:         "test-dags",
+			gitSyncInterval:   1,
+			expectedError:     "",
+			expectedOutput:    map[string]interface{}{"dagDeployment": map[string]interface{}{"branchName": "test-branch", "dagDirectoryLocation": "test-dags", "knownHosts": "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRTest1ngUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvTestingTYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTestingFImWwoG6mbUoWf9nzpIoaSjB+weqqUTestingXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydTestingS5ap43JXiUFFAaQ==", "repositoryUrl": "https://github.com/neel-astro/private-airflow-dags-test", "rev": "test-revision", "sshKey": "Test_ssh_key_file_content\n", "syncInterval": 1, "type": gitSyncDeploymentType}},
 		},
 	}
 

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -1059,3 +1059,42 @@ func TestGetDeploymentNamespaceNameError(t *testing.T) {
 	assert.Equal(t, "", name)
 	assert.EqualError(t, err, "no kubernetes namespaces specified")
 }
+
+func TestAddDagDeploymentArgs(t *testing.T) {
+	tests := []struct {
+		dagDeploymentType string
+		nfsLocation       string
+		sshKey            string
+		knownHosts        string
+		gitRepoURL        string
+		gitRevision       string
+		gitBranchName     string
+		gitDAGDir         string
+		gitSyncInterval   int
+		expectedError     string
+		expectedOutput    map[string]interface{}
+	}{
+		{dagDeploymentType: imageDeploymentType, expectedError: "", expectedOutput: map[string]interface{}{"dagDeployment": map[string]interface{}{"type": imageDeploymentType}}},
+		{dagDeploymentType: volumeDeploymentType, nfsLocation: "test", expectedError: "", expectedOutput: map[string]interface{}{"dagDeployment": map[string]interface{}{"type": volumeDeploymentType, "nfsLocation": "test"}}},
+		{
+			dagDeploymentType: gitSyncDeploymentType,
+			sshKey:            "../cmd/testfiles/ssh_key",
+			knownHosts:        "../cmd/testfiles/known_hosts",
+			gitRepoURL:        "https://github.com/neel-astro/private-airflow-dags-test",
+			gitRevision:       "test-revision", gitBranchName: "test-branch", gitDAGDir: "test-dags",
+			gitSyncInterval: 1, expectedError: "",
+			expectedOutput: map[string]interface{}{"dagDeployment": map[string]interface{}{"branchName": "test-branch", "dagDirectoryLocation": "test-dags", "knownHosts": "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRTest1ngUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvTestingTYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTestingFImWwoG6mbUoWf9nzpIoaSjB+weqqUTestingXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydTestingS5ap43JXiUFFAaQ==", "repositoryUrl": "https://github.com/neel-astro/private-airflow-dags-test", "rev": "test-revision", "sshKey": "Test_ssh_key_file_content\n", "syncInterval": 1, "type": gitSyncDeploymentType}},
+		},
+	}
+
+	for _, tt := range tests {
+		output := map[string]interface{}{}
+		err := addDagDeploymentArgs(output, tt.dagDeploymentType, tt.nfsLocation, tt.sshKey, tt.knownHosts, tt.gitRepoURL, tt.gitRevision, tt.gitBranchName, tt.gitDAGDir, tt.gitSyncInterval)
+		if tt.expectedError != "" {
+			assert.Equal(t, tt.expectedError, err.Error())
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, output, tt.expectedOutput)
+	}
+}


### PR DESCRIPTION
## Description
Changes:
- Fixed update deployment logic to pass dagDeploymentType if it is being passed as from the user (rolling back to original behaviour previous to this commit: https://github.com/astronomer/astro-cli/commit/277c5b4d0fb10608f96f4071ce26e5a6beac5bec).

## 🎟 Issue(s)

Related astronomer/issues#4235

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
