### PR TITLE
Initialize projects using Astro runtime images

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -76,14 +76,14 @@ func initFiles(root string, files map[string]string) error {
 }
 
 // Init will scaffold out a new airflow project
-func Init(path, airflowImageTag string) error {
+func Init(path, airflowImageName, airflowImageTag string) error {
 	// List of directories to create
 	dirs := []string{"dags", "plugins", "include"}
 
 	// Map of files to create
 	files := map[string]string{
 		".dockerignore":         include.Dockerignore,
-		"Dockerfile":            fmt.Sprintf(include.Dockerfile, airflowImageTag),
+		"Dockerfile":            fmt.Sprintf(include.Dockerfile, airflowImageName, airflowImageTag),
 		".gitignore":            include.Gitignore,
 		"packages.txt":          "",
 		"requirements.txt":      "",

--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -21,13 +21,16 @@ const (
 	defaultAirflowVersion = uint64(0x1) //nolint:gomnd
 	componentName         = "airflow"
 
-	airflowVersionLabelName        = "io.astronomer.docker.airflow.version"
 	triggererAllowedAirflowVersion = "2.2.0"
+	triggererAllowedRuntimeVersion = "4.0.0"
 
 	webserverHealthCheckInterval = 10 * time.Second
 )
 
-var repoNameSanitizeRegexp = regexp.MustCompile(`^[^a-z0-9]*`) // must not start with anything except lowercase letter or number
+var (
+	repoNameSanitizeRegexp = regexp.MustCompile(`^[^a-z0-9]*`) // must not start with anything except lowercase letter or number
+	runtimeVersionCheck    = fmt.Sprintf(">= %s", triggererAllowedRuntimeVersion)
+)
 
 func initDirs(root string, dirs []string) error {
 	// Create the dirs

--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -27,10 +27,7 @@ const (
 	webserverHealthCheckInterval = 10 * time.Second
 )
 
-var (
-	repoNameSanitizeRegexp = regexp.MustCompile(`^[^a-z0-9]*`) // must not start with anything except lowercase letter or number
-	runtimeVersionCheck    = fmt.Sprintf(">= %s", triggererAllowedRuntimeVersion)
-)
+var repoNameSanitizeRegexp = regexp.MustCompile(`^[^a-z0-9]*`) // must not start with anything except lowercase letter or number
 
 func initDirs(root string, dirs []string) error {
 	// Create the dirs

--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -22,7 +22,7 @@ const (
 	componentName         = "airflow"
 
 	triggererAllowedAirflowVersion = "2.2.0"
-	triggererAllowedRuntimeVersion = "4.0.0"
+	triggererAllowedRuntimeVersion = "4.2.5"
 
 	webserverHealthCheckInterval = 10 * time.Second
 )

--- a/airflow/airflow_test.go
+++ b/airflow/airflow_test.go
@@ -74,7 +74,7 @@ func TestInit(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	err = Init(tmpDir, "test")
+	err = Init(tmpDir, AstronomerCertifiedImageName, "test")
 	assert.NoError(t, err)
 
 	expectedFiles := []string{

--- a/airflow/constants.go
+++ b/airflow/constants.go
@@ -1,14 +1,8 @@
 package airflow
 
-import "fmt"
-
 const (
-	BaseImageName                = "quay.io/astronomer"
 	AstronomerCertifiedImageName = "ap-airflow"
 	AstroRuntimeImageName        = "astro-runtime"
-)
-
-var (
-	FullAstronomerCertifiedImageName = fmt.Sprintf("%s/%s", BaseImageName, AstronomerCertifiedImageName)
-	FullAstroRuntimeImageName        = fmt.Sprintf("%s/%s", BaseImageName, AstroRuntimeImageName)
+	airflowVersionLabelName      = "io.astronomer.docker.airflow.version"
+	runtimeVersionLabelName      = "io.astronomer.docker.runtime.version"
 )

--- a/airflow/constants.go
+++ b/airflow/constants.go
@@ -1,0 +1,6 @@
+package airflow
+
+const (
+	AstronomerCertifiedImageName = "ap-airflow"
+	AstroRuntimeImageName = "astro-runtime"
+)

--- a/airflow/constants.go
+++ b/airflow/constants.go
@@ -1,6 +1,14 @@
 package airflow
 
+import "fmt"
+
 const (
+	BaseImageName                = "quay.io/astronomer"
 	AstronomerCertifiedImageName = "ap-airflow"
 	AstroRuntimeImageName        = "astro-runtime"
+)
+
+var (
+	FullAstronomerCertifiedImageName = fmt.Sprintf("%s/%s", BaseImageName, AstronomerCertifiedImageName)
+	FullAstroRuntimeImageName        = fmt.Sprintf("%s/%s", BaseImageName, AstroRuntimeImageName)
 )

--- a/airflow/constants.go
+++ b/airflow/constants.go
@@ -2,5 +2,5 @@ package airflow
 
 const (
 	AstronomerCertifiedImageName = "ap-airflow"
-	AstroRuntimeImageName = "astro-runtime"
+	AstroRuntimeImageName        = "astro-runtime"
 )

--- a/airflow/container.go
+++ b/airflow/container.go
@@ -130,7 +130,6 @@ func generateConfig(projectName, airflowHome, envFile string, imageLabels map[st
 		return "", err
 	}
 
-	// check if Airflow triggerer is enabled, on AC images, look if version is > 2.1.0, for runtime if version >= 4.1.0
 	triggererEnabled, err := CheckTriggererEnabled(imageLabels)
 	if err != nil {
 		return "", err
@@ -273,7 +272,7 @@ var CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
 	runtimeVersion, ok := imageLabels[runtimeVersionLabelName]
 	if !ok {
 		// image doesn't have either runtime version or airflow version
-		// we don't want to block the user's experience in case this happens, so we disabled triggerer and warn error
+		// we don't want to block the user's experience in case this happens, so we disable triggerer and warn error
 		fmt.Println(messages.WarningTriggererDisabledNoVersionDetected)
 
 		return false, nil

--- a/airflow/container.go
+++ b/airflow/container.go
@@ -274,6 +274,9 @@ var CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
 	runtimeVersion, ok := imageLabels[runtimeVersionLabelName]
 	if !ok {
 		// image doesn't have either runtime version or airflow version
+		// we don't want to block the user's experience in case this happens, so we disabled triggerer and warn error
+		fmt.Println(messages.WarningTriggererDisabledNoVersionDetected)
+
 		return false, nil
 	}
 

--- a/airflow/container.go
+++ b/airflow/container.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/astronomer/astro-cli/airflow/include"
 	"github.com/astronomer/astro-cli/airflow/types"
 	"github.com/astronomer/astro-cli/config"
@@ -280,16 +279,5 @@ var CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
 		return false, nil
 	}
 
-	// check if runtime version matches minimum compatible for triggerer feature
-	semVer, err := semver.NewVersion(runtimeVersion)
-	if err != nil {
-		return false, err
-	}
-	// create semver constraint to check runtime version against minimum compatible one
-	c, err := semver.NewConstraint(runtimeVersionCheck)
-	if err != nil {
-		return false, err
-	}
-	// Check if the version meets the constraints
-	return c.Check(semVer), nil
+	return versions.GreaterThanOrEqualTo(runtimeVersion, triggererAllowedRuntimeVersion), nil
 }

--- a/airflow/container_test.go
+++ b/airflow/container_test.go
@@ -1,11 +1,16 @@
 package airflow
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/docker"
 	testUtils "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/spf13/afero"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -80,4 +85,84 @@ func TestGetTriggererServiceNamePodman(t *testing.T) {
 	config.CFG.TriggererContainerName.SetHomeString("triggerer_tmp")
 	triggererName := GetTriggererServiceName()
 	assert.Equal(t, triggererName, "triggerer_tmp")
+}
+
+func TestCheckTriggererEnabled(t *testing.T) {
+	oldParseFile := docker.ParseFile
+
+	t.Run("astro-runtime supported version", func(t *testing.T) {
+		image := fmt.Sprintf("%s:%s", FullAstroRuntimeImageName, triggererAllowedRuntimeVersion)
+		docker.ParseFile = func(filename string) ([]docker.Command, error) {
+			return []docker.Command{
+				{
+					Cmd:   command.From,
+					Value: []string{image},
+				},
+			}, nil
+		}
+
+		triggererEnabled, err := CheckTriggererEnabled("testing", "Dockerfile", runtimeVersionCheck)
+		assert.NoError(t, err)
+		assert.True(t, triggererEnabled)
+	})
+
+	t.Run("astro-runtime unsupported version", func(t *testing.T) {
+		image := fmt.Sprintf("%s:3.0.0", FullAstroRuntimeImageName)
+		docker.ParseFile = func(filename string) ([]docker.Command, error) {
+			return []docker.Command{
+				{
+					Cmd:   command.From,
+					Value: []string{image},
+				},
+			}, nil
+		}
+
+		triggererEnabled, err := CheckTriggererEnabled("testing", "Dockerfile", runtimeVersionCheck)
+		assert.NoError(t, err)
+		assert.False(t, triggererEnabled)
+	})
+
+	t.Run("astronomer-certified supported version", func(t *testing.T) {
+		image := fmt.Sprintf("%s:2.4.0-onbuild", FullAstronomerCertifiedImageName)
+		docker.ParseFile = func(filename string) ([]docker.Command, error) {
+			return []docker.Command{
+				{
+					Cmd:   command.From,
+					Value: []string{image},
+				},
+			}, nil
+		}
+
+		triggererEnabled, err := CheckTriggererEnabled("testing", "Dockerfile", runtimeVersionCheck)
+		assert.NoError(t, err)
+		assert.True(t, triggererEnabled)
+	})
+
+	t.Run("astronomer-certified unsupported version", func(t *testing.T) {
+		image := fmt.Sprintf("%s:2.1.0", FullAstronomerCertifiedImageName)
+		docker.ParseFile = func(filename string) ([]docker.Command, error) {
+			return []docker.Command{
+				{
+					Cmd:   command.From,
+					Value: []string{image},
+				},
+			}, nil
+		}
+
+		triggererEnabled, err := CheckTriggererEnabled("testing", "Dockerfile", runtimeVersionCheck)
+		assert.NoError(t, err)
+		assert.False(t, triggererEnabled)
+	})
+
+	t.Run("parse image error", func(t *testing.T) {
+		docker.ParseFile = func(filename string) ([]docker.Command, error) {
+			return []docker.Command{}, errors.New("test error") //nolint: goerr113
+		}
+
+		triggererEnabled, err := CheckTriggererEnabled("testing", "Dockerfile", runtimeVersionCheck)
+		assert.Error(t, err)
+		assert.False(t, triggererEnabled)
+	})
+
+	docker.ParseFile = oldParseFile
 }

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -105,13 +105,8 @@ func (d *DockerCompose) Start(options containerTypes.ContainerStartConfig) error
 		return err
 	}
 
-	labels, err := d.imageHandler.GetImageLabels()
-	if err != nil {
-		return err
-	}
-
 	// recreate the project, to pass the labels
-	project, err := createProject(d.projectName, d.airflowHome, d.envFile, labels)
+	project, err := createProject(d.projectName, d.airflowHome, d.envFile)
 	if err != nil {
 		return err
 	}
@@ -165,12 +160,7 @@ func (d *DockerCompose) Logs(follow bool, containerNames ...string) error {
 }
 
 func (d *DockerCompose) Stop() error {
-	labels, err := d.imageHandler.GetImageLabels()
-	if err != nil {
-		return err
-	}
-
-	project, err := createProject(d.projectName, d.airflowHome, d.envFile, labels)
+	project, err := createProject(d.projectName, d.airflowHome, d.envFile)
 	if err != nil {
 		return err
 	}
@@ -290,9 +280,9 @@ func (d *DockerCompose) getWebServerContainerID() (string, error) {
 }
 
 // createProject creates project with yaml config as context
-func createProject(projectName, airflowHome, envFile string, labels map[string]string) (*composeTypes.Project, error) {
+func createProject(projectName, airflowHome, envFile string) (*composeTypes.Project, error) {
 	// Generate the docker-compose yaml
-	yaml, err := generateConfig(projectName, airflowHome, envFile, labels, DockerEngine)
+	yaml, err := generateConfig(projectName, airflowHome, envFile, DockerEngine)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create project: %w", err)
 	}

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -106,7 +106,12 @@ func (d *DockerCompose) Start(options containerTypes.ContainerStartConfig) error
 	}
 
 	// recreate the project, to pass the labels
-	project, err := createProject(d.projectName, d.airflowHome, d.envFile)
+	labels, err := d.imageHandler.GetImageLabels()
+	if err != nil {
+		return err
+	}
+
+	project, err := createProject(d.projectName, d.airflowHome, d.envFile, labels)
 	if err != nil {
 		return err
 	}
@@ -160,7 +165,12 @@ func (d *DockerCompose) Logs(follow bool, containerNames ...string) error {
 }
 
 func (d *DockerCompose) Stop() error {
-	project, err := createProject(d.projectName, d.airflowHome, d.envFile)
+	labels, err := d.imageHandler.GetImageLabels()
+	if err != nil {
+		return err
+	}
+
+	project, err := createProject(d.projectName, d.airflowHome, d.envFile, labels)
 	if err != nil {
 		return err
 	}
@@ -280,9 +290,9 @@ func (d *DockerCompose) getWebServerContainerID() (string, error) {
 }
 
 // createProject creates project with yaml config as context
-func createProject(projectName, airflowHome, envFile string) (*composeTypes.Project, error) {
+func createProject(projectName, airflowHome, envFile string, imageLabels map[string]string) (*composeTypes.Project, error) {
 	// Generate the docker-compose yaml
-	yaml, err := generateConfig(projectName, airflowHome, envFile, DockerEngine)
+	yaml, err := generateConfig(projectName, airflowHome, envFile, imageLabels, DockerEngine)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create project: %w", err)
 	}

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -45,7 +45,7 @@ func TestCheckServiceStateFalse(t *testing.T) {
 func TestGenerateConfig(t *testing.T) {
 	oldCheckTriggererEnabled := CheckTriggererEnabled
 
-	CheckTriggererEnabled = func(airflowHome, dockerfile, runtimeConstraint string) (bool, error) {
+	CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
 		return true, nil
 	}
 
@@ -54,7 +54,8 @@ func TestGenerateConfig(t *testing.T) {
 	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
 	config.InitConfig(fs)
 	config.CFG.ProjectName.SetHomeString("test")
-	cfg, err := generateConfig("test-project-name", "airflow_home", ".env", DockerEngine)
+	labels := map[string]string{airflowVersionLabelName: triggererAllowedAirflowVersion}
+	cfg, err := generateConfig("test-project-name", "airflow_home", ".env", labels, DockerEngine)
 	assert.NoError(t, err)
 	expectedCfg := `version: '3.1'
 

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -219,9 +219,14 @@ func TestExecPipeNils(t *testing.T) {
 }
 
 func TestDockerStartFailure(t *testing.T) {
-	composeMock, docker, _ := getComposeMocks()
+	composeMock, docker, imageMock := getComposeMocks()
 	composeMock.On("Ps", mock.Anything, mock.Anything, mock.Anything).Return([]api.ContainerSummary{{ID: "testID", Name: "test", State: "running"}}, nil)
 	composeMock.On("Up", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	composeMock.On("Events", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	imageMock.On("Build", mock.Anything).Return(nil)
+	mockLabels := map[string]string{airflowVersionLabelName: triggererAllowedAirflowVersion}
+	imageMock.On("GetImageLabels").Return(mockLabels)
 	options := containerTypes.ContainerStartConfig{
 		DockerfilePath: "./testfiles/Dockerfile.Airflow1.ok",
 	}

--- a/airflow/include/dockerfile.go
+++ b/airflow/include/dockerfile.go
@@ -4,5 +4,5 @@ import "strings"
 
 // Dockerfile is the Dockerfile template
 var Dockerfile = strings.TrimSpace(`
-FROM quay.io/astronomer/ap-airflow:%s
+FROM quay.io/astronomer/%s:%s
 `)

--- a/airflow/podman.go
+++ b/airflow/podman.go
@@ -100,12 +100,7 @@ func (p *Podman) Start(options types.ContainerStartConfig) error {
 		return err
 	}
 
-	labels, err := imageBuilder.GetImageLabels()
-	if err != nil {
-		return err
-	}
-
-	_, err = p.startPod(p.projectName, p.projectDir, p.envFile, labels)
+	_, err = p.startPod(p.projectName, p.projectDir, p.envFile)
 	if err != nil {
 		return fmt.Errorf("%s: %w", messages.ErrContainerRecreate, err)
 	}
@@ -315,7 +310,7 @@ func (p *Podman) listContainers() ([]entities.ListContainer, error) {
 	return containerInfo, err
 }
 
-func (p *Podman) startPod(projectName, projectDir, envFile string, imageLabels map[string]string) (string, error) {
+func (p *Podman) startPod(projectName, projectDir, envFile string) (string, error) {
 	var podID string
 	// in case pod already there, try running pod start
 	exists, _ := p.podmanBind.Exists(p.conn, projectName, nil)
@@ -326,7 +321,7 @@ func (p *Podman) startPod(projectName, projectDir, envFile string, imageLabels m
 		}
 		return report.Id, nil
 	}
-	err := generatePodState(projectName, projectDir, envFile, imageLabels)
+	err := generatePodState(projectName, projectDir, envFile)
 	if err != nil {
 		return podID, err
 	}
@@ -345,7 +340,7 @@ func (p *Podman) startPod(projectName, projectDir, envFile string, imageLabels m
 	return "", nil
 }
 
-func generatePodState(projectName, projectDir, envFile string, imageLabels map[string]string) error {
+func generatePodState(projectName, projectDir, envFile string) error {
 	// Create the podman config yaml if not exists
 	if _, err := os.Stat(podConfigFile); errors.Is(err, os.ErrNotExist) {
 		err = initFiles("", map[string]string{podConfigFile: include.PodmanConfigYml})
@@ -353,7 +348,7 @@ func generatePodState(projectName, projectDir, envFile string, imageLabels map[s
 			return err
 		}
 	}
-	configYAML, err := generateConfig(projectName, projectDir, envFile, imageLabels, PodmanEngine)
+	configYAML, err := generateConfig(projectName, projectDir, envFile, PodmanEngine)
 	if err != nil {
 		return fmt.Errorf("failed to create pod state file: %w", err)
 	}

--- a/airflow/podman.go
+++ b/airflow/podman.go
@@ -348,7 +348,8 @@ func generatePodState(projectName, projectDir, envFile string) error {
 			return err
 		}
 	}
-	configYAML, err := generateConfig(projectName, projectDir, envFile, PodmanEngine)
+	labels := map[string]string{airflowVersionLabelName: triggererAllowedAirflowVersion}
+	configYAML, err := generateConfig(projectName, projectDir, envFile, labels, PodmanEngine)
 	if err != nil {
 		return fmt.Errorf("failed to create pod state file: %w", err)
 	}

--- a/airflow/podman_test.go
+++ b/airflow/podman_test.go
@@ -87,6 +87,12 @@ func TestPodmanGetContainerIDFailure(t *testing.T) {
 }
 
 func TestPodmanStartSuccess(t *testing.T) {
+	oldCheckTriggererEnabled := CheckTriggererEnabled
+
+	CheckTriggererEnabled = func(airflowHome, dockerfile, runtimeConstraint string) (bool, error) {
+		return true, nil
+	}
+
 	fs := afero.NewMemMapFs()
 	configYaml := testUtils.NewTestConfig("podman")
 	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
@@ -126,6 +132,8 @@ func TestPodmanStartSuccess(t *testing.T) {
 	// Case when pod is already present but in stop state
 	err = podmanMock.Start(options)
 	assert.NoError(t, err)
+
+	CheckTriggererEnabled = oldCheckTriggererEnabled
 }
 
 func TestPodmanStartFailure(t *testing.T) {

--- a/airflow/podman_test.go
+++ b/airflow/podman_test.go
@@ -137,6 +137,12 @@ func TestPodmanStartSuccess(t *testing.T) {
 }
 
 func TestPodmanStartFailure(t *testing.T) {
+	oldCheckTriggererEnabled := CheckTriggererEnabled
+
+	CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
+		return true, nil
+	}
+
 	fs := afero.NewMemMapFs()
 	configYaml := testUtils.NewTestConfig("podman")
 	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
@@ -177,6 +183,8 @@ func TestPodmanStartFailure(t *testing.T) {
 	bindMock.On("Start", podmanMock.conn, mock.Anything, mock.Anything).Return(nil, errPodman).Once()
 	err = podmanMock.Start(options)
 	assert.Contains(t, err.Error(), errPodman.Error())
+
+	CheckTriggererEnabled = oldCheckTriggererEnabled
 }
 
 func TestPodmanKillSuccess(t *testing.T) {

--- a/airflow/podman_test.go
+++ b/airflow/podman_test.go
@@ -89,7 +89,7 @@ func TestPodmanGetContainerIDFailure(t *testing.T) {
 func TestPodmanStartSuccess(t *testing.T) {
 	oldCheckTriggererEnabled := CheckTriggererEnabled
 
-	CheckTriggererEnabled = func(airflowHome, dockerfile, runtimeConstraint string) (bool, error) {
+	CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
 		return true, nil
 	}
 

--- a/airflow/podman_test.go
+++ b/airflow/podman_test.go
@@ -99,7 +99,7 @@ func TestPodmanStartSuccess(t *testing.T) {
 	config.InitConfig(fs)
 	projectDir, _ := os.Getwd()
 
-	mockResponse := []byte("Connection successful.")
+	mockResponse := []byte(webserverHealthStatus)
 
 	bindMock := new(mocks.PodmanBind)
 	bindMock.On("NewConnection", mock.Anything, mock.Anything).Return(context.TODO(), nil)
@@ -112,14 +112,10 @@ func TestPodmanStartSuccess(t *testing.T) {
 	bindMock.On("List", podmanMock.conn, mock.Anything).Return([]entities.ListContainer{{Names: []string{"test-webserver"}, ID: "test-id"}}, nil)
 	bindMock.On("ExecCreate", podmanMock.conn, mock.Anything, mock.Anything).Return("test-exec-id", nil)
 
-	respCounter := 0
 	mockCall := bindMock.On("ExecStartAndAttach", podmanMock.conn, mock.Anything, mock.Anything)
 	mockCall.RunFn = func(args mock.Arguments) {
-		if respCounter >= 1 {
-			streams := args.Get(2).(*containers.ExecStartAndAttachOptions)
-			streams.GetOutputStream().Write(mockResponse)
-		}
-		respCounter++
+		streams := args.Get(2).(*containers.ExecStartAndAttachOptions)
+		streams.GetOutputStream().Write(mockResponse)
 		mockCall.ReturnArguments = mock.Arguments{nil}
 	}
 

--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -17,9 +17,56 @@ func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, erro
 		return "", err
 	}
 
+	if httpClient.useAstronomerCertified {
+		return getAstronomerCertifiedTag(resp.AvailableReleases, airflowVersion)
+	}
+
+	return getAstroRuntimeTag(resp.RuntimeVersions, airflowVersion)
+}
+
+// get latest runtime tag associated to provided airflow version
+// if no airflow version is provided, returns the latest astro runtime version available
+func getAstroRuntimeTag(runtimeVersions map[string]RuntimeVersion, airflowVersion string) (string, error) {
 	availableTags := []string{}
-	vs := make(AirflowVersions, len(resp.AvailableReleases))
-	for i, r := range resp.AvailableReleases {
+	availableVersions := []string{}
+
+	for runtimeVersion, r := range runtimeVersions {
+		if r.Metadata.Channel != "stable" {
+			continue
+		}
+
+		// if user wants specific airflow version, get all runtime version associated to this airflow version
+		if r.Metadata.AirflowVersion == airflowVersion {
+			availableTags = append(availableTags, runtimeVersion)
+		} else {
+			availableVersions = append(availableVersions, runtimeVersion)
+		}
+	}
+
+	tagsToUse := availableVersions
+	if airflowVersion != "" {
+		tagsToUse = availableTags
+	}
+
+	// get latest runtime version
+	latestVersion, _ := NewAirflowVersion(tagsToUse[0], []string{tagsToUse[0]})
+	for i := 1; i < len(tagsToUse); i++ {
+		tag := tagsToUse[i]
+		nextVersion, err := NewAirflowVersion(tag, []string{tag})
+		if err == nil {
+			if nextVersion.GreaterThan(latestVersion) {
+				latestVersion = nextVersion
+			}
+		}
+	}
+
+	return latestVersion.Version.String(), nil
+}
+
+func getAstronomerCertifiedTag(availableReleases []AirflowVersionRaw, airflowVersion string) (string, error) {
+	availableTags := []string{}
+	vs := make(AirflowVersions, len(availableReleases))
+	for i, r := range availableReleases {
 		if r.Version == airflowVersion {
 			availableTags = r.Tags
 			break
@@ -31,6 +78,7 @@ func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, erro
 	}
 
 	var selectedVersion *AirflowVersion
+	var err error
 	if airflowVersion == "" && len(vs) != 0 {
 		sort.Sort(vs)
 		selectedVersion = vs[len(vs)-1]

--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -67,10 +67,8 @@ func getAstroRuntimeTag(runtimeVersions map[string]RuntimeVersion, airflowVersio
 	for i := 1; i < len(tagsToUse); i++ {
 		tag := tagsToUse[i]
 		nextVersion, err := NewAirflowVersion(tag, []string{tag})
-		if err == nil {
-			if nextVersion.GreaterThan(latestVersion) {
-				latestVersion = nextVersion
-			}
+		if err == nil && nextVersion.GreaterThan(latestVersion) {
+			latestVersion = nextVersion
 		}
 	}
 

--- a/airflow_versions/http_client.go
+++ b/airflow_versions/http_client.go
@@ -46,7 +46,7 @@ func (r *Request) Do() (*Response, error) {
 // Do executes a query against the updates astronomer API, logging out any errors contained in the response object
 func (c *Client) Do(doOpts httputil.DoOptions) (*Response, error) {
 	var response httputil.HTTPResponse
-	url := config.CFG.RuntimeReleaseURL.GetString()
+	url := config.CFG.RuntimeReleasesURL.GetString()
 	if c.useAstronomerCertified {
 		url = config.CFG.AirflowReleasesURL.GetString()
 	}

--- a/airflow_versions/http_client.go
+++ b/airflow_versions/http_client.go
@@ -12,14 +12,14 @@ import (
 
 // Client containers the logger and HTTPClient used to communicate with the HoustonAPI
 type Client struct {
-	HTTPClient *httputil.HTTPClient
+	HTTPClient             *httputil.HTTPClient
 	useAstronomerCertified bool
 }
 
 // NewClient returns a new Client with the logger and HTTP client setup.
 func NewClient(c *httputil.HTTPClient, useAstronomerCertified bool) *Client {
 	return &Client{
-		HTTPClient: c,
+		HTTPClient:             c,
 		useAstronomerCertified: useAstronomerCertified,
 	}
 }

--- a/airflow_versions/http_client.go
+++ b/airflow_versions/http_client.go
@@ -13,12 +13,14 @@ import (
 // Client containers the logger and HTTPClient used to communicate with the HoustonAPI
 type Client struct {
 	HTTPClient *httputil.HTTPClient
+	useAstronomerCertified bool
 }
 
 // NewClient returns a new Client with the logger and HTTP client setup.
-func NewClient(c *httputil.HTTPClient) *Client {
+func NewClient(c *httputil.HTTPClient, useAstronomerCertified bool) *Client {
 	return &Client{
 		HTTPClient: c,
+		useAstronomerCertified: useAstronomerCertified,
 	}
 }
 
@@ -38,13 +40,16 @@ func (r *Request) DoWithClient(api *Client) (*Response, error) {
 
 // Do executes the given HTTP request and returns the HTTP Response
 func (r *Request) Do() (*Response, error) {
-	return r.DoWithClient(NewClient(httputil.NewHTTPClient()))
+	return r.DoWithClient(NewClient(httputil.NewHTTPClient(), false))
 }
 
 // Do executes a query against the updates astronomer API, logging out any errors contained in the response object
 func (c *Client) Do(doOpts httputil.DoOptions) (*Response, error) {
 	var response httputil.HTTPResponse
-	url := config.CFG.AirflowReleasesURL.GetString()
+	url := config.CFG.RuntimeReleaseURL.GetString()
+	if c.useAstronomerCertified {
+		url = config.CFG.AirflowReleasesURL.GetString()
+	}
 	httpResponse, err := c.HTTPClient.Do("GET", url, &doOpts)
 	if err != nil {
 		return nil, err

--- a/airflow_versions/types.go
+++ b/airflow_versions/types.go
@@ -13,10 +13,26 @@ import (
 // only fixed: error parsing regexp: invalid or unsupported Perl syntax: `(?<` via replace `?<` with `?P<`
 var AirflowVersionReg = regexp.MustCompile(`v?(?:(?:(?P<epoch>[0-9]+)!)?(?P<release>[0-9]+(?:\.[0-9]+)*)(?P<pre>[-_.]?(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))[-_.]?(?P<pre_n>[0-9]+)?)?(?P<post>(?:-(?P<post_n1>[0-9]+))|(?:[-_.]?(?P<post_l>post|rev|r)[-_.]?(?P<post_n2>[0-9]+)?))?(?P<dev>[-_.]?(?P<dev_l>dev)[-_.]?(?P<dev_n>[0-9]+)?)?)(?:\+(?P<local>[a-z0-9]+(?:[-_.][a-z0-9]+)*))?`)
 
-// Response wraps all updates.astronomer.io response structs used for json marashalling
+// Response wraps all updates.astronomer.io response structs used for json marshalling
 type Response struct {
 	AvailableReleases []AirflowVersionRaw `json:"available_releases"`
 	Version           string              `json:"version"`
+	RuntimeVersions map[string]RuntimeVersion `json:"runtimeVersions"`
+}
+
+type RuntimeVersion struct {
+	Metadata RuntimeVersionMetadata `json:"metadata"`
+	Migrations RuntimeVersionMigrations `json:"migrations"`
+}
+
+type RuntimeVersionMetadata struct {
+	AirflowVersion string `json:"airflowVersion"`
+	Channel string `json:"channel"`
+	ReleaseDate string `json:"releaseDate"`
+}
+
+type RuntimeVersionMigrations struct {
+	AirflowDatabase bool `json:"airflowDatabase"`
 }
 
 // AirflowVersionRaw represents a single airflow version.

--- a/airflow_versions/types.go
+++ b/airflow_versions/types.go
@@ -13,22 +13,22 @@ import (
 // only fixed: error parsing regexp: invalid or unsupported Perl syntax: `(?<` via replace `?<` with `?P<`
 var AirflowVersionReg = regexp.MustCompile(`v?(?:(?:(?P<epoch>[0-9]+)!)?(?P<release>[0-9]+(?:\.[0-9]+)*)(?P<pre>[-_.]?(?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))[-_.]?(?P<pre_n>[0-9]+)?)?(?P<post>(?:-(?P<post_n1>[0-9]+))|(?:[-_.]?(?P<post_l>post|rev|r)[-_.]?(?P<post_n2>[0-9]+)?))?(?P<dev>[-_.]?(?P<dev_l>dev)[-_.]?(?P<dev_n>[0-9]+)?)?)(?:\+(?P<local>[a-z0-9]+(?:[-_.][a-z0-9]+)*))?`)
 
-// Response wraps all updates.astronomer.io response structs used for json marshalling
+// Response wraps all updates.astronomer.io response structs used for json marshaling
 type Response struct {
-	AvailableReleases []AirflowVersionRaw `json:"available_releases"`
-	Version           string              `json:"version"`
-	RuntimeVersions map[string]RuntimeVersion `json:"runtimeVersions"`
+	AvailableReleases []AirflowVersionRaw       `json:"available_releases"`
+	Version           string                    `json:"version"`
+	RuntimeVersions   map[string]RuntimeVersion `json:"runtimeVersions"`
 }
 
 type RuntimeVersion struct {
-	Metadata RuntimeVersionMetadata `json:"metadata"`
+	Metadata   RuntimeVersionMetadata   `json:"metadata"`
 	Migrations RuntimeVersionMigrations `json:"migrations"`
 }
 
 type RuntimeVersionMetadata struct {
 	AirflowVersion string `json:"airflowVersion"`
-	Channel string `json:"channel"`
-	ReleaseDate string `json:"releaseDate"`
+	Channel        string `json:"channel"`
+	ReleaseDate    string `json:"releaseDate"`
 }
 
 type RuntimeVersionMigrations struct {

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -31,17 +31,17 @@ var (
 )
 
 var (
-	projectName      string
-	airflowVersion   string
-	envFile          string
-	followLogs       bool
-	forceDeploy      bool
-	forcePrompt      bool
-	saveDeployConfig bool
-	schedulerLogs    bool
-	webserverLogs    bool
-	triggererLogs    bool
-	ignoreCacheDev   bool
+	projectName            string
+	airflowVersion         string
+	envFile                string
+	followLogs             bool
+	forceDeploy            bool
+	forcePrompt            bool
+	saveDeployConfig       bool
+	schedulerLogs          bool
+	webserverLogs          bool
+	triggererLogs          bool
+	ignoreCacheDev         bool
 	useAstronomerCertified bool
 
 	runExample = `

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/astronomer/astro-cli/airflow/types"
 
 	"github.com/astronomer/astro-cli/airflow"
@@ -306,6 +308,15 @@ func airflowInit(cmd *cobra.Command, _ []string, out io.Writer) error {
 		projectDirectory := filepath.Base(config.WorkingPath)
 		projectName = strings.Replace(strcase.ToSnake(projectDirectory), "_", "-", -1)
 	}
+
+	// check feature flag if AstroRuntime is enabled, if not, fallback to astronomer certified, if not able to get feature flag, we don't want to block the user
+	appConfig, err := houstonClient.GetAppConfig()
+	if err != nil {
+		logrus.Debugln("Error checking feature flag", err)
+	} else if !appConfig.Flags.AstroRuntimeEnabled {
+		useAstronomerCertified = true
+	}
+
 	httpClient := airflowversions.NewClient(httputil.NewHTTPClient(), useAstronomerCertified)
 	defaultImageTag, err := prepareDefaultAirflowImageTag(airflowVersion, httpClient, houstonClient, out)
 	if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -32,7 +32,11 @@ func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowver
 	defaultImageTag, _ := airflowversions.GetDefaultImageTag(httpClient, airflowVersion)
 
 	if defaultImageTag == "" {
-		defaultImageTag = "2.0.0-buster-onbuild"
+		if useAstronomerCertified {
+			defaultImageTag = "2.0.0-buster-onbuild"
+		} else {
+			defaultImageTag = "3.0.0"
+		}
 		fmt.Fprintf(out, "Initializing Airflow project, pulling Airflow development files from %s\n", defaultImageTag)
 	}
 	return defaultImageTag, nil

--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ var (
 		WebserverPort:          newCfg("webserver.port", "8080"),
 		ShowWarnings:           newCfg("show_warnings", "true"),
 		AirflowReleasesURL:     newCfg("airflow_releases_url", "https://updates.astronomer.io/astronomer-certified"),
+		RuntimeReleaseURL:      newCfg("runtime_releases_url", "https://updates.astronomer.io/astronomer-runtime"),
 		SkipVerifyTLS:          newCfg("skip_verify_tls", "false"),
 		Verbosity:              newCfg("verbosity", "warning"),
 		ContainerEngine:        newCfg("container.engine", "docker"),

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ var (
 		WebserverPort:          newCfg("webserver.port", "8080"),
 		ShowWarnings:           newCfg("show_warnings", "true"),
 		AirflowReleasesURL:     newCfg("airflow_releases_url", "https://updates.astronomer.io/astronomer-certified"),
-		RuntimeReleaseURL:      newCfg("runtime_releases_url", "https://updates.astronomer.io/astronomer-runtime"),
+		RuntimeReleasesURL:     newCfg("runtime_releases_url", "https://updates.astronomer.io/astronomer-runtime"),
 		SkipVerifyTLS:          newCfg("skip_verify_tls", "false"),
 		Verbosity:              newCfg("verbosity", "warning"),
 		ContainerEngine:        newCfg("container.engine", "docker"),

--- a/config/types.go
+++ b/config/types.go
@@ -34,7 +34,7 @@ type cfgs struct {
 	WebserverPort          cfg
 	ShowWarnings           cfg
 	AirflowReleasesURL     cfg
-	RuntimeReleaseURL      cfg
+	RuntimeReleasesURL     cfg
 	SkipVerifyTLS          cfg
 	Verbosity              cfg
 	ContainerEngine        cfg

--- a/config/types.go
+++ b/config/types.go
@@ -34,6 +34,7 @@ type cfgs struct {
 	WebserverPort          cfg
 	ShowWarnings           cfg
 	AirflowReleasesURL     cfg
+	RuntimeReleaseURL      cfg
 	SkipVerifyTLS          cfg
 	Verbosity              cfg
 	ContainerEngine        cfg

--- a/docker/parse.go
+++ b/docker/parse.go
@@ -86,8 +86,8 @@ func ParseReader(file io.Reader) ([]Command, error) {
 	return ret, nil
 }
 
-// Parse a Dockerfile from a filename.  An IOError or ParseError may occur.
-func ParseFile(filename string) ([]Command, error) {
+// ParseFile parses a Dockerfile from a filename.  An IOError or ParseError may occur.
+var ParseFile = func(filename string) ([]Command, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, IOError{err.Error()}

--- a/houston/types.go
+++ b/houston/types.go
@@ -343,6 +343,7 @@ type FeatureFlags struct {
 	TriggererEnabled       bool `json:"triggererEnabled"`
 	GitSyncEnabled         bool `json:"gitSyncDagDeployment"`
 	NamespaceFreeFormEntry bool `json:"namespaceFreeFormEntry"`
+	AstroRuntimeEnabled    bool `json:"astroRuntimeEnabled"`
 }
 
 // coerce a string into SemVer if possible

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -81,6 +81,7 @@ var (
 
 	NA                                        = "N/A"
 	ValidDockerfileBaseImage                  = "quay.io/astronomer/ap-airflow"
+	WarningTriggererDisabledNoVersionDetected = "warning: could not find the version of Airflow or Runtime you're using, are you using an official Docker image for your project ? Disabling Airflow triggerer."
 	WarningDowngradeVersion                   = "Your Astro CLI Version (%s) is ahead of the server version (%s).\nConsider downgrading your Astro CLI to match. See https://www.astronomer.io/docs/cli-quickstart for more information.\n"
 	WarningInvalidImageName                   = "WARNING! The image in your Dockerfile is pulling from '%s', which is not supported. We strongly recommend that you use Astronomer Certified images that pull from 'astronomerinc/ap-airflow' or 'quay.io/astronomer/ap-airflow'. If you're running a custom image, you can override this. Are you sure you want to continue?\n"
 	WarningInvalidNameTag                     = "WARNING! You are about to push an image using the '%s' tag. This is not recommended.\nPlease use one of the following tags: %s.\nAre you sure you want to continue?"


### PR DESCRIPTION
## Description

With the recent additions of Astro runtimes, we want to allow users to initialize new airflow projects using the Astro runtime as a base image instead of the Astronomer Certified Airflow images.

By default, we want to initialize a project with Astro runtime images, but still allow users to use Astronomer Certified images by providing a flag like:
```bash
# this will initialize a project using Astronomer Certified Airflow images, which is the behaviour in current releases 0.28.* and below.
astro dev init --use-astronomer-certified
```

**This PR should not be merged before Astro Runtime is supported on all components of the platform (Houston etc...)**.

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/4253

## 🧪 Functional Testing

To test this feature:
- create a new directory 
- Initalize a new project with default latest astronomer runtime tag/version:
```bash
# this should initialize a project using the latest "stable" Astro Runtime tag
astro dev init

# you can check it by looking at the content of the generated Dockerfile
cat Dockerfile
# image should be astro-runtime:whichever version is the latest stable one
```

You can also try to generate a project using a specific airflow version:
```bash
astro dev init -v 2.2.0
```

Also, try and generate a project using Astronomer Certified images:
```bash
astro dev init --use-astronomer-certified

# with given airflow version
astro dev init --use-astronomer-certified -v 2.0.0
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
