### PR TITLE
Feature/get team

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .idea/
 .vscode/
+airflow/pod-config.yml
 astro
 astro-cli
 cover.out
@@ -9,4 +10,5 @@ coverage.txt
 dist/
 packages.txt
 requirements.txt
+testbin/golangci-lint
 vendor/github.com/theupdateframework/notary/Dockerfile

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func NewRootCmd(client houston.ClientInterface, out io.Writer) *cobra.Command {
 		// TODO: remove newAirflowRootCmd, after 1.0 we have only devRootCmd
 		newAirflowRootCmd(out),
 		newLogsDeprecatedCmd(out),
+		newTeamCmd(out),
 	)
 	return rootCmd
 }

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -11,7 +11,7 @@ func newTeamCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "team",
 		Short: "Manage Astronomer Teams",
-		Long:  "Teams represents a Team in or a group from an IDP in the Astronomer platform",
+		Long:  "Teams represents a Team in or a group from an IDP in the Astronomer Platform",
 	}
 	cmd.AddCommand(
 		newTeamGetCmd(out),
@@ -20,21 +20,18 @@ func newTeamCmd(out io.Writer) *cobra.Command {
 }
 
 func newTeamGetCmd(out io.Writer) *cobra.Command {
-	var (
-		teamID       string
-		usersEnabled bool
-	)
+	var usersEnabled bool
 	cmd := &cobra.Command{
 		Use:     "get",
 		Aliases: []string{"g"},
-		Short:   "Get a team in the astronomer platform",
-		Long:    "Get a team in the astronomer platform",
+		Short:   "Get a team in the Astronomer Platform",
+		Long:    "Get a team in the Astronomer Platform",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			return team.Get(teamID, usersEnabled, houstonClient, out)
+			return team.Get(args, usersEnabled, houstonClient, out)
 		},
 	}
-	cmd.Flags().StringVarP(&teamID, "team-id", "i", "", "Team Id")
 	cmd.Flags().BoolVarP(&usersEnabled, "users", "u", false, "add team Users")
 	return cmd
 }

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -11,7 +11,7 @@ func newTeamCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "team",
 		Short: "Manage Astronomer Teams",
-		Long:  "Teams represents a Team in or a group from an IDP in the Astronomer Platform",
+		Long:  "Teams represents a team or a group from an IDP in the Astronomer Platform",
 	}
 	cmd.AddCommand(
 		newTeamGetCmd(out),
@@ -29,7 +29,9 @@ func newTeamGetCmd(out io.Writer) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			return team.Get(args, usersEnabled, houstonClient, out)
+
+			teamID := args[0]
+			return team.Get(teamID, usersEnabled, houstonClient, out)
 		},
 	}
 	cmd.Flags().BoolVarP(&usersEnabled, "users", "u", false, "add team Users")

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"io"
+
+	team "github.com/astronomer/astro-cli/team"
+	"github.com/spf13/cobra"
+)
+
+func newTeamCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "team",
+		Short: "Manage Astronomer Teams",
+		Long:  "Teams represents a Team in or a group from an IDP in the Astronomer platform",
+	}
+	cmd.AddCommand(
+		newTeamGetCmd(out),
+	)
+	return cmd
+}
+
+func newTeamGetCmd(out io.Writer) *cobra.Command {
+	var (
+		teamID       string
+		usersEnabled bool
+	)
+	cmd := &cobra.Command{
+		Use:     "get",
+		Aliases: []string{"g"},
+		Short:   "Get a team in the astronomer platform",
+		Long:    "Get a team in the astronomer platform",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			return team.Get(teamID, usersEnabled, houstonClient, out)
+		},
+	}
+	cmd.Flags().StringVarP(&teamID, "team-id", "i", "", "Team Id")
+	cmd.Flags().BoolVarP(&usersEnabled, "users", "u", false, "add team Users")
+	return cmd
+}

--- a/cmd/team_test.go
+++ b/cmd/team_test.go
@@ -29,6 +29,7 @@ func TestNewGetTeamCmd(t *testing.T) {
 	output, err := executeCommandC(api, "team", "get", "test-id")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "")
