### PR TITLE
Switch Airflow 1 and 2 CLI commands

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -85,7 +85,7 @@ services:
     image: test-project-name/airflow:latest
     container_name: scheduler
     command: >
-      bash -c "(airflow upgradedb || airflow db upgrade) && airflow scheduler"
+      bash -c "(airflow db upgrade || airflow upgradedb) && airflow scheduler"
     restart: unless-stopped
     networks:
       - airflow
@@ -154,7 +154,7 @@ services:
     image: test-project-name/airflow:latest
     container_name: triggerer
     command: >
-      bash -c "(airflow upgradedb || airflow db upgrade) && airflow triggerer"
+      bash -c "(airflow db upgrade || airflow upgradedb) && airflow triggerer"
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -115,8 +115,8 @@ services:
       bash -c 'if [[ -z "$$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $$(pip show -f apache-airflow | grep basic_auth.py) ]];
         then export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.basic_auth ;
         else export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.default ; fi &&
-        { airflow create_user "$$@" || airflow users create "$$@" ; } &&
-        { airflow sync_perm || airflow sync-perm ;} &&
+        { airflow users create "$$@" || airflow create_user "$$@" ; } &&
+        { airflow sync-perm || airflow sync_perm ;} &&
         airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -40,7 +40,7 @@ services:
     image: {{ .AirflowImage }}
     container_name: {{ .SchedulerContainerName }}
     command: >
-      bash -c "(airflow upgradedb || airflow db upgrade) && airflow scheduler"
+      bash -c "(airflow db upgrade || airflow upgradedb) && airflow scheduler"
     restart: unless-stopped
     networks:
       - airflow
@@ -109,7 +109,7 @@ services:
     image: {{ .AirflowImage }}
     container_name: {{ .TriggererContainerName }}
     command: >
-      bash -c "(airflow upgradedb || airflow db upgrade) && airflow triggerer"
+      bash -c "(airflow db upgrade || airflow upgradedb) && airflow triggerer"
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -70,8 +70,8 @@ services:
       bash -c 'if [[ -z "$$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $$(pip show -f apache-airflow | grep basic_auth.py) ]];
         then export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.basic_auth ;
         else export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.default ; fi &&
-        { airflow create_user "$$@" || airflow users create "$$@" ; } &&
-        { airflow sync_perm || airflow sync-perm ;} &&
+        { airflow users create "$$@" || airflow create_user "$$@" ; } &&
+        { airflow sync-perm || airflow sync_perm ;} &&
         airflow webserver' -- -r Admin -u admin -e admin@example.com -f admin -l user -p admin
     restart: unless-stopped
     networks:

--- a/airflow/include/podconfigyml.go
+++ b/airflow/include/podconfigyml.go
@@ -41,7 +41,7 @@ spec:
   - args:
     - bash
     - -c
-    - (airflow upgradedb || airflow db upgrade) && airflow scheduler
+    - (airflow db upgrade || airflow upgradedb) && airflow scheduler
     command:
     - /entrypoint
     env:
@@ -154,7 +154,7 @@ spec:
   - args:
     - bash
     - -c
-    - (airflow upgradedb || airflow db upgrade) && airflow triggerer
+    - (airflow db upgrade || airflow upgradedb) && airflow triggerer
     command:
     - /entrypoint
     env:

--- a/airflow/include/podconfigyml.go
+++ b/airflow/include/podconfigyml.go
@@ -93,8 +93,8 @@ spec:
       if [[ -z "$AIRFLOW__API__AUTH_BACKEND" ]] && [[ $(pip show -f apache-airflow | grep basic_auth.py) ]];
         then export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.basic_auth ;
         else export AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.default ; fi &&
-        { airflow create_user "$@" || airflow users create "$@" ; } &&
-        { airflow sync_perm || airflow sync-perm ;} &&
+        { airflow users create "$@" || airflow create_user "$@" ; } &&
+        { airflow sync-perm || airflow sync_perm ;} &&
         airflow webserver
     - --
     - -r


### PR DESCRIPTION
## Description

Similar to https://github.com/astronomer/cloud-cli/pull/179, first run Airflow 2 commands, next Airflow 1 commands. This results in a speedup during `astro dev start` for all Airflow 2 users.

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/3536
https://github.com/astronomer/cloud-cli/pull/179

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
