### PR TITLE
Update example DAG to Airflow 2

### DIFF
--- a/airflow/include/exampledag.go
+++ b/airflow/include/exampledag.go
@@ -4,21 +4,24 @@ import "strings"
 
 // Exampledag created with astro airflow init
 var Exampledag = strings.TrimSpace(`
-from airflow import DAG
-from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.bash_operator import BashOperator
-from airflow.operators.python_operator import PythonOperator
-from airflow.version import version
 from datetime import datetime, timedelta
 
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.operators.dummy import DummyOperator
+from airflow.operators.python import PythonOperator
 
-def my_custom_function(ts,**kwargs):
+
+def my_custom_function(ts, **kwargs):
     """
-    This can be any python code you want and is called from the python operator. The code is not executed until
-    the task is run by the airflow scheduler.
+    This can be any Python code you want and is called from the Python operator.
+    The code is not executed until the task is run by the Airflow scheduler.
     """
-    print(f"I am task number {kwargs['task_number']}. This DAG Run execution date is {ts} and the current time is {datetime.now()}")
-    print('Here is the full DAG Run context. It is available because provide_context=True')
+    print(
+        f"I am task number {kwargs['task_number']}. "
+        f"This DAG Run execution date is {ts} and the current time is {datetime.now()}"
+    )
+    print("Here is the full DAG Run context. It is available because provide_context=True")
     print(kwargs)
 
 
@@ -33,47 +36,32 @@ default_args = {
 }
 
 # Using a DAG context manager, you don't have to specify the dag property of each task
-with DAG('example_dag',
-         start_date=datetime(2019, 1, 1),
-         max_active_runs=3,
-         schedule_interval=timedelta(minutes=30),  # https://airflow.apache.org/docs/stable/scheduler.html#dag-runs
-         default_args=default_args,
-         # catchup=False # enable if you don't want historical dag runs to run
-         ) as dag:
+with DAG(
+    'example_dag',
+    start_date=datetime(2019, 1, 1),
+    max_active_runs=3,
+    schedule_interval=timedelta(minutes=30),  # https://airflow.apache.org/docs/stable/scheduler.html#dag-runs
+    default_args=default_args,
+    # catchup=False # enable if you don't want historical dag runs to run
+) as dag:
 
-    t0 = DummyOperator(
-        task_id='start'
-    )
+    t0 = DummyOperator(task_id='start')
 
-    t1 = DummyOperator(
-        task_id='group_bash_tasks'
-    )
-    t2 = BashOperator(
-        task_id='bash_print_date1',
-        bash_command='sleep $[ ( $RANDOM % 30 )  + 1 ]s && date')
-    t3 = BashOperator(
-        task_id='bash_print_date2',
-        bash_command='sleep $[ ( $RANDOM % 30 )  + 1 ]s && date')
+    t1 = DummyOperator(task_id='group_bash_tasks')
+    t2 = BashOperator(task_id='bash_print_date1', bash_command='sleep $[ ( $RANDOM % 30 )  + 1 ]s && date')
+    t3 = BashOperator(task_id='bash_print_date2', bash_command='sleep $[ ( $RANDOM % 30 )  + 1 ]s && date')
 
     # generate tasks with a loop. task_id must be unique
     for task in range(5):
-        if version.startswith('2'):
-            tn = PythonOperator(
-                task_id=f'python_print_date_{task}',
-                python_callable=my_custom_function,  # make sure you don't include the () of the function
-                op_kwargs={'task_number': task},
-            )
-        else:
-            tn = PythonOperator(
-                task_id=f'python_print_date_{task}',
-                python_callable=my_custom_function,  # make sure you don't include the () of the function
-                op_kwargs={'task_number': task},
-                provide_context=True,
-            )
+        tn = PythonOperator(
+            task_id=f'python_print_date_{task}',
+            python_callable=my_custom_function,  # make sure you don't include the () of the function
+            op_kwargs={'task_number': task},
+        )
 
-
-        t0 >> tn # indented inside for loop so each task is added downstream of t0
+        t0 >> tn  # indented inside for loop so each task is added downstream of t0
 
     t0 >> t1
-    t1 >> [t2, t3] # lists can be used to specify multiple tasks
+    t1 >> [t2, t3]  # lists can be used to specify multiple tasks
+
 `)

--- a/airflow/include/exampledag.go
+++ b/airflow/include/exampledag.go
@@ -21,7 +21,7 @@ def my_custom_function(ts, **kwargs):
         f"I am task number {kwargs['task_number']}. "
         f"This DAG Run execution date is {ts} and the current time is {datetime.now()}"
     )
-    print("Here is the full DAG Run context. It is available because provide_context=True")
+    print("Here is the full DAG run context:")
     print(kwargs)
 
 


### PR DESCRIPTION
## Description

Following discussion in https://github.com/astronomer/issues/issues/3536 and https://github.com/astronomer/cloud-cli/pull/179, I suggest updating the example DAG code to Airflow 2 only. We don't want any customers using Airflow 1, so IMO we should default to Airflow 2 example code.

The current example DAG works on both Airflow 1 and 2 (raises deprecation warnings on Airflow 2). The example DAG in this PR works _only_ on Airflow 2.

Besides Airflow 1/2 code changes, I've updated a few other points for consistency and to comply with PEP8 standards, such as a consistent number of tab whitespaces and two whitespaces between code & comment.

Tested DAG on Airflow 2.0.0 and Airflow 2.2.4.

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/3536

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
