### PR TITLE
fix for a non system admin user to create a deployment

### DIFF
--- a/astro-client/astro.go
+++ b/astro-client/astro.go
@@ -177,7 +177,7 @@ func (c *HTTPClient) DeployImage(input ImageDeployInput) (*Image, error) {
 func (c *HTTPClient) ListClusters(vars map[string]interface{}) ([]Cluster, error) {
 	req := Request{
 		Query:     GetClusters,
-		Variables: map[string]interface{}{"input": vars},
+		Variables: map[string]interface{}{"organizationId": vars["organizationId"]},
 	}
 
 	resp, err := req.DoWithClient(c)

--- a/astro-client/astro.go
+++ b/astro-client/astro.go
@@ -22,7 +22,7 @@ type Client interface {
 	CreateImage(input ImageCreateInput) (*Image, error)
 	DeployImage(input ImageDeployInput) (*Image, error)
 	// Cluster
-	ListClusters(organizationId string) ([]Cluster, error)
+	ListClusters(organizationID string) ([]Cluster, error)
 	// RuntimeRelease
 	ListInternalRuntimeReleases() ([]RuntimeRelease, error)
 	ListPublicRuntimeReleases() ([]RuntimeRelease, error)
@@ -174,10 +174,10 @@ func (c *HTTPClient) DeployImage(input ImageDeployInput) (*Image, error) {
 	return resp.Data.DeployImage, nil
 }
 
-func (c *HTTPClient) ListClusters(organizationId string) ([]Cluster, error) {
+func (c *HTTPClient) ListClusters(organizationID string) ([]Cluster, error) {
 	req := Request{
 		Query:     GetClusters,
-		Variables: map[string]interface{}{"organizationId": organizationId},
+		Variables: map[string]interface{}{"organizationId": organizationID},
 	}
 
 	resp, err := req.DoWithClient(c)

--- a/astro-client/astro.go
+++ b/astro-client/astro.go
@@ -22,7 +22,7 @@ type Client interface {
 	CreateImage(input ImageCreateInput) (*Image, error)
 	DeployImage(input ImageDeployInput) (*Image, error)
 	// Cluster
-	ListClusters(vars map[string]interface{}) ([]Cluster, error)
+	ListClusters(organizationId string) ([]Cluster, error)
 	// RuntimeRelease
 	ListInternalRuntimeReleases() ([]RuntimeRelease, error)
 	ListPublicRuntimeReleases() ([]RuntimeRelease, error)
@@ -174,10 +174,10 @@ func (c *HTTPClient) DeployImage(input ImageDeployInput) (*Image, error) {
 	return resp.Data.DeployImage, nil
 }
 
-func (c *HTTPClient) ListClusters(vars map[string]interface{}) ([]Cluster, error) {
+func (c *HTTPClient) ListClusters(organizationId string) ([]Cluster, error) {
 	req := Request{
 		Query:     GetClusters,
-		Variables: map[string]interface{}{"organizationId": vars["organizationId"]},
+		Variables: map[string]interface{}{"organizationId": organizationId},
 	}
 
 	resp, err := req.DoWithClient(c)

--- a/astro-client/astro_test.go
+++ b/astro-client/astro_test.go
@@ -592,7 +592,7 @@ func TestListClusters(t *testing.T) {
 		})
 		astroClient := NewAstroClient(client)
 
-		resp, err := astroClient.ListClusters(map[string]interface{}{})
+		resp, err := astroClient.ListClusters("test-org-id")
 		assert.NoError(t, err)
 		assert.Equal(t, resp, mockResponse.Data.GetClusters)
 	})
@@ -607,7 +607,7 @@ func TestListClusters(t *testing.T) {
 		})
 		astroClient := NewAstroClient(client)
 
-		_, err := astroClient.ListClusters(map[string]interface{}{})
+		_, err := astroClient.ListClusters("test-org-id")
 		assert.Contains(t, err.Error(), "Internal Server Error")
 	})
 }

--- a/astro-client/mocks/Client.go
+++ b/astro-client/mocks/Client.go
@@ -142,6 +142,29 @@ func (_m *Client) GetDeploymentHistory(vars map[string]interface{}) (astro.Deplo
 	return r0, r1
 }
 
+// ListClusters provides a mock function with given fields: organizationId
+func (_m *Client) ListClusters(organizationId string) ([]astro.Cluster, error) {
+	ret := _m.Called(organizationId)
+
+	var r0 []astro.Cluster
+	if rf, ok := ret.Get(0).(func(string) []astro.Cluster); ok {
+		r0 = rf(organizationId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]astro.Cluster)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(organizationId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListDeployments provides a mock function with given fields: input
 func (_m *Client) ListDeployments(input astro.DeploymentsInput) ([]astro.Deployment, error) {
 	ret := _m.Called(input)
@@ -181,29 +204,6 @@ func (_m *Client) ListInternalRuntimeReleases() ([]astro.RuntimeRelease, error) 
 	var r1 error
 	if rf, ok := ret.Get(1).(func() error); ok {
 		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ListClusters provides a mock function with given fields: vars
-func (_m *Client) ListClusters(vars map[string]interface{}) ([]astro.Cluster, error) {
-	ret := _m.Called(vars)
-
-	var r0 []astro.Cluster
-	if rf, ok := ret.Get(0).(func(map[string]interface{}) []astro.Cluster); ok {
-		r0 = rf(vars)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]astro.Cluster)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
-		r1 = rf(vars)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -290,8 +290,7 @@ func selectCluster(clusterID, organizationID string, client astro.Client) (newCl
 		Header:         []string{"#", "CLUSTER NAME", "CLOUD PROVIDER", "CLUSTER ID"},
 	}
 	// cluster request
-	clusterInput := map[string]interface{}{"organizationId": organizationID}
-	cs, err := client.ListClusters(clusterInput)
+	cs, err := client.ListClusters(organizationID)
 	if err != nil {
 		return "", errors.Wrap(err, astro.AstronomerConnectionErrMsg)
 	}

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -111,7 +111,7 @@ func TestCreate(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Once()
 		mockClient.On("ListWorkspaces").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
-		mockClient.On("ListClusters", map[string]interface{}{"organizationId": "test-org-id"}).Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Once()
 		mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 
 		// mock os.Stdin
@@ -200,7 +200,7 @@ func TestSelectCluster(t *testing.T) {
 	csID := "test-cluster-id"
 	t.Run("list cluster failure", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", map[string]interface{}{"organizationId": orgID}).Return([]astro.Cluster{}, errMock).Once()
+		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{}, errMock).Once()
 
 		_, err := selectCluster("", orgID, mockClient)
 		assert.ErrorIs(t, err, errMock)
@@ -209,7 +209,7 @@ func TestSelectCluster(t *testing.T) {
 
 	t.Run("cluster id via selection", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", map[string]interface{}{"organizationId": orgID}).Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{{ID: csID}}, nil).Once()
 
 		// mock os.Stdin
 		input := []byte("1")
@@ -234,7 +234,7 @@ func TestSelectCluster(t *testing.T) {
 
 	t.Run("cluster id invalid selection", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", map[string]interface{}{"organizationId": orgID}).Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{{ID: csID}}, nil).Once()
 
 		// mock os.Stdin
 		input := []byte("4")
@@ -258,7 +258,7 @@ func TestSelectCluster(t *testing.T) {
 
 	t.Run("not able to find cluster", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", map[string]interface{}{"organizationId": orgID}).Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{{ID: csID}}, nil).Once()
 
 		_, err := selectCluster("test-invalid-id", orgID, mockClient)
 		assert.Error(t, err)

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -82,7 +82,7 @@ func TestDeploymentCreate(t *testing.T) {
 	mockClient := new(astro_mocks.Client)
 	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Once()
 	mockClient.On("ListWorkspaces").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
-	mockClient.On("ListClusters", map[string]interface{}{"organizationId": "test-org-id"}).Return([]astro.Cluster{{ID: csID}}, nil).Once()
+	mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Once()
 	mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 	astroClient = mockClient
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

fix for a non system admin user to create a deployment

## 🎟 Issue(s)

Related #595

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screen Shot 2022-06-09 at 16 35 46](https://user-images.githubusercontent.com/65428224/172962119-e0530d59-2d48-4e43-8e95-d7eb1be97807.png)


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
