### PR TITLE
Add breaking changes message in auth cmd & clarified help command to have current ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-## [1.0.0] - 2022-06-23
+## [1.0.0] - 2022-05-23
 
 ### New Features
 - The Astro CLI v1.0.0 works with [Astro](https://www.astronomer.io/product/), Astronomer's new cloud product. The Astro CLI deployment, workspace, and deploy commands will work with the Astro when a user logs into [astronomer.io](https://www.astronomer.io/). The function of these commands change slightly when logged into Astro. Details on how these commands change when working with Astro cna be found in the [Astro CLI Command Reference](https://docs.astronomer.io/astro/cli-reference)

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -96,7 +96,7 @@ func logout(cmd *cobra.Command, args []string, out io.Writer) error {
 func newAuthCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:        "auth",
-		Deprecated: "use 'astro login' or 'astro logout' instead",
+		Deprecated: "use 'astro login' or 'astro logout' instead.\n\nWelcome to the Astro CLI v1.0.0, go to https://github.com/astronomer/astro-cli/blob/main/CHANGELOG.md#100---2022-05-23 to see a full list of breaking changes.\n",
 		Hidden:     true,
 	}
 	return cmd


### PR DESCRIPTION
## Description
Changes:
- Added breaking changes message to `astro auth login` command
<img width="1132" alt="Screenshot 2022-05-26 at 12 20 35 AM" src="https://user-images.githubusercontent.com/92356010/170346951-6a84de5e-551a-4729-aea1-2de61514a4ef.png">

- Added current context to all the help commands, which could help users understand available command list changes with changes in context
  - In the case of Cloud context (notice `Current Context: Astro`):
<img width="1146" alt="Screenshot 2022-05-26 at 12 20 03 AM" src="https://user-images.githubusercontent.com/92356010/170347196-ef535b85-0881-4e02-8d5b-4771e3d0a10e.png">
  
  - In the case of Software context (notice `Current Context: Astronomer Software`):
<img width="1151" alt="Screenshot 2022-05-26 at 12 20 24 AM" src="https://user-images.githubusercontent.com/92356010/170347267-e066da2a-5815-41c3-aef1-29da3055c3fd.png">

- Fixed the date for the 1.0.0 release in Changelog