### PR TITLE
small fix to ignore the Dockerfile in the generated docker image

### DIFF
--- a/airflow/include/dockerignore.go
+++ b/airflow/include/dockerignore.go
@@ -10,4 +10,5 @@ var Dockerignore = strings.TrimSpace(`
 airflow_settings.yaml
 pod-config.yml
 logs/
+Dockerfile
 `)


### PR DESCRIPTION
## Description

mainly a cosmetic fix, but we probably don't need to include the generated Dockerfile in the generated Docker image

## 🎟 Issue(s)

## 🧪 Functional Testing

tested locally that when running `astro dev init`, the .dockerignore file is properly populated

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
