### PR TITLE
GH Actions to Auto-Label Issues

### DIFF
--- a/.github/.github/workflows/issue.yml
+++ b/.github/.github/workflows/issue.yml
@@ -1,0 +1,15 @@
+name: Label all new GitHub Issues with App CLI
+on:
+  issues:
+    types: ['opened']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-comments: false
+          labels-synonyms: false
+          labels-not-allowed: false
+          default-labels: '["app/astro-cli"]'


### PR DESCRIPTION
## Description

Creating a GitHub Action here to auto-label all new GitHub issues in this repository with the `app/astro-cli` label. This will make CLI issues easier to track in boards that are cross-functional and have issues from other repos.

Based on: https://github.com/marketplace/actions/auto-label

@sunkickr This look right to you?