### PR TITLE
Removing deprecated type `isManaged`

### DIFF
--- a/astro-client/astro_test.go
+++ b/astro-client/astro_test.go
@@ -573,7 +573,6 @@ func TestListClusters(t *testing.T) {
 				{
 					ID:            "test-id",
 					Name:          "test-name",
-					IsManaged:     false,
 					CloudProvider: "test-cloud-provider",
 				},
 			},

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -68,14 +68,12 @@ type Deployment struct {
 type Cluster struct {
 	ID            string `json:"id"`
 	Name          string `json:"name"`
-	IsManaged     bool   `json:"isManaged"`
 	CloudProvider string `json:"cloudProvider"`
 }
 
 type Orchestrator struct {
 	ID            string `json:"id"`
 	Name          string `json:"name"`
-	IsManaged     bool   `json:"isManaged"`
 	CloudProvider string `json:"cloudProvider"`
 }
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Removing Deprecated Type `isManaged`
## 🎟 Issue(s)

Related astronomer/issues#XXXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
