### PR TITLE
deployment teams crud cli

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -89,6 +89,22 @@ var (
 # Update a workspace user's deployment role
   $ astro deployment user update --deployment-id=xxxxx --role=DEPLOYMENT_ROLE <user-email-address>
 `
+	deploymentTeamAddExample = `
+# Add a workspace team to a deployment with a particular role
+  $ astro deployment team add --deployment-id=xxxxx --team-id=<team-id> --role=DEPLOYMENT_ROLE
+`
+	deploymentTeamRemoveExample = `
+# Remove team access to a deployment
+	$ astro deployment team remove <team-id> --deployment-id=xxxxx
+`
+	deploymentTeamUpdateExample = `
+# Update a workspace team's deployment role
+  $ astro deployment team update <team-id> --deployment-id=xxxxx --role=DEPLOYMENT_ROLE
+`
+	deploymentTeamsListExample = `
+# List all teams added to a deployment
+  $ astro deployment teams list <deployment-id>
+`
 	deploymentSaCreateExample = `
 # Create service-account
   $ astro deployment service-account create --deployment-id=xxxxx --label=my_label --role=ROLE
@@ -126,6 +142,7 @@ func newDeploymentRootCmd(out io.Writer) *cobra.Command {
 		newLogsCmd(out),
 		newDeploymentSaRootCmd(out),
 		newDeploymentUserRootCmd(out),
+		newDeploymentTeamRootCmd(out),
 		newDeploymentAirflowRootCmd(out),
 	)
 	return cmd
@@ -292,6 +309,83 @@ func newDeploymentUserRootCmd(out io.Writer) *cobra.Command {
 		newDeploymentUserDeleteCmd(out),
 		newDeploymentUserUpdateCmd(out),
 	)
+	return cmd
+}
+
+func newDeploymentTeamRootCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "team",
+		Short: "Manage deployment team resources",
+		Long:  "Teams can be added or removed from deployment",
+	}
+	_ = cmd.MarkFlagRequired("deployment-id")
+	cmd.PersistentFlags().StringVar(&workspaceID, "deployment-id", "", "deployment to associate team to")
+	cmd.AddCommand(
+		newDeploymentTeamListCmd(out),
+		newDeploymentTeamAddCmd(out),
+		newDeploymentTeamRemoveCmd(out),
+		newDeploymentTeamUpdateCmd(out),
+	)
+	return cmd
+}
+
+func newDeploymentTeamAddCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "add",
+		Short:   "Add a team to a deployment",
+		Long:    "Add a team to a deployment",
+		Example: deploymentTeamAddExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentUserAdd(cmd, out, args)
+		},
+	}
+	cmd.PersistentFlags().StringVar(&deploymentID, "team-id", "", "team to be added to deployment")
+	cmd.PersistentFlags().StringVar(&deploymentRole, "role", houston.DeploymentViewerRole, "role assigned to user")
+	return cmd
+}
+
+func newDeploymentTeamRemoveCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "remove",
+		Short:   "Remove a team from a deployment",
+		Long:    "Remove a team from a deployment",
+		Args:    cobra.ExactArgs(1),
+		Example: deploymentTeamRemoveExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentTeamRemove(cmd, out, args)
+		},
+	}
+	cmd.PersistentFlags().StringVar(&teamID, "team-id", "", "team to be removed from deployment")
+	return cmd
+}
+
+func newDeploymentTeamUpdateCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "update",
+		Short:   "Update a team's role for a deployment",
+		Long:    "Update a team's role for a deployment",
+		Args:    cobra.ExactArgs(1),
+		Example: deploymentTeamUpdateExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentTeamUpdate(cmd, out, args)
+		},
+	}
+	cmd.PersistentFlags().StringVar(&deploymentID, "team-id", "", "team to be updated")
+	cmd.PersistentFlags().StringVar(&deploymentRole, "role", houston.DeploymentViewerRole, "role assigned to team")
+	return cmd
+}
+
+func newDeploymentTeamListCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List Teams inside an Astronomer Deployment",
+		Long:    "List Teams inside an Astronomer Deployment",
+		Args:    cobra.ExactArgs(1),
+		Example: deploymentTeamsListExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentTeamsList(cmd, out, args)
+		},
+	}
 	return cmd
 }
 
