### PR TITLE
only pytest tests in tests/ folder

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -347,6 +347,19 @@ func (d *DockerCompose) Pytest(pytestFile, projectImageName string) (string, err
 		return "", err
 	}
 
+	fmt.Println("pytest file1: "+pytestFile)
+
+	// Determine pytest file
+	if pytestFile != ".astro/test_dag_integrity_default.py" {
+		if !strings.Contains(pytestFile, "tests") {
+			pytestFile = "tests/" + pytestFile
+		} else  if pytestFile == "" {
+			pytestFile = "tests/"
+		}
+	}
+
+	fmt.Println("pytest file2: "+pytestFile)
+
 	// Create a compose project
 	project, err := createDockerProject(d.projectName, d.airflowHome, d.envFile, pytestFile, projectImageName, imageLabels, true)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR makes it so pytest only tests files located in the `tests/` directory. This is important do that files in the dags, includes, etc... folders don't get mistaken for tests. This can create confusing results for some

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/549

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
