### PR TITLE
Add linter to circle ci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ commands:
           environment:
             HOUSTON_HOST: houston
           command: |
+            make lint
             make test
             bash -c "bash <(curl -s https://codecov.io/bash)"
   commit-next-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,16 @@
 ---
 version: 2.1
 jobs:
+  lint:
+    working_directory: /go/src/github.com/astronomer/astro-cli
+    docker:
+      - image: quay.io/astronomer/ap-dind-golang:20.10.14-1
+    steps:
+      - lint
   test:
     working_directory: /go/src/github.com/astronomer/astro-cli
     docker:
-      - image: quay.io/astronomer/ap-dind-golang:20.10.11
+      - image: quay.io/astronomer/ap-dind-golang:20.10.14-1
     steps:
       - test
   new-tag:
@@ -25,6 +31,7 @@ workflows:
   version: 2.1
   build-images:
     jobs:
+      - lint
       - test
       - approve-release:
           type: approval
@@ -55,6 +62,13 @@ executors:
     docker:
       - image: circleci/python:3
 commands:
+  lint:
+    description: "Run linting checks"
+    steps:
+      - checkout
+      - run:
+          name: Run golangci-lint
+          command: make lint
   test:
     description: "Run tests and code coverage"
     steps:
@@ -70,7 +84,6 @@ commands:
           environment:
             HOUSTON_HOST: houston
           command: |
-            make lint
             make test
             bash -c "bash <(curl -s https://codecov.io/bash)"
   commit-next-tag:

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -125,7 +125,7 @@ func newAirflowInitCmd() *cobra.Command {
 	_, err := context.GetCurrentContext()
 	if err != nil { // Case when user is not logged in to any platform
 		cmd.Flags().BoolVarP(&useAstronomerCertified, "use-astronomer-certified", "", false, "If specified, initializes a project using Astronomer Certified Airflow image instead of Astro Runtime.")
-		cmd.Flags().MarkHidden("use-astronomer-certified")
+		_ = cmd.Flags().MarkHidden("use-astronomer-certified")
 	}
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,11 +96,11 @@ func NewRootCmd() *cobra.Command {
 	return rootCmd
 }
 
-func getResourcesHelpTemplate(context string) string {
+func getResourcesHelpTemplate(ctx string) string {
 	return fmt.Sprintf(`{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
 
 Current Context: %s
 
 {{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
-`, ansi.Bold(context))
+`, ansi.Bold(ctx))
 }


### PR DESCRIPTION
## Description
Changes:
- After merging converged code base, linting seems to have been missed out in circle ci workflow, added it back
- Fixed linting errors in the code written after bringing the new converged CLI to this repo.

## 🎟 Issue(s)

Related astronomer/issues#XXXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
