### PR TITLE
hide --use-astronomer-certified flag behind context

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -61,7 +61,7 @@ astro dev init
 astro dev init --runtime-version 4.1.0
 
 # Initialize a new Astro project with the latest Astro Runtime version based on Airflow 2.2.3
-astro dev init --airflow-version 2.2.3	
+astro dev init --airflow-version 2.2.3
 `
 	dockerfile = "Dockerfile"
 

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -10,6 +10,7 @@ import (
 	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	"github.com/astronomer/astro-cli/cmd/utils"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -35,7 +36,7 @@ var (
 # Create default admin user.
 astro dev run users create -r Admin -u admin -e admin@example.com -f admin -l user -p admin
 `
-	initExample = `
+	initSoftwareExample = `
 # Initialize a new Astro project with the latest version of Astro Runtime
 astro dev init
 
@@ -50,6 +51,17 @@ astro dev init --use-astronomer-certified
 
 # Initialize a new Astro project with the latest version of Astronomer Certified based on Airflow 2.2.3
 astro dev init --use-astronomer-certified --airflow-version 2.2.3
+`
+
+	initCloudExample = `
+# Initialize a new Astro project with the latest version of Astro Runtime
+astro dev init
+
+# Initialize a new Astro project with Astro Runtime 4.1.0
+astro dev init --runtime-version 4.1.0
+
+# Initialize a new Astro project with the latest Astro Runtime version based on Airflow 2.2.3
+astro dev init --airflow-version 2.2.3	
 `
 	dockerfile = "Dockerfile"
 
@@ -93,7 +105,7 @@ func newAirflowInitCmd() *cobra.Command {
 		Use:     "init",
 		Short:   "Create a new Astro project in your working directory",
 		Long:    "Create a new Astro project in your working directory. This generates the files you need to start an Airflow environment on your local machine and deploy your project to a Deployment on Astro or Astronomer Software.",
-		Example: initExample,
+		Example: initCloudExample,
 		Args:    cobra.MaximumNArgs(1),
 		// ignore PersistentPreRunE of root command
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -103,8 +115,18 @@ func newAirflowInitCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&projectName, "name", "n", "", "Name of Astro project")
 	cmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "v", "", "Specify a version of Astro Runtime that you want to create an Astro project with. If not specified, the latest is assumed. You can change this version in your Dockerfile at any time.")
-	cmd.Flags().BoolVarP(&useAstronomerCertified, "use-astronomer-certified", "", false, "If specified, initializes a project using Astronomer Certified Airflow image instead of Astro Runtime.")
 	cmd.Flags().StringVarP(&airflowVersion, "airflow-version", "a", "", "Version of Airflow you want to create an Astro project with. If not specified, latest is assumed. You can change this version in your Dockerfile at any time.")
+
+	if !context.IsCloudContext() {
+		cmd.Example = initSoftwareExample
+		cmd.Flags().BoolVarP(&useAstronomerCertified, "use-astronomer-certified", "", false, "If specified, initializes a project using Astronomer Certified Airflow image instead of Astro Runtime.")
+	}
+
+	_, err := context.GetCurrentContext()
+	if err != nil { // Case when user is not logged in to any platform
+		cmd.Flags().BoolVarP(&useAstronomerCertified, "use-astronomer-certified", "", false, "If specified, initializes a project using Astronomer Certified Airflow image instead of Astro Runtime.")
+		cmd.Flags().MarkHidden("use-astronomer-certified")
+	}
 	return cmd
 }
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -225,6 +225,7 @@ func TestAirflowInit(t *testing.T) {
 		assert.ErrorIs(t, err, errInvalidBothAirflowAndRuntimeVersions)
 	})
 
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
 	t.Run("runtime version passed alongside AC flag", func(t *testing.T) {
 		cmd := newAirflowInitCmd()
 		cmd.Flag("name").Value.Set("test-project-name")

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -24,6 +24,20 @@ func TestDevRootCommand(t *testing.T) {
 	assert.Contains(t, output, "astro dev", output)
 }
 
+func TestDevInitCommand(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	output, err := executeCommand("dev", "init", "--help")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "astro dev", output)
+	assert.NotContains(t, output, "--use-astronomer-certified")
+
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	output, err = executeCommand("dev", "init", "--help")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "astro dev", output)
+	assert.Contains(t, output, "--use-astronomer-certified")
+}
+
 func TestNewAirflowInitCmd(t *testing.T) {
 	cmd := newAirflowInitCmd()
 	assert.Nil(t, cmd.PersistentPreRunE(new(cobra.Command), []string{}))


### PR DESCRIPTION
## Description
Changes:
- Hide `--use-astronomer-certified` flag behind context
  - In case no context set, keep the flag hidden
  - In case cloud context set, don't add the flag at all
  - In case software context set, show the flag

```Bash
neel@Neels-MacBook-Pro airflow-test-7 % ../astro login astronomer-dev.io            
Welcome to the Astro CLI 🚀

