### PR TITLE
Fix typo in `postgresUserPasswordMsg` value

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -52,7 +52,7 @@ const (
 	composeLinkWebserverMsg = "Airflow Webserver: %s"
 	composeLinkPostgresMsg  = "Postgres Database: %s"
 	composeUserPasswordMsg  = "The default Airflow UI credentials are: %s"
-	postgresUserPasswordMsg = "The default Postrgres DB credentials are: %s"
+	postgresUserPasswordMsg = "The default Postgres DB credentials are: %s"
 
 	envPathMsg     = "Error looking for \"%s\""
 	envFoundMsg    = "Env file \"%s\" found. Loading...\n"


### PR DESCRIPTION
## Description

Correcting a typo when running `astro dev start`:
>The default Postrgres DB credentials are: postgres:postgres

## 🎟 Issue(s)

Related: https://github.com/astronomer/cloud-cli/pull/290

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ X] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
