### PR TITLE
added local environment variable

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -109,6 +109,7 @@ services:
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://postgres:postgres@postgres:5432
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+      ASTRONOMER_ENVIRONMENT: local
     volumes:
       - airflow_home/dags:/usr/local/airflow/dags:ro
       - airflow_home/plugins:/usr/local/airflow/plugins:z
@@ -143,6 +144,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
       AIRFLOW__WEBSERVER__RBAC: "True"
+      ASTRONOMER_ENVIRONMENT: local
     ports:
       - 8080:8080
     volumes:
@@ -179,6 +181,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
       AIRFLOW__WEBSERVER__RBAC: "True"
+      ASTRONOMER_ENVIRONMENT: local
     volumes:
       - airflow_home/dags:/usr/local/airflow/dags:z
       - airflow_home/plugins:/usr/local/airflow/plugins:z

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -56,6 +56,7 @@ services:
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@{{ .PostgresHost }}:5432
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+      ASTRONOMER_ENVIRONMENT: local
     volumes:
       - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:ro
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:{{ .MountLabel }}
@@ -90,6 +91,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
       AIRFLOW__WEBSERVER__RBAC: "True"
+      ASTRONOMER_ENVIRONMENT: local
     ports:
       - {{ .AirflowWebserverPort }}:8080
     volumes:
@@ -126,6 +128,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
       AIRFLOW__WEBSERVER__RBAC: "True"
+      ASTRONOMER_ENVIRONMENT: local
     volumes:
       - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:{{ .MountLabel }}
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:{{ .MountLabel }}

--- a/airflow/include/podconfigyml.go
+++ b/airflow/include/podconfigyml.go
@@ -61,6 +61,8 @@ spec:
       value: "False"
     - name: ASTRONOMER_USER
       value: astro
+    - name: ASTRONOMER_ENVIRONMENT
+      value: local
 {{ .AirflowEnvFile }}
     image: {{ .AirflowImage }}
     name: {{ .SchedulerContainerName }}
@@ -130,6 +132,8 @@ spec:
       value: ASTRONOMER
     - name: AIRFLOW__CORE__LOAD_EXAMPLES
       value: "False"
+    - name: ASTRONOMER_ENVIRONMENT
+      value: local
 {{ .AirflowEnvFile }}
     image: {{ .AirflowImage }}
     name: {{ .WebserverContainerName }}
@@ -176,6 +180,8 @@ spec:
       value: ASTRONOMER
     - name: AIRFLOW__CORE__LOAD_EXAMPLES
       value: "False"
+    - name: ASTRONOMER_ENVIRONMENT
+      value: local
 {{ .AirflowEnvFile }}
     image: {{ .AirflowImage }}
     name: {{ .TriggererContainerName }}


### PR DESCRIPTION
## Description
Changes:
- Added required env variable `ASTRONOMER_ENVIRONMENT=local` in pod config and docker-compose file, in order to avoid airflow components trying to push logs to s3 when running locally

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-cli/issues/582

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