To learn more about Astro, go to https://docs.astronomer.io

Please enter your account email: neel.dalsania@astronomer.io

Press Enter to open the browser to log in or ^C to quit…
done
 CONTEXT DOMAIN                      WORKSPACE                           
 astronomer-dev.io                   cl0v1p6lc728255byzyfs7lw21          

 Switched context

"CLI Test Workspace" Workspace found. This is your default Workspace.

Successfully authenticated to Astronomer
neel@Neels-MacBook-Pro airflow-test-7 % ../astro dev init --use-astronomer-certified
Error: unknown flag: --use-astronomer-certified
Usage:
  astro dev init [flags]

Examples:

# Initialize a new Astro project with the latest version of Astro Runtime
astro dev init

# Initialize a new Astro project with Astro Runtime 4.1.0
astro dev init --runtime-version 4.1.0

# Initialize a new Astro project with the latest Astro Runtime version based on Airflow 2.2.3
astro dev init --airflow-version 2.2.3

# Initialize a new Astro project with the latest version of Astronomer Certified. Use this only if you run on Astronomer Software
astro dev init --use-astronomer-certified

# Initialize a new Astro project with the latest version of Astronomer Certified based on Airflow 2.2.3
astro dev init --use-astronomer-certified --airflow-version 2.2.3


Flags:
  -a, --airflow-version string   Version of Airflow you want to create an Astro project with. If not specified, latest is assumed. You can change this version in your Dockerfile at any time.
  -h, --help                     help for init
  -n, --name string              Name of Astro project
  -v, --runtime-version string   Specify a version of Astro Runtime that you want to create an Astro project with. If not specified, the latest is assumed. You can change this version in your Dockerfile at any time.

neel@Neels-MacBook-Pro airflow-test-7 % 
neel@Neels-MacBook-Pro airflow-test-7 % ../astro login dev.astrodev.io              
 CLUSTER                             WORKSPACE                           
 dev.astrodev.io                     ckx7eu6qk09836k8n9jf1wvl3           
Username (leave blank for oAuth): neel.dalsania@astronomer.io
Password: 
 CONTEXT DOMAIN                      WORKSPACE                           
 dev.astrodev.io                     ckx7eu6qk09836k8n9jf1wvl3           

 Switched context

Successfully authenticated to registry.dev.astrodev.io
neel@Neels-MacBook-Pro airflow-test-7 % ../astro dev init --use-astronomer-certified
Initializing Astro project
Pulling Airflow development files from Astronomer Certified Airflow Version 2.3.1-onbuild
/Users/neel/go/src/github.com/astronomer/astro-cli/airflow-test-7 
You are not in an empty directory. Are you sure you want to initialize a project? (y/n) y
Reinitialized existing Astro project in /Users/neel/go/src/github.com/astronomer/astro-cli/airflow-test-7

neel@Neels-MacBook-Pro airflow-test-7 % ../astro logout
neel@Neels-MacBook-Pro airflow-test-7 % ../astro dev init --use-astronomer-certified
Initializing Astro project
Pulling Airflow development files from Astronomer Certified Airflow Version 2.3.1-onbuild
/Users/neel/go/src/github.com/astronomer/astro-cli/airflow-test-7 
You are not in an empty directory. Are you sure you want to initialize a project? (y/n) y
Reinitialized existing Astro project in /Users/neel/go/src/github.com/astronomer/astro-cli/airflow-test-7

neel@Neels-MacBook-Pro airflow-test-7 %
```

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-cli/issues/556

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
