### PR TITLE
Fix image push logic for podman

### DIFF
--- a/airflow/podman_image.go
+++ b/airflow/podman_image.go
@@ -69,19 +69,11 @@ func (p *PodmanImage) Push(cloudDomain, token, remoteImageTag string) error {
 	registry := "registry." + cloudDomain
 	remoteImage := fmt.Sprintf("%s/%s", registry, imageName(p.imageName, remoteImageTag))
 
-	err := p.podmanBind.Tag(p.conn, imageName(p.imageName, "latest"), remoteImageTag, fmt.Sprintf("%s/%s", registry, p.imageName), nil)
-	if err != nil {
-		return fmt.Errorf("command 'podman tag %s %s' failed: %w", p.imageName, remoteImage, err)
-	}
 	options := new(images.PushOptions)
-	if err := p.podmanBind.Push(p.conn, p.imageName, remoteImage, options); err != nil {
+	if err := p.podmanBind.Push(p.conn, imageName(p.imageName, "latest"), remoteImage, options); err != nil {
 		return fmt.Errorf("error pushing %s image to %s: %w", p.imageName, registry, err)
 	}
 
-	err = p.podmanBind.Untag(p.conn, imageName(p.imageName, "latest"), remoteImageTag, fmt.Sprintf("%s/%s", registry, p.imageName), nil)
-	if err != nil {
-		return fmt.Errorf("command 'podman untag %s' failed: %w", remoteImage, err)
-	}
 	return nil
 }
 

--- a/airflow/podman_image_test.go
+++ b/airflow/podman_image_test.go
@@ -13,9 +13,7 @@ import (
 func TestPodmanPushSuccess(t *testing.T) {
 	bindMock := new(mocks.PodmanBind)
 	podmanImageMock := &PodmanImage{imageName: "test", podmanBind: bindMock, conn: context.TODO()}
-	bindMock.On("Tag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	bindMock.On("Push", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	bindMock.On("Untag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	err := podmanImageMock.Push("test.astro.io", "token", "2")
 	assert.NoError(t, err)
@@ -24,20 +22,9 @@ func TestPodmanPushSuccess(t *testing.T) {
 func TestPodmanPushFailure(t *testing.T) {
 	bindMock := new(mocks.PodmanBind)
 	podmanImageMock := &PodmanImage{imageName: "test", podmanBind: bindMock, conn: context.TODO()}
-	bindMock.On("Tag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errPodman).Once()
 
-	err := podmanImageMock.Push("test.astro.io", "token", "2")
-	assert.Contains(t, err.Error(), "command 'podman tag test registry.test.astro.io/test/airflow:2' failed")
-
-	bindMock.On("Tag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	bindMock.On("Push", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything).Return(errPodman).Once()
 
-	err = podmanImageMock.Push("test.astro.io", "token", "2")
+	err := podmanImageMock.Push("test.astro.io", "token", "2")
 	assert.Contains(t, err.Error(), "error pushing test image to registry.test.astro.io")
-
-	bindMock.On("Push", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	bindMock.On("Untag", podmanImageMock.conn, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errPodman)
-
-	err = podmanImageMock.Push("test.astro.io", "token", "2")
-	assert.Contains(t, err.Error(), "command 'podman untag registry.test.astro.io/test/airflow:2' failed")
 }


### PR DESCRIPTION
## Description
Changes:
- Fixes image push logic for Podman

Earlier we use to tag the image name currently, thus not requiring the source in the image push method to be accurate, but with podman 4.x, it ensures that the source image exists before trying to push the image

with astro 0.29.0 & podman 4.x
<img width="1276" alt="Screenshot 2022-06-09 at 11 25 03 PM" src="https://user-images.githubusercontent.com/92356010/172913302-234c2847-36f4-4b8c-b103-162570e1165f.png">

with this image branch & podman 4.x
<img width="1282" alt="Screenshot 2022-06-09 at 11 22 02 PM" src="https://user-images.githubusercontent.com/92356010/172913371-22561b58-5ae4-43c8-bcb3-c7671d325e65.png">

## 🎟 Issue(s)

Related astronomer/issues#4490

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
