### PR TITLE
Fix checksum filename & pull latest patch via godownloader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,29 +5,6 @@ jobs:
     working_directory: /go/src/github.com/astronomer/astro-cli
     docker:
       - image: quay.io/astronomer/ap-dind-golang:20.10.11
-      - image: postgres
-        name: postgres
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-      - image: quay.io/astronomer/ap-houston-api:0.28.4
-        name: houston
-        entrypoint: "yarn start"
-        environment:
-          NODE_ENV: "development"
-          WEBSERVER__PORT: "8871"
-          ORBIT__PORT: "8080"
-          DATABASE_URL: "postgres://postgres:postgres@postgres:5432/postgres"
-          DATABASE__CONNECTION: "postgresql://postgres:postgres@postgres:5432/postgres"
-          DATABASE__SCHEMA: "public"
-          PUBLIC_SIGNUPS: "true"
-          EMAIL_CONFIRMATION: "false"
-          EMAIL__ENABLED: "false"
-          JWT__PASSPHRASE: "secretpassword"
-          DEPLOYMENTS__DATABASE__CONNECTION: "postgres://postgres:postgres@postgres:5432/postgres"
-          DEPLOYMENTS__DATABASE__ENABLED: "true"
-          DEPLOYMENTS__LOG_HELM_VALUES: "true"
-          HELM__RELEASE_VERSION: "0.7.5"
     steps:
       - test
   new-tag:
@@ -88,12 +65,6 @@ commands:
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.6.1
-      - run:
-          name: Wait for db
-          command: dockerize -wait tcp://postgres:5432 -timeout 1m
-      - run:
-          name: Wait for houston
-          command: dockerize -wait tcp://houston:8871 -timeout 2m
       - run:
           name: Run unit tests
           environment:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+project_name: astro
 before:
   hooks:
     # You may remove this if you don't use go modules.

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -70,13 +70,6 @@ func Test_validateDomain(t *testing.T) {
 	assert.Errorf(t, err, "Error! Invalid domain. "+
 		"Are you trying to authenticate to Astronomer Software? If so, change your current context with 'astro context switch'. ")
 
-	domain = "astronomer-perf.io"
-	actual, err = ValidateDomain(domain)
-	assert.NoError(t, err)
-	assert.Equal(t, actual.ClientID, "3PKxm3e1ldZYP1xWh5rXbOgFzIWbxnTN")
-	assert.Equal(t, actual.Audience, "astronomer-ee")
-	assert.Equal(t, actual.DomainURL, "https://auth.astronomer-perf.io/")
-
 	domain = "fail.astronomer-perf.io"
 	actual, err = ValidateDomain(domain)
 	assert.Error(t, err)

--- a/godownloader.sh
+++ b/godownloader.sh
@@ -300,6 +300,10 @@ http_copy() {
 github_release() {
   owner_repo=$1
   version=$2
+  if [[ "$version" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+    escaped_version=$(echo $version | sed -e 's/[]\/$*.^[]/\\&/g') # escape the version string
+    version=$(curl https://api.github.com/repos/${owner_repo}/releases -s | jq -r '.[] | .tag_name' | grep '^'"$escaped_version"'\.[0-9]*$' -m1)
+  fi
   test -z "$version" && version="latest"
   giturl="https://github.com/${owner_repo}/releases/${version}"
   json=$(http_copy "$giturl" "Accept:application/json")


### PR DESCRIPTION
## Description
Changes:
- Fixed checksum filename format to be `astro_<version>` instead of `astro-cli_<version>`
- Added logic to pick the latest patch release, if no patch release is mentioned
```Bash
neel@Neels-MacBook-Pro astro-cli % ./godownloader.sh v0.28 
astronomer/astro-cli info checking GitHub for tag 'v0.28'
astronomer/astro-cli info found version: 0.28.1 for v0.28.1/darwin/arm64
astronomer/astro-cli info installed ./bin/astro
```

## 🎟 Issue(s)

Relates to: https://github.com/astronomer/cloud-cli/issues/275

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
