### PR TITLE
add flag --runtime-version to dev init command

### DIFF
--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -41,8 +41,12 @@ func getAstroRuntimeTag(runtimeVersions map[string]RuntimeVersion, airflowVersio
 	availableVersions := []string{}
 
 	// If user wants a specific runtime version, check that it is a valid runtime released version
-	if _, ok := runtimeVersions[userRuntimeVersion]; userRuntimeVersion != "" && ok {
-		return userRuntimeVersion, nil
+	if userRuntimeVersion != "" {
+		if _, ok := runtimeVersions[userRuntimeVersion]; ok {
+			return userRuntimeVersion, nil
+		}
+		// user provided invalid runtime version, print warning
+		fmt.Printf("You provided an invalid runtime version %s, ignoring provided version...", userRuntimeVersion)
 	}
 
 	for runtimeVersion, r := range runtimeVersions {

--- a/airflow_versions/airflow_versions_test.go
+++ b/airflow_versions/airflow_versions_test.go
@@ -145,16 +145,19 @@ func TestGetAstroRuntimeTag(t *testing.T) {
 
 	tests := []struct {
 		airflowVersion string
+		runtimeVersion string
 		output         string
 		err            error
 	}{
 		{airflowVersion: "", output: "4.0.0", err: nil},
+		{airflowVersion: "", runtimeVersion: "9.9.9", output: "4.0.0", err: nil},
 		{airflowVersion: "2.1.1", output: "3.0.1", err: nil},
+		{airflowVersion: "", runtimeVersion: "3.1.0", output: "3.1.0", err: nil},
 		{airflowVersion: "2.2.2", output: "", err: ErrNoTagAvailable{airflowVersion: "2.2.2"}},
 	}
 
 	for _, tt := range tests {
-		defaultImageTag, err := getAstroRuntimeTag(tagToRuntimeVersion, tt.airflowVersion)
+		defaultImageTag, err := getAstroRuntimeTag(tagToRuntimeVersion, tt.airflowVersion, tt.runtimeVersion)
 		if tt.err == nil {
 			assert.NoError(t, err)
 		} else {
@@ -176,7 +179,7 @@ func TestGetDefaultImageTagError(t *testing.T) {
 	})
 	httpClient := NewClient(client, true)
 
-	defaultImageTag, err := GetDefaultImageTag(httpClient, "")
+	defaultImageTag, err := GetDefaultImageTag(httpClient, "", "")
 	assert.Error(t, err)
 	assert.Equal(t, "", defaultImageTag)
 }

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -28,7 +28,7 @@ var (
 	errNotProjectDir                        = errors.New("not in a project directory")
 	errProjectConfigNotFound                = errors.New("project config file does not exists")
 	errInvalidProjectName                   = errors.New(messages.ErrInvalidConfigProjectName)
-	errInvalidBothAirflowAndRuntimeVersions = errors.New("You provided both a runtime version and an Airflow version. You have to provide only one of these to initialize your project.") //nolint
+	errInvalidBothAirflowAndRuntimeVersions = errors.New("You provided both a Runtime version and an Airflow version. You have to provide only one of these to initialize your project.") //nolint
 )
 
 var (

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -13,7 +13,7 @@ import (
 
 var errAirflowVersionNotSupported = errors.New("the --airflow-version flag is not supported if you're not authenticated to Astronomer. Please authenticate and try again")
 
-func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowversions.Client, houstonClient houston.ClientInterface, out io.Writer) (string, error) {
+func prepareDefaultAirflowImageTag(airflowVersion, userRuntimeVersion string, httpClient *airflowversions.Client, houstonClient houston.ClientInterface, out io.Writer) (string, error) {
 	deploymentConfig, err := houstonClient.GetDeploymentConfig()
 	if err == nil {
 		acceptableAirflowVersions := deploymentConfig.AirflowVersions
@@ -29,7 +29,7 @@ func prepareDefaultAirflowImageTag(airflowVersion string, httpClient *airflowver
 		}
 	}
 
-	defaultImageTag, _ := airflowversions.GetDefaultImageTag(httpClient, airflowVersion)
+	defaultImageTag, _ := airflowversions.GetDefaultImageTag(httpClient, airflowVersion, userRuntimeVersion)
 
 	if defaultImageTag == "" {
 		if useAstronomerCertified {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -67,7 +67,7 @@ func Test_prepareDefaultAirflowImageTag(t *testing.T) {
 
 	output := new(bytes.Buffer)
 
-	myTests := []struct {
+	airflowTests := []struct {
 		airflowVersion   string
 		expectedImageTag string
 		expectedError    string
@@ -78,8 +78,122 @@ func Test_prepareDefaultAirflowImageTag(t *testing.T) {
 		{airflowVersion: "2.0.2", expectedImageTag: "2.0.2", expectedError: ""},
 		{airflowVersion: "9.9.9", expectedImageTag: "", expectedError: "Unsupported Airflow Version specified. Please choose from: 2.1.0, 2.0.2, 2.0.0, 1.10.15, 1.10.14, 1.10.12, 1.10.10, 1.10.7, 1.10.5 \n"},
 	}
-	for _, tt := range myTests {
-		defaultTag, err := prepareDefaultAirflowImageTag(tt.airflowVersion, httpClient, api, output)
+	for _, tt := range airflowTests {
+		defaultTag, err := prepareDefaultAirflowImageTag(tt.airflowVersion, "", httpClient, api, output)
+		if tt.expectedError != "" {
+			assert.EqualError(t, err, tt.expectedError)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, tt.expectedImageTag, defaultTag)
+	}
+}
+
+func Test_prepareDefaultImageTagRuntime(t *testing.T) {
+	runtimeResponse := `
+{
+   "runtimeVersions":{
+      "3.0.0":{
+         "metadata":{
+            "airflowVersion":"2.1.1",
+            "channel":"stable",
+            "releaseDate":"2021-08-12"
+         },
+         "migrations":{
+            "airflowDatabase":false
+         }
+      },
+      "3.0.1":{
+         "metadata":{
+            "airflowVersion":"2.1.1",
+            "channel":"stable",
+            "releaseDate":"2021-08-31"
+         },
+         "migrations":{
+            "airflowDatabase":false
+         }
+      },
+      "4.0.0":{
+         "metadata":{
+            "airflowVersion":"2.2.0",
+            "channel":"stable",
+            "releaseDate":"2021-10-12"
+         },
+         "migrations":{
+            "airflowDatabase":true
+         }
+      },
+      "4.0.1":{
+         "metadata":{
+            "airflowVersion":"2.2.0",
+            "channel":"stable",
+            "releaseDate":"2021-10-25"
+         },
+         "migrations":{
+            "airflowDatabase":false
+         }
+      },
+      "4.1.0":{
+         "metadata":{
+            "airflowVersion":"2.2.4",
+            "channel":"stable",
+            "releaseDate":"2022-02-22"
+         },
+         "migrations":{
+            "airflowDatabase":true
+         }
+      },
+      "4.2.0":{
+         "metadata":{
+            "airflowVersion":"2.2.4",
+            "channel":"stable",
+            "releaseDate":"2022-03-08"
+         },
+         "migrations":{
+            "airflowDatabase":false
+         }
+      },
+      "5.0.0":{
+         "metadata":{
+            "airflowVersion":"2.3.0",
+            "channel":"alpha",
+            "releaseDate":"2022-04-21"
+         },
+         "migrations":{
+            "airflowDatabase":true
+         }
+      }
+   },
+   "schemaVersion":"1.3"
+}
+`
+	// prepare fake response from houston
+	api := new(mocks.ClientInterface)
+	api.On("GetDeploymentConfig").Return(mockDeploymentConfig, nil)
+
+	output := new(bytes.Buffer)
+
+	clientRuntime := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(runtimeResponse)),
+			Header:     make(http.Header),
+		}
+	})
+	runtimeHTTPClient := airflowversions.NewClient(clientRuntime, false)
+
+	runtimeTests := []struct {
+		runtimeVersion   string
+		expectedImageTag string
+		expectedError    string
+	}{
+		{runtimeVersion: "3.0.1", expectedImageTag: "3.0.1", expectedError: ""},
+		{runtimeVersion: "", expectedImageTag: "4.2.0", expectedError: ""},
+		{runtimeVersion: "9.9.9", expectedImageTag: "4.2.0", expectedError: ""},
+	}
+
+	for _, tt := range runtimeTests {
+		defaultTag, err := prepareDefaultAirflowImageTag("", tt.runtimeVersion, runtimeHTTPClient, api, output)
 		if tt.expectedError != "" {
 			assert.EqualError(t, err, tt.expectedError)
 		} else {
@@ -113,7 +227,7 @@ func Test_fallbackDefaultAirflowImageTag(t *testing.T) {
 
 		output := new(bytes.Buffer)
 
-		defaultTag, err := prepareDefaultAirflowImageTag("", httpClient, api, output)
+		defaultTag, err := prepareDefaultAirflowImageTag("", "", httpClient, api, output)
 		assert.NoError(t, err)
 		assert.Equal(t, "2.0.0-buster-onbuild", defaultTag)
 	})
@@ -139,7 +253,7 @@ func Test_fallbackDefaultAirflowImageTag(t *testing.T) {
 
 		output := new(bytes.Buffer)
 
-		defaultTag, err := prepareDefaultAirflowImageTag("", httpClient, api, output)
+		defaultTag, err := prepareDefaultAirflowImageTag("", "", httpClient, api, output)
 		assert.NoError(t, err)
 		assert.Equal(t, "3.0.0", defaultTag)
 	})
@@ -183,7 +297,7 @@ func Test_prepareDefaultAirflowImageTagHoustonBadRequest(t *testing.T) {
 
 	output := new(bytes.Buffer)
 
-	defaultTag, err := prepareDefaultAirflowImageTag("2.0.2", httpClient, api, output)
+	defaultTag, err := prepareDefaultAirflowImageTag("2.0.2", "", httpClient, api, output)
 	assert.Equal(t, mockErrorResponse.Error(), err.Error())
 	assert.Equal(t, "", defaultTag)
 }
@@ -226,7 +340,7 @@ func Test_prepareDefaultAirflowImageTagHoustonUnauthedRequest(t *testing.T) {
 
 	output := new(bytes.Buffer)
 
-	defaultTag, err := prepareDefaultAirflowImageTag("2.0.2", httpClient, api, output)
+	defaultTag, err := prepareDefaultAirflowImageTag("2.0.2", "", httpClient, api, output)
 	assert.Equal(t, "the --airflow-version flag is not supported if you're not authenticated to Astronomer. Please authenticate and try again", err.Error())
 	assert.Equal(t, "", defaultTag)
 }


### PR DESCRIPTION
## Description

We want to allow users to initialize a project with a specific runtime version. Before this PR, users could only provide an airflow version (with flag --airflow-version or -v) and we would find the latest release for runtime matching this airflow version.

In this PR, I added a flag --runtime-version that allows users to specify which runtime version they want to use. We check if the provided runtime version is a valid one, else we ignore and use the latest stable one.

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/4542

## 🧪 Functional Testing

Will be added to the linked issue.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
