### PR TITLE
Fix: Set Celery as default executor for astro deployment create cmd

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -17,16 +17,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	celeryExecutorArg     = "celery"
+	localExecutorArg      = "local"
+	kubernetesExecutorArg = "kubernetes"
+	k8sExecutorArg        = "k8s"
+)
+
 var (
 	errUpdateDeploymentInvalidArgs = errors.New("must specify a deployment ID and at least one attribute to update")
 	errServiceAccountNotPresent    = errors.New("must provide a service-account label with the --label (-l) flag")
 )
 
 var (
-	allDeployments        bool
-	cancel                bool
-	hardDelete            bool
-	executor              string
+	allDeployments bool
+	cancel         bool
+	hardDelete     bool
+	executor       string
+	// have to use two different executor flags for create and update commands otherwhise both commands override this value
+	executorUpdate        string
 	deploymentID          string
 	desiredAirflowVersion string
 	email                 string
@@ -163,7 +172,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 		cmd.Flags().IntVarP(&triggererReplicas, "triggerer-replicas", "", 0, "Number of replicas to use for triggerer airflow component, valid 0-2")
 	}
 
-	cmd.Flags().StringVarP(&executor, "executor", "e", "", "Add executor parameter: local, celery, or kubernetes")
+	cmd.Flags().StringVarP(&executor, "executor", "e", celeryExecutorArg, "Add executor parameter: local, celery, or kubernetes")
 	cmd.Flags().StringVarP(&airflowVersion, "airflow-version", "a", "", "Add desired airflow version parameter: e.g: 1.10.5 or 1.10.7")
 	cmd.Flags().StringVarP(&releaseName, "release-name", "r", "", "Set custom release-name if possible")
 	cmd.Flags().StringVarP(&cloudRole, "cloud-role", "c", "", "Set cloud role to annotate service accounts in deployment")
@@ -236,7 +245,7 @@ $ astro deployment update UUID --dag-deployment-type=volume --nfs-location=test:
 		gitSyncDAGDeploymentEnabled = appConfig.Flags.GitSyncEnabled
 	}
 
-	cmd.Flags().StringVarP(&executor, "executor", "e", "", "Add executor parameter: local, celery, or kubernetes")
+	cmd.Flags().StringVarP(&executorUpdate, "executor", "e", "", "Add executor parameter: local, celery, or kubernetes")
 
 	// let's hide under feature flag
 	if nfsMountDAGDeploymentEnabled || gitSyncDAGDeploymentEnabled {
@@ -318,7 +327,7 @@ func newDeploymentUserAddCmd(out io.Writer) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&deploymentID, "deployment-id", "", "deployment assigned to user")
-	cmd.PersistentFlags().StringVar(&deploymentRole, "role", houston.DeploymentViewer, "role assigned to user")
+	cmd.PersistentFlags().StringVar(&deploymentRole, "role", houston.DeploymentViewerRole, "role assigned to user")
 	return cmd
 }
 
@@ -351,7 +360,7 @@ func newDeploymentUserUpdateCmd(out io.Writer) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&deploymentID, "deployment-id", "", "deployment assigned to user")
-	cmd.PersistentFlags().StringVar(&deploymentRole, "role", houston.DeploymentViewer, "role assigned to user")
+	cmd.PersistentFlags().StringVar(&deploymentRole, "role", houston.DeploymentViewerRole, "role assigned to user")
 	return cmd
 }
 
@@ -556,8 +565,8 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 	}
 
 	var executorType string
