### PR TITLE
Simple Generic PoC for 1.18 - List Contains util

### DIFF
--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -452,13 +452,7 @@ func ValidateDomain(domain string) (astro.AuthConfig, error) {
 	validDomainsList := []string{"astronomer-dev.io", "astronomer-stage.io", "astronomer-perf.io", "astronomer.io", "localhost"}
 	var authConfig astro.AuthConfig
 
-	validDomain := false
-	for _, x := range validDomainsList {
-		if x == domain {
-			validDomain = true
-			break
-		}
-	}
+	validDomain := util.Contains(validDomainsList, domain)
 	if !validDomain {
 		return authConfig, errors.New("Error! Invalid domain. You are attempting to login into Astro. " +
 			"Are you trying to authenticate to Astronomer Software? If so, please change your current context with 'astro context switch'")

--- a/cmd/software/validation.go
+++ b/cmd/software/validation.go
@@ -3,6 +3,7 @@ package software
 import (
 	"errors"
 	"fmt"
+	"github.com/astronomer/astro-cli/pkg/util"
 	"net/url"
 	"strings"
 
@@ -64,22 +65,20 @@ func coalesceWorkspace() (string, error) {
 func validateWorkspaceRole(role string) error {
 	validRoles := []string{houston.WorkspaceAdminRole, houston.WorkspaceEditorRole, houston.WorkspaceViewerRole}
 
-	for _, validRole := range validRoles {
-		if role == validRole {
-			return nil
-		}
+	if util.Contains(validRoles, role) {
+		return nil
 	}
+
 	return fmt.Errorf("please use one of: %s", strings.Join(validRoles, ", ")) //nolint:goerr113
 }
 
 func validateDeploymentRole(role string) error {
 	validRoles := []string{houston.DeploymentAdminRole, houston.DeploymentEditorRole, houston.DeploymentViewerRole}
 
-	for _, validRole := range validRoles {
-		if role == validRole {
-			return nil
-		}
+	if util.Contains(validRoles, role) {
+		return nil
 	}
+
 	return fmt.Errorf("please use one of: %s", strings.Join(validRoles, ", ")) //nolint:goerr113
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/astronomer/astro-cli
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,7 +29,7 @@ func Contains[T comparable](elems []T, v T) bool {
 			return true
 		}
 	}
-	return true
+	return false
 }
 
 func GetStringInBetweenTwoString(str, startS, endS string) (result string, found bool) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,13 +23,13 @@ func Coerce(version string) *semver.Version {
 	return coerceVer
 }
 
-func Contains(elems []string, v string) bool {
-	for _, s := range elems {
-		if v == s {
+func Contains[T comparable](elems []T, v T) bool {
+	for _, elem := range elems {
+		if v == elem {
 			return true
 		}
 	}
-	return false
+	return true
 }
 
 func GetStringInBetweenTwoString(str, startS, endS string) (result string, found bool) {


### PR DESCRIPTION
## Description

PoC for 1.18.  Changes the string contains method that finds a string in a list of strings to be generic for any type that is comparable.

## 🎟 Issue(s)

n/a

## 🧪 Functional Testing

Existing unit tests are adequate

## 📋 Checklist

- [ x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
