### PR TITLE
BYO Registry support for CLI in Software

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -89,11 +89,21 @@ func (d *DockerImage) Push(registry, username, token, remoteImage string) error 
 		return fmt.Errorf("error reading credentials: %w", err)
 	}
 
-	if username != "" {
-		authConfig.Username = username
+	if username == "" && token == "" {
+		registryDomain := strings.Split(registry, "/")[0]
+		creds := configFile.GetCredentialsStore(registryDomain)
+		authConfig, err = creds.Get(registryDomain)
+		if err != nil {
+			log.Debugf("Error reading credentials for domain: %s from docker credentials store: %v", registryDomain, err)
+		}
+	} else {
+		if username != "" {
+			authConfig.Username = username
+		}
+		authConfig.Password = token
+		authConfig.ServerAddress = registry
 	}
-	authConfig.Password = token
-	authConfig.ServerAddress = registry
+
 	log.Debugf("Exec Push docker creds %v \n", authConfig)
 
 	ctx := context.Background()

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -86,7 +86,20 @@ func TestDockerImagePush(t *testing.T) {
 			return nil
 		}
 
-		err := handler.Push("test", "", "test", "test")
+		err := handler.Push("test", "test-username", "test", "test")
+		assert.NoError(t, err)
+	})
+
+	t.Run("success with docker cred store", func(t *testing.T) {
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			return nil
+		}
+
+		displayJSONMessagesToStream = func(responseBody io.ReadCloser, auxCallback func(jsonmessage.JSONMessage)) error {
+			return nil
+		}
+
+		err := handler.Push("test", "", "", "test")
 		assert.NoError(t, err)
 	})
 }

--- a/airflow/docker_registry.go
+++ b/airflow/docker_registry.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	cliconfig "github.com/docker/cli/cli/config"
+	cliConfig "github.com/docker/cli/cli/config"
 	cliTypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -41,6 +41,18 @@ func (d *DockerRegistry) Login(username, token string) error {
 		Password:      token,
 	}
 
