### PR TITLE
Fix dev logs logic for custom container name

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -205,3 +205,39 @@ func getFmtEnvFile(envFile string, containerEngine Container) (string, error) {
 		return "", nil
 	}
 }
+
+func GetWebserverServiceName() string {
+	containerEngine := config.CFG.ContainerEngine.GetString()
+	switch containerEngine {
+	case string(DockerEngine):
+		return webserverServiceName
+	case string(PodmanEngine):
+		return config.CFG.WebserverContainerName.GetString()
+	default:
+		return webserverServiceName
+	}
+}
+
+func GetSchedulerServiceName() string {
+	containerEngine := config.CFG.ContainerEngine.GetString()
+	switch containerEngine {
+	case string(DockerEngine):
+		return schedulerServiceName
+	case string(PodmanEngine):
+		return config.CFG.SchedulerContainerName.GetString()
+	default:
+		return schedulerServiceName
+	}
+}
+
+func GetTriggererServiceName() string {
+	containerEngine := config.CFG.ContainerEngine.GetString()
+	switch containerEngine {
+	case string(DockerEngine):
+		return triggererServiceName
+	case string(PodmanEngine):
+		return config.CFG.TriggererContainerName.GetString()
+	default:
+		return triggererServiceName
+	}
+}

--- a/airflow/container_test.go
+++ b/airflow/container_test.go
@@ -3,6 +3,9 @@ package airflow
 import (
 	"testing"
 
+	"github.com/astronomer/astro-cli/config"
+	testUtils "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,4 +20,64 @@ func TestGetFmtEnvFileSuccess(t *testing.T) {
 	resp, err = getFmtEnvFile("testfiles/env.test.valid", "docker")
 	assert.NoError(t, err)
 	assert.Equal(t, "env_file: testfiles/env.test.valid", resp)
+}
+
+func TestGetWebserverServiceNameDocker(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configYaml := testUtils.NewTestConfig("docker")
+	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
+	config.InitConfig(fs)
+	config.CFG.WebserverContainerName.SetHomeString("webserver_tmp")
+	webserverName := GetWebserverServiceName()
+	assert.Equal(t, webserverName, webserverServiceName)
+}
+
+func TestGetWebserverServiceNamePodman(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configYaml := testUtils.NewTestConfig("podman")
+	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
+	config.InitConfig(fs)
+	config.CFG.WebserverContainerName.SetHomeString("webserver_tmp")
+	webserverName := GetWebserverServiceName()
+	assert.Equal(t, webserverName, "webserver_tmp")
+}
+
+func TestGetSchedulerServiceNameDocker(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configYaml := testUtils.NewTestConfig("docker")
+	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
+	config.InitConfig(fs)
+	config.CFG.SchedulerContainerName.SetHomeString("scheduler_tmp")
+	schedulerName := GetSchedulerServiceName()
+	assert.Equal(t, schedulerName, schedulerServiceName)
+}
+
+func TestGetSchedulerServiceNamePodman(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configYaml := testUtils.NewTestConfig("podman")
+	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
+	config.InitConfig(fs)
+	config.CFG.SchedulerContainerName.SetHomeString("scheduler_tmp")
+	schedulerName := GetSchedulerServiceName()
+	assert.Equal(t, schedulerName, "scheduler_tmp")
+}
+
+func TestGetTriggererServiceNameDocker(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configYaml := testUtils.NewTestConfig("docker")
+	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
+	config.InitConfig(fs)
+	config.CFG.TriggererContainerName.SetHomeString("triggerer_tmp")
+	triggererName := GetTriggererServiceName()
+	assert.Equal(t, triggererName, triggererServiceName)
+}
+
+func TestGetTriggererServiceNamePodman(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configYaml := testUtils.NewTestConfig("podman")
+	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
+	config.InitConfig(fs)
+	config.CFG.TriggererContainerName.SetHomeString("triggerer_tmp")
+	triggererName := GetTriggererServiceName()
+	assert.Equal(t, triggererName, "triggerer_tmp")
 }

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -43,6 +43,8 @@ const (
 	execDieStatus         = "exec_die"
 
 	webserverServiceName = "webserver"
+	schedulerServiceName = "scheduler"
+	triggererServiceName = "triggerer"
 )
 
 type DockerCompose struct {

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -411,16 +411,16 @@ func airflowLogs(cmd *cobra.Command, args []string) error {
 	containersNames := make([]string, 0)
 	// default is to display all logs
 	if !schedulerLogs && !webserverLogs && !triggererLogs {
-		containersNames = append(containersNames, []string{config.CFG.SchedulerContainerName.GetString(), config.CFG.WebserverContainerName.GetString(), config.CFG.TriggererContainerName.GetString()}...)
+		containersNames = append(containersNames, []string{airflow.GetWebserverServiceName(), airflow.GetSchedulerServiceName(), airflow.GetTriggererServiceName()}...)
 	}
 	if schedulerLogs {
-		containersNames = append(containersNames, config.CFG.SchedulerContainerName.GetString())
+		containersNames = append(containersNames, airflow.GetSchedulerServiceName())
 	}
 	if webserverLogs {
-		containersNames = append(containersNames, config.CFG.WebserverContainerName.GetString())
+		containersNames = append(containersNames, airflow.GetWebserverServiceName())
 	}
 	if triggererLogs {
-		containersNames = append(containersNames, config.CFG.TriggererContainerName.GetString())
+		containersNames = append(containersNames, airflow.GetTriggererServiceName())
 	}
 
 	// Silence Usage as we have now validated command input


### PR DESCRIPTION
## Description
Changes:
- Fix `astro dev logs` returning no logs in case of using custom container names for airflow components when using Docker container engine.

## 🎟 Issue(s)

Related astronomer/issues#4284

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