+	api.AssertExpectations(t)
 }
 
 func TestNewGetTeamUsersCmd(t *testing.T) {
@@ -56,4 +57,5 @@ func TestNewGetTeamUsersCmd(t *testing.T) {
 	output, err := executeCommandC(api, "team", "get", "-u", "test-id")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "USERNAME            ID          \n email@email.com     test-id")
+	api.AssertExpectations(t)
 }

--- a/cmd/team_test.go
+++ b/cmd/team_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/astronomer/astro-cli/houston"
+	mocks "github.com/astronomer/astro-cli/houston/mocks"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNewGetTeamCmd(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	team := &houston.Team{
+		Name: "Everyone",
+		ID:   "blah-id",
+	}
+	appConfig := &houston.AppConfig{
+		NfsMountDagDeployment: false,
+	}
+
+	api := new(mocks.ClientInterface)
+	api.On("GetTeam", mock.Anything).Return(team, nil)
+	api.On("GetAppConfig").Return(appConfig, nil)
+
+	output, err := executeCommandC(api, "team", "get", "test-id")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "")
+}
+
+func TestNewGetTeamUsersCmd(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	team := &houston.Team{
+		Name: "Everyone",
+		ID:   "blah-id",
+	}
+	users := []houston.User{
+		{
+			Username: "email@email.com",
+			ID:       "test-id",
+		},
+	}
+	appConfig := &houston.AppConfig{
+		NfsMountDagDeployment: false,
+	}
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig").Return(appConfig, nil)
+	api.On("GetTeam", mock.Anything).Return(team, nil)
+	api.On("GetTeamUsers", mock.Anything).Return(users, nil)
+
+	output, err := executeCommandC(api, "team", "get", "-u", "test-id")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "USERNAME            ID          \n email@email.com     test-id")
+}

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -61,6 +61,9 @@ type ClientInterface interface {
 	// app
 	GetAppConfig() (*AppConfig, error)
 	GetAvailableNamespaces() ([]Namespace, error)
+	// teams
+	GetTeam(teamID string) (*Team, error)
+	GetTeamUsers(teamId string) ([]User, error)
 }
 
 // ClientImplementation - implementation of the Houston Client Interface

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -63,7 +63,7 @@ type ClientInterface interface {
 	GetAvailableNamespaces() ([]Namespace, error)
 	// teams
 	GetTeam(teamID string) (*Team, error)
-	GetTeamUsers(teamId string) ([]User, error)
+	GetTeamUsers(teamID string) ([]User, error)
 }
 
 // ClientImplementation - implementation of the Houston Client Interface

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -447,6 +447,52 @@ func (_m *ClientInterface) GetDeploymentConfig() (*houston.DeploymentConfig, err
 	return r0, r1
 }
 