+	if username == "" && token == "" {
+		configFile := cliConfig.LoadDefaultConfigFile(os.Stderr)
+
+		creds := configFile.GetCredentialsStore(d.registry)
+		auth, err := creds.Get(d.registry)
+		if err != nil {
+			return err
+		}
+		authConfig.Username = auth.Username
+		authConfig.Password = auth.Password
+	}
+
 	log.Debugf("docker creds %v \n", authConfig)
 	_, err := d.cli.RegistryLogin(ctx, authConfig)
 	if err != nil {
@@ -52,7 +64,7 @@ func (d *DockerRegistry) Login(username, token string) error {
 	// Get this idea from docker login cli
 	cliAuthConfig.RegistryToken = ""
 
-	configFile := cliconfig.LoadDefaultConfigFile(os.Stderr)
+	configFile := cliConfig.LoadDefaultConfigFile(os.Stderr)
 
 	creds := configFile.GetCredentialsStore(serverAddress)
 

--- a/astro-client/mocks/Client.go
+++ b/astro-client/mocks/Client.go
@@ -142,6 +142,29 @@ func (_m *Client) GetDeploymentHistory(vars map[string]interface{}) (astro.Deplo
 	return r0, r1
 }
 
+// ListClusters provides a mock function with given fields: vars
+func (_m *Client) ListClusters(vars map[string]interface{}) ([]astro.Cluster, error) {
+	ret := _m.Called(vars)
+
+	var r0 []astro.Cluster
+	if rf, ok := ret.Get(0).(func(map[string]interface{}) []astro.Cluster); ok {
+		r0 = rf(vars)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]astro.Cluster)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
+		r1 = rf(vars)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListDeployments provides a mock function with given fields: input
 func (_m *Client) ListDeployments(input astro.DeploymentsInput) ([]astro.Deployment, error) {
 	ret := _m.Called(input)
@@ -181,29 +204,6 @@ func (_m *Client) ListInternalRuntimeReleases() ([]astro.RuntimeRelease, error) 
 	var r1 error
 	if rf, ok := ret.Get(1).(func() error); ok {
 		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ListClusters provides a mock function with given fields: vars
-func (_m *Client) ListClusters(vars map[string]interface{}) ([]astro.Cluster, error) {
-	ret := _m.Called(vars)
-
-	var r0 []astro.Cluster
-	if rf, ok := ret.Get(0).(func(map[string]interface{}) []astro.Cluster); ok {
-		r0 = rf(vars)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]astro.Cluster)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
-		r1 = rf(vars)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -83,5 +83,12 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	return deployAirflowImage(houstonClient, config.WorkingPath, deploymentID, ws, ignoreCacheDeploy, forcePrompt)
+	var byoRegistryEnabled bool
+	var byoRegistryDomain string
+	if appConfig != nil && appConfig.Flags.BYORegistryEnabled {
+		byoRegistryEnabled = true
+		byoRegistryDomain = appConfig.BYORegistryDomain
+	}
+
+	return deployAirflowImage(houstonClient, config.WorkingPath, deploymentID, ws, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, forcePrompt)
 }

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -21,7 +21,7 @@ func TestDeploy(t *testing.T) {
 	ensureProjectDir = func(cmd *cobra.Command, args []string) error {
 		return nil
 	}
-	deployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool) error {
+	deployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID, byoRegistryDomain string, ignoreCacheDeploy, byoRegistryEnabled, prompt bool) error {
 		return nil
 	}
 

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -18,6 +18,12 @@ func execDeployCmd(args ...string) error {
 
 func TestDeploy(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	appConfig = &houston.AppConfig{
+		BYORegistryDomain: "test.registry.io",
+		Flags: houston.FeatureFlags{
+			BYORegistryEnabled: true,
+		},
+	}
 	ensureProjectDir = func(cmd *cobra.Command, args []string) error {
 		return nil
 	}

--- a/cmd/software/root.go
+++ b/cmd/software/root.go
@@ -1,6 +1,7 @@
 package software
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/astronomer/astro-cli/houston"
@@ -15,11 +16,19 @@ var (
 	initDebugLogs = []string{}
 	houstonClient houston.ClientInterface
 	workspaceID   string
+	appConfig     *houston.AppConfig
 )
 
 // AddCmds adds all the command initialized in this package for the cmd package to import
 func AddCmds(client houston.ClientInterface, out io.Writer) []*cobra.Command {
 	houstonClient = client
+
+	var err error
+	appConfig, err = houstonClient.GetAppConfig()
+	if err != nil {
+		initDebugLogs = append(initDebugLogs, fmt.Sprintf("Error checking feature flag: %s", err.Error()))
+	}
+
 	return []*cobra.Command{
 		newDeploymentRootCmd(out),
 		newWorkspaceCmd(out),

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -16,6 +16,13 @@ type ListDeploymentLogsRequest struct {
 	Timestamp    time.Time `json:"timestamp"`
 }
 
+type UpdateDeploymentImageRequest struct {
+	ReleaseName    string `json:"releaseName"`
+	Image          string `json:"image"`
+	AirflowVersion string `json:"airflowVersion"`
+	RuntimeVersion string `json:"runtimeVersion"`
+}
+
 // CreateDeployment - create a deployment
 func (h ClientImplementation) CreateDeployment(vars map[string]interface{}) (*Deployment, error) {
 	req := Request{
@@ -144,4 +151,18 @@ func (h ClientImplementation) ListDeploymentLogs(filters ListDeploymentLogsReque
 	}
 
 	return r.Data.DeploymentLog, nil
+}
+
+func (h ClientImplementation) UpdateDeploymentImage(updateReq UpdateDeploymentImageRequest) error {
+	req := Request{
+		Query:     DeploymentImageUpdateRequest,
+		Variables: updateReq,
+	}
+
+	_, err := req.DoWithClient(h.client)
+	if err != nil {
+		return handleAPIErr(err)
+	}
+
+	return nil
 }

--- a/houston/deployment_test.go
+++ b/houston/deployment_test.go
@@ -575,3 +575,47 @@ func TestCancelUpdateDeploymentRuntime(t *testing.T) {
 		assert.Contains(t, err.Error(), "Internal Server Error")
 	})
 }
+
+func TestUpdateDeploymentImage(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	mockDeployment := &Response{
+		Data: ResponseData{
+			UpdateDeploymentImage: UpdateDeploymentImageResp{
+				ReleaseName:    "prehistoric-gravity-930",
+				AirflowVersion: "2.2.0",
+				RuntimeVersion: "",
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockDeployment)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, AirflowVersion: mockDeployment.Data.UpdateDeploymentImage.AirflowVersion})
+		assert.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, AirflowVersion: mockDeployment.Data.UpdateDeploymentImage.AirflowVersion})
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -48,6 +48,7 @@ type ClientInterface interface {
 	UpdateDeploymentAirflow(variables map[string]interface{}) (*Deployment, error)
 	GetDeploymentConfig() (*DeploymentConfig, error)
 	ListDeploymentLogs(filters ListDeploymentLogsRequest) ([]DeploymentLog, error)
+	UpdateDeploymentImage(req UpdateDeploymentImageRequest) error
 	// deployment users
 	ListDeploymentUsers(filters ListDeploymentUsersRequest) ([]DeploymentUser, error)
 	AddDeploymentUser(variables UpdateDeploymentUserRequest) (*RoleBinding, error)

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -746,6 +746,20 @@ func (_m *ClientInterface) UpdateDeploymentAirflow(variables map[string]interfac
 	return r0, r1
 }
 
+// UpdateDeploymentImage provides a mock function with given fields: req
+func (_m *ClientInterface) UpdateDeploymentImage(req houston.UpdateDeploymentImageRequest) error {
+	ret := _m.Called(req)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(houston.UpdateDeploymentImageRequest) error); ok {
+		r0 = rf(req)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdateDeploymentRuntime provides a mock function with given fields: variables
 func (_m *ClientInterface) UpdateDeploymentRuntime(variables map[string]interface{}) (*houston.Deployment, error) {
 	ret := _m.Called(variables)

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -618,6 +618,7 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 		appConfig {
 			version
 			baseDomain
+			byoUpdateRegistryHost
 			smtpConfigured
 			manualReleaseNames
 			configureDagDeployment
@@ -628,4 +629,21 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 			featureFlags
 		}
 	}`
+
+	DeploymentImageUpdateRequest = `
+	mutation updateDeploymentImage(
+		$releaseName: String!,
+		$image: String!,
+		$airflowVersion: String,
+		$runtimeVersion: String
+	) {
+		updateDeploymentImage(
+			releaseName: $releaseName,
+			image: $image,
+			airflowVersion: $airflowVersion,
+			runtimeVersion: $runtimeVersion
+		) {
+		}
+	}
+	`
 )

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -665,17 +665,20 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 
 	DeploymentImageUpdateRequest = `
 	mutation updateDeploymentImage(
-		$releaseName: String!,
-		$image: String!,
-		$airflowVersion: String,
-		$runtimeVersion: String
+		$releaseName:String!,
+		$image:String!,
+		$airflowVersion:String,
+		$runtimeVersion:String,
 	) {
 		updateDeploymentImage(
-			releaseName: $releaseName,
-			image: $image,
-			airflowVersion: $airflowVersion,
-			runtimeVersion: $runtimeVersion
+			releaseName:$releaseName,
+			image:$image,
+			airflowVersion:$airflowVersion,
+			runtimeVersion:$runtimeVersion
 		) {
+			releaseName
+			airflowVersion
+			runtimeVersion
 		}
 	}
 	`

--- a/houston/types.go
+++ b/houston/types.go
@@ -50,6 +50,7 @@ type ResponseData struct {
 	DeploymentConfig               DeploymentConfig            `json:"deploymentConfig,omitempty"`
 	GetDeploymentNamespaces        []Namespace                 `json:"availableNamespaces,omitempty"`
 	RuntimeReleases                RuntimeReleases             `json:"runtimeReleases,omitempty"`
+	UpdateDeploymentImage          UpdateDeploymentImageResp   `json:"updateDeploymentImage,omitempty"`
 }
 
 type Namespace struct {
@@ -261,6 +262,12 @@ type DeploymentLog struct {
 type AirflowImage struct {
 	Version string `json:"version"`
 	Tag     string `json:"tag"`
+}
+
+type UpdateDeploymentImageResp struct {
+	ReleaseName    string `json:"releaseName"`
+	AirflowVersion string `json:"airflowVersion"`
+	RuntimeVersion string `json:"runtimeVersion"`
 }
 
 // DeploymentConfig contains current airflow image tag

--- a/houston/types.go
+++ b/houston/types.go
@@ -298,6 +298,7 @@ func (config *DeploymentConfig) IsValidTag(tag string) bool {
 type AppConfig struct {
 	Version                string       `json:"version"`
 	BaseDomain             string       `json:"baseDomain"`
+	BYORegistryDomain      string       `json:"byoUpdateRegistryHost"`
 	SMTPConfigured         bool         `json:"smtpConfigured"`
 	ManualReleaseNames     bool         `json:"manualReleaseNames"`
 	ConfigureDagDeployment bool         `json:"configureDagDeployment"`
@@ -315,6 +316,7 @@ type FeatureFlags struct {
 	TriggererEnabled       bool `json:"triggererEnabled"`
 	GitSyncEnabled         bool `json:"gitSyncDagDeployment"`
 	NamespaceFreeFormEntry bool `json:"namespaceFreeFormEntry"`
+	BYORegistryEnabled     bool `json:"byoUpdateRegistryEnabled"`
 }
 
 // coerce a string into SemVer if possible

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -100,14 +100,18 @@ func registryAuth(client houston.ClientInterface, out io.Writer) error {
 	}
 
 	token := c.Token
-	registryHandler, err := registryHandlerInit(registry)
+	registryDomain := strings.Split(registry, "/")[0]
+	registryHandler, err := registryHandlerInit(registryDomain)
 	if err != nil {
 		return err
 	}
-	err = registryHandler.Login("user", token)
 
+	if !appConfig.Flags.BYORegistryEnabled {
+		err = registryHandler.Login("user", token)
+	} else {
+		err = registryHandler.Login("", "")
+	}
 	if err != nil && appConfig.Flags.BYORegistryEnabled {
-		registryDomain := strings.Split(registry, "/")[0]
 		fmt.Fprintf(out, defaultRegistryLoginFailMsg, registryDomain)
 		return nil
 	}

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -111,6 +111,7 @@ func registryAuth(client houston.ClientInterface, out io.Writer) error {
 	} else {
 		err = registryHandler.Login("", "")
 	}
+
 	if err != nil && appConfig.Flags.BYORegistryEnabled {
 		fmt.Fprintf(out, defaultRegistryLoginFailMsg, registryDomain)
 		return nil

--- a/software/auth/auth_test.go
+++ b/software/auth/auth_test.go
@@ -121,6 +121,10 @@ func TestRegistryAuthSuccess(t *testing.T) {
 		return mockRegistryHandler, nil
 	}
 
+	out := new(bytes.Buffer)
+	houstonMock := new(houstonMocks.ClientInterface)
+	houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil)
+
 	tests := []struct {
 		name    string
 		domain  string
@@ -161,7 +165,7 @@ func TestRegistryAuthSuccess(t *testing.T) {
 			err = ctx.SwitchContext()
 			assert.NoError(t, err)
 
-			err = registryAuth()
+			err = registryAuth(houstonMock, out)
 			if tt.wantErr {
 				assert.NotNil(t, err)
 				assert.ErrorIs(t, err, tt.err)
@@ -183,7 +187,11 @@ func TestRegistryAuthFailure(t *testing.T) {
 		return nil, errMockRegistry
 	}
 
-	err := registryAuth()
+	out := new(bytes.Buffer)
+	houstonMock := new(houstonMocks.ClientInterface)
+	houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil)
+
+	err := registryAuth(houstonMock, out)
 	assert.ErrorIs(t, err, errMockRegistry)
 
 	mockRegistryHandler := new(mocks.RegistryHandler)
@@ -192,7 +200,7 @@ func TestRegistryAuthFailure(t *testing.T) {
 		return mockRegistryHandler, nil
 	}
 
-	err = registryAuth()
+	err = registryAuth(houstonMock, out)
 	assert.ErrorIs(t, err, errMockRegistry)
 	mockRegistryHandler.AssertExpectations(t)
 }
@@ -236,83 +244,95 @@ func TestLoginFailure(t *testing.T) {
 	afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
 	config.InitConfig(fs)
 
-	houstonMock := new(houstonMocks.ClientInterface)
-	houstonMock.On("GetAuthConfig", mock.Anything).Return(nil, errMockRegistry)
+	t.Run("getAuthConfig failure", func(t *testing.T) {
+		houstonMock := new(houstonMocks.ClientInterface)
+		houstonMock.On("GetAuthConfig", mock.Anything).Return(nil, errMockRegistry)
 
-	out := &bytes.Buffer{}
-	if err := Login("localhost", false, "test", "test", houstonMock, out); !errors.Is(err, errMockRegistry) {
-		t.Errorf("Login() error = %v, wantErr %v", err, errMockRegistry)
-		return
-	}
-	if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
-		t.Errorf("Login() = %v, want %v", gotOut, []string{"localhost"})
-	}
-	houstonMock.AssertExpectations(t)
+		out := &bytes.Buffer{}
+		if err := Login("localhost", false, "test", "test", houstonMock, out); !errors.Is(err, errMockRegistry) {
+			t.Errorf("Login() error = %v, wantErr %v", err, errMockRegistry)
+			return
+		}
+		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
+			t.Errorf("Login() = %v, want %v", gotOut, []string{"localhost"})
+		}
+		houstonMock.AssertExpectations(t)
+	})
 
-	houstonMock = new(houstonMocks.ClientInterface)
-	houstonMock.On("GetAuthConfig", mock.Anything).Return(&houston.AuthConfig{LocalEnabled: true}, nil)
-	houstonMock.On("AuthenticateWithBasicAuth", mock.Anything, mock.Anything, mock.Anything).Return("", errMockRegistry)
+	t.Run("AuthenticateWithBasicAuth failure", func(t *testing.T) {
+		houstonMock := new(houstonMocks.ClientInterface)
+		houstonMock.On("GetAuthConfig", mock.Anything).Return(&houston.AuthConfig{LocalEnabled: true}, nil)
+		houstonMock.On("AuthenticateWithBasicAuth", mock.Anything, mock.Anything, mock.Anything).Return("", errMockRegistry)
 
-	out = &bytes.Buffer{}
-	if err := Login("localhost", false, "test", "test", houstonMock, out); !errors.Is(err, errMockRegistry) {
-		t.Errorf("Login() error = %v, wantErr %v", err, errMockRegistry)
-		return
-	}
-	if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
-		t.Errorf("Login() = %v, want %v", gotOut, []string{"localhost"})
-	}
-	houstonMock.AssertExpectations(t)
+		out := &bytes.Buffer{}
+		if err := Login("localhost", false, "test", "test", houstonMock, out); !errors.Is(err, errMockRegistry) {
+			t.Errorf("Login() error = %v, wantErr %v", err, errMockRegistry)
+			return
+		}
+		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
+			t.Errorf("Login() = %v, want %v", gotOut, []string{"localhost"})
+		}
+		houstonMock.AssertExpectations(t)
+	})
 
-	houstonMock = new(houstonMocks.ClientInterface)
-	houstonMock.On("GetAuthConfig", mock.Anything).Return(&houston.AuthConfig{LocalEnabled: true}, nil)
-	houstonMock.On("AuthenticateWithBasicAuth", mock.Anything, mock.Anything, mock.Anything).Return(mockToken, nil)
-	houstonMock.On("ListWorkspaces").Return([]houston.Workspace{}, errMockRegistry).Once()
+	t.Run("ListWorkspaces failure", func(t *testing.T) {
+		houstonMock := new(houstonMocks.ClientInterface)
+		houstonMock.On("GetAuthConfig", mock.Anything).Return(&houston.AuthConfig{LocalEnabled: true}, nil)
+		houstonMock.On("AuthenticateWithBasicAuth", mock.Anything, mock.Anything, mock.Anything).Return(mockToken, nil)
+		houstonMock.On("ListWorkspaces").Return([]houston.Workspace{}, errMockRegistry).Once()
 
-	out = &bytes.Buffer{}
-	if err := Login("localhost", false, "test", "test", houstonMock, out); !errors.Is(err, errMockRegistry) {
-		t.Errorf("Login() error = %v, wantErr %v", err, errMockRegistry)
-		return
-	}
-	if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
-		t.Errorf("Login() = %v, want %v", gotOut, []string{"localhost"})
-	}
-	houstonMock.AssertExpectations(t)
+		out := &bytes.Buffer{}
+		if err := Login("localhost", false, "test", "test", houstonMock, out); !errors.Is(err, errMockRegistry) {
+			t.Errorf("Login() error = %v, wantErr %v", err, errMockRegistry)
+			return
+		}
+		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
+			t.Errorf("Login() = %v, want %v", gotOut, []string{"localhost"})
+		}
+		houstonMock.AssertExpectations(t)
+	})
 
-	houstonMock = new(houstonMocks.ClientInterface)
-	houstonMock.On("GetAuthConfig", mock.Anything).Return(&houston.AuthConfig{LocalEnabled: true}, nil)
-	houstonMock.On("AuthenticateWithBasicAuth", mock.Anything, mock.Anything, mock.Anything).Return(mockToken, nil)
-	houstonMock.On("ListWorkspaces").Return([]houston.Workspace{{ID: "ck05r3bor07h40d02y2hw4n4v"}, {ID: "test-workspace-id"}}, nil)
+	t.Run("no workspace failure", func(t *testing.T) {
+		houstonMock := new(houstonMocks.ClientInterface)
+		houstonMock.On("GetAuthConfig", mock.Anything).Return(&houston.AuthConfig{LocalEnabled: true}, nil)
+		houstonMock.On("AuthenticateWithBasicAuth", mock.Anything, mock.Anything, mock.Anything).Return(mockToken, nil)
+		houstonMock.On("ListWorkspaces").Return([]houston.Workspace{{ID: "ck05r3bor07h40d02y2hw4n4v"}, {ID: "test-workspace-id"}}, nil)
+		houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil)
 
-	out = &bytes.Buffer{}
-	if err := Login("dev.astro.io", false, "test", "test", houstonMock, out); !errors.Is(err, nil) {
-		t.Errorf("Login() error = %v, wantErr %v", err, nil)
-		return
-	}
-	if gotOut := out.String(); !testUtil.StringContains([]string{"dev.astro.io", "No default workspace detected"}, gotOut) {
-		t.Errorf("Login() = %v, want %v", gotOut, []string{"dev.astro.io", "No default workspace detected"})
-	}
-	houstonMock.AssertExpectations(t)
+		out := &bytes.Buffer{}
+		if err := Login("dev.astro.io", false, "test", "test", houstonMock, out); !errors.Is(err, nil) {
+			t.Errorf("Login() error = %v, wantErr %v", err, nil)
+			return
+		}
+		if gotOut := out.String(); !testUtil.StringContains([]string{"dev.astro.io", "No default workspace detected"}, gotOut) {
+			t.Errorf("Login() = %v, want %v", gotOut, []string{"dev.astro.io", "No default workspace detected"})
+		}
+		houstonMock.AssertExpectations(t)
+	})
 
-	houstonMock = new(houstonMocks.ClientInterface)
-	houstonMock.On("GetAuthConfig", mock.Anything).Return(&houston.AuthConfig{LocalEnabled: true}, nil)
-	houstonMock.On("AuthenticateWithBasicAuth", mock.Anything, mock.Anything, mock.Anything).Return(mockToken, nil)
-	houstonMock.On("ListWorkspaces").Return([]houston.Workspace{{ID: "test-workspace-id"}}, nil).Once()
+	t.Run("registry login failure", func(t *testing.T) {
+		houstonMock := new(houstonMocks.ClientInterface)
+		houstonMock.On("GetAuthConfig", mock.Anything).Return(&houston.AuthConfig{LocalEnabled: true}, nil)
+		houstonMock.On("AuthenticateWithBasicAuth", mock.Anything, mock.Anything, mock.Anything).Return(mockToken, nil)
+		houstonMock.On("ListWorkspaces").Return([]houston.Workspace{{ID: "test-workspace-id"}}, nil).Once()
+		houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil)
 
-	mockRegistryHandler := new(mocks.RegistryHandler)
-	registryHandlerInit = func(registry string) (airflow.RegistryHandler, error) {
-		mockRegistryHandler.On("Login", mock.Anything, mock.Anything).Return(errMockRegistry).Once()
-		return mockRegistryHandler, nil
-	}
+		mockRegistryHandler := new(mocks.RegistryHandler)
+		registryHandlerInit = func(registry string) (airflow.RegistryHandler, error) {
+			mockRegistryHandler.On("Login", mock.Anything, mock.Anything).Return(errMockRegistry).Once()
+			return mockRegistryHandler, nil
+		}
 
-	out = &bytes.Buffer{}
-	if err := Login("test.astro.io", false, "test", "test", houstonMock, out); !errors.Is(err, nil) {
-		t.Errorf("Login() error = %v, wantErr %v", err, nil)
-		return
-	}
-	if gotOut := out.String(); !testUtil.StringContains([]string{"test.astro.io", "Failed to authenticate to the registry"}, gotOut) {
-		t.Errorf("Login() = %v, want %v", gotOut, []string{"test.astro.io", "Failed to authenticate to the registry"})
-	}
-	houstonMock.AssertExpectations(t)
+		out := &bytes.Buffer{}
+		if err := Login("test.astro.io", false, "test", "test", houstonMock, out); !errors.Is(err, nil) {
+			t.Errorf("Login() error = %v, wantErr %v", err, nil)
+			return
+		}
+		if gotOut := out.String(); !testUtil.StringContains([]string{"test.astro.io", "Failed to authenticate to the registry"}, gotOut) {
+			t.Errorf("Login() = %v, want %v", gotOut, []string{"test.astro.io", "Failed to authenticate to the registry"})
+		}
+		houstonMock.AssertExpectations(t)
+	})
 }
 
 func TestLogout(t *testing.T) {

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -219,16 +219,17 @@ func buildPushDockerImage(houstonClient houston.ClientInterface, c *config.Conte
 		return err
 	}
 
-	var registry, remoteImage string
+	var registry, remoteImage, token string
 	if byoRegistryEnabled {
 		registry = byoRegistryDomain
 		remoteImage = fmt.Sprintf("%s:%s", registry, fmt.Sprintf("%s-%s", name, nextTag))
 	} else {
 		registry = registryDomainPrefix + cloudDomain
 		remoteImage = fmt.Sprintf("%s/%s", registry, airflow.ImageName(name, nextTag))
+		token = c.Token
 	}
 
-	err = imageHandler.Push(registry, "", "", remoteImage)
+	err = imageHandler.Push(registry, "", token, remoteImage)
 	if err != nil {
 		return err
 	}

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/astronomer/astro-cli/airflow"
 	"github.com/astronomer/astro-cli/airflow/types"
@@ -128,6 +129,10 @@ func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, by
 			nextTag = deployment.DeploymentInfo.NextCli
 			releaseName = deployment.ReleaseName
 		}
+	}
+
+	if byoRegistryEnabled {
+		nextTag = "deploy-" + time.Now().UTC().Format("2006-01-02T15-04") // updating nextTag logic for private registry, since houston won't maintain next tag in case of BYO registry
 	}
 
 	deploymentInfo, err := houstonClient.GetDeployment(deploymentID)


### PR DESCRIPTION
## Description
Changes:
- Updated registry login flow in `astro login` to handle cases for private registry
- Updated `astro deploy` logic to push the image to the private registry and then separately call Houston to update the deployment image in case the user is using the private registry

<img width="1480" alt="Screenshot 2022-06-13 at 11 15 15 AM" src="https://user-images.githubusercontent.com/92356010/173288045-526a498a-2839-4f88-a4e8-37819b639723.png">

## 🎟 Issue(s)

Related astronomer/issues#4568

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