-	if executor != "" {
-		executorType, err = validateExecutorArg(executor)
+	if executorUpdate != "" {
+		executorType, err = validateExecutorArg(executorUpdate)
 		if err != nil {
 			return nil
 		}

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -44,7 +44,7 @@ var (
 		Active:     true,
 	}
 	mockDeploymentUserRole = &houston.RoleBinding{
-		Role: "DEPLOYMENT_VIEWER",
+		Role: houston.DeploymentViewerRole,
 		User: houston.RoleBindingUser{
 			Username: "somebody@astronomer.io",
 		},
@@ -78,6 +78,8 @@ func TestDeploymentCreateCommandNfsMountDisabled(t *testing.T) {
 		expectedError  string
 	}{
 		{cmdArgs: []string{"deployment", "create", "new-deployment-name", "--executor=celery", "--dag-deployment-type=volume", "--nfs-location=test:/test"}, expectedOutput: "", expectedError: "unknown flag: --dag-deployment-type"},
+		// test default executor is celery if --executor flag is not provided
+		{cmdArgs: []string{"deployment", "create", "new-deployment-name"}, expectedOutput: "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs", expectedError: ""},
 		{cmdArgs: []string{"deployment", "create", "new-deployment-name", "--executor=celery"}, expectedOutput: "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs", expectedError: ""},
 	}
 	for _, tt := range myTests {
@@ -404,7 +406,7 @@ func TestDeploymentSaCreateCommand(t *testing.T) {
 		DeploymentID: "ck1qg6whg001r08691y117hub",
 		Label:        "my_label",
 		Category:     "default",
-		Role:         "DEPLOYMENT_VIEWER",
+		Role:         houston.DeploymentViewerRole,
 	}
 
 	api := new(mocks.ClientInterface)
@@ -477,7 +479,7 @@ func TestDeploymentUserDeleteCommand(t *testing.T) {
 
 func TestDeploymentUserUpdateCommand(t *testing.T) {
 	testUtil.InitTestConfig()
-	expectedNewRole := "DEPLOYMENT_ADMIN"
+	expectedNewRole := houston.DeploymentAdminRole
 	expectedOut := `Successfully updated somebody@astronomer.io to a ` + expectedNewRole
 	mockResponseUserRole := *mockDeploymentUserRole
 	mockResponseUserRole.Role = expectedNewRole

--- a/cmd/validation.go
+++ b/cmd/validation.go
@@ -21,18 +21,12 @@ var (
 	errInvalidExecutorType      = errors.New("please specify correct executor, one of: local, celery, kubernetes, k8s")
 )
 
-var (
-	volumeDeploymentType  = "volume"
-	imageDeploymentType   = "image"
-	gitSyncDeploymentType = "git_sync"
-
-	validGitScheme = map[string]struct{}{
-		"git":   {},
-		"ssh":   {},
-		"http":  {},
-		"https": {},
-	}
-)
+var validGitScheme = map[string]struct{}{
+	"git":   {},
+	"ssh":   {},
+	"http":  {},
+	"https": {},
+}
 
 type ErrParsingKV struct {
 	kv string
@@ -110,7 +104,7 @@ func coalesceWorkspace() (string, error) {
 }
 
 func validateWorkspaceRole(role string) error {
-	validRoles := []string{"WORKSPACE_ADMIN", "WORKSPACE_EDITOR", "WORKSPACE_VIEWER"}
+	validRoles := []string{houston.WorkspaceAdminRole, houston.WorkspaceEditorRole, houston.WorkspaceViewerRole}
 
 	for _, validRole := range validRoles {
 		if role == validRole {
@@ -121,7 +115,7 @@ func validateWorkspaceRole(role string) error {
 }
 
 func validateDeploymentRole(role string) error {
-	validRoles := []string{houston.DeploymentAdmin, houston.DeploymentEditor, houston.DeploymentViewer}
+	validRoles := []string{houston.DeploymentAdminRole, houston.DeploymentEditorRole, houston.DeploymentViewerRole}
 
 	for _, validRole := range validRoles {
 		if role == validRole {
@@ -143,13 +137,16 @@ func validateRole(role string) error {
 }
 
 func validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL string, acceptEmptyArgs bool) error {
-	if dagDeploymentType != imageDeploymentType && dagDeploymentType != volumeDeploymentType && dagDeploymentType != gitSyncDeploymentType && dagDeploymentType != "" {
+	if dagDeploymentType != houston.ImageDeploymentType &&
+		dagDeploymentType != houston.VolumeDeploymentType &&
+		dagDeploymentType != houston.GitSyncDeploymentType &&
+		dagDeploymentType != "" {
 		return errInvalidDAGDeploymentType
 	}
-	if dagDeploymentType == volumeDeploymentType && nfsLocation == "" {
+	if dagDeploymentType == houston.VolumeDeploymentType && nfsLocation == "" {
 		return errNFSLocationNotFound
 	}
-	if dagDeploymentType == gitSyncDeploymentType && !validURL(gitRepoURL, acceptEmptyArgs) {
+	if dagDeploymentType == houston.GitSyncDeploymentType && !validURL(gitRepoURL, acceptEmptyArgs) {
 		return errGitRepoNotFound
 	}
 	return nil
@@ -158,12 +155,12 @@ func validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL string
 func validateExecutorArg(executor string) (string, error) {
 	var executorType string
 	switch executor {
-	case "local":
-		executorType = "LocalExecutor"
-	case "celery":
-		executorType = "CeleryExecutor"
-	case "kubernetes", "k8s":
-		executorType = "KubernetesExecutor"
+	case localExecutorArg:
+		executorType = houston.LocalExecutorType
+	case celeryExecutorArg:
+		executorType = houston.CeleryExecutorType
+	case kubernetesExecutorArg, k8sExecutorArg:
+		executorType = houston.KubernetesExecutorType
 	default:
 		return executorType, errInvalidExecutorType
 	}

--- a/cmd/validation_test.go
+++ b/cmd/validation_test.go
@@ -29,15 +29,15 @@ func TestValidateDagDeploymentArgs(t *testing.T) {
 		expectedOutput                             string
 		expectedError                              error
 	}{
-		{dagDeploymentType: "volume", nfsLocation: "test:/test", expectedError: nil},
-		{dagDeploymentType: "image", expectedError: nil},
-		{dagDeploymentType: "git_sync", gitRepoURL: "https://github.com/neel-astro/private-airflow-dags-test", expectedError: nil},
-		{dagDeploymentType: "git_sync", gitRepoURL: "http://github.com/neel-astro/private-airflow-dags-test", expectedError: nil},
-		{dagDeploymentType: "git_sync", gitRepoURL: "git@github.com:neel-astro/private-airflow-dags-test.git", expectedError: nil},
-		{dagDeploymentType: "git_sync", gitRepoURL: "ssh://login@server.com:8080/~/private-airflow-dags-test.git", expectedError: nil},
-		{dagDeploymentType: "git_sync", gitRepoURL: "user@server.com:path/to/repo.git", expectedError: nil},
-		{dagDeploymentType: "git_sync", gitRepoURL: "git://server.com/~user/path/to/repo.git/", expectedError: nil},
-		{dagDeploymentType: "git_sync", gitRepoURL: "", acceptEmptyArgs: true, expectedError: nil},
+		{dagDeploymentType: houston.VolumeDeploymentType, nfsLocation: "test:/test", expectedError: nil},
+		{dagDeploymentType: houston.ImageDeploymentType, expectedError: nil},
+		{dagDeploymentType: houston.GitSyncDeploymentType, gitRepoURL: "https://github.com/neel-astro/private-airflow-dags-test", expectedError: nil},
+		{dagDeploymentType: houston.GitSyncDeploymentType, gitRepoURL: "http://github.com/neel-astro/private-airflow-dags-test", expectedError: nil},
+		{dagDeploymentType: houston.GitSyncDeploymentType, gitRepoURL: "git@github.com:neel-astro/private-airflow-dags-test.git", expectedError: nil},
+		{dagDeploymentType: houston.GitSyncDeploymentType, gitRepoURL: "ssh://login@server.com:8080/~/private-airflow-dags-test.git", expectedError: nil},
+		{dagDeploymentType: houston.GitSyncDeploymentType, gitRepoURL: "user@server.com:path/to/repo.git", expectedError: nil},
+		{dagDeploymentType: houston.GitSyncDeploymentType, gitRepoURL: "git://server.com/~user/path/to/repo.git/", expectedError: nil},
+		{dagDeploymentType: houston.GitSyncDeploymentType, gitRepoURL: "", acceptEmptyArgs: true, expectedError: nil},
 	}
 
 	for _, tt := range myTests {
@@ -53,12 +53,12 @@ func TestValidateDagDeploymentArgsErrors(t *testing.T) {
 		expectedOutput                             string
 		expectedError                              string
 	}{
-		{dagDeploymentType: "volume", expectedError: "please specify the nfs location via --nfs-location flag"},
+		{dagDeploymentType: houston.VolumeDeploymentType, expectedError: "please specify the nfs location via --nfs-location flag"},
 		{dagDeploymentType: "unknown", expectedError: "please specify the correct DAG deployment type, one of the following: image, volume, git_sync"},
-		{dagDeploymentType: "image", expectedError: ""},
-		{dagDeploymentType: "git_sync", expectedError: "please specify a valid git repository URL via --git-repository-url"},
-		{dagDeploymentType: "git_sync", gitRepoURL: "/tmp/test/local-repo.git", expectedError: "please specify a valid git repository URL via --git-repository-url"},
-		{dagDeploymentType: "git_sync", gitRepoURL: "http://192.168.0.%31:8080/", expectedError: "please specify a valid git repository URL via --git-repository-url"},
+		{dagDeploymentType: houston.ImageDeploymentType, expectedError: ""},
+		{dagDeploymentType: houston.GitSyncDeploymentType, expectedError: "please specify a valid git repository URL via --git-repository-url"},
+		{dagDeploymentType: houston.GitSyncDeploymentType, gitRepoURL: "/tmp/test/local-repo.git", expectedError: "please specify a valid git repository URL via --git-repository-url"},
+		{dagDeploymentType: houston.GitSyncDeploymentType, gitRepoURL: "http://192.168.0.%31:8080/", expectedError: "please specify a valid git repository URL via --git-repository-url"},
 	}
 
 	for _, tt := range myTests {
@@ -83,7 +83,7 @@ func Test_validateWorkspaceRole(t *testing.T) {
 		{
 			name: "basic valid case",
 			args: args{
-				role: "WORKSPACE_ADMIN",
+				role: houston.WorkspaceAdminRole,
 			},
 			wantErr: false,
 		},
@@ -116,7 +116,7 @@ func Test_validateDeploymentRole(t *testing.T) {
 		{
 			name: "basic valid case",
 			args: args{
-				role: houston.DeploymentAdmin,
+				role: houston.DeploymentAdminRole,
 			},
 			wantErr: false,
 		},
@@ -232,20 +232,26 @@ func TestValidateExecutorArg(t *testing.T) {
 	}{
 		{
 			name:        "valid local executor",
-			args:        args{executor: "local"},
-			result:      "LocalExecutor",
+			args:        args{executor: localExecutorArg},
+			result:      houston.LocalExecutorType,
 			expectedErr: "",
 		},
 		{
 			name:        "valid kubernetes executor",
-			args:        args{executor: "kubernetes"},
-			result:      "KubernetesExecutor",
+			args:        args{executor: kubernetesExecutorArg},
+			result:      houston.KubernetesExecutorType,
+			expectedErr: "",
+		},
+		{
+			name:        "valid kubernetes executor",
+			args:        args{executor: k8sExecutorArg},
+			result:      houston.KubernetesExecutorType,
 			expectedErr: "",
 		},
 		{
 			name:        "valid celery executor",
-			args:        args{executor: "celery"},
-			result:      "CeleryExecutor",
+			args:        args{executor: celeryExecutorArg},
+			result:      houston.CeleryExecutorType,
 			expectedErr: "",
 		},
 		{

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/astronomer/astro-cli/houston"
+
 	sa "github.com/astronomer/astro-cli/serviceaccount"
 	"github.com/astronomer/astro-cli/workspace"
 
@@ -151,7 +153,7 @@ func newWorkspaceUserAddCmd(out io.Writer) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&workspaceID, "workspace-id", "", "workspace assigned to deployment")
-	cmd.PersistentFlags().StringVar(&workspaceRole, "role", "WORKSPACE_VIEWER", "role assigned to user")
+	cmd.PersistentFlags().StringVar(&workspaceRole, "role", houston.WorkspaceViewerRole, "role assigned to user")
 	return cmd
 }
 
@@ -165,7 +167,7 @@ func newWorkspaceUserUpdateCmd(out io.Writer) *cobra.Command {
 			return workspaceUserUpdate(cmd, out, args)
 		},
 	}
-	cmd.PersistentFlags().StringVar(&workspaceRole, "role", "WORKSPACE_VIEWER", "role assigned to user")
+	cmd.PersistentFlags().StringVar(&workspaceRole, "role", houston.WorkspaceViewerRole, "role assigned to user")
 	return cmd
 }
 

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -25,12 +25,6 @@ import (
 var (
 	minAirflowVersion = "1.10.14"
 
-	celeryExecutor = "CeleryExecutor"
-
-	volumeDeploymentType  = "volume"
-	gitSyncDeploymentType = "git_sync"
-	imageDeploymentType   = "image"
-
 	ErrKubernetesNamespaceNotAvailable = errors.New("no kubernetes namespaces are available")
 	ErrNumberOutOfRange                = errors.New("number is out of available range")
 	ErrMajorAirflowVersionUpgrade      = fmt.Errorf("Airflow 2.0 has breaking changes. To upgrade to Airflow 2.0, upgrade to %s first and make sure your DAGs and configs are 2.0 compatible", minAirflowVersion) //nolint:golint,stylecheck
@@ -190,7 +184,7 @@ func Create(label, ws, releaseName, cloudRole, executor, airflowVersion, dagDepl
 		fmt.Sprintf("\n Airflow Dashboard: %s", airflowURL)
 
 	// The Flower URL is specific to CeleryExecutor only
-	if executor == celeryExecutor || executor == "" {
+	if executor == houston.CeleryExecutorType || executor == "" {
 		tab.SuccessMsg += fmt.Sprintf("\n Flower Dashboard: %s", flowerURL)
 	}
 	tab.Print(out)
@@ -481,11 +475,11 @@ func addDagDeploymentArgs(vars map[string]interface{}, dagDeploymentType, nfsLoc
 		dagDeploymentConfig["type"] = dagDeploymentType
 	}
 
-	if dagDeploymentType == volumeDeploymentType && nfsLocation != "" {
+	if dagDeploymentType == houston.VolumeDeploymentType && nfsLocation != "" {
 		dagDeploymentConfig["nfsLocation"] = nfsLocation
 	}
 
-	if dagDeploymentType == gitSyncDeploymentType {
+	if dagDeploymentType == houston.GitSyncDeploymentType {
 		if sshKey != "" {
 			sshPubKey, err := readSSHKeyFile(sshKey)
 			if err != nil {

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -89,9 +89,9 @@ func TestCreate(t *testing.T) {
 	ws := "ck1qg6whg001r08691y117hub"
 	releaseName := ""
 	role := "test-role"
-	executor := "CeleryExecutor"
+	executor := houston.CeleryExecutorType
 	airflowVersion := "1.10.5"
-	dagDeploymentType := "image"
+	dagDeploymentType := houston.ImageDeploymentType
 	nfsLocation := ""
 	triggerReplicas := 0
 
@@ -185,7 +185,7 @@ func TestCreate(t *testing.T) {
 		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 		releaseName = ""
-		dagDeploymentType = "volume"
+		dagDeploymentType = houston.VolumeDeploymentType
 		nfsLocation = "test:/test"
 
 		buf := new(bytes.Buffer)
@@ -502,8 +502,8 @@ func TestUpdate(t *testing.T) {
 			dagDeploymentType string
 			expectedOutput    string
 		}{
-			{deploymentConfig: map[string]string{"executor": "CeleryExecutor"}, dagDeploymentType: "", expectedOutput: expected},
-			{deploymentConfig: map[string]string{"executor": "CeleryExecutor"}, dagDeploymentType: "image", expectedOutput: expected},
+			{deploymentConfig: map[string]string{"executor": houston.CeleryExecutorType}, dagDeploymentType: "", expectedOutput: expected},
+			{deploymentConfig: map[string]string{"executor": houston.CeleryExecutorType}, dagDeploymentType: houston.ImageDeploymentType, expectedOutput: expected},
 		}
 		for _, tt := range myTests {
 			buf := new(bytes.Buffer)
@@ -531,8 +531,8 @@ func TestUpdate(t *testing.T) {
 			dagDeploymentType string
 			expectedOutput    string
 		}{
-			{deploymentConfig: map[string]string{"executor": "CeleryExecutor"}, dagDeploymentType: "", expectedOutput: expected},
-			{deploymentConfig: map[string]string{"executor": "CeleryExecutor"}, dagDeploymentType: "image", expectedOutput: expected},
+			{deploymentConfig: map[string]string{"executor": houston.CeleryExecutorType}, dagDeploymentType: "", expectedOutput: expected},
+			{deploymentConfig: map[string]string{"executor": houston.CeleryExecutorType}, dagDeploymentType: houston.ImageDeploymentType, expectedOutput: expected},
 		}
 		for _, tt := range myTests {
 			buf := new(bytes.Buffer)
@@ -550,7 +550,7 @@ func TestUpdate(t *testing.T) {
 		api.On("UpdateDeployment", mock.Anything).Return(nil, mockError)
 
 		deploymentConfig := make(map[string]string)
-		deploymentConfig["executor"] = "CeleryExecutor"
+		deploymentConfig["executor"] = houston.CeleryExecutorType
 
 		buf := new(bytes.Buffer)
 		err := Update(mockDeployment.ID, role, deploymentConfig, "", "", "", "", "", "", "", "", "", 1, 0, api, buf)
@@ -1075,18 +1075,18 @@ func TestAddDagDeploymentArgs(t *testing.T) {
 		expectedOutput    map[string]interface{}
 	}{
 		{
-			dagDeploymentType: imageDeploymentType,
+			dagDeploymentType: houston.ImageDeploymentType,
 			expectedError:     "",
-			expectedOutput:    map[string]interface{}{"dagDeployment": map[string]interface{}{"type": imageDeploymentType}},
+			expectedOutput:    map[string]interface{}{"dagDeployment": map[string]interface{}{"type": houston.ImageDeploymentType}},
 		},
 		{
-			dagDeploymentType: volumeDeploymentType,
+			dagDeploymentType: houston.VolumeDeploymentType,
 			nfsLocation:       "test",
 			expectedError:     "",
-			expectedOutput:    map[string]interface{}{"dagDeployment": map[string]interface{}{"type": volumeDeploymentType, "nfsLocation": "test"}},
+			expectedOutput:    map[string]interface{}{"dagDeployment": map[string]interface{}{"type": houston.VolumeDeploymentType, "nfsLocation": "test"}},
 		},
 		{
-			dagDeploymentType: gitSyncDeploymentType,
+			dagDeploymentType: houston.GitSyncDeploymentType,
 			sshKey:            "../cmd/testfiles/ssh_key",
 			knownHosts:        "../cmd/testfiles/known_hosts",
 			gitRepoURL:        "https://github.com/neel-astro/private-airflow-dags-test",
@@ -1095,7 +1095,7 @@ func TestAddDagDeploymentArgs(t *testing.T) {
 			gitDAGDir:         "test-dags",
 			gitSyncInterval:   1,
 			expectedError:     "",
-			expectedOutput:    map[string]interface{}{"dagDeployment": map[string]interface{}{"branchName": "test-branch", "dagDirectoryLocation": "test-dags", "knownHosts": "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRTest1ngUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvTestingTYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTestingFImWwoG6mbUoWf9nzpIoaSjB+weqqUTestingXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydTestingS5ap43JXiUFFAaQ==", "repositoryUrl": "https://github.com/neel-astro/private-airflow-dags-test", "rev": "test-revision", "sshKey": "Test_ssh_key_file_content\n", "syncInterval": 1, "type": gitSyncDeploymentType}},
+			expectedOutput:    map[string]interface{}{"dagDeployment": map[string]interface{}{"branchName": "test-branch", "dagDirectoryLocation": "test-dags", "knownHosts": "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRTest1ngUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvTestingTYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTestingFImWwoG6mbUoWf9nzpIoaSjB+weqqUTestingXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydTestingS5ap43JXiUFFAaQ==", "repositoryUrl": "https://github.com/neel-astro/private-airflow-dags-test", "rev": "test-revision", "sshKey": "Test_ssh_key_file_content\n", "syncInterval": 1, "type": houston.GitSyncDeploymentType}},
 		},
 	}
 

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -146,7 +146,7 @@ func TestCreate(t *testing.T) {
 		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 		nfsLocation = ""
-		dagDeploymentType = "git_sync"
+		dagDeploymentType = houston.GitSyncDeploymentType
 
 		myTests := []struct {
 			repoURL              string

--- a/deployment/user_test.go
+++ b/deployment/user_test.go
@@ -22,10 +22,10 @@ func TestUserList(t *testing.T) {
 		FullName: "Some Person",
 		Username: "somebody",
 		RoleBindings: []houston.RoleBinding{
-			{Role: "SYSTEM_ADMIN"},
-			{Role: "WORKSPACE_ADMIN"},
-			{Role: "WORKSPACE_VIEWER"},
-			{Role: "DEPLOYMENT_ADMIN"},
+			{Role: houston.SystemAdminRole},
+			{Role: houston.WorkspaceAdminRole},
+			{Role: houston.WorkspaceViewerRole},
+			{Role: houston.DeploymentAdminRole},
 		},
 		Emails: []houston.Email{
 			{Address: "somebody@astronomer.io"},
@@ -62,8 +62,8 @@ func TestUserList(t *testing.T) {
 				FullName: "Another Person",
 				Username: "anotherperson",
 				RoleBindings: []houston.RoleBinding{
-					{Role: "WORKSPACE_VIEWER"},
-					{Role: "DEPLOYMENT_EDITOR"},
+					{Role: houston.WorkspaceViewerRole},
+					{Role: houston.DeploymentEditorRole},
 				},
 			},
 		}
@@ -120,7 +120,7 @@ func TestAdd(t *testing.T) {
 
 	t.Run("add user success", func(t *testing.T) {
 		mockUserRole := &houston.RoleBinding{
-			Role: "DEPLOYMENT_ADMIN",
+			Role: houston.DeploymentAdminRole,
 			User: houston.RoleBindingUser{
 				Username: "somebody@astronomer.io",
 			},
@@ -151,7 +151,7 @@ func TestAdd(t *testing.T) {
 
 		deploymentID := "ckggzqj5f4157qtc9lescmehm"
 		email := "somebody@astronomer.com"
-		role := "DEPLOYMENT_ADMIN"
+		role := houston.DeploymentAdminRole
 
 		expectedRequest := houston.UpdateDeploymentUserRequest{
 			Email:        email,
@@ -176,7 +176,7 @@ func TestDeleteUser(t *testing.T) {
 	t.Run("delete user success", func(t *testing.T) {
 		mockUserRole := &houston.RoleBinding{
 			User: houston.RoleBindingUser{Username: "somebody@astronomer.com"},
-			Role: "DEPLOYMENT_ADMIN",
+			Role: houston.DeploymentAdminRole,
 			Deployment: houston.Deployment{
 				ID:          "deploymentid",
 				ReleaseName: "prehistoric-gravity-9229",
@@ -215,7 +215,7 @@ func TestUpdateUser(t *testing.T) {
 
 	t.Run("update user success", func(t *testing.T) {
 		mockUserRole := &houston.RoleBinding{
-			Role: houston.DeploymentEditor,
+			Role: houston.DeploymentEditorRole,
 			User: houston.RoleBindingUser{
 				Username: "somebody@astronomer.com",
 			},
@@ -227,7 +227,7 @@ func TestUpdateUser(t *testing.T) {
 
 		expectedRequest := houston.UpdateDeploymentUserRequest{
 			Email:        mockUserRole.User.Username,
-			Role:         houston.DeploymentEditor,
+			Role:         houston.DeploymentEditorRole,
 			DeploymentID: mockUserRole.Deployment.ID,
 		}
 
@@ -235,7 +235,7 @@ func TestUpdateUser(t *testing.T) {
 		api.On("UpdateDeploymentUser", expectedRequest).Return(mockUserRole, nil)
 
 		buf := new(bytes.Buffer)
-		err := UpdateUser(mockUserRole.Deployment.ID, mockUserRole.User.Username, houston.DeploymentEditor, api, buf)
+		err := UpdateUser(mockUserRole.Deployment.ID, mockUserRole.User.Username, houston.DeploymentEditorRole, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully updated somebody@astronomer.com to a DEPLOYMENT_EDITOR")
 		api.AssertExpectations(t)

--- a/houston/constants.go
+++ b/houston/constants.go
@@ -2,11 +2,24 @@ package houston
 
 // Houston Constants
 const (
-	// Deployment Level Role Based Access
-	DeploymentRole   = "DEPLOYMENT"
-	DeploymentAdmin  = "DEPLOYMENT_ADMIN"
-	DeploymentEditor = "DEPLOYMENT_EDITOR"
-	DeploymentViewer = "DEPLOYMENT_VIEWER"
+	// RBAC
+	SystemAdminRole      = "SYSTEM_ADMIN"
+	WorkspaceAdminRole   = "WORKSPACE_ADMIN"
+	WorkspaceViewerRole  = "WORKSPACE_VIEWER"
+	WorkspaceEditorRole  = "WORKSPACE_EDITOR"
+	DeploymentRole       = "DEPLOYMENT"
+	DeploymentAdminRole  = "DEPLOYMENT_ADMIN"
+	DeploymentEditorRole = "DEPLOYMENT_EDITOR"
+	DeploymentViewerRole = "DEPLOYMENT_VIEWER"
 
+	// Deployment
 	AirflowURLType = "airflow"
+
+	CeleryExecutorType     = "CeleryExecutor"
+	LocalExecutorType      = "LocalExecutor"
+	KubernetesExecutorType = "KubernetesExecutor"
+
+	GitSyncDeploymentType = "git_sync"
+	VolumeDeploymentType  = "volume"
+	ImageDeploymentType   = "image"
 )

--- a/houston/deployment_user_test.go
+++ b/houston/deployment_user_test.go
@@ -25,7 +25,7 @@ func TestListDeploymentUsers(t *testing.T) {
 					},
 					Username: "somebody",
 					RoleBindings: []RoleBinding{
-						{Role: DeploymentAdmin},
+						{Role: DeploymentAdminRole},
 					},
 				},
 			},
@@ -70,7 +70,7 @@ func TestAddDeploymentUser(t *testing.T) {
 	mockResponse := &Response{
 		Data: ResponseData{
 			AddDeploymentUser: &RoleBinding{
-				Role: DeploymentAdmin,
+				Role: DeploymentAdminRole,
 				User: struct {
 					ID       string `json:"id"`
 					Username string `json:"username"`
@@ -124,7 +124,7 @@ func TestUpdateDeploymentUser(t *testing.T) {
 	mockResponse := &Response{
 		Data: ResponseData{
 			UpdateDeploymentUser: &RoleBinding{
-				Role: DeploymentAdmin,
+				Role: DeploymentAdminRole,
 				User: struct {
 					ID       string `json:"id"`
 					Username string `json:"username"`
@@ -178,7 +178,7 @@ func TestDeleteDeploymentUser(t *testing.T) {
 	mockResponse := &Response{
 		Data: ResponseData{
 			DeleteDeploymentUser: &RoleBinding{
-				Role: DeploymentAdmin,
+				Role: DeploymentAdminRole,
 				User: struct {
 					ID       string `json:"id"`
 					Username string `json:"username"`

--- a/houston/workspace_users_test.go
+++ b/houston/workspace_users_test.go
@@ -186,7 +186,7 @@ func TestUpdateWorkspaceUserAndRole(t *testing.T) {
 
 	mockResponse := &Response{
 		Data: ResponseData{
-			WorkspaceUpdateUserRole: DeploymentAdmin,
+			WorkspaceUpdateUserRole: DeploymentAdminRole,
 		},
 	}
 	jsonResponse, err := json.Marshal(mockResponse)
@@ -202,7 +202,7 @@ func TestUpdateWorkspaceUserAndRole(t *testing.T) {
 		})
 		api := NewClient(client)
 
-		response, err := api.UpdateWorkspaceUserRole("workspace-id", "email", DeploymentAdmin)
+		response, err := api.UpdateWorkspaceUserRole("workspace-id", "email", DeploymentAdminRole)
 		assert.NoError(t, err)
 		assert.Equal(t, response, mockResponse.Data.WorkspaceUpdateUserRole)
 	})
@@ -230,10 +230,10 @@ func TestGetWorkspaceUserRole(t *testing.T) {
 			WorkspaceGetUser: WorkspaceUserRoleBindings{
 				RoleBindings: []RoleBindingWorkspace{
 					{
-						Role: DeploymentAdmin,
+						Role: DeploymentAdminRole,
 					},
 					{
-						Role: "WORKSPACE_ADMIN",
+						Role: WorkspaceAdminRole,
 					},
 				},
 			},

--- a/workspace/user_test.go
+++ b/workspace/user_test.go
@@ -19,7 +19,7 @@ var (
 	mockRoles = houston.WorkspaceUserRoleBindings{
 		RoleBindings: []houston.RoleBindingWorkspace{
 			{
-				Role: "WORKSPACE_VIEWER",
+				Role: houston.WorkspaceViewerRole,
 				Workspace: struct {
 					ID string `json:"id"`
 				}{ID: "ckoixo6o501496qemiwsja1tl"},
@@ -115,7 +115,7 @@ func TestListRoles(t *testing.T) {
 		UpdatedAt: "2020-06-25T20:09:29.917Z",
 		RoleBindings: []houston.RoleBinding{
 			{
-				Role: "WORKSPACE_ADMIN",
+				Role: houston.WorkspaceAdminRole,
 				User: houston.RoleBindingUser{
 					ID:       "ckbv7zpkh00og0760ki4mhl6r",
 					Username: "andrii@astronomer.io",
@@ -149,14 +149,14 @@ func TestListRolesWithServiceAccounts(t *testing.T) {
 		UpdatedAt: "2020-06-25T20:09:29.917Z",
 		RoleBindings: []houston.RoleBinding{
 			{
-				Role: "WORKSPACE_ADMIN",
+				Role: houston.WorkspaceAdminRole,
 				User: houston.RoleBindingUser{
 					ID:       "ckbv7zpkh00og0760ki4mhl6r",
 					Username: "andrii@astronomer.io",
 				},
 			},
 			{
-				Role: "WORKSPACE_ADMIN",
+				Role: houston.WorkspaceAdminRole,
 				ServiceAccount: houston.WorkspaceServiceAccount{
 					ID:    "ckxaolfky0822zsvcrgts3c6a",
 					Label: "WA1",


### PR DESCRIPTION
## Description

- Set `celery` as default value for `executor` type on the `astro deployment create` command. Previously, if user did not provide the `--executor` flag, the command threw an error. However, the doc for this commands states that the default value for --executor is celery, and this is the behaviour in the UI.
- Enforce use of constants for houston-related values (Deployment Types, RBAC roles, Executor types)...

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/3711

## 🧪 Functional Testing

- try and create a new deployment without specifying the --executor flag:
```bash
astro deployment create my-deployment
```
This should create the deployment successfully, with the `Celery` executor type.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