+// GetTeam provides a mock function with given fields: teamID
+func (_m *ClientInterface) GetTeam(teamID string) (*houston.Team, error) {
+	ret := _m.Called(teamID)
+
+	var r0 *houston.Team
+	if rf, ok := ret.Get(0).(func(string) *houston.Team); ok {
+		r0 = rf(teamID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Team)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(teamID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetTeamUsers provides a mock function with given fields: teamId
+func (_m *ClientInterface) GetTeamUsers(teamId string) ([]houston.User, error) {
+	ret := _m.Called(teamId)
+
+	var r0 []houston.User
+	if rf, ok := ret.Get(0).(func(string) []houston.User); ok {
+		r0 = rf(teamId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]houston.User)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(teamId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetWorkspace provides a mock function with given fields: workspaceID
 func (_m *ClientInterface) GetWorkspace(workspaceID string) (*houston.Workspace, error) {
 	ret := _m.Called(workspaceID)

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -606,4 +606,30 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 			featureFlags
 		}
 	}`
+	TeamGetRequest = `
+	query GetTeam(
+		$teamUuid: Uuid
+	) {
+		team(
+			teamUuid: $teamUuid
+		)	{
+			name
+			id
+		}
+	}
+	`
+	TeamGetUsersRequest = `
+	query GetTeamUsers(
+		$teamUuid: Uuid!
+	) {
+		teamUsers(
+			teamUuid: $teamUuid
+		)	{
+			username
+			id
+			emails
+			status
+		}
+	}
+	`
 )

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -627,7 +627,11 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 		)	{
 			username
 			id
-			emails
+			emails{
+				address
+				verified
+				primary
+			      }
 			status
 		}
 	}

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -627,11 +627,11 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 		)	{
 			username
 			id
-			emails{
+			emails {
 				address
 				verified
 				primary
-			      }
+			}
 			status
 		}
 	}

--- a/houston/teams.go
+++ b/houston/teams.go
@@ -1,0 +1,29 @@
+package houston
+
+// GetTeam - return a specific team
+func (h ClientImplementation) GetTeam(teamId string) (*Team, error) {
+	req := Request{
+		Query:     TeamGetRequest,
+		Variables: map[string]interface{}{"teamUuid": teamId},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+	return r.Data.GetTeam, nil
+}
+
+// GetTeamUsers - return a specific teams Users
+func (h ClientImplementation) GetTeamUsers(teamId string) ([]User, error) {
+	req := Request{
+		Query:     TeamGetUsersRequest,
+		Variables: map[string]interface{}{"teamUuid": teamId},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+	return r.Data.GetTeamUsers, nil
+}

--- a/houston/teams.go
+++ b/houston/teams.go
@@ -1,10 +1,10 @@
 package houston
 
 // GetTeam - return a specific team
-func (h ClientImplementation) GetTeam(teamId string) (*Team, error) {
+func (h ClientImplementation) GetTeam(teamID string) (*Team, error) {
 	req := Request{
 		Query:     TeamGetRequest,
-		Variables: map[string]interface{}{"teamUuid": teamId},
+		Variables: map[string]interface{}{"teamUuid": teamID},
 	}
 
 	r, err := req.DoWithClient(h.client)
@@ -15,10 +15,10 @@ func (h ClientImplementation) GetTeam(teamId string) (*Team, error) {
 }
 
 // GetTeamUsers - return a specific teams Users
-func (h ClientImplementation) GetTeamUsers(teamId string) ([]User, error) {
+func (h ClientImplementation) GetTeamUsers(teamID string) ([]User, error) {
 	req := Request{
 		Query:     TeamGetUsersRequest,
-		Variables: map[string]interface{}{"teamUuid": teamId},
+		Variables: map[string]interface{}{"teamUuid": teamID},
 	}
 
 	r, err := req.DoWithClient(h.client)

--- a/houston/teams_test.go
+++ b/houston/teams_test.go
@@ -1,0 +1,100 @@
+package houston
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTeam(t *testing.T) {
+	testUtil.InitTestConfig()
+	mockResponse := &Response{
+		Data: ResponseData{
+			GetTeam: &Team{
+				Name: "Everyone",
+				ID:   "blah-id",
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.GetTeam("team-id")
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.GetTeam)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.GetTeam("team-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestGetTeamUsers(t *testing.T) {
+	testUtil.InitTestConfig()
+	mockResponse := &Response{
+		Data: ResponseData{
+			GetTeamUsers: []User{
+				{
+					Username: "email@email.com",
+					ID:       "test-id",
+				},
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.GetTeamUsers("team-id")
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.GetTeamUsers)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.GetTeamUsers("team-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}

--- a/houston/types.go
+++ b/houston/types.go
@@ -46,6 +46,8 @@ type ResponseData struct {
 	WorkspaceGetUser               WorkspaceUserRoleBindings `json:"workspaceUser,omitempty"`
 	DeploymentConfig               DeploymentConfig          `json:"deploymentConfig,omitempty"`
 	GetDeploymentNamespaces        []Namespace               `json:"availableNamespaces,omitempty"`
+	GetTeam                        *Team                     `json:"team,omitempty"`
+	GetTeamUsers                   []User                    `json:"teamUsers,omitempty"`
 }
 
 type Namespace struct {
@@ -310,6 +312,16 @@ type FeatureFlags struct {
 	TriggererEnabled       bool `json:"triggererEnabled"`
 	GitSyncEnabled         bool `json:"gitSyncDagDeployment"`
 	NamespaceFreeFormEntry bool `json:"namespaceFreeFormEntry"`
+}
+
+// Team contains all components of an Astronomer Team
+type Team struct {
+	ID           string        `json:"id"`
+	Name         string        `json:"name"`
+	SortId       int           `json:"sortid"`
+	CreatedAt    string        `json:"createdAt"`
+	UpdatedAt    string        `json:"updatedAt"`
+	RoleBindings []RoleBinding `json:"roleBindings"`
 }
 
 // coerce a string into SemVer if possible

--- a/houston/types.go
+++ b/houston/types.go
@@ -318,7 +318,7 @@ type FeatureFlags struct {
 type Team struct {
 	ID           string        `json:"id"`
 	Name         string        `json:"name"`
-	SortID       int           `json:"sortid"`
+	SortID       int           `json:"sortId"`
 	CreatedAt    string        `json:"createdAt"`
 	UpdatedAt    string        `json:"updatedAt"`
 	RoleBindings []RoleBinding `json:"roleBindings"`

--- a/houston/types.go
+++ b/houston/types.go
@@ -318,7 +318,7 @@ type FeatureFlags struct {
 type Team struct {
 	ID           string        `json:"id"`
 	Name         string        `json:"name"`
-	SortId       int           `json:"sortid"`
+	SortID       int           `json:"sortid"`
 	CreatedAt    string        `json:"createdAt"`
 	UpdatedAt    string        `json:"updatedAt"`
 	RoleBindings []RoleBinding `json:"roleBindings"`

--- a/team/team.go
+++ b/team/team.go
@@ -1,0 +1,49 @@
+package team
+
+import (
+	"io"
+
+	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/printutil"
+)
+
+// retrieves a team and all of its users if passed optional param
+func Get(teamID string, usersEnabled bool, client houston.ClientInterface, out io.Writer) error {
+
+	team, err := client.GetTeam(teamID)
+	if err != nil {
+		return err
+	}
+	tableTeam := printutil.Table{
+		Padding:        []int{44, 50},
+		DynamicPadding: true,
+		Header:         []string{"NAME", "ID"},
+		ColorRowCode:   [2]string{"\033[1;32m", "\033[0m"},
+	}
+
+	tableTeam.AddRow([]string{team.Name, team.ID}, false)
+
+	tableTeam.Print(out)
+
+	if usersEnabled {
+		users, err := client.GetTeamUsers(teamID)
+		if err != nil {
+			return err
+		}
+		teamUsers := printutil.Table{
+			Padding:        []int{44, 50},
+			DynamicPadding: true,
+			Header:         []string{"USERNAME", "ID"},
+			ColorRowCode:   [2]string{"\033[1;32m", "\033[0m"},
+		}
+		for i := range users {
+			user := users[i]
+			teamUsers.AddRow([]string{user.Username, user.ID}, false)
+		}
+
+		teamUsers.AddRow([]string{team.Name, team.ID}, false)
+		teamUsers.Print(out)
+	}
+
+	return nil
+}

--- a/team/team.go
+++ b/team/team.go
@@ -10,8 +10,10 @@ import (
 )
 
 // retrieves a team and all of its users if passed optional param
-func Get(args []string, usersEnabled bool, client houston.ClientInterface, out io.Writer) error {
-	teamID := args[0]
+func Get(teamID string, usersEnabled bool, client houston.ClientInterface, out io.Writer) error {
+	if teamID == "" {
+		return fmt.Errorf("missing team Id")
+	}
 	team, err := client.GetTeam(teamID)
 	if err != nil {
 		return err
@@ -26,7 +28,7 @@ func Get(args []string, usersEnabled bool, client houston.ClientInterface, out i
 		if err != nil {
 			return err
 		}
-		teamUsers := printutil.Table{
+		teamUsersTable := printutil.Table{
 			Padding:        []int{44, 50},
 			DynamicPadding: true,
 			Header:         []string{"USERNAME", "ID"},
@@ -34,9 +36,9 @@ func Get(args []string, usersEnabled bool, client houston.ClientInterface, out i
 		}
 		for i := range users {
 			user := users[i]
-			teamUsers.AddRow([]string{user.Username, user.ID}, false)
+			teamUsersTable.AddRow([]string{user.Username, user.ID}, false)
 		}
-		return teamUsers.Print(out)
+		return teamUsersTable.Print(out)
 	}
 
 	return nil

--- a/team/team.go
+++ b/team/team.go
@@ -10,12 +10,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var errGetMissingTeamID = errors.New("missing team Id")
+var errMissingTeamID = errors.New("missing team ID")
 
 // retrieves a team and all of its users if passed optional param
 func Get(teamID string, usersEnabled bool, client houston.ClientInterface, out io.Writer) error {
 	if teamID == "" {
-		return errGetMissingTeamID
+		return errMissingTeamID
 	}
 	team, err := client.GetTeam(teamID)
 	if err != nil {

--- a/team/team.go
+++ b/team/team.go
@@ -1,31 +1,27 @@
 package team
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/printutil"
+	"github.com/sirupsen/logrus"
 )
 
 // retrieves a team and all of its users if passed optional param
-func Get(teamID string, usersEnabled bool, client houston.ClientInterface, out io.Writer) error {
-
+func Get(args []string, usersEnabled bool, client houston.ClientInterface, out io.Writer) error {
+	teamID := args[0]
 	team, err := client.GetTeam(teamID)
 	if err != nil {
 		return err
 	}
-	tableTeam := printutil.Table{
-		Padding:        []int{44, 50},
-		DynamicPadding: true,
-		Header:         []string{"NAME", "ID"},
-		ColorRowCode:   [2]string{"\033[1;32m", "\033[0m"},
-	}
 
-	tableTeam.AddRow([]string{team.Name, team.ID}, false)
-
-	tableTeam.Print(out)
+	fmt.Printf("\n Team Name: %s and team id: %s \n", team.Name, team.ID)
 
 	if usersEnabled {
+		logrus.Debug("retrieving users part of team")
+		fmt.Println("Users part of Team:")
 		users, err := client.GetTeamUsers(teamID)
 		if err != nil {
 			return err
@@ -40,9 +36,7 @@ func Get(teamID string, usersEnabled bool, client houston.ClientInterface, out i
 			user := users[i]
 			teamUsers.AddRow([]string{user.Username, user.ID}, false)
 		}
-
-		teamUsers.AddRow([]string{team.Name, team.ID}, false)
-		teamUsers.Print(out)
+		return teamUsers.Print(out)
 	}
 
 	return nil

--- a/team/team.go
+++ b/team/team.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -9,10 +10,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var errGetMissingTeamID = errors.New("missing team Id")
+
 // retrieves a team and all of its users if passed optional param
 func Get(teamID string, usersEnabled bool, client houston.ClientInterface, out io.Writer) error {
 	if teamID == "" {
-		return fmt.Errorf("missing team Id")
+		return errGetMissingTeamID
 	}
 	team, err := client.GetTeam(teamID)
 	if err != nil {


### PR DESCRIPTION
## Description

get team for idp retrieve one single team and it users if specified

## 🎟 Issue(s)

Related astronomer/issues#4314

## 🧪 Functional Testing

```
./astro team get  cl0k12lnf0347qe0r5kxm0k4c  --skip-version-check  

 Team Name: Everyone and team id: cl0k12lnf0347qe0r5kxm0k4c 
```


```
./astro team get  cl0k12lnf0347qe0r5kxm0k4c -u  --skip-version-check 

 Team Name: Everyone and team id: cl0k12lnf0347qe0r5kxm0k4c 
Users part of Team:
 USERNAME                 ID                            
 test-user@company.io     cl0k12lmg0315qe0ri2jyc8dd     
```
## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
