### PR TITLE
Fix envFile value for astro dev commands

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -397,7 +397,7 @@ func airflowKill(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile)
+	containerHandler, err := containerHandlerInit(config.WorkingPath, "")
 	if err != nil {
 		return err
 	}
@@ -426,7 +426,7 @@ func airflowLogs(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile)
+	containerHandler, err := containerHandlerInit(config.WorkingPath, "")
 	if err != nil {
 		return err
 	}
@@ -439,7 +439,7 @@ func airflowStop(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile)
+	containerHandler, err := containerHandlerInit(config.WorkingPath, "")
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func airflowPS(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile)
+	containerHandler, err := containerHandlerInit(config.WorkingPath, "")
 	if err != nil {
 		return err
 	}
@@ -469,7 +469,7 @@ func airflowRun(cmd *cobra.Command, args []string) error {
 	args = append([]string{"airflow"}, args...)
 	// ignore last user parameter
 
-	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile)
+	containerHandler, err := containerHandlerInit(config.WorkingPath, "")
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,7 @@ func airflowUpgradeCheck(cmd *cobra.Command, args []string) error {
 	// Add airflow command, to simplify astro cli usage
 	args = append([]string{"bash", "-c", "pip install --no-deps 'apache-airflow-upgrade-check'; python -c 'from packaging.version import Version\nfrom airflow import __version__\nif Version(__version__) < Version(\"1.10.14\"):\n  print(\"Please upgrade your image to Airflow 1.10.14 first, then try again.\");exit(1)\nelse:\n  from airflow.upgrade.checker import __main__;__main__()'"}, args...)
 
-	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile)
+	containerHandler, err := containerHandlerInit(config.WorkingPath, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Changes:
- Fixed `envFile` value being passed for all astro dev commands except `astro dev start`, since by default cobra library was passing it as `.env` set by `astro dev start` (Reference: https://github.com/astronomer/astro-cli/blob/main/cmd/airflow.go#L153)

## 🎟 Issue(s)

Related astronomer/issues#4445

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