@@ -625,6 +719,59 @@ func deploymentUserUpdate(cmd *cobra.Command, out io.Writer, args []string) erro
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 	return deployment.UpdateUser(deploymentID, args[0], deploymentRole, houstonClient, out)
+}
+
+// Deployment teams
+func deploymentTeamsList(cmd *cobra.Command, out io.Writer, args []string) error {
+	_, err := coalesceWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+	return deployment.TeamsList(deploymentID, args[0], houstonClient, out)
+}
+
+func deploymentTeamAdd(cmd *cobra.Command, out io.Writer, args []string) error {
+	_, err := coalesceWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
+	}
+
+	if err := validateDeploymentRole(deploymentRole); err != nil {
+		return fmt.Errorf("failed to find a valid role: %w", err)
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+	return deployment.AddTeam(deploymentID, args[0], deploymentRole, houstonClient, out)
+}
+
+func deploymentTeamRemove(cmd *cobra.Command, out io.Writer, args []string) error {
+	_, err := coalesceWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+	return deployment.RemoveTeam(deploymentID, args[0], houstonClient, out)
+}
+
+func deploymentTeamUpdate(cmd *cobra.Command, out io.Writer, args []string) error {
+	_, err := coalesceWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
+	}
+
+	if err := validateDeploymentRole(deploymentRole); err != nil {
+		return fmt.Errorf("failed to find a valid role: %w", err)
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+	return deployment.UpdateTeam(deploymentID, args[0], deploymentRole, houstonClient, out)
 }
 
 func deploymentSaCreate(cmd *cobra.Command, _ []string, out io.Writer) error {

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -57,70 +57,70 @@ var (
 	sshKey                string
 	knowHosts             string
 	CreateExample         = `
-	# Create new deployment with Celery executor (default: celery without params).
-  $ astro deployment create new-deployment-name --executor=celery
+# Create new deployment with Celery executor (default: celery without params).
+$ astro deployment create new-deployment-name --executor=celery
 
-	# Create new deployment with Local executor.
-  $ astro deployment create new-deployment-name-local --executor=local
+# Create new deployment with Local executor.
+$ astro deployment create new-deployment-name-local --executor=local
 
-	# Create new deployment with Kubernetes executor.
-  $ astro deployment create new-deployment-name-k8s --executor=k8s
+# Create new deployment with Kubernetes executor.
+$ astro deployment create new-deployment-name-k8s --executor=k8s
 
-	# Create new deployment with Kubernetes executor.
-  $ astro deployment create my-new-deployment --executor=k8s --airflow-version=1.10.10
+# Create new deployment with Kubernetes executor.
+$ astro deployment create my-new-deployment --executor=k8s --airflow-version=1.10.10
 `
 	createExampleDagDeployment = `
-	# Create new deployment with Kubernetes executor and dag deployment type volume and nfs location.
-  $ astro deployment create my-new-deployment --executor=k8s --airflow-version=2.0.0 --dag-deployment-type=volume --nfs-location=test:/test
+# Create new deployment with Kubernetes executor and dag deployment type volume and nfs location.
+$ astro deployment create my-new-deployment --executor=k8s --airflow-version=2.0.0 --dag-deployment-type=volume --nfs-location=test:/test
 `
 	deploymentUserListExample = `
-	# Search for deployment users
-  $ astro deployment user list <deployment-id> --email=EMAIL_ADDRESS --user-id=ID --name=NAME
+# Search for deployment users
+$ astro deployment user list <deployment-id> --email=EMAIL_ADDRESS --user-id=ID --name=NAME
 `
 	deploymentUserCreateExample = `
-	# Add a workspace user to a deployment with a particular role
-  $ astro deployment user add --deployment-id=xxxxx --role=DEPLOYMENT_ROLE <user-email-address>
+# Add a workspace user to a deployment with a particular role
+$ astro deployment user add --deployment-id=xxxxx --role=DEPLOYMENT_ROLE <user-email-address>
 `
 	deploymentUserDeleteExample = `
-	# Delete user access to a deployment
-	$ astro deployment user delete --deployment-id=xxxxx <user-email-address>
+# Delete user access to a deployment
+$ astro deployment user delete --deployment-id=xxxxx <user-email-address>
 `
 	deploymentUserUpdateExample = `
-	# Update a workspace user's deployment role
-  $ astro deployment user update --deployment-id=xxxxx --role=DEPLOYMENT_ROLE <user-email-address>
+# Update a workspace user's deployment role
+$ astro deployment user update --deployment-id=xxxxx --role=DEPLOYMENT_ROLE <user-email-address>
 `
 	deploymentTeamAddExample = `
-	# Add a workspace team to a deployment with a particular role
-  $ astro deployment team add --deployment-id=xxxxx --team-id=<team-id> --role=DEPLOYMENT_ROLE
+# Add a workspace team to a deployment with a particular role
+$ astro deployment team add --deployment-id=xxxxx --team-id=<team-id> --role=DEPLOYMENT_ROLE
 `
 	deploymentTeamRemoveExample = `
-	# Remove team access to a deployment
-	$ astro deployment team remove <team-id> --deployment-id=xxxxx
+# Remove team access to a deployment
+$ astro deployment team remove <team-id> --deployment-id=xxxxx
 `
 	deploymentTeamUpdateExample = `
-	# Update a workspace team's deployment role
-  $ astro deployment team update <team-id> --deployment-id=xxxxx --role=DEPLOYMENT_ROLE
+# Update a workspace team's deployment role
+$ astro deployment team update <team-id> --deployment-id=xxxxx --role=DEPLOYMENT_ROLE
 `
 	deploymentTeamsListExample = `
-	# List all teams added to a deployment
-  $ astro deployment teams list <deployment-id>
+# List all teams added to a deployment
+$ astro deployment teams list <deployment-id>
 `
 	deploymentSaCreateExample = `
-	# Create service-account
-  $ astro deployment service-account create --deployment-id=xxxxx --label=my_label --role=ROLE
+# Create service-account
+$ astro deployment service-account create --deployment-id=xxxxx --label=my_label --role=ROLE
 `
 	deploymentSaGetExample = `
-  # Get deployment service-accounts
-  $ astro deployment service-account get --deployment-id=<deployment-id>
+# Get deployment service-accounts
+$ astro deployment service-account get --deployment-id=<deployment-id>
 `
 	deploymentSaDeleteExample = `
-  $ astro deployment service-account delete <service-account-id> --deployment-id=<deployment-id>
+$ astro deployment service-account delete <service-account-id> --deployment-id=<deployment-id>
 `
 	deploymentAirflowUpgradeExample = `
-  $ astro deployment airflow upgrade --deployment-id=<deployment-id> --desired-airflow-version=<desired-airflow-version>
+$ astro deployment airflow upgrade --deployment-id=<deployment-id> --desired-airflow-version=<desired-airflow-version>
 
-	# Abort the initial airflow upgrade step:
-  $ astro deployment airflow upgrade --cancel --deployment-id=<deployment-id>
+# Abort the initial airflow upgrade step:
+$ astro deployment airflow upgrade --cancel --deployment-id=<deployment-id>
 `
 
 	deploymentUpdateAttrs = []string{"label"}

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -57,56 +57,56 @@ var (
 	sshKey                string
 	knowHosts             string
 	CreateExample         = `
-# Create new deployment with Celery executor (default: celery without params).
+	# Create new deployment with Celery executor (default: celery without params).
   $ astro deployment create new-deployment-name --executor=celery
 
-# Create new deployment with Local executor.
+	# Create new deployment with Local executor.
   $ astro deployment create new-deployment-name-local --executor=local
 
-# Create new deployment with Kubernetes executor.
+	# Create new deployment with Kubernetes executor.
   $ astro deployment create new-deployment-name-k8s --executor=k8s
 
-# Create new deployment with Kubernetes executor.
+	# Create new deployment with Kubernetes executor.
   $ astro deployment create my-new-deployment --executor=k8s --airflow-version=1.10.10
 `
 	createExampleDagDeployment = `
-# Create new deployment with Kubernetes executor and dag deployment type volume and nfs location.
+	# Create new deployment with Kubernetes executor and dag deployment type volume and nfs location.
   $ astro deployment create my-new-deployment --executor=k8s --airflow-version=2.0.0 --dag-deployment-type=volume --nfs-location=test:/test
 `
 	deploymentUserListExample = `
-# Search for deployment users
+	# Search for deployment users
   $ astro deployment user list <deployment-id> --email=EMAIL_ADDRESS --user-id=ID --name=NAME
 `
 	deploymentUserCreateExample = `
-# Add a workspace user to a deployment with a particular role
+	# Add a workspace user to a deployment with a particular role
   $ astro deployment user add --deployment-id=xxxxx --role=DEPLOYMENT_ROLE <user-email-address>
 `
 	deploymentUserDeleteExample = `
-# Delete user access to a deployment
+	# Delete user access to a deployment
 	$ astro deployment user delete --deployment-id=xxxxx <user-email-address>
 `
 	deploymentUserUpdateExample = `
-# Update a workspace user's deployment role
+	# Update a workspace user's deployment role
   $ astro deployment user update --deployment-id=xxxxx --role=DEPLOYMENT_ROLE <user-email-address>
 `
 	deploymentTeamAddExample = `
-# Add a workspace team to a deployment with a particular role
+	# Add a workspace team to a deployment with a particular role
   $ astro deployment team add --deployment-id=xxxxx --team-id=<team-id> --role=DEPLOYMENT_ROLE
 `
 	deploymentTeamRemoveExample = `
-# Remove team access to a deployment
+	# Remove team access to a deployment
 	$ astro deployment team remove <team-id> --deployment-id=xxxxx
 `
 	deploymentTeamUpdateExample = `
-# Update a workspace team's deployment role
+	# Update a workspace team's deployment role
   $ astro deployment team update <team-id> --deployment-id=xxxxx --role=DEPLOYMENT_ROLE
 `
 	deploymentTeamsListExample = `
-# List all teams added to a deployment
+	# List all teams added to a deployment
   $ astro deployment teams list <deployment-id>
 `
 	deploymentSaCreateExample = `
-# Create service-account
+	# Create service-account
   $ astro deployment service-account create --deployment-id=xxxxx --label=my_label --role=ROLE
 `
 	deploymentSaGetExample = `
@@ -119,7 +119,7 @@ var (
 	deploymentAirflowUpgradeExample = `
   $ astro deployment airflow upgrade --deployment-id=<deployment-id> --desired-airflow-version=<desired-airflow-version>
 
-# Abort the initial airflow upgrade step:
+	# Abort the initial airflow upgrade step:
   $ astro deployment airflow upgrade --cancel --deployment-id=<deployment-id>
 `
 

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -361,7 +361,7 @@ func newDeploymentTeamRemoveCmd(out io.Writer) *cobra.Command {
 
 func newDeploymentTeamUpdateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "update",
+		Use:     "update TEAM",
 		Short:   "Update a team's role for a deployment",
 		Long:    "Update a team's role for a deployment",
 		Args:    cobra.ExactArgs(1),

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -339,7 +339,8 @@ func newDeploymentTeamAddCmd(out io.Writer) *cobra.Command {
 			return deploymentTeamAdd(cmd, out, args)
 		},
 	}
-	cmd.PersistentFlags().StringVar(&deploymentID, "team-id", "", "team to be added to deployment")
+	cmd.PersistentFlags().StringVar(&teamID, "team-id", "", "team to be added to deployment")
+	_ = cmd.MarkFlagRequired("team-id")
 	cmd.PersistentFlags().StringVar(&deploymentRole, "role", houston.DeploymentViewerRole, "deployment role assigned to team")
 	return cmd
 }
@@ -721,22 +722,12 @@ func deploymentUserUpdate(cmd *cobra.Command, out io.Writer, args []string) erro
 
 // Deployment teams
 func deploymentTeamsList(cmd *cobra.Command, out io.Writer, args []string) error {
-	_, err := coalesceWorkspace()
-	if err != nil {
-		return fmt.Errorf("failed to find a valid workspace: %w", err)
-	}
-
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 	return deployment.ListTeamRoles(deploymentID, houstonClient, out)
 }
 
 func deploymentTeamAdd(cmd *cobra.Command, out io.Writer, _ []string) error {
-	_, err := coalesceWorkspace()
-	if err != nil {
-		return fmt.Errorf("failed to find a valid deployment: %w", err)
-	}
-
 	if err := validateDeploymentRole(deploymentRole); err != nil {
 		return fmt.Errorf("failed to find a valid role: %w", err)
 	}
@@ -747,22 +738,12 @@ func deploymentTeamAdd(cmd *cobra.Command, out io.Writer, _ []string) error {
 }
 
 func deploymentTeamRemove(cmd *cobra.Command, out io.Writer, args []string) error {
-	_, err := coalesceWorkspace()
-	if err != nil {
-		return fmt.Errorf("failed to find a valid workspace: %w", err)
-	}
-
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 	return deployment.RemoveTeam(deploymentID, args[0], houstonClient, out)
 }
 
 func deploymentTeamUpdate(cmd *cobra.Command, out io.Writer, args []string) error {
-	_, err := coalesceWorkspace()
-	if err != nil {
-		return fmt.Errorf("failed to find a valid workspace: %w", err)
-	}
-
 	if err := validateDeploymentRole(deploymentRole); err != nil {
 		return fmt.Errorf("failed to find a valid role: %w", err)
 	}

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -316,7 +316,7 @@ func newDeploymentTeamRootCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "team",
 		Short: "Manage deployment team resources",
-		Long:  "Teams can be added or removed from deployment",
+		Long:  "A Team is a group of users imported from your Identity Provider, teams can be added to and removed from a deployment to manage group user access",
 	}
 	_ = cmd.MarkFlagRequired("deployment-id")
 	cmd.PersistentFlags().StringVar(&deploymentID, "deployment-id", "", "deployment to associate team to")
@@ -721,7 +721,7 @@ func deploymentUserUpdate(cmd *cobra.Command, out io.Writer, args []string) erro
 }
 
 // Deployment teams
-func deploymentTeamsList(cmd *cobra.Command, out io.Writer, args []string) error {
+func deploymentTeamsList(cmd *cobra.Command, out io.Writer, _ []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 	return deployment.ListTeamRoles(deploymentID, houstonClient, out)

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -694,10 +694,10 @@ func TestDeploymentDeleteHardResponseYes(t *testing.T) {
 // Deployment Teams
 func TestDeploymentTeamAddCommand(t *testing.T) {
 	testUtil.InitTestConfig()
-	expectedOut := ` NAME        DEPLOYMENT ID                 TEAM ID                       ROLE                  
- airflow     ck05r3bor07h40d02y2hw4n4v     cl0evnxfl0120dxxu1s4nbnk7     DEPLOYMENT_VIEWER     
+	expectedOut := ` DEPLOYMENT ID                 TEAM ID                       ROLE                  
+ cknz133ra49758zr9w34b87ua     cl0evnxfl0120dxxu1s4nbnk7     DEPLOYMENT_VIEWER     
 
-Successfully added cl0evnxfl0120dxxu1s4nbnk7 as a DEPLOYMENT_VIEWER
+Successfully added team cl0evnxfl0120dxxu1s4nbnk7 to deployment cknz133ra49758zr9w34b87ua as a DEPLOYMENT_VIEWER
 `
 
 	api := new(mocks.ClientInterface)
@@ -718,10 +718,10 @@ Successfully added cl0evnxfl0120dxxu1s4nbnk7 as a DEPLOYMENT_VIEWER
 
 func TestDeploymentTeamRm(t *testing.T) {
 	testUtil.InitTestConfig()
-	expectedOut := ` DEPLOYMENT ID                 TEAM ID                       ROLE                  
- cknz133ra49758zr9w34b87ua     cl0evnxfl0120dxxu1s4nbnk7     DEPLOYMENT_VIEWER     
+	expectedOut := ` DEPLOYMENT ID                 TEAM ID                       
+ cknz133ra49758zr9w34b87ua     cl0evnxfl0120dxxu1s4nbnk7     
 
- Successfully removed the DEPLOYMENT_VIEWER role for test-team from deployment cknz133ra49758zr9w34b87ua
+ Successfully removed team cl0evnxfl0120dxxu1s4nbnk7 from deployment cknz133ra49758zr9w34b87ua
 `
 
 	api := new(mocks.ClientInterface)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,6 @@ var (
 	workspaceRole  string
 	deploymentRole string
 	role           string
-	teamID         string
 	skipVerCheck   bool
 	verboseLevel   string
 	// init debug logs should be used only for logs produced during the CLI-initialization, before the SetUpLogs Method has been called

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 var (
 	houstonClient  houston.ClientInterface
 	workspaceID    string
+	teamID         string
 	workspaceRole  string
 	deploymentRole string
 	role           string

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -33,13 +33,13 @@ var (
 	$ astro workspace team add --workspace-id=<workspace-id> --team-id=<team-id> --role=ROLE
 	`
 	workspaceTeamRemoveExample = `
-	$ astro workspace team remove cl0ck2snm0064jexu3ljfn9um --workspace-id ckwwb09aj0048u8xuts287erj
+	$ astro workspace team remove <team-id> --workspace-id=<workspace-id>
 	`
 	workspaceTeamUpdateExample = `
-	$ astro workspace team update cl0ck2snm0064jexu3ljfn9um --workspace-id ckwwb09aj0048u8xuts287erj --role WORKSPACE_EDITOR
+	$ astro workspace team update <team-id> --workspace-id=<workspace-id> --role WORKSPACE_EDITOR
 	`
 	workspaceTeamsListExample = `
-	$ astro workspace team list --workspace-id ckwwb09aj0048u8xuts287erj`
+	$ astro workspace team list --workspace-id=<workspace-id>`
 )
 
 func newWorkspaceCmd(out io.Writer) *cobra.Command {

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -217,7 +217,7 @@ func newWorkspaceTeamRootCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "team",
 		Short: "Manage Workspace Team resources",
-		Long:  "Teams can be added or removed from Workspaces",
+		Long:  "A Team is a group of users imported from your Identity Provider, teams can be added to and removed from a deployment to manage group user access",
 	}
 	cmd.PersistentFlags().StringVar(&workspaceID, "workspace-id", "", "workspace to associate team to")
 	cmd.AddCommand(

--- a/deployment/team.go
+++ b/deployment/team.go
@@ -1,0 +1,93 @@
+package deployment
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/messages"
+	"github.com/astronomer/astro-cli/pkg/printutil"
+)
+
+// TeamsList returns a list of teams with deployment access
+func TeamsList(deploymentID string, teamID string, client houston.ClientInterface, out io.Writer) error {
+	deploymentTeams, err := client.ListDeploymentTeamsAndRoles(deploymentID)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	if len(deploymentTeams) < 1 {
+		_, err = out.Write([]byte(messages.HoustonInvalidDeploymentTeams))
+		return err
+	}
+
+	header = []string{"DEPLOYMENT ID", "TEAM ID", "ROLE"}
+	tab = printutil.Table{
+		Padding:        []int{44, 50},
+		DynamicPadding: true,
+		Header:         header,
+	}
+
+	// Build rows
+	for _, d := range deploymentTeams {
+		role := filterByRoleType(d.RoleBindings, houston.DeploymentRole)
+		tab.AddRow([]string{deploymentID, d.ID, role}, false)
+	}
+
+	tab.Print(out)
+
+	return nil
+}
+
+// nolint:dupl
+// Add a user to a deployment with specified role
+func AddTeam(deploymentID, teamID string, role string, client houston.ClientInterface, out io.Writer) error {
+	d, err := client.AddDeploymentTeam(deploymentID, teamID, role)
+	if err != nil {
+		return err
+	}
+
+	tab.AddRow([]string{d.Deployment.ReleaseName, d.Deployment.ID, d.Team.ID, d.Role}, false)
+	tab.SuccessMsg = fmt.Sprintf("\n Successfully added %s as a %s", teamID, role)
+	tab.Print(out)
+
+	return nil
+}
+
+// nolint:dupl
+// UpdateUser updates a user's deployment role
+func UpdateTeam(deploymentID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
+	d, err := client.UpdateDeploymentTeamRole(deploymentID, teamID, role)
+	if err != nil {
+		return err
+	}
+
+	tab.AddRow([]string{d.Deployment.ReleaseName, d.Deployment.ID, d.Team.ID, d.Role}, false)
+	tab.SuccessMsg = fmt.Sprintf("\n Successfully updated %s to a %s", teamID, role)
+	tab.Print(out)
+
+	return nil
+}
+
+// DeleteUser removes user access for a deployment
+func RemoveTeam(deploymentID, teamID string, client houston.ClientInterface, out io.Writer) error {
+	d, err := client.DeleteDeploymentTeam(deploymentID, teamID)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	header := []string{"DEPLOYMENT ID", "TEAM ID", "ROLE"}
+
+	tab := printutil.Table{
+		Padding:        []int{44, 50},
+		DynamicPadding: true,
+		Header:         header,
+	}
+
+	tab.AddRow([]string{deploymentID, teamID, d.Role}, false)
+	tab.SuccessMsg = fmt.Sprintf("\n Successfully removed the %s role for %s from deployment %s", d.Role, d.Team.Name, deploymentID)
+	tab.Print(out)
+
+	return nil
+}

--- a/deployment/team.go
+++ b/deployment/team.go
@@ -46,7 +46,7 @@ func ListTeamRoles(deploymentID string, client houston.ClientInterface, out io.W
 // nolint:dupl
 // AddTeam add's a team to a deployment with specified role
 func AddTeam(deploymentID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
-	d, err := client.AddDeploymentTeam(deploymentID, teamID, role)
+	_, err := client.AddDeploymentTeam(deploymentID, teamID, role)
 	if err != nil {
 		return err
 	}
@@ -54,10 +54,10 @@ func AddTeam(deploymentID, teamID, role string, client houston.ClientInterface, 
 	tab := printutil.Table{
 		Padding:        []int{44, 50},
 		DynamicPadding: true,
-		Header:         []string{"NAME", "DEPLOYMENT ID", "TEAM ID", "ROLE"},
+		Header:         []string{"DEPLOYMENT ID", "TEAM ID", "ROLE"},
 	}
-	tab.AddRow([]string{d.Deployment.Label, d.Deployment.ID, d.Team.ID, d.Role}, false)
-	tab.SuccessMsg = fmt.Sprintf("\nSuccessfully added %s as a %s", teamID, role)
+	tab.AddRow([]string{deploymentID, teamID, role}, false)
+	tab.SuccessMsg = fmt.Sprintf("\nSuccessfully added team %s to deployment %s as a %s", teamID, deploymentID, role)
 	tab.Print(out)
 
 	return nil
@@ -66,7 +66,7 @@ func AddTeam(deploymentID, teamID, role string, client houston.ClientInterface, 
 // nolint:dupl
 // UpdateTeam updates a team's deployment role
 func UpdateTeamRole(deploymentID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
-	d, err := client.UpdateDeploymentTeamRole(deploymentID, teamID, role)
+	_, err := client.UpdateDeploymentTeamRole(deploymentID, teamID, role)
 	if err != nil {
 		return err
 	}
@@ -77,8 +77,8 @@ func UpdateTeamRole(deploymentID, teamID, role string, client houston.ClientInte
 		Header:         []string{"DEPLOYMENT ID", "TEAM ID", "ROLE"},
 	}
 
-	tab.AddRow([]string{d.Deployment.ID, d.Team.ID, d.Role}, false)
-	tab.SuccessMsg = fmt.Sprintf("\n Successfully updated %s to a %s", teamID, role)
+	tab.AddRow([]string{deploymentID, teamID, role}, false)
+	tab.SuccessMsg = fmt.Sprintf("\n Successfully updated team %s to a %s", teamID, role)
 	tab.Print(out)
 
 	return nil
@@ -86,7 +86,7 @@ func UpdateTeamRole(deploymentID, teamID, role string, client houston.ClientInte
 
 // DeleteTeam removes team access for a deployment
 func RemoveTeam(deploymentID, teamID string, client houston.ClientInterface, out io.Writer) error {
-	d, err := client.RemoveDeploymentTeam(deploymentID, teamID)
+	_, err := client.RemoveDeploymentTeam(deploymentID, teamID)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -95,11 +95,11 @@ func RemoveTeam(deploymentID, teamID string, client houston.ClientInterface, out
 	tab := printutil.Table{
 		Padding:        []int{44, 50},
 		DynamicPadding: true,
-		Header:         []string{"DEPLOYMENT ID", "TEAM ID", "ROLE"},
+		Header:         []string{"DEPLOYMENT ID", "TEAM ID"},
 	}
 
-	tab.AddRow([]string{deploymentID, teamID, d.Role}, false)
-	tab.SuccessMsg = fmt.Sprintf("\n Successfully removed the %s role for %s from deployment %s", d.Role, d.Team.Name, deploymentID)
+	tab.AddRow([]string{deploymentID, teamID}, false)
+	tab.SuccessMsg = fmt.Sprintf("\n Successfully removed team %s from deployment %s", teamID, deploymentID)
 	tab.Print(out)
 
 	return nil

--- a/deployment/team.go
+++ b/deployment/team.go
@@ -8,7 +8,6 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/messages"
 	"github.com/astronomer/astro-cli/pkg/printutil"
-	log "github.com/sirupsen/logrus"
 )
 
 var errHoustonInvalidDeploymentTeams = errors.New(messages.HoustonInvalidDeploymentTeams)
@@ -17,7 +16,6 @@ var errHoustonInvalidDeploymentTeams = errors.New(messages.HoustonInvalidDeploym
 func ListTeamRoles(deploymentID string, client houston.ClientInterface, out io.Writer) error {
 	deploymentTeams, err := client.ListDeploymentTeamsAndRoles(deploymentID)
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 
@@ -44,7 +42,7 @@ func ListTeamRoles(deploymentID string, client houston.ClientInterface, out io.W
 }
 
 // nolint:dupl
-// AddTeam add's a team to a deployment with specified role
+// AddTeam adds a team to a deployment with specified role
 func AddTeam(deploymentID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
 	_, err := client.AddDeploymentTeam(deploymentID, teamID, role)
 	if err != nil {
@@ -88,7 +86,6 @@ func UpdateTeamRole(deploymentID, teamID, role string, client houston.ClientInte
 func RemoveTeam(deploymentID, teamID string, client houston.ClientInterface, out io.Writer) error {
 	_, err := client.RemoveDeploymentTeam(deploymentID, teamID)
 	if err != nil {
-		log.Error(err)
 		return err
 	}
 

--- a/deployment/team.go
+++ b/deployment/team.go
@@ -11,6 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var errHoustonInvalidDeploymentTeams = errors.New(messages.HoustonInvalidDeploymentTeams)
+
 // TeamsList returns a list of teams with deployment access
 func ListTeamRoles(deploymentID string, client houston.ClientInterface, out io.Writer) error {
 	deploymentTeams, err := client.ListDeploymentTeamsAndRoles(deploymentID)
@@ -20,7 +22,7 @@ func ListTeamRoles(deploymentID string, client houston.ClientInterface, out io.W
 	}
 
 	if len(deploymentTeams) < 1 {
-		return errors.New(messages.HoustonInvalidDeploymentTeams)
+		return errHoustonInvalidDeploymentTeams
 	}
 
 	tab := printutil.Table{
@@ -43,7 +45,7 @@ func ListTeamRoles(deploymentID string, client houston.ClientInterface, out io.W
 
 // nolint:dupl
 // AddTeam add's a team to a deployment with specified role
-func AddTeam(deploymentID, teamID string, role string, client houston.ClientInterface, out io.Writer) error {
+func AddTeam(deploymentID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
 	d, err := client.AddDeploymentTeam(deploymentID, teamID, role)
 	if err != nil {
 		return err

--- a/deployment/team.go
+++ b/deployment/team.go
@@ -7,13 +7,14 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/messages"
 	"github.com/astronomer/astro-cli/pkg/printutil"
+	log "github.com/sirupsen/logrus"
 )
 
 // TeamsList returns a list of teams with deployment access
 func ListTeamRoles(deploymentID string, client houston.ClientInterface, out io.Writer) error {
 	deploymentTeams, err := client.ListDeploymentTeamsAndRoles(deploymentID)
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		return err
 	}
 
@@ -85,7 +86,7 @@ func UpdateTeamRole(deploymentID, teamID, role string, client houston.ClientInte
 func RemoveTeam(deploymentID, teamID string, client houston.ClientInterface, out io.Writer) error {
 	d, err := client.RemoveDeploymentTeam(deploymentID, teamID)
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		return err
 	}
 

--- a/deployment/team.go
+++ b/deployment/team.go
@@ -82,7 +82,7 @@ func UpdateTeamRole(deploymentID, teamID, role string, client houston.ClientInte
 	return nil
 }
 
-// DeleteTeam removes team access for a deployment
+// RemoveTeam removes team access for a deployment
 func RemoveTeam(deploymentID, teamID string, client houston.ClientInterface, out io.Writer) error {
 	_, err := client.RemoveDeploymentTeam(deploymentID, teamID)
 	if err != nil {

--- a/deployment/team.go
+++ b/deployment/team.go
@@ -1,6 +1,7 @@
 package deployment
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -19,8 +20,7 @@ func ListTeamRoles(deploymentID string, client houston.ClientInterface, out io.W
 	}
 
 	if len(deploymentTeams) < 1 {
-		_, err = out.Write([]byte(messages.HoustonInvalidDeploymentTeams))
-		return err
+		return errors.New(messages.HoustonInvalidDeploymentTeams)
 	}
 
 	tab := printutil.Table{

--- a/deployment/team.go
+++ b/deployment/team.go
@@ -56,8 +56,8 @@ func AddTeam(deploymentID, teamID, role string, client houston.ClientInterface, 
 		DynamicPadding: true,
 		Header:         []string{"NAME", "DEPLOYMENT ID", "TEAM ID", "ROLE"},
 	}
-	tab.AddRow([]string{d.Deployment.ReleaseName, d.Deployment.ID, d.Team.ID, d.Role}, false)
-	tab.SuccessMsg = fmt.Sprintf("\n Successfully added %s as a %s", teamID, role)
+	tab.AddRow([]string{d.Deployment.Label, d.Deployment.ID, d.Team.ID, d.Role}, false)
+	tab.SuccessMsg = fmt.Sprintf("\nSuccessfully added %s as a %s", teamID, role)
 	tab.Print(out)
 
 	return nil

--- a/houston/deployment_team.go
+++ b/houston/deployment_team.go
@@ -17,7 +17,7 @@ func (h ClientImplementation) ListDeploymentTeamsAndRoles(deploymentID string) (
 	return r.Data.DeploymentGetTeams, nil
 }
 
-// AddUserToDeployment - Add a user to a deployment with specified role
+// AddTeamToDeployment - Add a team to a deployment with specified role
 func (h ClientImplementation) AddDeploymentTeam(deploymentID, teamID, role string) (*RoleBinding, error) {
 	req := Request{
 		Query: DeploymentTeamAddRequest,
@@ -37,7 +37,7 @@ func (h ClientImplementation) AddDeploymentTeam(deploymentID, teamID, role strin
 }
 
 // UpdateTeamInDeployment - update a team's role inside a deployment
-func (h ClientImplementation) UpdateDeploymentTeam(deploymentID, teamID, role string) (*RoleBinding, error) {
+func (h ClientImplementation) UpdateDeploymentTeamRole(deploymentID, teamID, role string) (*RoleBinding, error) {
 	req := Request{
 		Query: DeploymentTeamUpdateRequest,
 		Variables: map[string]interface{}{
@@ -56,7 +56,7 @@ func (h ClientImplementation) UpdateDeploymentTeam(deploymentID, teamID, role st
 }
 
 // DeleteTeamFromDeployment - remove a team from a deployment
-func (h ClientImplementation) DeleteDeploymentTeam(deploymentID, teamID string) (*RoleBinding, error) {
+func (h ClientImplementation) RemoveDeploymentTeam(deploymentID, teamID string) (*RoleBinding, error) {
 	req := Request{
 		Query: DeploymentTeamRemoveRequest,
 		Variables: map[string]interface{}{

--- a/houston/deployment_team.go
+++ b/houston/deployment_team.go
@@ -1,0 +1,79 @@
+package houston
+
+// ListDeploymentUsersRequest - properties to filter users in a deployment
+type ListDeploymentTeamsRequest struct {
+	DeploymentID string `json:"deploymentId"`
+}
+
+// UpdateDeploymentUserRequest - properties to create a user in a deployment
+type UpdateDeploymentTeamRequest struct {
+	TeamID       string `json:"teamUuid"`
+	DeploymentID string `json:"deploymentId"`
+}
+
+// ListUsersInDeployment - list users with deployment access
+func (h ClientImplementation) ListDeploymentTeams(variables ListDeploymentTeamsRequest) ([]DeploymentTeam, error) {
+	req := Request{
+		Query:     DeploymentGetTeamsRequest,
+		Variables: variables,
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return []DeploymentTeam{}, handleAPIErr(err)
+	}
+
+	return r.Data.DeploymentTeamsList, nil
+}
+
+// AddUserToDeployment - Add a user to a deployment with specified role
+func (h ClientImplementation) AddDeploymentTeam(deploymentID, teamID string, role string) (*RoleBinding, error) {
+	req := Request{
+		Query: DeploymentTeamAddRequest,
+		Variables: map[string]interface{}{
+			"teamId":       teamID,
+			"deploymentId": deploymentID,
+			"role":         role,
+		},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return r.Data.AddDeploymentTeam, nil
+}
+
+// UpdateUserInDeployment - update a user's role inside a deployment
+func (h ClientImplementation) UpdateDeploymentTeam(variables UpdateDeploymentTeamRequest) (*RoleBinding, error) {
+	req := Request{
+		Query:     DeploymentTeamUpdateRequest,
+		Variables: variables,
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return r.Data.UpdateDeploymentTeam, nil
+}
+
+// DeleteUserFromDeployment - remove a user from a deployment
+func (h ClientImplementation) DeleteDeploymentTeam(deploymentID, teamID string) (*RoleBinding, error) {
+	req := Request{
+		Query: DeploymentTeamRemoveRequest,
+		Variables: map[string]interface{}{
+			"teamId":       teamID,
+			"deploymentId": deploymentID,
+		},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return r.Data.DeleteDeploymentTeam, nil
+}

--- a/houston/deployment_team.go
+++ b/houston/deployment_team.go
@@ -55,7 +55,7 @@ func (h ClientImplementation) UpdateDeploymentTeamRole(deploymentID, teamID, rol
 	return r.Data.UpdateDeploymentTeam, nil
 }
 
-// DeleteTeamFromDeployment - remove a team from a deployment
+// RemoveDeploymentTeam - remove a team from a deployment
 func (h ClientImplementation) RemoveDeploymentTeam(deploymentID, teamID string) (*RoleBinding, error) {
 	req := Request{
 		Query: DeploymentTeamRemoveRequest,

--- a/houston/deployment_team.go
+++ b/houston/deployment_team.go
@@ -1,39 +1,30 @@
 package houston
 
-// ListDeploymentUsersRequest - properties to filter users in a deployment
-type ListDeploymentTeamsRequest struct {
-	DeploymentID string `json:"deploymentId"`
-}
-
-// UpdateDeploymentUserRequest - properties to create a user in a deployment
-type UpdateDeploymentTeamRequest struct {
-	TeamID       string `json:"teamUuid"`
-	DeploymentID string `json:"deploymentId"`
-}
-
-// ListUsersInDeployment - list users with deployment access
-func (h ClientImplementation) ListDeploymentTeams(variables ListDeploymentTeamsRequest) ([]DeploymentTeam, error) {
+// ListTeamsInDeployment - list teams with deployment access
+func (h ClientImplementation) ListDeploymentTeamsAndRoles(deploymentID string) ([]Team, error) {
 	req := Request{
-		Query:     DeploymentGetTeamsRequest,
-		Variables: variables,
+		Query: DeploymentGetTeamsRequest,
+		Variables: map[string]interface{}{
+			"deploymentUuid": deploymentID,
+		},
 	}
 
 	r, err := req.DoWithClient(h.client)
 	if err != nil {
-		return []DeploymentTeam{}, handleAPIErr(err)
+		return nil, handleAPIErr(err)
 	}
 
-	return r.Data.DeploymentTeamsList, nil
+	return r.Data.DeploymentGetTeams, nil
 }
 
 // AddUserToDeployment - Add a user to a deployment with specified role
-func (h ClientImplementation) AddDeploymentTeam(deploymentID, teamID string, role string) (*RoleBinding, error) {
+func (h ClientImplementation) AddDeploymentTeam(deploymentID, teamID, role string) (*RoleBinding, error) {
 	req := Request{
 		Query: DeploymentTeamAddRequest,
 		Variables: map[string]interface{}{
-			"teamId":       teamID,
-			"deploymentId": deploymentID,
-			"role":         role,
+			"teamUuid":       teamID,
+			"deploymentUuid": deploymentID,
+			"role":           role,
 		},
 	}
 
@@ -45,11 +36,15 @@ func (h ClientImplementation) AddDeploymentTeam(deploymentID, teamID string, rol
 	return r.Data.AddDeploymentTeam, nil
 }
 
-// UpdateUserInDeployment - update a user's role inside a deployment
-func (h ClientImplementation) UpdateDeploymentTeam(variables UpdateDeploymentTeamRequest) (*RoleBinding, error) {
+// UpdateTeamInDeployment - update a team's role inside a deployment
+func (h ClientImplementation) UpdateDeploymentTeam(deploymentID, teamID, role string) (*RoleBinding, error) {
 	req := Request{
-		Query:     DeploymentTeamUpdateRequest,
-		Variables: variables,
+		Query: DeploymentTeamUpdateRequest,
+		Variables: map[string]interface{}{
+			"teamUuid":       teamID,
+			"deploymentUuid": deploymentID,
+			"role":           role,
+		},
 	}
 
 	r, err := req.DoWithClient(h.client)
@@ -60,13 +55,13 @@ func (h ClientImplementation) UpdateDeploymentTeam(variables UpdateDeploymentTea
 	return r.Data.UpdateDeploymentTeam, nil
 }
 
-// DeleteUserFromDeployment - remove a user from a deployment
+// DeleteTeamFromDeployment - remove a team from a deployment
 func (h ClientImplementation) DeleteDeploymentTeam(deploymentID, teamID string) (*RoleBinding, error) {
 	req := Request{
 		Query: DeploymentTeamRemoveRequest,
 		Variables: map[string]interface{}{
-			"teamId":       teamID,
-			"deploymentId": deploymentID,
+			"teamUuid":       teamID,
+			"deploymentUuid": deploymentID,
 		},
 	}
 
@@ -75,5 +70,5 @@ func (h ClientImplementation) DeleteDeploymentTeam(deploymentID, teamID string) 
 		return nil, handleAPIErr(err)
 	}
 
-	return r.Data.DeleteDeploymentTeam, nil
+	return r.Data.RemoveDeploymentTeam, nil
 }

--- a/houston/deployment_teams_test.go
+++ b/houston/deployment_teams_test.go
@@ -1,0 +1,209 @@
+package houston
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddDeploymentTeam(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	mockResponse := &Response{
+		Data: ResponseData{
+			AddDeploymentTeam: &RoleBinding{
+				Role: DeploymentViewerRole,
+				Team: Team{
+					ID:   "test-id",
+					Name: "test-team-name",
+				},
+				Deployment: Deployment{
+					ID: "deployment-id",
+				},
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.AddDeploymentTeam("deployment-id", "team-id", "role")
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.AddDeploymentTeam)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.AddDeploymentTeam("deployment-id", "team-id", "role")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestDeleteDeploymentTeam(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	mockResponse := &Response{
+		Data: ResponseData{
+			RemoveDeploymentTeam: &RoleBinding{
+				Role: DeploymentViewerRole,
+				Team: Team{
+					ID:   "test-id",
+					Name: "test-team-name",
+				},
+				Deployment: Deployment{
+					ID: "deployment-id",
+				},
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.RemoveDeploymentTeam("deployment-id", "team-id")
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.RemoveDeploymentTeam)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.RemoveDeploymentTeam("deployment-id", "team-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestListDeploymentTeamsAndRoles(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	mockResponse := []Team{
+		{
+			ID: "test-id",
+		},
+	}
+	jsonResponse, err := json.Marshal(Response{Data: ResponseData{
+		DeploymentGetTeams: []Team{
+			{
+				ID: "test-id",
+			},
+		},
+	}})
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.ListDeploymentTeamsAndRoles("deployment-id")
+		assert.NoError(t, err)
+		assert.Equal(t, mockResponse, response)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.ListDeploymentTeamsAndRoles("deploymeny-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestUpdateDeploymentTeamAndRole(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	mockResponse := &Response{
+		Data: ResponseData{
+			UpdateDeploymentTeam: &RoleBinding{
+				Role: DeploymentAdminRole,
+				Team: Team{
+					ID:   "test-id",
+					Name: "test-team-name",
+				},
+				Deployment: Deployment{
+					ID: "deployment-id",
+				},
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.UpdateDeploymentTeamRole("deployment-id", "team-id", DeploymentAdminRole)
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.UpdateDeploymentTeam)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.UpdateDeploymentTeamRole("deployment-id", "team-id", "role")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}

--- a/houston/deployment_user.go
+++ b/houston/deployment_user.go
@@ -8,7 +8,7 @@ type ListDeploymentUsersRequest struct {
 	DeploymentID string `json:"deploymentId"`
 }
 
-// UpdateDeploymentUserRequest - properties to create a user in a deployment
+// UpdateDeploymentUserRequest - properties to update a user in a deployment
 type UpdateDeploymentUserRequest struct {
 	Email        string `json:"email"`
 	Role         string `json:"role"`

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -51,6 +51,11 @@ type ClientInterface interface {
 	AddDeploymentUser(variables UpdateDeploymentUserRequest) (*RoleBinding, error)
 	UpdateDeploymentUser(variables UpdateDeploymentUserRequest) (*RoleBinding, error)
 	DeleteDeploymentUser(deploymentID, email string) (*RoleBinding, error)
+	// deployment teams
+	AddDeploymentTeam(deploymentID string, teamID, role string) (*RoleBinding, error)
+	DeleteDeploymentTeam(deploymentID string, teamID string) (*RoleBinding, error)
+	ListDeploymentTeamsAndRoles(deploymentID string) ([]Team, error)
+	UpdateDeploymentTeamRole(deploymentID string, teamID, role string) (*RoleBinding, error)
 	// service account
 	CreateDeploymentServiceAccount(variables *CreateServiceAccountRequest) (*DeploymentServiceAccount, error)
 	DeleteDeploymentServiceAccount(deploymentID, serviceAccountID string) (*ServiceAccount, error)

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -58,10 +58,10 @@ type ClientInterface interface {
 	UpdateDeploymentUser(variables UpdateDeploymentUserRequest) (*RoleBinding, error)
 	DeleteDeploymentUser(deploymentID, email string) (*RoleBinding, error)
 	// deployment teams
-	AddDeploymentTeam(deploymentID string, teamID, role string) (*RoleBinding, error)
-	DeleteDeploymentTeam(deploymentID string, teamID string) (*RoleBinding, error)
+	AddDeploymentTeam(deploymentID string, teamID string, role string) (*RoleBinding, error)
+	RemoveDeploymentTeam(deploymentID string, teamID string) (*RoleBinding, error)
 	ListDeploymentTeamsAndRoles(deploymentID string) ([]Team, error)
-	UpdateDeploymentTeamRole(deploymentID string, teamID, role string) (*RoleBinding, error)
+	UpdateDeploymentTeamRole(deploymentID string, teamID string, role string) (*RoleBinding, error)
 	// service account
 	CreateDeploymentServiceAccount(variables *CreateServiceAccountRequest) (*DeploymentServiceAccount, error)
 	DeleteDeploymentServiceAccount(deploymentID, serviceAccountID string) (*ServiceAccount, error)

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -12,6 +12,29 @@ type ClientInterface struct {
 	mock.Mock
 }
 
+// AddDeploymentTeam provides a mock function with given fields: deploymentID, teamID, role
+func (_m *ClientInterface) AddDeploymentTeam(deploymentID string, teamID string, role string) (*houston.RoleBinding, error) {
+	ret := _m.Called(deploymentID, teamID, role)
+
+	var r0 *houston.RoleBinding
+	if rf, ok := ret.Get(0).(func(string, string, string) *houston.RoleBinding); ok {
+		r0 = rf(deploymentID, teamID, role)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.RoleBinding)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(deploymentID, teamID, role)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // AddDeploymentUser provides a mock function with given fields: variables
 func (_m *ClientInterface) AddDeploymentUser(variables houston.UpdateDeploymentUserRequest) (*houston.RoleBinding, error) {
 	ret := _m.Called(variables)
@@ -652,6 +675,29 @@ func (_m *ClientInterface) ListDeploymentServiceAccounts(deploymentID string) ([
 	return r0, r1
 }
 
+// ListDeploymentTeamsAndRoles provides a mock function with given fields: deploymentID
+func (_m *ClientInterface) ListDeploymentTeamsAndRoles(deploymentID string) ([]houston.Team, error) {
+	ret := _m.Called(deploymentID)
+
+	var r0 []houston.Team
+	if rf, ok := ret.Get(0).(func(string) []houston.Team); ok {
+		r0 = rf(deploymentID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]houston.Team)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(deploymentID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListDeploymentUsers provides a mock function with given fields: filters
 func (_m *ClientInterface) ListDeploymentUsers(filters houston.ListDeploymentUsersRequest) ([]houston.DeploymentUser, error) {
 	ret := _m.Called(filters)
@@ -790,6 +836,29 @@ func (_m *ClientInterface) ListWorkspaces() ([]houston.Workspace, error) {
 	return r0, r1
 }
 
+// RemoveDeploymentTeam provides a mock function with given fields: deploymentID, teamID
+func (_m *ClientInterface) RemoveDeploymentTeam(deploymentID string, teamID string) (*houston.RoleBinding, error) {
+	ret := _m.Called(deploymentID, teamID)
+
+	var r0 *houston.RoleBinding
+	if rf, ok := ret.Get(0).(func(string, string) *houston.RoleBinding); ok {
+		r0 = rf(deploymentID, teamID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.RoleBinding)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(deploymentID, teamID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpdateDeployment provides a mock function with given fields: variables
 func (_m *ClientInterface) UpdateDeployment(variables map[string]interface{}) (*houston.Deployment, error) {
 	ret := _m.Called(variables)
@@ -829,6 +898,29 @@ func (_m *ClientInterface) UpdateDeploymentAirflow(variables map[string]interfac
 	var r1 error
 	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
 		r1 = rf(variables)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateDeploymentTeamRole provides a mock function with given fields: deploymentID, teamID, role
+func (_m *ClientInterface) UpdateDeploymentTeamRole(deploymentID string, teamID string, role string) (*houston.RoleBinding, error) {
+	ret := _m.Called(deploymentID, teamID, role)
+
+	var r0 *houston.RoleBinding
+	if rf, ok := ret.Get(0).(func(string, string, string) *houston.RoleBinding); ok {
+		r0 = rf(deploymentID, teamID, role)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.RoleBinding)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(deploymentID, teamID, role)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -606,4 +606,49 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 			featureFlags
 		}
 	}`
+
+	DeploymentTeamAddRequest = `
+	mutation deploymentAddTeamRole($teamUuid: Uuid!, $deploymentUuid: Uuid!, $role: Role!) {
+		deploymentAddTeamRole(teamUuid: $teamUuid, deploymentUuid: $deploymentUuid, role: $role) {
+			id
+			role
+		}
+	}`
+
+	DeploymentTeamRemoveRequest = `
+	mutation deploymentRemoveTeamRole($deploymentUuid: Uuid!, $teamUuid: Uuid!) {
+		deploymentRemoveTeamRole(
+			deploymentUuid: $deploymentUuid
+			teamUuid: $teamUuid
+		) {
+			id
+		}
+	}`
+
+	DeploymentTeamUpdateRequest = `
+	mutation deploymentUpdateTeamRole($deploymentUuid: Uuid!, $teamUuid: Uuid!, $role: Role!) {
+		deploymentUpdateTeamRole(deploymentUuid: $deploymentUuid, teamUuid: $teamUuid, role: $role) {
+			id
+			role
+		}
+	}`
+
+	DeploymentGetTeamsRequest = `
+	query deploymentTeams($deploymentUuid: Uuid!) {
+		deploymentTeams(deploymentUuid: $deploymentUuid) {
+			id
+			name
+			roleBindings {
+				role
+				workspace {
+					id
+					label
+				}
+				deployment {
+					id
+					label
+				}
+			}
+		}
+	}`
 )

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -711,7 +711,7 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 	mutation deploymentAddTeamRole(
 		$teamUuid: Uuid!
 		$deploymentUuid: Uuid!
-		$role: Role!
+		$role: Role! = WORKSPACE_VIEWER
 	) {
 		deploymentAddTeamRole(
 			teamUuid: $teamUuid

--- a/houston/types.go
+++ b/houston/types.go
@@ -16,11 +16,11 @@ type ResponseData struct {
 	AddDeploymentUser              *RoleBinding              `json:"deploymentAddUserRole,omitempty"`
 	AddDeploymentTeam              *RoleBinding              `json:"deploymentAddTeamRole,omitempty"`
 	DeleteDeploymentUser           *RoleBinding              `json:"deploymentRemoveUserRole,omitempty"`
-	DeleteDeploymentTeam           *RoleBinding              `json:"deploymentRemoveTeamRole,omitempty"`
+	RemoveDeploymentTeam           *RoleBinding              `json:"deploymentRemoveTeamRole,omitempty"`
 	UpdateDeploymentUser           *RoleBinding              `json:"deploymentUpdateUserRole,omitempty"`
 	UpdateDeploymentTeam           *RoleBinding              `json:"deploymentUpdateTeamRole,omitempty"`
 	DeploymentUserList             []DeploymentUser          `json:"deploymentUsers,omitempty"`
-	DeploymentTeamsList            []DeploymentTeam          `json:"deploymentTeams,omitempty"`
+	DeploymentGetTeams             []Team                    `json:"deploymentTeams,omitempty"`
 	AddWorkspaceUser               *Workspace                `json:"workspaceAddUser,omitempty"`
 	AddWorkspaceTeam               *Workspace                `json:"workspaceAddTeam,omitempty"`
 	RemoveWorkspaceUser            *Workspace                `json:"workspaceRemoveUser,omitempty"`

--- a/houston/types.go
+++ b/houston/types.go
@@ -14,9 +14,13 @@ type Response struct {
 
 type ResponseData struct {
 	AddDeploymentUser              *RoleBinding              `json:"deploymentAddUserRole,omitempty"`
+	AddDeploymentTeam              *RoleBinding              `json:"deploymentAddTeamRole,omitempty"`
 	DeleteDeploymentUser           *RoleBinding              `json:"deploymentRemoveUserRole,omitempty"`
+	DeleteDeploymentTeam           *RoleBinding              `json:"deploymentRemoveTeamRole,omitempty"`
 	UpdateDeploymentUser           *RoleBinding              `json:"deploymentUpdateUserRole,omitempty"`
+	UpdateDeploymentTeam           *RoleBinding              `json:"deploymentUpdateTeamRole,omitempty"`
 	DeploymentUserList             []DeploymentUser          `json:"deploymentUsers,omitempty"`
+	DeploymentTeamsList            []DeploymentTeam          `json:"deploymentTeams,omitempty"`
 	AddWorkspaceUser               *Workspace                `json:"workspaceAddUser,omitempty"`
 	RemoveWorkspaceUser            *Workspace                `json:"workspaceRemoveUser,omitempty"`
 	CreateDeployment               *Deployment               `json:"createDeployment,omitempty"`
@@ -162,6 +166,12 @@ type DeploymentUser struct {
 	Emails       []Email       `json:"emails"`
 	FullName     string        `json:"fullName"`
 	Username     string        `json:"username"`
+	RoleBindings []RoleBinding `json:"roleBindings"`
+}
+
+// DeploymentTeam defines a structure of RBAC deployment teams
+type DeploymentTeam struct {
+	ID           string        `json:"id"`
 	RoleBindings []RoleBinding `json:"roleBindings"`
 }
 

--- a/houston/workspace_teams.go
+++ b/houston/workspace_teams.go
@@ -33,8 +33,10 @@ func (h ClientImplementation) DeleteWorkspaceTeam(workspaceID, teamID string) (*
 // ListTeamAndRolesFromWorkspace - list teams and roles from a workspace
 func (h ClientImplementation) ListWorkspaceTeamsAndRoles(workspaceID string) ([]Team, error) {
 	req := Request{
-		Query:     WorkspaceGetTeamsRequest,
-		Variables: map[string]interface{}{"workspaceUuid": workspaceID},
+		Query: WorkspaceGetTeamsRequest,
+		Variables: map[string]interface{}{
+			"workspaceUuid": workspaceID,
+		},
 	}
 
 	r, err := req.DoWithClient(h.client)

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -67,6 +67,8 @@ var (
 
 	HoustonInvalidDeploymentUsers = "No users were found for this deployment.  Check the deploymentId and try again.\n"
 
+	HoustonInvalidDeploymentTeams = "No teams were found for this deployment.  Check the deploymentId and try again.\n"
+
 	InputPassword   = "Password: "
 	InputUsername   = "Username (leave blank for oAuth): "
 	InputOAuthToken = "oAuth Token: " // nolint:gosec // false positive


### PR DESCRIPTION
## Description

CLI commands for performing CRUD on deployment teams. This relates to the IDP groups feature currently released on the astronomer enterprise platform

1. Add team to a deployment
2. Remove team from a deployment
3. Get all teams belonging to a deployment
4. Remove a team from a deployment

## 🎟 Issue(s)

Related astronomer/issues#4306
astronomer/issues#4307
astronomer/issues#4309
astronomer/issues#4310


## 🧪 Functional Testing

Setup :

Set up houston-api to enable IDP Teams, follow step 0 of this doc - https://www.notion.so/astronomerio/81b7d488cb014998875b0f9d75ec4b2f?v=a44011d8561645a3b036368e6bd8fc49

Run make build

add flags `--skip-version-check --verbosity=debug` to below commands for debugging.

Commands :

To add a new team to a deployment
`./astro deployment team add --deployment-id=ckwyz795w01950k99y48eft6s --team-id=cl0ck2snm0064jexu3ljfn9um`

To remove the team from the deployment
`./astro deployment team remove cl0ck2snm0064jexu3ljfn9um --deployment-id=ckwyz795w01950k99y48eft6s`

To update a team role of a deployment
`./astro deployment team update cl0ck2snm0064jexu3ljfn9um --deployment-id=ckwyz795w01950k99y48eft6s --role=DEPLOYMENT_ADMIN`

To list all teams and their roles belonging to a deployment
`./astro deployment team list --deployment-id ckwwb09aj0048u8xuts287erj`

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
