### PR TITLE
Runtime changes in CLI

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -9,8 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/astronomer/astro-cli/airflow/types"
 
 	"github.com/astronomer/astro-cli/airflow"
@@ -310,10 +308,7 @@ func airflowInit(cmd *cobra.Command, _ []string, out io.Writer) error {
 	}
 
 	// check feature flag if AstroRuntime is enabled, if not, fallback to astronomer certified, if not able to get feature flag, we don't want to block the user
-	appConfig, err := houstonClient.GetAppConfig()
-	if err != nil {
-		logrus.Debugln("Error checking feature flag", err)
-	} else if !appConfig.Flags.AstroRuntimeEnabled {
+	if appConfig != nil && !appConfig.Flags.AstroRuntimeEnabled {
 		useAstronomerCertified = true
 	}
 

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -606,8 +606,8 @@ func newDeploymentRuntimeUpgradeCmd(out io.Writer) *cobra.Command {
 			return deploymentRuntimeUpgrade(cmd, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "[ID]")
-	cmd.Flags().StringVarP(&desiredRuntimeVersion, "desired-runtime-version", "v", "", "[DESIRED_AIRFLOW_VERSION]")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "ID of the deployment to upgrade")
+	cmd.Flags().StringVarP(&desiredRuntimeVersion, "desired-runtime-version", "v", "", "Desired Runtime version you wish to upgrade your deployment to")
 	cmd.Flags().BoolVarP(&cancel, "cancel", "c", false, "Abort the initial runtime upgrade step")
 	err := cmd.MarkFlagRequired("deployment-id")
 	if err != nil {
@@ -627,7 +627,7 @@ func newDeploymentRuntimeMigrateCmd(out io.Writer) *cobra.Command {
 			return deploymentRuntimeMigrate(cmd, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "[ID]")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "ID of the deployment to migrate")
 	cmd.Flags().BoolVarP(&cancel, "cancel", "c", false, "Abort the initial runtime migrate step")
 	err := cmd.MarkFlagRequired("deployment-id")
 	if err != nil {
@@ -667,7 +667,26 @@ func deploymentCreate(cmd *cobra.Command, args []string, out io.Writer) error {
 		}
 	}
 
-	return deployment.Create(args[0], ws, releaseName, cloudRole, executorType, airflowVersion, runtimeVersion, dagDeploymentType, nfsLocation, gitRepoURL, gitRevision, gitBranchName, gitDAGDir, sshKey, knowHosts, gitSyncInterval, triggererReplicas, houstonClient, out)
+	req := &deployment.CreateDeploymentRequest{
+		Label:             args[0],
+		WS:                ws,
+		ReleaseName:       releaseName,
+		CloudRole:         cloudRole,
+		Executor:          executorType,
+		AirflowVersion:    airflowVersion,
+		RuntimeVersion:    runtimeVersion,
+		DagDeploymentType: dagDeploymentType,
+		NFSLocation:       nfsLocation,
+		GitRepoURL:        gitRepoURL,
+		GitRevision:       gitRevision,
+		GitBranchName:     gitBranchName,
+		GitDAGDir:         gitDAGDir,
+		SSHKey:            sshKey,
+		KnownHosts:        knowHosts,
+		GitSyncInterval:   gitSyncInterval,
+		TriggererReplicas: triggererReplicas,
+	}
+	return deployment.Create(req, houstonClient, out)
 }
 
 func deploymentDelete(cmd *cobra.Command, args []string, out io.Writer) error {

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -35,7 +35,11 @@ var (
 		CreatedAt: "2021-04-26T20:03:36.262Z",
 		UpdatedAt: "2021-04-26T20:03:36.262Z",
 	}
-	mockAppConfig    = &houston.AppConfig{}
+	mockAppConfig = &houston.AppConfig{
+		Flags: houston.FeatureFlags{
+			AstroRuntimeEnabled: true,
+		},
+	}
 	mockDeploymentSA = &houston.ServiceAccount{
 		ID:         "q1w2e3r4t5y6u7i8o9p0",
 		APIKey:     "000000000000000000000000",

--- a/cmd/deployment_test.go
+++ b/cmd/deployment_test.go
@@ -773,3 +773,133 @@ func TestDeploymentTeamsListCmd(t *testing.T) {
 	assert.NotNil(t, cmd)
 	assert.Nil(t, cmd.Args)
 }
+
+func TestDeploymentRuntimeUpgradeCommand(t *testing.T) {
+	testUtil.InitTestConfig()
+	expectedOut := `The upgrade from Runtime 4.2.4 to 4.2.5 has been started. To complete this process, add an Runtime 4.2.5 image to your Dockerfile and deploy to Astronomer.`
+
+	mockDeploymentResponse := *mockDeployment
+	mockDeploymentResponse.AirflowVersion = ""
+	mockDeploymentResponse.DesiredAirflowVersion = ""
+	mockDeploymentResponse.RuntimeVersion = "4.2.4"
+	mockDeploymentResponse.RuntimeAirflowVersion = "2.2.5"
+	mockDeploymentResponse.DesiredRuntimeVersion = "4.2.5"
+
+	mockUpdateRequest := map[string]interface{}{
+		"deploymentUuid":        mockDeploymentResponse.ID,
+		"desiredRuntimeVersion": mockDeploymentResponse.DesiredRuntimeVersion,
+	}
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig").Return(mockAppConfig, nil)
+	api.On("GetDeployment", mockDeploymentResponse.ID).Return(&mockDeploymentResponse, nil)
+	api.On("UpdateDeploymentRuntime", mockUpdateRequest).Return(&mockDeploymentResponse, nil)
+
+	output, err := executeCommandC(api,
+		"deployment",
+		"runtime",
+		"upgrade",
+		"--deployment-id="+mockDeploymentResponse.ID,
+		"--desired-runtime-version="+mockDeploymentResponse.DesiredRuntimeVersion,
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, output, expectedOut)
+}
+
+func TestDeploymentRuntimeUpgradeCancelCommand(t *testing.T) {
+	testUtil.InitTestConfig()
+	expectedOut := `Runtime upgrade process has been successfully canceled. Your Deployment was not interrupted and you are still running Runtime 4.2.4.`
+
+	mockDeploymentResponse := *mockDeployment
+	mockDeploymentResponse.AirflowVersion = ""
+	mockDeploymentResponse.DesiredAirflowVersion = ""
+	mockDeploymentResponse.RuntimeVersion = "4.2.4"
+	mockDeploymentResponse.DesiredRuntimeVersion = "4.2.5"
+	mockDeploymentResponse.RuntimeAirflowVersion = "2.2.5"
+
+	expectedUpdateRequest := map[string]interface{}{
+		"deploymentUuid": mockDeploymentResponse.ID,
+	}
+
+	mockDeploymentUpdated := mockDeploymentResponse
+	mockDeploymentUpdated.DesiredRuntimeVersion = mockDeploymentUpdated.RuntimeVersion
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig").Return(mockAppConfig, nil)
+	api.On("GetDeployment", mockDeploymentResponse.ID).Return(&mockDeploymentResponse, nil)
+	api.On("CancelUpdateDeploymentRuntime", expectedUpdateRequest).Return(&mockDeploymentUpdated, nil)
+
+	output, err := executeCommandC(api,
+		"deployment",
+		"runtime",
+		"upgrade",
+		"--cancel",
+		"--deployment-id="+mockDeploymentResponse.ID,
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, output, expectedOut)
+}
+
+func TestDeploymentRuntimeMigrateCommand(t *testing.T) {
+	testUtil.InitTestConfig()
+	expectedOut := `The migration from Airflow 2.2.4 image to Runtime 4.2.4 has been started. To complete this process, add an Runtime 4.2.4 image to your Dockerfile and deploy to Astronomer.`
+
+	mockDeploymentResponse := *mockDeployment
+	mockDeploymentResponse.AirflowVersion = "2.2.4"
+	mockDeploymentResponse.DesiredAirflowVersion = "2.2.4"
+
+	mockUpdateRequest := map[string]interface{}{
+		"deploymentUuid":        mockDeploymentResponse.ID,
+		"desiredRuntimeVersion": "4.2.4",
+	}
+
+	mockRuntimeReleaseResp := houston.RuntimeReleases{houston.RuntimeRelease{AirflowVersion: "2.2.4", Version: "4.2.4"}}
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig").Return(mockAppConfig, nil)
+	api.On("GetDeployment", mockDeploymentResponse.ID).Return(&mockDeploymentResponse, nil)
+	api.On("UpdateDeploymentRuntime", mockUpdateRequest).Return(&mockDeploymentResponse, nil)
+	api.On("GetRuntimeReleases", mockDeploymentResponse.AirflowVersion).Return(mockRuntimeReleaseResp, nil)
+
+	output, err := executeCommandC(api,
+		"deployment",
+		"runtime",
+		"migrate",
+		"--deployment-id="+mockDeploymentResponse.ID,
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, output, expectedOut)
+}
+
+func TestDeploymentRuntimeMigrateCancelCommand(t *testing.T) {
+	testUtil.InitTestConfig()
+	expectedOut := `Runtime migrate process has been successfully canceled. Your Deployment was not interrupted and you are still running Airflow 2.2.4.`
+
+	mockDeploymentResponse := *mockDeployment
+	mockDeploymentResponse.AirflowVersion = "2.2.4"
+	mockDeploymentResponse.DesiredAirflowVersion = "2.2.4"
+	mockDeploymentResponse.RuntimeVersion = ""
+	mockDeploymentResponse.DesiredRuntimeVersion = "4.2.4"
+
+	mockUpdateRequest := map[string]interface{}{
+		"deploymentUuid": mockDeploymentResponse.ID,
+	}
+
+	mockRuntimeReleaseResp := houston.RuntimeReleases{houston.RuntimeRelease{AirflowVersion: mockDeploymentResponse.AirflowVersion, Version: mockDeploymentResponse.DesiredRuntimeVersion}}
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig").Return(mockAppConfig, nil)
+	api.On("GetDeployment", mockDeploymentResponse.ID).Return(&mockDeploymentResponse, nil)
+	api.On("CancelUpdateDeploymentRuntime", mockUpdateRequest).Return(&mockDeploymentResponse, nil)
+	api.On("GetRuntimeReleases", mockDeploymentResponse.AirflowVersion).Return(mockRuntimeReleaseResp, nil)
+
+	output, err := executeCommandC(api,
+		"deployment",
+		"runtime",
+		"migrate",
+		"--cancel",
+		"--deployment-id="+mockDeploymentResponse.ID,
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, output, expectedOut)
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 	"time"
 
@@ -50,10 +49,7 @@ func newLogsCmd(out io.Writer) *cobra.Command {
 		newWorkersLogsCmd(out),
 	)
 
-	appConfig, err := houstonClient.GetAppConfig()
-	if err != nil {
-		initDebugLogs = append(initDebugLogs, fmt.Sprintf("Error checking feature flag: %s", err.Error()))
-	} else if appConfig.Flags.TriggererEnabled {
+	if appConfig != nil && appConfig.Flags.TriggererEnabled {
 		cmd.AddCommand(newTriggererLogsCmd(out))
 	}
 
@@ -75,10 +71,7 @@ func newLogsDeprecatedCmd(out io.Writer) *cobra.Command {
 		newWorkersLogsCmd(out),
 	)
 
-	appConfig, err := houstonClient.GetAppConfig()
-	if err != nil {
-		initDebugLogs = append(initDebugLogs, fmt.Sprintf("Error checking feature flag: %s", err.Error()))
-	} else if appConfig.Flags.TriggererEnabled {
+	if appConfig != nil && appConfig.Flags.TriggererEnabled {
 		cmd.AddCommand(newTriggererLogsCmd(out))
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/astronomer/astro-cli/config"
@@ -22,11 +23,19 @@ var (
 	verboseLevel   string
 	// init debug logs should be used only for logs produced during the CLI-initialization, before the SetUpLogs Method has been called
 	initDebugLogs = []string{}
+
+	appConfig *houston.AppConfig
 )
 
 // NewRootCmd adds all of the primary commands for the cli
 func NewRootCmd(client houston.ClientInterface, out io.Writer) *cobra.Command {
 	houstonClient = client
+
+	var err error
+	appConfig, err = houstonClient.GetAppConfig()
+	if err != nil {
+		initDebugLogs = append(initDebugLogs, fmt.Sprintf("Error checking feature flag: %s", err.Error()))
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "astro",

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"testing"
 
-	testUtil "github.com/astronomer/astro-cli/pkg/testing"
-
+	"github.com/Masterminds/semver/v3"
 	"github.com/astronomer/astro-cli/houston"
 	mocks "github.com/astronomer/astro-cli/houston/mocks"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -102,7 +102,7 @@ func TestCreate(t *testing.T) {
 		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -117,7 +117,7 @@ func TestCreate(t *testing.T) {
 
 		triggerReplicas = 1
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -134,7 +134,7 @@ func TestCreate(t *testing.T) {
 		triggerReplicas = 0
 
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -169,7 +169,7 @@ func TestCreate(t *testing.T) {
 
 		for _, tt := range myTests {
 			buf := new(bytes.Buffer)
-			err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, "", tt.repoURL, tt.revision, tt.branchName, tt.dagDirectoryLocation, tt.sshKey, tt.knownHosts, tt.syncInterval, triggerReplicas, api, buf)
+			err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, "", tt.repoURL, tt.revision, tt.branchName, tt.dagDirectoryLocation, tt.sshKey, tt.knownHosts, tt.syncInterval, triggerReplicas, api, buf)
 			if tt.expectedError != "" {
 				assert.EqualError(t, err, tt.expectedError)
 			} else {
@@ -206,7 +206,7 @@ func TestCreate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err = Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -244,7 +244,7 @@ func TestCreate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err = Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
 		assert.EqualError(t, err, "number is out of available range")
 		api.AssertExpectations(t)
 	})
@@ -261,7 +261,7 @@ func TestCreate(t *testing.T) {
 		api.On("GetAvailableNamespaces").Return([]houston.Namespace{}, mockError)
 
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
 		assert.EqualError(t, err, mockError.Error())
 		api.AssertExpectations(t)
 	})
@@ -274,7 +274,7 @@ func TestCreate(t *testing.T) {
 		api.On("CreateDeployment", mock.Anything).Return(nil, mockError)
 
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
 		assert.EqualError(t, err, mockError.Error())
 		api.AssertExpectations(t)
 	})
@@ -303,7 +303,7 @@ func TestCreate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err = Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -333,7 +333,7 @@ func TestCreate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Create(label, ws, releaseName, role, executor, airflowVersion, dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err = Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
 		assert.EqualError(t, err, "no kubernetes namespaces specified")
 	})
 }
@@ -411,8 +411,8 @@ func TestList(t *testing.T) {
 		buf := new(bytes.Buffer)
 		err := List(mockDeployments[0].Workspace.ID, false, api, buf)
 		assert.NoError(t, err)
-		expected := ` NAME     DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 TAG     AIRFLOW VERSION     
- test     burning-terrestrial-5940     v1.1.0     ckbv801t300qh0760pck7ea0c     ?       1.1.0               
+		expected := ` NAME     DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 TAG     IMAGE VERSION                  
+ test     burning-terrestrial-5940     v1.1.0     ckbv801t300qh0760pck7ea0c     ?       Astronomer-Certified-1.1.0     
 `
 		assert.Equal(t, expected, buf.String())
 		api.AssertExpectations(t)
@@ -438,8 +438,8 @@ func TestList(t *testing.T) {
 		buf := new(bytes.Buffer)
 		err := List(mockDeployments[0].Workspace.ID, true, api, buf)
 		assert.NoError(t, err)
-		expected := ` NAME     DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 TAG     AIRFLOW VERSION     
- test     burning-terrestrial-5940     v1.1.0     ckbv801t300qh0760pck7ea0c     ?       1.1.0               
+		expected := ` NAME     DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 TAG     IMAGE VERSION                  
+ test     burning-terrestrial-5940     v1.1.0     ckbv801t300qh0760pck7ea0c     ?       Astronomer-Certified-1.1.0     
 `
 		assert.Equal(t, expected, buf.String())
 		api.AssertExpectations(t)
@@ -492,8 +492,8 @@ func TestUpdate(t *testing.T) {
 		api.On("GetAppConfig").Return(mockAppConfig, nil)
 		api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
 
-		expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG         AIRFLOW VERSION     
- test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c     2.2.2-1     2.2.2               
+		expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG         IMAGE VERSION                  
+ test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c     2.2.2-1     Astronomer-Certified-2.2.2     
 
  Successfully updated deployment
 `
@@ -521,8 +521,8 @@ func TestUpdate(t *testing.T) {
 		api.On("GetAppConfig").Return(mockAppConfig, nil)
 		api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
 
-		expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG         AIRFLOW VERSION     
- test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c     2.2.2-1     2.2.2               
+		expected := ` NAME        DEPLOYMENT NAME              ASTRO     DEPLOYMENT ID                 TAG         IMAGE VERSION                  
+ test123     burning-terrestrial-5940     0.0.0     ckbv801t300qh0760pck7ea0c     2.2.2-1     Astronomer-Certified-2.2.2     
 
  Successfully updated deployment
 `
@@ -582,8 +582,8 @@ func TestAirflowUpgrade(t *testing.T) {
 		buf := new(bytes.Buffer)
 		err := AirflowUpgrade(mockDeployment.ID, mockDeployment.DesiredAirflowVersion, api, buf)
 		assert.NoError(t, err)
-		expected := ` NAME        DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 AIRFLOW VERSION     
- test123     burning-terrestrial-5940     v0.0.0     ckbv818oa00r107606ywhoqtw     1.10.5              
+		expected := ` NAME        DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 IMAGE VERSION                    
+ test123     burning-terrestrial-5940     v0.0.0     ckbv818oa00r107606ywhoqtw     Astronomer-Certified-1.10.10     
 
 The upgrade from Airflow 1.10.5 to 1.10.10 has been started. To complete this process, add an Airflow 1.10.10 image to your Dockerfile and deploy to Astronomer.
 To cancel, run: 
@@ -710,12 +710,12 @@ Airflow upgrade process has been successfully canceled. Your Deployment was not 
 		t.Log(buf.String()) // Log the buffer so that this test is recognized by go test
 
 		assert.NoError(t, err)
-		expected := `#     AIRFLOW VERSION     
-1     1.10.7              
-2     1.10.10             
-3     1.10.12             
- NAME     DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 AIRFLOW VERSION     
- test     burning-terrestrial-5940     v0.0.0     ckggzqj5f4157qtc9lescmehm     1.10.5              
+		expected := `#     AIRFLOW VERSION                  
+1     Astronomer-Certified-1.10.7      
+2     Astronomer-Certified-1.10.10     
+3     Astronomer-Certified-1.10.12     
+ NAME     DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 IMAGE VERSION                    
+ test     burning-terrestrial-5940     v0.0.0     ckggzqj5f4157qtc9lescmehm     Astronomer-Certified-1.10.10     
 
 The upgrade from Airflow 1.10.5 to 1.10.10 has been started. To complete this process, add an Airflow 1.10.10 image to your Dockerfile and deploy to Astronomer.
 To cancel, run: 
@@ -1108,5 +1108,372 @@ func TestAddDagDeploymentArgs(t *testing.T) {
 			assert.NoError(t, err)
 		}
 		assert.Equal(t, output, tt.expectedOutput)
+	}
+}
+
+func TestRuntimeUpgrade(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	mockDeployment := &houston.Deployment{
+		ID:                    "ckbv818oa00r107606ywhoqtw",
+		Type:                  "airflow",
+		Label:                 "test123",
+		ReleaseName:           "burning-terrestrial-5940",
+		Version:               "0.0.0",
+		RuntimeVersion:        "4.2.4",
+		RuntimeAirflowVersion: "2.2.4",
+		DesiredRuntimeVersion: "4.2.5",
+	}
+
+	t.Run("upgrade runtime success", func(t *testing.T) {
+		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": mockDeployment.DesiredRuntimeVersion}
+
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("UpdateDeploymentRuntime", expectedVars).Return(mockDeployment, nil)
+		buf := new(bytes.Buffer)
+		err := RuntimeUpgrade(mockDeployment.ID, mockDeployment.DesiredRuntimeVersion, api, buf)
+		assert.NoError(t, err)
+		expected := ` NAME        DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 IMAGE VERSION     
+ test123     burning-terrestrial-5940     v0.0.0     ckbv818oa00r107606ywhoqtw     Runtime-4.2.5     
+
+The upgrade from Runtime 4.2.4 to 4.2.5 has been started. To complete this process, add an Runtime 4.2.5 image to your Dockerfile and deploy to Astronomer.
+To cancel, run: 
+ $ astro deployment runtime upgrade --cancel
+
+`
+
+		assert.Equal(t, expected, buf.String())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("upgrade runtime get deployment error", func(t *testing.T) {
+		mockError := errors.New("get deployment error") //nolint:goerr113
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(nil, mockError)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeUpgrade(mockDeployment.ID, mockDeployment.DesiredRuntimeVersion, api, buf)
+		assert.Error(t, err, mockError.Error())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("upgrade runtime update deployment error", func(t *testing.T) {
+		mockError := errors.New("update deployment error") //nolint:goerr113
+		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": mockDeployment.DesiredRuntimeVersion}
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("UpdateDeploymentRuntime", expectedVars).Return(nil, mockError)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeUpgrade(mockDeployment.ID, mockDeployment.DesiredRuntimeVersion, api, buf)
+		assert.Error(t, err, mockError.Error())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("upgrade runtime with empty desired version", func(t *testing.T) {
+		mockRuntimeReleases := houston.RuntimeReleases{
+			houston.RuntimeRelease{Version: "4.2.4", AirflowVersion: "2.2.5"},
+			houston.RuntimeRelease{Version: "4.2.5", AirflowVersion: "2.2.5"},
+		}
+		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": mockDeployment.DesiredRuntimeVersion}
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("GetRuntimeReleases", "").Return(mockRuntimeReleases, nil)
+		api.On("UpdateDeploymentRuntime", expectedVars).Return(mockDeployment, nil)
+
+		// mock os.Stdin for when prompted by getAirflowVersionSelection()
+		input := []byte("1")
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = w.Write(input)
+		if err != nil {
+			t.Error(err)
+		}
+		w.Close()
+		stdin := os.Stdin
+		// Restore stdin right after the test.
+		defer func() { os.Stdin = stdin }()
+		os.Stdin = r
+
+		buf := new(bytes.Buffer)
+		err = RuntimeUpgrade(mockDeployment.ID, "", api, buf)
+		t.Log(buf.String()) // Log the buffer so that this test is recognized by go test
+
+		assert.NoError(t, err)
+		expected := `#     RUNTIME VERSION     
+1     Runtime-4.2.5       
+ NAME        DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 IMAGE VERSION     
+ test123     burning-terrestrial-5940     v0.0.0     ckbv818oa00r107606ywhoqtw     Runtime-4.2.5     
+
+The upgrade from Runtime 4.2.4 to 4.2.5 has been started. To complete this process, add an Runtime 4.2.5 image to your Dockerfile and deploy to Astronomer.
+To cancel, run: 
+ $ astro deployment runtime upgrade --cancel
+
+`
+		assert.Equal(t, expected, buf.String())
+		api.AssertExpectations(t)
+	})
+}
+
+func TestRuntimeUpgradeCancel(t *testing.T) {
+	testUtil.InitTestConfig()
+	deploymentID := "ckggzqj5f4157qtc9lescmehm"
+
+	mockDeployment := &houston.Deployment{
+		ID:                    "ckggzqj5f4157qtc9lescmehm",
+		Type:                  "airflow",
+		Label:                 "test",
+		ReleaseName:           "burning-terrestrial-5940",
+		Version:               "0.0.0",
+		RuntimeVersion:        "4.2.4",
+		DesiredRuntimeVersion: "4.2.5",
+	}
+
+	expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID}
+
+	t.Run("upgrade cancel success", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("CancelUpdateDeploymentRuntime", expectedVars).Return(mockDeployment, nil)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeUpgradeCancel(deploymentID, api, buf)
+		assert.NoError(t, err)
+		expected := `
+Runtime upgrade process has been successfully canceled. Your Deployment was not interrupted and you are still running Runtime 4.2.4.
+`
+		assert.Equal(t, expected, buf.String())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("upgrade cancel get deployment error", func(t *testing.T) {
+		mockError := errors.New("get deployment error") //nolint:goerr113
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(nil, mockError)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeUpgradeCancel(deploymentID, api, buf)
+		assert.EqualError(t, err, mockError.Error())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("upgrade cancel error", func(t *testing.T) {
+		mockError := errors.New("update deployment error") //nolint:goerr113
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("CancelUpdateDeploymentRuntime", expectedVars).Return(nil, mockError)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeUpgradeCancel(deploymentID, api, buf)
+		assert.EqualError(t, err, mockError.Error())
+		api.AssertExpectations(t)
+	})
+}
+
+func TestRuntimeMigrate(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	mockDeployment := &houston.Deployment{
+		ID:             "ckbv818oa00r107606ywhoqtw",
+		Type:           "airflow",
+		Label:          "test123",
+		ReleaseName:    "burning-terrestrial-5940",
+		Version:        "0.0.0",
+		RuntimeVersion: "",
+		AirflowVersion: "2.2.4",
+	}
+
+	t.Run("migrate runtime success", func(t *testing.T) {
+		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": "4.2.4"}
+
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("GetRuntimeReleases", mockDeployment.AirflowVersion).Return(houston.RuntimeReleases{houston.RuntimeRelease{Version: "4.2.4", AirflowVersion: "2.2.4"}}, nil)
+		mockMigrateRuntimeResp := *mockDeployment
+		mockMigrateRuntimeResp.RuntimeVersion = "4.2.4"
+		api.On("UpdateDeploymentRuntime", expectedVars).Return(&mockMigrateRuntimeResp, nil)
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrate(mockDeployment.ID, api, buf)
+		assert.NoError(t, err)
+		expected := ` NAME        DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 IMAGE VERSION     
+ test123     burning-terrestrial-5940     v0.0.0     ckbv818oa00r107606ywhoqtw     Runtime-4.2.4     
+
+The migration from Airflow 2.2.4 image to Runtime 4.2.4 has been started. To complete this process, add an Runtime 4.2.4 image to your Dockerfile and deploy to Astronomer.
+To cancel, run: 
+ $ astro deployment runtime migrate --cancel
+
+`
+
+		assert.Equal(t, expected, buf.String())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("migrate runtime get deployment error", func(t *testing.T) {
+		mockError := errors.New("get deployment error") //nolint:goerr113
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(nil, mockError)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrate(mockDeployment.ID, api, buf)
+		assert.Error(t, err, mockError.Error())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("already on runtime error", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		mockDeploymentResp := *mockDeployment
+		mockDeploymentResp.RuntimeVersion = "4.2.4"
+		mockDeploymentResp.AirflowVersion = ""
+		api.On("GetDeployment", mockDeployment.ID).Return(&mockDeploymentResp, nil)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrate(mockDeployment.ID, api, buf)
+		assert.Error(t, err, errDeploymentAlreadyOnRuntime)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("migrate runtime get runtime releases error", func(t *testing.T) {
+		mockError := errors.New("get runtime releases error") //nolint:goerr113
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("GetRuntimeReleases", mockDeployment.AirflowVersion).Return(houston.RuntimeReleases{}, mockError)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrate(mockDeployment.ID, api, buf)
+		assert.Error(t, err, mockError.Error())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("invalid airflow version to migrate to runtime", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("GetRuntimeReleases", mockDeployment.AirflowVersion).Return(houston.RuntimeReleases{}, nil)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrate(mockDeployment.ID, api, buf)
+		assert.Error(t, err, errInvalidAirflowVersion)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("migrate runtime update deployment error", func(t *testing.T) {
+		mockError := errors.New("update deployment error") //nolint:goerr113
+		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": "4.2.4"}
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("GetRuntimeReleases", mockDeployment.AirflowVersion).Return(houston.RuntimeReleases{houston.RuntimeRelease{Version: "4.2.4", AirflowVersion: "2.2.4"}}, nil)
+		api.On("UpdateDeploymentRuntime", expectedVars).Return(nil, mockError)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrate(mockDeployment.ID, api, buf)
+		assert.Error(t, err, mockError.Error())
+		api.AssertExpectations(t)
+	})
+}
+
+func TestRuntimeMigrateCancel(t *testing.T) {
+	testUtil.InitTestConfig()
+	deploymentID := "ckggzqj5f4157qtc9lescmehm"
+
+	mockDeployment := &houston.Deployment{
+		ID:                    "ckggzqj5f4157qtc9lescmehm",
+		Type:                  "airflow",
+		Label:                 "test",
+		ReleaseName:           "burning-terrestrial-5940",
+		Version:               "0.0.0",
+		RuntimeVersion:        "",
+		DesiredRuntimeVersion: "4.2.4",
+		AirflowVersion:        "2.2.4",
+	}
+
+	expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID}
+
+	t.Run("migrate cancel success", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("CancelUpdateDeploymentRuntime", expectedVars).Return(mockDeployment, nil)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrateCancel(deploymentID, api, buf)
+		assert.NoError(t, err)
+		expected := `
+Runtime migrate process has been successfully canceled. Your Deployment was not interrupted and you are still running Airflow 2.2.4.
+`
+		assert.Equal(t, expected, buf.String())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("migrate cancel get deployment error", func(t *testing.T) {
+		mockError := errors.New("get deployment error") //nolint:goerr113
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(nil, mockError)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrateCancel(deploymentID, api, buf)
+		assert.EqualError(t, err, mockError.Error())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("migrate cancel error", func(t *testing.T) {
+		mockError := errors.New("update deployment error") //nolint:goerr113
+		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("CancelUpdateDeploymentRuntime", expectedVars).Return(nil, mockError)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrateCancel(deploymentID, api, buf)
+		assert.EqualError(t, err, mockError.Error())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("already migrated error", func(t *testing.T) {
+		api := new(mocks.ClientInterface)
+		mockDeploymentResp := *mockDeployment
+		mockDeploymentResp.AirflowVersion = ""
+		mockDeploymentResp.RuntimeVersion = mockDeployment.DesiredRuntimeVersion
+		api.On("GetDeployment", mockDeployment.ID).Return(&mockDeploymentResp, nil)
+
+		buf := new(bytes.Buffer)
+		err := RuntimeMigrateCancel(deploymentID, api, buf)
+		assert.NoError(t, err)
+		expected := `
+Nothing to cancel. You are already running Runtime 4.2.4 and you have either not indicated that you want to migrate or migration has been completed.`
+		assert.Equal(t, expected, buf.String())
+		api.AssertExpectations(t)
+	})
+}
+
+func TestMeetsRuntimeUpgradeReqs(t *testing.T) {
+	type args struct {
+		runtimeVersion        string
+		desiredRuntimeVersion string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		expectedErr error
+	}{
+		{
+			name:        "valid case",
+			args:        args{runtimeVersion: "4.2.4", desiredRuntimeVersion: "4.2.5"},
+			expectedErr: nil,
+		},
+		{
+			name:        "invalid case",
+			args:        args{runtimeVersion: "4.2.4", desiredRuntimeVersion: "4.2.4"},
+			expectedErr: ErrInvalidRuntimeVersion{currentVersion: semver.MustParse("4.2.4"), desiredVersion: "4.2.4"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := meetsRuntimeUpgradeReqs(tt.args.runtimeVersion, tt.args.desiredRuntimeVersion)
+			if tt.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+			}
+		})
 	}
 }

--- a/deployment/deployment_test.go
+++ b/deployment/deployment_test.go
@@ -94,6 +94,7 @@ func TestCreate(t *testing.T) {
 	dagDeploymentType := houston.ImageDeploymentType
 	nfsLocation := ""
 	triggerReplicas := 0
+	req := &CreateDeploymentRequest{label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas}
 
 	t.Run("create success", func(t *testing.T) {
 		api := new(mocks.ClientInterface)
@@ -102,7 +103,7 @@ func TestCreate(t *testing.T) {
 		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(req, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -117,7 +118,7 @@ func TestCreate(t *testing.T) {
 
 		triggerReplicas = 1
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(req, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -134,7 +135,7 @@ func TestCreate(t *testing.T) {
 		triggerReplicas = 0
 
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(req, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -169,7 +170,8 @@ func TestCreate(t *testing.T) {
 
 		for _, tt := range myTests {
 			buf := new(bytes.Buffer)
-			err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, "", tt.repoURL, tt.revision, tt.branchName, tt.dagDirectoryLocation, tt.sshKey, tt.knownHosts, tt.syncInterval, triggerReplicas, api, buf)
+			createReq := &CreateDeploymentRequest{label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, "", tt.repoURL, tt.revision, tt.branchName, tt.dagDirectoryLocation, tt.sshKey, tt.knownHosts, tt.syncInterval, triggerReplicas}
+			err := Create(createReq, api, buf)
 			if tt.expectedError != "" {
 				assert.EqualError(t, err, tt.expectedError)
 			} else {
@@ -206,7 +208,7 @@ func TestCreate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err = Create(req, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -244,7 +246,7 @@ func TestCreate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err = Create(req, api, buf)
 		assert.EqualError(t, err, "number is out of available range")
 		api.AssertExpectations(t)
 	})
@@ -261,7 +263,7 @@ func TestCreate(t *testing.T) {
 		api.On("GetAvailableNamespaces").Return([]houston.Namespace{}, mockError)
 
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(req, api, buf)
 		assert.EqualError(t, err, mockError.Error())
 		api.AssertExpectations(t)
 	})
@@ -274,7 +276,7 @@ func TestCreate(t *testing.T) {
 		api.On("CreateDeployment", mock.Anything).Return(nil, mockError)
 
 		buf := new(bytes.Buffer)
-		err := Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err := Create(req, api, buf)
 		assert.EqualError(t, err, mockError.Error())
 		api.AssertExpectations(t)
 	})
@@ -303,7 +305,7 @@ func TestCreate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err = Create(req, api, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
 		api.AssertExpectations(t)
@@ -333,7 +335,7 @@ func TestCreate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Create(label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, api, buf)
+		err = Create(req, api, buf)
 		assert.EqualError(t, err, "no kubernetes namespaces specified")
 	})
 }

--- a/deployment/types.go
+++ b/deployment/types.go
@@ -1,0 +1,21 @@
+package deployment
+
+type CreateDeploymentRequest struct {
+	Label             string
+	WS                string
+	ReleaseName       string
+	CloudRole         string
+	Executor          string
+	AirflowVersion    string
+	RuntimeVersion    string
+	DagDeploymentType string
+	NFSLocation       string
+	GitRepoURL        string
+	GitRevision       string
+	GitBranchName     string
+	GitDAGDir         string
+	SSHKey            string
+	KnownHosts        string
+	GitSyncInterval   int
+	TriggererReplicas int
+}

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -145,3 +145,31 @@ func (h ClientImplementation) ListDeploymentLogs(filters ListDeploymentLogsReque
 
 	return r.Data.DeploymentLog, nil
 }
+
+func (h ClientImplementation) UpdateDeploymentRuntime(variables map[string]interface{}) (*Deployment, error) {
+	req := Request{
+		Query:     UpdateDeploymentRuntimeRequest,
+		Variables: variables,
+	}
+
+	res, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return res.Data.UpdateDeploymentRuntime, nil
+}
+
+func (h ClientImplementation) CancelUpdateDeploymentRuntime(variables map[string]interface{}) (*Deployment, error) {
+	req := Request{
+		Query:     CancelUpdateDeploymentRuntimeRequest,
+		Variables: variables,
+	}
+
+	res, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return res.Data.CancelUpdateDeploymentRuntime, nil
+}

--- a/houston/deployment_test.go
+++ b/houston/deployment_test.go
@@ -464,3 +464,114 @@ func TestListDeploymentLogs(t *testing.T) {
 		assert.Contains(t, err.Error(), "Internal Server Error")
 	})
 }
+
+func TestUpdateDeploymentRuntime(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	mockDeployment := &Response{
+		Data: ResponseData{
+			UpdateDeploymentRuntime: &Deployment{
+				ID:                    "deployment-test-id",
+				Type:                  "airflow",
+				Label:                 "test deployment",
+				ReleaseName:           "prehistoric-gravity-930",
+				Version:               "2.2.0",
+				AirflowVersion:        "",
+				DesiredAirflowVersion: "",
+				RuntimeVersion:        "4.2.4",
+				DesiredRuntimeVersion: "4.2.4",
+				RuntimeAirflowVersion: "2.2.5",
+				DeploymentInfo:        DeploymentInfo{},
+				Workspace: Workspace{
+					ID: "test-workspace-id",
+				},
+				Urls: []DeploymentURL{
+					{Type: "airflow", URL: "http://airflow.com"},
+					{Type: "flower", URL: "http://flower.com"},
+				},
+				CreatedAt: "2020-06-25T22:10:42.385Z",
+				UpdatedAt: "2020-06-25T22:10:42.385Z",
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockDeployment)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		deployment, err := api.UpdateDeploymentRuntime(map[string]interface{}{})
+		assert.NoError(t, err)
+		assert.Equal(t, deployment, mockDeployment.Data.UpdateDeploymentRuntime)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.UpdateDeploymentRuntime(map[string]interface{}{})
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestCancelUpdateDeploymentRuntime(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	mockDeployment := &Response{
+		Data: ResponseData{
+			CancelUpdateDeploymentRuntime: &Deployment{
+				ID:                    "deployment-test-id",
+				Label:                 "test deployment",
+				ReleaseName:           "prehistoric-gravity-930",
+				Version:               "2.2.0",
+				RuntimeVersion:        "4.2.4",
+				DesiredRuntimeVersion: "4.2.4",
+				RuntimeAirflowVersion: "2.2.5",
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockDeployment)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		deployment, err := api.CancelUpdateDeploymentRuntime(map[string]interface{}{})
+		assert.NoError(t, err)
+		assert.Equal(t, deployment, mockDeployment.Data.CancelUpdateDeploymentRuntime)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.CancelUpdateDeploymentRuntime(map[string]interface{}{})
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -51,6 +51,8 @@ type ClientInterface interface {
 	UpdateDeployment(variables map[string]interface{}) (*Deployment, error)
 	GetDeployment(deploymentID string) (*Deployment, error)
 	UpdateDeploymentAirflow(variables map[string]interface{}) (*Deployment, error)
+	UpdateDeploymentRuntime(variables map[string]interface{}) (*Deployment, error)
+	CancelUpdateDeploymentRuntime(variables map[string]interface{}) (*Deployment, error)
 	GetDeploymentConfig() (*DeploymentConfig, error)
 	ListDeploymentLogs(filters ListDeploymentLogsRequest) ([]DeploymentLog, error)
 	// deployment users
@@ -76,6 +78,8 @@ type ClientInterface interface {
 	// teams
 	GetTeam(teamID string) (*Team, error)
 	GetTeamUsers(teamID string) ([]User, error)
+	// runtime
+	GetRuntimeReleases(airflowVersion string) (RuntimeReleases, error)
 }
 
 // ClientImplementation - implementation of the Houston Client Interface

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -125,6 +125,29 @@ func (_m *ClientInterface) AuthenticateWithBasicAuth(username string, password s
 	return r0, r1
 }
 
+// CancelUpdateDeploymentRuntime provides a mock function with given fields: variables
+func (_m *ClientInterface) CancelUpdateDeploymentRuntime(variables map[string]interface{}) (*houston.Deployment, error) {
+	ret := _m.Called(variables)
+
+	var r0 *houston.Deployment
+	if rf, ok := ret.Get(0).(func(map[string]interface{}) *houston.Deployment); ok {
+		r0 = rf(variables)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Deployment)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
+		r1 = rf(variables)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateDeployment provides a mock function with given fields: vars
 func (_m *ClientInterface) CreateDeployment(vars map[string]interface{}) (*houston.Deployment, error) {
 	ret := _m.Called(vars)
@@ -516,6 +539,29 @@ func (_m *ClientInterface) GetDeploymentConfig() (*houston.DeploymentConfig, err
 	return r0, r1
 }
 
+// GetRuntimeReleases provides a mock function with given fields: airflowVersion
+func (_m *ClientInterface) GetRuntimeReleases(airflowVersion string) (houston.RuntimeReleases, error) {
+	ret := _m.Called(airflowVersion)
+
+	var r0 houston.RuntimeReleases
+	if rf, ok := ret.Get(0).(func(string) houston.RuntimeReleases); ok {
+		r0 = rf(airflowVersion)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(houston.RuntimeReleases)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(airflowVersion)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetTeam provides a mock function with given fields: teamID
 func (_m *ClientInterface) GetTeam(teamID string) (*houston.Team, error) {
 	ret := _m.Called(teamID)
@@ -884,6 +930,29 @@ func (_m *ClientInterface) UpdateDeployment(variables map[string]interface{}) (*
 
 // UpdateDeploymentAirflow provides a mock function with given fields: variables
 func (_m *ClientInterface) UpdateDeploymentAirflow(variables map[string]interface{}) (*houston.Deployment, error) {
+	ret := _m.Called(variables)
+
+	var r0 *houston.Deployment
+	if rf, ok := ret.Get(0).(func(map[string]interface{}) *houston.Deployment); ok {
+		r0 = rf(variables)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Deployment)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
+		r1 = rf(variables)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateDeploymentRuntime provides a mock function with given fields: variables
+func (_m *ClientInterface) UpdateDeploymentRuntime(variables map[string]interface{}) (*houston.Deployment, error) {
 	ret := _m.Called(variables)
 
 	var r0 *houston.Deployment

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -24,6 +24,7 @@ var (
 		$workspaceId: Uuid!
 		$executor: ExecutorType!
 		$airflowVersion: String
+		$runtimeVersion: String
 		$namespace: String
 		$config: JSON
 		$cloudRole: String
@@ -36,7 +37,8 @@ var (
 			workspaceUuid: $workspaceId
 			releaseName: $releaseName
 			executor: $executor
-		        airflowVersion: $airflowVersion
+			airflowVersion: $airflowVersion
+			runtimeVersion: $runtimeVersion
 			namespace: $namespace
 			config: $config
 			cloudRole: $cloudRole
@@ -51,6 +53,7 @@ var (
 			releaseName
 			version
 			airflowVersion
+			runtimeVersion
 			urls {
 				type
 				url
@@ -105,6 +108,7 @@ var (
 			}
 			version
 			airflowVersion
+			runtimeVersion
 			createdAt
 			updatedAt
 		}
@@ -127,6 +131,9 @@ var (
 			id
 			airflowVersion
 			desiredAirflowVersion
+			runtimeVersion
+			desiredRuntimeVersion
+			runtimeAirflowVersion
 			urls {
 				type
 				url
@@ -164,6 +171,32 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 			releaseName
 			airflowVersion
 			desiredAirflowVersion
+		}
+	}`
+
+	UpdateDeploymentRuntimeRequest = `
+	mutation updateDeploymentRuntime($deploymentUuid: Uuid!, $desiredRuntimeVersion: String!) {
+		updateDeploymentRuntime(deploymentUuid: $deploymentUuid, desiredRuntimeVersion: $desiredRuntimeVersion) {
+		  	id
+			label
+			version
+			releaseName
+		  	runtimeVersion
+		  	desiredRuntimeVersion
+		  	runtimeAirflowVersion
+		}
+	}`
+
+	CancelUpdateDeploymentRuntimeRequest = `
+	mutation cancelRuntimeUpdate($deploymentUuid: Uuid!) {
+		cancelRuntimeUpdate(deploymentUuid: $deploymentUuid) {
+			id
+			label
+			version
+			releaseName
+			runtimeVersion
+			desiredRuntimeVersion
+			runtimeAirflowVersion
 		}
 	}`
 
@@ -765,6 +798,15 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 					label
 				}
 			}
+		}
+	}`
+
+	GetRuntimeReleases = `
+	query runtimeReleases($airflowVersion: String) {
+		runtimeReleases(airflowVersion: $airflowVersion) {
+		  	version
+		  	airflowVersion
+		  	airflowDatabaseMigrations
 		}
 	}`
 )

--- a/houston/runtime.go
+++ b/houston/runtime.go
@@ -1,0 +1,19 @@
+package houston
+
+func (h ClientImplementation) GetRuntimeReleases(airflowVersion string) (RuntimeReleases, error) {
+	vars := make(map[string]interface{})
+	if airflowVersion != "" {
+		vars["airflowVersion"] = airflowVersion
+	}
+	dReq := Request{
+		Query:     GetRuntimeReleases,
+		Variables: vars,
+	}
+
+	resp, err := dReq.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return resp.Data.RuntimeReleases, nil
+}

--- a/houston/runtime_test.go
+++ b/houston/runtime_test.go
@@ -1,0 +1,70 @@
+package houston
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRuntimeReleases(t *testing.T) {
+	testUtil.InitTestConfig()
+
+	mockResp := &Response{
+		Data: ResponseData{
+			RuntimeReleases: RuntimeReleases{
+				RuntimeRelease{Version: "4.2.4", AirflowVersion: "2.2.4"},
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResp)
+	assert.NoError(t, err)
+
+	t.Run("success without airflow version", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		resp, err := api.GetRuntimeReleases("")
+		assert.NoError(t, err)
+		assert.Equal(t, resp, mockResp.Data.RuntimeReleases)
+	})
+
+	t.Run("success with airflow version", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		resp, err := api.GetRuntimeReleases("2.2.4")
+		assert.NoError(t, err)
+		assert.Equal(t, resp, mockResp.Data.RuntimeReleases)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.GetRuntimeReleases("")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}

--- a/houston/types.go
+++ b/houston/types.go
@@ -46,6 +46,8 @@ type ResponseData struct {
 	GetWorkspace                   *Workspace                `json:"workspace,omitempty"`
 	UpdateDeployment               *Deployment               `json:"updateDeployment,omitempty"`
 	UpdateDeploymentAirflow        *Deployment               `json:"updateDeploymentAirflow,omitempty"`
+	UpdateDeploymentRuntime        *Deployment               `json:"updateDeploymentRuntime,omitempty"`
+	CancelUpdateDeploymentRuntime  *Deployment               `json:"cancelRuntimeUpdate,omitempty"`
 	UpdateWorkspace                *Workspace                `json:"updateWorkspace,omitempty"`
 	DeploymentLog                  []DeploymentLog           `json:"logs,omitempty"`
 	WorkspaceUpdateUserRole        string                    `json:"workspaceUpdateUserRole,omitempty"`
@@ -56,6 +58,7 @@ type ResponseData struct {
 	GetDeploymentNamespaces        []Namespace               `json:"availableNamespaces,omitempty"`
 	GetTeam                        *Team                     `json:"team,omitempty"`
 	GetTeamUsers                   []User                    `json:"teamUsers,omitempty"`
+	RuntimeReleases                RuntimeReleases           `json:"runtimeReleases,omitempty"`
 }
 
 type Namespace struct {
@@ -97,6 +100,9 @@ type Deployment struct {
 	ReleaseName           string          `json:"releaseName"`
 	Version               string          `json:"version"`
 	AirflowVersion        string          `json:"airflowVersion"`
+	RuntimeVersion        string          `json:"runtimeVersion"`
+	RuntimeAirflowVersion string          `json:"runtimeAirflowVersion"`
+	DesiredRuntimeVersion string          `json:"desiredRuntimeVersion"`
 	DesiredAirflowVersion string          `json:"desiredAirflowVersion"`
 	DeploymentInfo        DeploymentInfo  `json:"deployInfo"`
 	Workspace             Workspace       `json:"workspace"`
@@ -285,6 +291,15 @@ type AirflowImage struct {
 	Tag     string `json:"tag"`
 }
 
+// RuntimeRelease contains info releated to a runtime release
+type RuntimeRelease struct {
+	Version           string `json:"version"`
+	AirflowVersion    string `json:"airflowVersion"`
+	AirflowDBMigraion bool   `json:"airflowDatabaseMigrations"`
+}
+
+type RuntimeReleases []RuntimeRelease
+
 // DeploymentConfig contains current airflow image tag
 type DeploymentConfig struct {
 	AirflowImages          []AirflowImage `json:"airflowImages"`
@@ -320,6 +335,33 @@ func (config *DeploymentConfig) IsValidTag(tag string) bool {
 		}
 	}
 	return false
+}
+
+func (r RuntimeReleases) IsValidVersion(version string) bool {
+	for idx := range r {
+		if r[idx].Version == version {
+			return true
+		}
+	}
+	return false
+}
+
+func (r RuntimeReleases) GreaterVersions(version string) []string {
+	greaterVersions := []string{}
+	currentVersion, err := coerce(version)
+	if err != nil {
+		return greaterVersions
+	}
+	for idx := range r {
+		runtimeVersion, err := coerce(r[idx].Version)
+		if err != nil {
+			continue
+		}
+		if runtimeVersion.Compare(currentVersion) >= 0 {
+			greaterVersions = append(greaterVersions, r[idx].Version)
+		}
+	}
+	return greaterVersions
 }
 
 // AppConfig contains current houston config

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -82,7 +82,7 @@ var (
 	NA                                        = "N/A"
 	ValidDockerfileBaseImage                  = "quay.io/astronomer/ap-airflow"
 	WarningDowngradeVersion                   = "Your Astro CLI Version (%s) is ahead of the server version (%s).\nConsider downgrading your Astro CLI to match. See https://www.astronomer.io/docs/cli-quickstart for more information.\n"
-	WarningInvalidImageName                   = "WARNING! The image in your Dockerfile is pulling from '%s', which is not supported. We strongly recommend that you use Astronomer Certified images that pull from 'astronomerinc/ap-airflow' or 'quay.io/astronomer/ap-airflow'. If you're running a custom image, you can override this. Are you sure you want to continue?\n"
+	WarningInvalidImageName                   = "WARNING! The image in your Dockerfile is pulling from '%s', which is not supported. We strongly recommend that you use Astronomer Certified or Runtime images that pull from 'astronomerinc/ap-airflow' or 'quay.io/astronomer/ap-airflow' or 'quay.io/astronomer/astro-runtime'. If you're running a custom image, you can override this. Are you sure you want to continue?\n"
 	WarningInvalidNameTag                     = "WARNING! You are about to push an image using the '%s' tag. This is not recommended.\nPlease use one of the following tags: %s.\nAre you sure you want to continue?"
 	WarningInvalidNameTagEmptyRecommendations = "WARNING! You are about to push an image using the '%s' tag. This is not recommended.\nAre you sure you want to continue?"
 	WarningNewMinorVersion                    = "A new minor version of Astro CLI is available. Your version is %s and %s is the latest.\nSee https://www.astronomer.io/docs/cli-quickstart for more information.\n"


### PR DESCRIPTION
## Description
Runtime Changes:
- Added runtime version check in `astro deploy`
- Added runtime version flag in `astro deployment create`
- Updated response structure for `astro deployment update` & `astro deployment list`
- Added `astro deployment runtime migrate` to migrate from AC to runtime
- Added `astro deployment runtime upgrade` to upgrade from one runtime version to another
- Tag verification & recommendation in `astro deploy` will be based on whether `DesiredRuntimeVersion` or `DesiredAirflowVersion` is set
- Kept runtime-based commands behind a runtime feature flag, passed from the software platform, CLI is connected to.
- Centralised getAppConfig method call from newRootCommand, instead of individually calling the same method in different places to get the same response.

Corresponding houston PR: https://github.com/astronomer/houston-api/pull/1043
Link to doc covering Runtime CLI changes: https://www.notion.so/astronomerio/Astro-CLI-Runtime-Changes-119e82adee744830b73dc7ad4047ea31

## 🎟 Issue(s)

Related astronomer/issues#3985

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
