### PR TITLE
fix docker webserver health check

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -39,6 +39,8 @@ const (
 	healthCheckBreakPoint = 100 // Maximum number of events to wait for health check to pass
 	healthyProjectStatus  = "health_status: healthy"
 	execDieStatus         = "exec_die"
+
+	webserverServiceName = "webserver"
 )
 
 type DockerCompose struct {
@@ -328,7 +330,7 @@ func checkServiceState(serviceState, expectedState string) bool {
 func (d *DockerCompose) webserverHealthCheck() error {
 	healthCheckCounter := 0
 	err := d.composeService.Events(context.Background(), d.projectName, api.EventsOptions{
-		Services: []string{config.CFG.WebserverContainerName.GetString()}, Consumer: func(event api.Event) error {
+		Services: []string{webserverServiceName}, Consumer: func(event api.Event) error {
 			if event.Status == healthyProjectStatus {
 				fmt.Println("\nProject is running! All components are now available.")
 				// have to return an error to break from the event listener loop


### PR DESCRIPTION
## Description
Changes:
- Fixed the service name passed for webserver health check as the service name from docker-compose instead of container name

## 🎟 Issue(s)

Related astronomer/issues#4266

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
