### PR TITLE
Add directory name to container prefix

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -137,6 +137,22 @@ func generateConfig(projectName, airflowHome, envFile string, imageLabels map[st
 		triggererEnabled = true
 	}
 
+	dirName := config.CFG.ProjectName.GetString()
+	schedulerName := config.CFG.SchedulerContainerName.GetString()
+	if schedulerName == config.DefaultSchedulerName && containerEngine != PodmanEngine {
+		schedulerName = fmt.Sprintf("%s-%s", dirName, schedulerName)
+	}
+
+	webserverName := config.CFG.WebserverContainerName.GetString()
+	if webserverName == config.DefaultWebserverName && containerEngine != PodmanEngine {
+		webserverName = fmt.Sprintf("%s-%s", dirName, webserverName)
+	}
+
+	triggererName := config.CFG.TriggererContainerName.GetString()
+	if triggererName == config.DefaultTriggererName && containerEngine != PodmanEngine {
+		triggererName = fmt.Sprintf("%s-%s", dirName, triggererName)
+	}
+
 	cfg := ComposeConfig{
 		PostgresUser:           config.CFG.PostgresUser.GetString(),
 		PostgresPassword:       config.CFG.PostgresPassword.GetString(),
@@ -150,9 +166,9 @@ func generateConfig(projectName, airflowHome, envFile string, imageLabels map[st
 		MountLabel:             "z",
 		ProjectName:            sanitizeRepoName(projectName),
 		TriggererEnabled:       triggererEnabled,
-		SchedulerContainerName: config.CFG.SchedulerContainerName.GetString(),
-		WebserverContainerName: config.CFG.WebserverContainerName.GetString(),
-		TriggererContainerName: config.CFG.TriggererContainerName.GetString(),
+		SchedulerContainerName: schedulerName,
+		WebserverContainerName: webserverName,
+		TriggererContainerName: triggererName,
 	}
 
 	buff := new(bytes.Buffer)

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -47,6 +47,7 @@ func TestGenerateConfig(t *testing.T) {
 	configYaml := testUtils.NewTestConfig("docker")
 	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
 	config.InitConfig(fs)
+	config.CFG.ProjectName.SetHomeString("test")
 	cfg, err := generateConfig("test-project-name", "airflow_home", ".env", map[string]string{airflowVersionLabelName: triggererAllowedAirflowVersion}, DockerEngine)
 	assert.NoError(t, err)
 	expectedCfg := `version: '3.1'
@@ -83,7 +84,7 @@ services:
 
   scheduler:
     image: test-project-name/airflow:latest
-    container_name: scheduler
+    container_name: test-scheduler
     command: >
       bash -c "(airflow upgradedb || airflow db upgrade) && airflow scheduler"
     restart: unless-stopped
@@ -110,7 +111,7 @@ services:
 
   webserver:
     image: test-project-name/airflow:latest
-    container_name: webserver
+    container_name: test-webserver
     command: >
       bash -c 'if [[ -z "$$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $$(pip show -f apache-airflow | grep basic_auth.py) ]];
         then export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.basic_auth ;
@@ -152,7 +153,7 @@ services:
 
   triggerer:
     image: test-project-name/airflow:latest
-    container_name: triggerer
+    container_name: test-triggerer
     command: >
       bash -c "(airflow upgradedb || airflow db upgrade) && airflow triggerer"
     restart: unless-stopped

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,10 @@ import (
 const (
 	defaultDirPerm os.FileMode = 0770
 	newFilePerm    os.FileMode = 0600
+
+	DefaultWebserverName = "webserver"
+	DefaultSchedulerName = "scheduler"
+	DefaultTriggererName = "triggerer"
 )
 
 var (
@@ -64,9 +68,9 @@ var (
 		Verbosity:              newCfg("verbosity", "warning"),
 		ContainerEngine:        newCfg("container.engine", "docker"),
 		PodmanConnectionURI:    newCfg("podman.connection_uri", ""),
-		SchedulerContainerName: newCfg("scheduler.container_name", "scheduler"),
-		WebserverContainerName: newCfg("webserver.container_name", "webserver"),
-		TriggererContainerName: newCfg("triggerer.container_name", "triggerer"),
+		SchedulerContainerName: newCfg("scheduler.container_name", DefaultSchedulerName),
+		WebserverContainerName: newCfg("webserver.container_name", DefaultWebserverName),
+		TriggererContainerName: newCfg("triggerer.container_name", DefaultTriggererName),
 		HoustonDialTimeout:     newCfg("houston.dial_timeout", "10"),
 	}
 


### PR DESCRIPTION
## Description
Changes:
- Added directory name as a prefix to container name, only in case of default container name being used with Docker engine. (Podman already appends pod name as a prefix to container name)

## 🎟 Issue(s)

Related astronomer/issues#4300

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
