### PR TITLE
add ability to skip parse on deploy

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -193,7 +193,7 @@ func parseDAG(pytest, version, envFile, deployImage, namespace string) error {
 				return errDagsParseFailed
 			}
 		} else {
-			fmt.Println("Skiping parsing dags due to skip parse being set to true in either the config.yaml or local environemnt variables")
+			fmt.Println("Skiping parsing dags due to skip parse being set to true in either the config.yaml or local environment variables")
 		}
 		// check pytests
 	} else if pytest != "" && pytest != parse {

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -83,9 +83,13 @@ func Deploy(path, deploymentID, wsID, pytest, envFile string, prompt bool, clien
 		return err
 	}
 
-	err = parseDAG(pytest, version, envFile, deployInfo.deployImage, deployInfo.namespace)
-	if err != nil {
-		return err
+	if !config.CFG.SkipParse.GetBool() && !CheckEnvBool(os.Getenv("ASTRONOMER_SKIP_PARSE")) {
+		err = parseDAG(pytest, version, envFile, deployInfo.deployImage, deployInfo.namespace)
+		if err != nil {
+			return err
+		}
+	} else {
+		fmt.Println("Skiping parsing dags due to skip parse being set to true in either the config.yaml or local environemnt variables")
 	}
 
 	// Create the image
@@ -405,4 +409,14 @@ func CheckVersion(version string, out io.Writer) {
 	default:
 		fmt.Fprintf(out, "Runtime Version: %s\n", version)
 	}
+}
+
+func CheckEnvBool(envBool string) bool {
+	if envBool == "False" || envBool == "false" {
+		return false
+	}
+	if envBool == "True" || envBool == "true" {
+		return true
+	}
+	return false
 }

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,7 @@ var (
 		Verbosity:            newCfg("verbosity", "warning"),
 		HoustonDialTimeout:   newCfg("houston.dial_timeout", "10"),
 		HoustonSkipVerifyTLS: newCfg("houston.skip_verify_tls", "false"),
+		SkipParse:            newCfg("skip_parse", "false"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/types.go
+++ b/config/types.go
@@ -32,6 +32,7 @@ type cfgs struct {
 	Verbosity            cfg
 	HoustonDialTimeout   cfg
 	HoustonSkipVerifyTLS cfg
+	SkipParse            cfg
 }
 
 // Creates a new cfg struct

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -66,3 +66,13 @@ func Base64URLEncode(arg []byte) string {
 	s = strings.Replace(s, "/", "_", -1)
 	return s
 }
+
+func CheckEnvBool(envBool string) bool {
+	if envBool == "False" || envBool == "false" {
+		return false
+	}
+	if envBool == "True" || envBool == "true" {
+		return true
+	}
+	return false
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -200,6 +200,11 @@ func TestCheckEnvBool(t *testing.T) {
 			args: args{"true"},
 			want: true,
 		},
+		{
+			name: "third false case",
+			args: args{""},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -170,3 +170,42 @@ func TestBase64URLEncode(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckEnvBool(t *testing.T) {
+	type args struct {
+		arg string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "first false case",
+			args: args{"False"},
+			want: false,
+		},
+		{
+			name: "second false case",
+			args: args{"false"},
+			want: false,
+		},
+		{
+			name: "first true case",
+			args: args{"True"},
+			want: true,
+		},
+		{
+			name: "second true case",
+			args: args{"true"},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CheckEnvBool(tt.args.arg); got != tt.want {
+				t.Errorf("CheckEnvBool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Use config or env vars to skip parse on deploy

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/610

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
