### PR TITLE
fixed binary case for darwin/arm64 in godownloader

### DIFF
--- a/godownloader.sh
+++ b/godownloader.sh
@@ -68,8 +68,7 @@ get_binaries() {
     linux/amd64) BINARIES="astro" ;;
     windows/386) BINARIES="astro" ;;
     windows/amd64) BINARIES="astro" ;;
-    darwin/arm64) ;;
-    linux/arm64)
+    linux/arm64|darwin/arm64)
       # MANUALLY ADDED LOGIC: darwin/arm64 only available from 0.27.2 release onwards
       if version_gte "0.27.2" $VERSION; then
         BINARIES="astro"


### PR DESCRIPTION
## Description
Changes:
- Fixed godownloader script for darwin/arm64 arch to pick correct binary

## 🎟 Issue(s)

Related astronomer/issues#XXXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
