### PR TITLE
Move from dummy operator to empty operator in example DAG

### DIFF
--- a/airflow/include/exampledag.go
+++ b/airflow/include/exampledag.go
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 
 
@@ -45,9 +45,9 @@ with DAG(
     # catchup=False # enable if you don't want historical dag runs to run
 ) as dag:
 
-    t0 = DummyOperator(task_id='start')
+    t0 = EmptyOperator(task_id='start')
 
-    t1 = DummyOperator(task_id='group_bash_tasks')
+    t1 = EmptyOperator(task_id='group_bash_tasks')
     t2 = BashOperator(task_id='bash_print_date1', bash_command='sleep $[ ( $RANDOM % 30 )  + 1 ]s && date')
     t3 = BashOperator(task_id='bash_print_date2', bash_command='sleep $[ ( $RANDOM % 30 )  + 1 ]s && date')
 


### PR DESCRIPTION
## Description
Changes:
- Move from deprecated dummy operator to empty operator
This resolves following deprecation warnings:
```Bash
python3 test-dag.py
/Users/neel/go/src/github.com/astronomer/astro-cli/airflow-test/dags/test-dag.py:5 DeprecationWarning: This module is deprecated. Please use `airflow.operators.empty`.
/Users/neel/go/src/github.com/astronomer/astro-cli/airflow-test/dags/test-dag.py:42 DeprecationWarning: This class is deprecated. Please use `airflow.operators.empty.EmptyOperator`.
/Users/neel/go/src/github.com/astronomer/astro-cli/airflow-test/dags/test-dag.py:44 DeprecationWarning: This class is deprecated. Please use `airflow.operators.empty.EmptyOperator`.
```

## 🎟 Issue(s)

Related astronomer/issues#3536

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
