### PR TITLE
Fix: Print friendly message when server and CLI version mismatch (GraphQL Schema errors)

### DIFF
--- a/houston/app.go
+++ b/houston/app.go
@@ -8,7 +8,7 @@ func (h ClientImplementation) GetAppConfig() (*AppConfig, error) {
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.GetAppConfig, nil
@@ -22,7 +22,7 @@ func (h ClientImplementation) GetAvailableNamespaces() ([]Namespace, error) {
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return []Namespace{}, err
+		return []Namespace{}, handleAPIErr(err)
 	}
 
 	return r.Data.GetDeploymentNamespaces, nil

--- a/houston/app_test.go
+++ b/houston/app_test.go
@@ -52,6 +52,21 @@ func TestGetAppConfig(t *testing.T) {
 		_, err := api.GetAppConfig()
 		assert.Contains(t, err.Error(), "Internal Server Error")
 	})
+
+	t.Run("unavailable fields error", func(t *testing.T) {
+		response := `{"errors": [{"message": "Cannot query field \"triggererEnabled\" on type AppConfig."}]}`
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 400,
+				Body:       ioutil.NopCloser(bytes.NewBufferString(response)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.GetAppConfig()
+		assert.EqualError(t, err, ErrFieldsNotAvailable{}.Error())
+	})
 }
 
 func TestGetAvailableNamespaces(t *testing.T) {

--- a/houston/auth.go
+++ b/houston/auth.go
@@ -9,7 +9,7 @@ func (h ClientImplementation) AuthenticateWithBasicAuth(username, password strin
 
 	resp, err := req.DoWithClient(h.client)
 	if err != nil {
-		return "", err
+		return "", handleAPIErr(err)
 	}
 
 	return resp.Data.CreateToken.Token.Value, nil
@@ -23,7 +23,7 @@ func (h ClientImplementation) GetAuthConfig() (*AuthConfig, error) {
 
 	acResp, err := acReq.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 	return acResp.Data.GetAuthConfig, nil
 }

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -25,7 +25,7 @@ func (h ClientImplementation) CreateDeployment(vars map[string]interface{}) (*De
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.CreateDeployment, nil
@@ -40,7 +40,7 @@ func (h ClientImplementation) DeleteDeployment(deploymentID string, doHardDelete
 
 	res, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return res.Data.DeleteDeployment, nil
@@ -66,7 +66,7 @@ func (h ClientImplementation) ListDeployments(filters ListDeploymentsRequest) ([
 
 	res, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return res.Data.GetDeployments, nil
@@ -81,7 +81,7 @@ func (h ClientImplementation) UpdateDeployment(variables map[string]interface{})
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.UpdateDeployment, nil
@@ -96,7 +96,7 @@ func (h ClientImplementation) GetDeployment(deploymentID string) (*Deployment, e
 
 	res, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return &res.Data.GetDeployment, nil
@@ -111,7 +111,7 @@ func (h ClientImplementation) UpdateDeploymentAirflow(variables map[string]inter
 
 	res, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return res.Data.UpdateDeploymentAirflow, nil
@@ -125,7 +125,7 @@ func (h ClientImplementation) GetDeploymentConfig() (*DeploymentConfig, error) {
 
 	resp, err := dReq.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return &resp.Data.DeploymentConfig, nil
@@ -140,7 +140,7 @@ func (h ClientImplementation) ListDeploymentLogs(filters ListDeploymentLogsReque
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.DeploymentLog, nil

--- a/houston/deployment_user.go
+++ b/houston/deployment_user.go
@@ -33,7 +33,7 @@ func (h ClientImplementation) ListDeploymentUsers(filters ListDeploymentUsersReq
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return []DeploymentUser{}, err
+		return []DeploymentUser{}, handleAPIErr(err)
 	}
 
 	return r.Data.DeploymentUserList, nil
@@ -48,7 +48,7 @@ func (h ClientImplementation) AddDeploymentUser(variables UpdateDeploymentUserRe
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.AddDeploymentUser, nil
@@ -63,7 +63,7 @@ func (h ClientImplementation) UpdateDeploymentUser(variables UpdateDeploymentUse
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.UpdateDeploymentUser, nil
@@ -81,7 +81,7 @@ func (h ClientImplementation) DeleteDeploymentUser(deploymentID, email string) (
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.DeleteDeploymentUser, nil

--- a/houston/errors.go
+++ b/houston/errors.go
@@ -1,6 +1,27 @@
 package houston
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+type ErrFieldsNotAvailable struct {
+	BaseError error
+}
+
+func (e ErrFieldsNotAvailable) Error() string {
+	return "Some fields requested by the CLI are not available in the server schema."
+}
+
+func handleAPIErr(err error) error {
+	if strings.Contains(err.Error(), "Cannot query field") {
+		return ErrFieldsNotAvailable{
+			BaseError: err,
+		}
+	}
+
+	return err
+}
 
 type ErrWorkspaceNotFound struct {
 	workspaceID string

--- a/houston/errors_test.go
+++ b/houston/errors_test.go
@@ -1,0 +1,24 @@
+package houston
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleAPIError(t *testing.T) {
+	t.Run("should return same error", func(t *testing.T) {
+		err := errors.New("internal server error") //nolint:goerr113
+
+		gotErr := handleAPIErr(err)
+		assert.EqualError(t, gotErr, err.Error())
+	})
+
+	t.Run("should return query fields error", func(t *testing.T) {
+		err := errors.New("error: Cannot query field \"triggererEnabled\" on AppConfig") //nolint:goerr113
+
+		gotErr := handleAPIErr(err)
+		assert.EqualError(t, gotErr, ErrFieldsNotAvailable{}.Error())
+	})
+}

--- a/houston/service_account.go
+++ b/houston/service_account.go
@@ -17,7 +17,7 @@ func (h ClientImplementation) CreateDeploymentServiceAccount(variables *CreateSe
 	}
 	resp, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return resp.Data.CreateDeploymentServiceAccount, nil
@@ -31,7 +31,7 @@ func (h ClientImplementation) CreateWorkspaceServiceAccount(variables *CreateSer
 	}
 	resp, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return resp.Data.CreateWorkspaceServiceAccount, nil
@@ -46,7 +46,7 @@ func (h ClientImplementation) DeleteDeploymentServiceAccount(deploymentID, servi
 
 	resp, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return resp.Data.DeleteDeploymentServiceAccount, nil
@@ -61,7 +61,7 @@ func (h ClientImplementation) DeleteWorkspaceServiceAccount(workspaceID, service
 
 	resp, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return resp.Data.DeleteWorkspaceServiceAccount, nil
@@ -76,7 +76,7 @@ func (h ClientImplementation) ListDeploymentServiceAccounts(deploymentID string)
 
 	resp, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return resp.Data.GetDeploymentServiceAccounts, nil
@@ -91,7 +91,7 @@ func (h ClientImplementation) ListWorkspaceServiceAccounts(workspaceID string) (
 
 	resp, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return resp.Data.GetWorkspaceServiceAccounts, nil

--- a/houston/user.go
+++ b/houston/user.go
@@ -9,7 +9,7 @@ func (h ClientImplementation) CreateUser(email, password string) (*AuthUser, err
 
 	resp, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return resp.Data.CreateUser, nil

--- a/houston/workspace.go
+++ b/houston/workspace.go
@@ -9,7 +9,7 @@ func (h ClientImplementation) CreateWorkspace(label, description string) (*Works
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.CreateWorkspace, nil
@@ -23,7 +23,7 @@ func (h ClientImplementation) ListWorkspaces() ([]Workspace, error) {
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.GetWorkspaces, nil
@@ -38,7 +38,7 @@ func (h ClientImplementation) DeleteWorkspace(workspaceID string) (*Workspace, e
 
 	res, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return res.Data.DeleteWorkspace, nil
@@ -54,7 +54,7 @@ func (h ClientImplementation) GetWorkspace(workspaceID string) (*Workspace, erro
 
 	res, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	if len(res.Data.GetWorkspaces) < 1 {
@@ -74,7 +74,7 @@ func (h ClientImplementation) UpdateWorkspace(workspaceID string, args map[strin
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.UpdateWorkspace, nil

--- a/houston/workspace_users.go
+++ b/houston/workspace_users.go
@@ -9,7 +9,7 @@ func (h ClientImplementation) AddWorkspaceUser(workspaceID, email, role string) 
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.AddWorkspaceUser, nil
@@ -24,7 +24,7 @@ func (h ClientImplementation) DeleteWorkspaceUser(workspaceID, userID string) (*
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return r.Data.RemoveWorkspaceUser, nil
@@ -39,7 +39,7 @@ func (h ClientImplementation) ListWorkspaceUserAndRoles(workspaceID string) (*Wo
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return nil, err
+		return nil, handleAPIErr(err)
 	}
 
 	return &r.Data.GetWorkspaces[0], nil
@@ -54,7 +54,7 @@ func (h ClientImplementation) UpdateWorkspaceUserRole(workspaceID, email, role s
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return "", err
+		return "", handleAPIErr(err)
 	}
 
 	return r.Data.WorkspaceUpdateUserRole, nil
@@ -69,7 +69,7 @@ func (h ClientImplementation) GetWorkspaceUserRole(workspaceID, email string) (W
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return WorkspaceUserRoleBindings{}, err
+		return WorkspaceUserRoleBindings{}, handleAPIErr(err)
 	}
 
 	return r.Data.WorkspaceGetUser, nil

--- a/version/errors.go
+++ b/version/errors.go
@@ -5,7 +5,7 @@ type ErrVersionMismatch struct{}
 func (e ErrVersionMismatch) Error() string {
 	return `
   Some fields requested by the CLI are not available in the server schema, it seems there is a version mismatch between your CLI and the server.
-  In order to fix this issue, you might want to use the same version for both the server and the CLI.
+  In order to fix this issue, you might want to use the same minor version for both the server and the CLI.
   You can use the command "astro version" to check your CLI and server versions.
   You can use the flag --verbosity=debug to get the full error trace.
 	`

--- a/version/errors.go
+++ b/version/errors.go
@@ -1,0 +1,12 @@
+package version
+
+type ErrVersionMismatch struct{}
+
+func (e ErrVersionMismatch) Error() string {
+	return `
+  Some fields requested by the CLI are not available in the server schema, it seems there is a version mismatch between your CLI and the server.
+  In order to fix this issue, you might want to use the same version for both the server and the CLI.
+  You can use the command "astro version" to check your CLI and server versions.
+  You can use the flag --verbosity=debug to get the full error trace.
+	`
+}

--- a/version/validate_compatibility.go
+++ b/version/validate_compatibility.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -20,7 +21,11 @@ func ValidateCompatibility(client houston.ClientInterface, out io.Writer, cliVer
 
 	serverCfg, err := client.GetAppConfig()
 	if err != nil {
-		return err
+		var e *houston.ErrFieldsNotAvailable
+		if errors.As(err, &e) {
+			logrus.Debugln(e.BaseError)
+		}
+		return ErrVersionMismatch{}
 	}
 	// Skip check if AppConfig is nil or is cv is empty
 	if serverCfg != nil && cliVer != "" {

--- a/version/validate_compatibility_test.go
+++ b/version/validate_compatibility_test.go
@@ -4,116 +4,118 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/astronomer/astro-cli/houston"
+
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 
 	mocks "github.com/astronomer/astro-cli/houston/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateCompatibilityVersionsMatched(t *testing.T) {
+func TestValidateCompatibility(t *testing.T) {
 	testUtil.InitTestConfig()
 
-	api := new(mocks.ClientInterface)
-	api.On("GetAppConfig").Return(mockAppConfig, nil)
-	output := new(bytes.Buffer)
-	cliVer := "0.19.1"
-	err := ValidateCompatibility(api, output, cliVer, false)
-	assert.NoError(t, err)
-	// check that there is no output because version matched
-	assert.Equal(t, output, &bytes.Buffer{})
-}
+	t.Run("version mismatched", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig").Return(mockAppConfig, nil)
+		output := new(bytes.Buffer)
+		cliVer := "0.19.1"
+		err := ValidateCompatibility(api, output, cliVer, false)
+		assert.NoError(t, err)
+		// check that there is no output because version matched
+		assert.Equal(t, output, &bytes.Buffer{})
+	})
 
-func TestValidateCompatibilityMissingCliVersion(t *testing.T) {
-	testUtil.InitTestConfig()
+	t.Run("missing cli version", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig").Return(mockAppConfig, nil)
 
-	api := new(mocks.ClientInterface)
-	api.On("GetAppConfig").Return(mockAppConfig, nil)
+		output := new(bytes.Buffer)
+		cliVer := ""
+		err := ValidateCompatibility(api, output, cliVer, false)
+		assert.NoError(t, err)
+		// check that there is no output because cli version is missing
+		assert.Equal(t, output, &bytes.Buffer{})
+		api.AssertExpectations(t)
+	})
 
-	output := new(bytes.Buffer)
-	cliVer := ""
-	err := ValidateCompatibility(api, output, cliVer, false)
-	assert.NoError(t, err)
-	// check that there is no output because cli version is missing
-	assert.Equal(t, output, &bytes.Buffer{})
-	api.AssertExpectations(t)
-}
+	t.Run("cli downgrade", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig").Return(mockAppConfig, nil)
 
-func TestValidateCompatibilityVersionsCliDowngrade(t *testing.T) {
-	testUtil.InitTestConfig()
+		output := new(bytes.Buffer)
+		cliVer := "0.20.1"
+		err := ValidateCompatibility(api, output, cliVer, false)
+		assert.NoError(t, err)
+		expected := "Your Astro CLI Version (0.20.1) is ahead of the server version (0.19.1).\nConsider downgrading your Astro CLI to match. See https://www.astronomer.io/docs/cli-quickstart for more information.\n"
+		// check that user can see correct message
+		assert.Equal(t, expected, output.String())
+		api.AssertExpectations(t)
+	})
 
-	api := new(mocks.ClientInterface)
-	api.On("GetAppConfig").Return(mockAppConfig, nil)
+	t.Run("cli upgrade", func(t *testing.T) {
+		appConfig := *mockAppConfig
+		appConfig.Version = "1.0.0"
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig").Return(&appConfig, nil)
 
-	output := new(bytes.Buffer)
-	cliVer := "0.20.1"
-	err := ValidateCompatibility(api, output, cliVer, false)
-	assert.NoError(t, err)
-	expected := "Your Astro CLI Version (0.20.1) is ahead of the server version (0.19.1).\nConsider downgrading your Astro CLI to match. See https://www.astronomer.io/docs/cli-quickstart for more information.\n"
-	// check that user can see correct message
-	assert.Equal(t, expected, output.String())
-	api.AssertExpectations(t)
-}
+		output := new(bytes.Buffer)
+		cliVer := "0.17.1"
+		err := ValidateCompatibility(api, output, cliVer, false)
+		assert.Error(t, err)
+		expected := "There is an update for Astro CLI. You're using version 0.17.1, but 1.0.0 is the server version.\nPlease upgrade to the matching version before continuing. See https://www.astronomer.io/docs/cli-quickstart for more information.\nTo skip this check use the --skip-version-check flag.\n"
+		// check that user can see correct message
+		assert.EqualError(t, err, expected)
+		api.AssertExpectations(t)
+	})
 
-func TestValidateCompatibilityVersionsCliUpgrade(t *testing.T) {
-	testUtil.InitTestConfig()
+	t.Run("version bypass", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
 
-	appConfig := *mockAppConfig
-	appConfig.Version = "1.0.0"
-	api := new(mocks.ClientInterface)
-	api.On("GetAppConfig").Return(&appConfig, nil)
+		output := new(bytes.Buffer)
+		cliVer := "0.17.1"
+		err := ValidateCompatibility(api, output, cliVer, true)
+		expected := ""
 
-	output := new(bytes.Buffer)
-	cliVer := "0.17.1"
-	err := ValidateCompatibility(api, output, cliVer, false)
-	assert.Error(t, err)
-	expected := "There is an update for Astro CLI. You're using version 0.17.1, but 1.0.0 is the server version.\nPlease upgrade to the matching version before continuing. See https://www.astronomer.io/docs/cli-quickstart for more information.\nTo skip this check use the --skip-version-check flag.\n"
-	// check that user can see correct message
-	assert.EqualError(t, err, expected)
-	api.AssertExpectations(t)
-}
+		assert.NoError(t, err)
+		// check that user can bypass major version check
+		assert.Equal(t, expected, output.String())
+	})
 
-func TestValidateCompatibilityVersionBypass(t *testing.T) {
-	testUtil.InitTestConfig()
+	t.Run("minor warning", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig").Return(mockAppConfig, nil)
 
-	api := new(mocks.ClientInterface)
+		output := new(bytes.Buffer)
+		cliVer := "0.18.1"
+		err := ValidateCompatibility(api, output, cliVer, false)
+		assert.NoError(t, err)
+		expected := "A new minor version of Astro CLI is available. Your version is 0.18.1 and 0.19.1 is the latest.\nSee https://www.astronomer.io/docs/cli-quickstart for more information.\n"
+		// check that user can see correct warning message
+		assert.Equal(t, expected, output.String())
+		api.AssertExpectations(t)
+	})
 
-	output := new(bytes.Buffer)
-	cliVer := "0.17.1"
-	err := ValidateCompatibility(api, output, cliVer, true)
-	expected := ""
+	t.Run("client failure", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig").Return(nil, errMock)
 
-	assert.NoError(t, err)
-	// check that user can bypass major version check
-	assert.Equal(t, expected, output.String())
-}
+		output := new(bytes.Buffer)
+		cliVer := "0.15.1"
+		err := ValidateCompatibility(api, output, cliVer, false)
+		assert.Error(t, err)
+		api.AssertExpectations(t)
+	})
 
-func TestValidateCompatibilityVersionsMinorWarning(t *testing.T) {
-	testUtil.InitTestConfig()
+	t.Run("get config version mismatch", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig").Return(nil, houston.ErrFieldsNotAvailable{})
 
-	api := new(mocks.ClientInterface)
-	api.On("GetAppConfig").Return(mockAppConfig, nil)
-
-	output := new(bytes.Buffer)
-	cliVer := "0.18.1"
-	err := ValidateCompatibility(api, output, cliVer, false)
-	assert.NoError(t, err)
-	expected := "A new minor version of Astro CLI is available. Your version is 0.18.1 and 0.19.1 is the latest.\nSee https://www.astronomer.io/docs/cli-quickstart for more information.\n"
-	// check that user can see correct warning message
-	assert.Equal(t, expected, output.String())
-	api.AssertExpectations(t)
-}
-
-func TestValidateCompatibilityClientFailure(t *testing.T) {
-	testUtil.InitTestConfig()
-
-	api := new(mocks.ClientInterface)
-	api.On("GetAppConfig").Return(nil, errMock)
-
-	output := new(bytes.Buffer)
-	cliVer := "0.15.1"
-	err := ValidateCompatibility(api, output, cliVer, false)
-	assert.Error(t, err)
-	api.AssertExpectations(t)
+		output := new(bytes.Buffer)
+		err := ValidateCompatibility(api, output, "0.15.1", false)
+		assert.EqualError(t, err, ErrVersionMismatch{}.Error())
+		api.AssertExpectations(t)
+	})
 }
 
 func TestCompareVersionsInvalidServerVer(t *testing.T) {


### PR DESCRIPTION
## Description

When the CLI and server version mismatch, users encounter "hard-to-understand" errors like the following:
```bash
astro user create
Error checking feature flag API error (400): {"errors":[{"message":"Cannot query field \"triggererEnabled\" on type \"AppConfig\". Did you mean \"prometheusEnabled\" or \"elasticSearchEnabled\"?","locations":[{"line":12,"column":4}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}},{"message":"Cannot query field \"featureFlags\" on type \"AppConfig\".","locations":[{"line":13,"column":4}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}]}
```

As the above error states, the CLI requests certain fields (`triggererEnabled` in this example) which are not supported in the server's GraphQL schema. But this error is not friendly and the user can hardly understand how to fix it.

In this PR, I added error management to return a friendly message to the user, and also log the base error to the debug level so that the user can still access the error trace with the `--verbosity=debug` flag.

Now the error looks like this:
```bash
./astro user create
Error:
  Some fields requested by the CLI are not available in the server schema, it seems there is a version mismatch between your CLI and the server.
  In order to fix this issue, you might want to use the same version for both the server and the CLI.
  You can use the command "astro version" to check your CLI and server versions.
  You can use the flag --verbosity=debug to get the full error trace.
```

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/3964

## 🧪 Functional Testing

- To test this fix, you'll need to use an old version of Houston, in my case, I used release-0.25 locally and set up my astro CLI to use localhost.
- Then, make sure you start the authentication process:
```bash
astro auth login localhost
# in my case, i had just initialized houston locally, so I had to create a user, but to do this with the CLI, I had to start the auth process
```
- Then, run whatever command you'd like, in my case, I needed to create the first user in fresh houston:
```bash
astro user create
Error checking feature flag Some fields requested by the CLI are not available in the server schema.
Error checking feature flag Some fields requested by the CLI are not available in the server schema.
Error checking feature flag Some fields requested by the CLI are not available in the server schema.
Error checking feature flag Some fields requested by the CLI are not available in the server schema.
Error:
  Some fields requested by the CLI are not available in the server schema, it seems there is a version mismatch between your CLI and the server.
  In order to fix this issue, you might want to use the same version for both the server and the CLI.
  You can use the command "astro version" to check your CLI and server versions.
  You can use the flag --verbosity=debug to get the full error trace.

Usage:
  astro user create [flags]

Aliases:
  create, cr

Flags:
  -e, --email string      Supply user email at runtime
  -h, --help              help for create
  -p, --password string   Supply user password at runtime

Global Flags:
      --skip-version-check   skip version compatibility check
      --verbosity string     Log level (debug, info, warn, error, fatal, panic (default "warning")
```

**Warning**: The first 4 `Error checking for feature flags` have been moved to "debug level" in this PR: https://github.com/astronomer/astro-cli/pull/502


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
