### PR TITLE
Revert "small fix to ignore the Dockerfile in the generated docker image (#509)"

### DIFF
--- a/airflow/include/dockerignore.go
+++ b/airflow/include/dockerignore.go
@@ -10,5 +10,4 @@ var Dockerignore = strings.TrimSpace(`
 airflow_settings.yaml
 pod-config.yml
 logs/
-Dockerfile
 `)


### PR DESCRIPTION
This reverts commit 9497c7f318d75fd63de8f24e94689401051d7bbd.

## Description

Reverting the above commit since having the Dockerfile in the image is useful for debugging

## 🎟 Issue(s)

## 🧪 Functional Testing

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
