### PR TITLE
parse on deploy kills local project

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -178,7 +178,7 @@ func parseDAG(pytest, version, envFile, deployImage, namespace string) error {
 	}
 
 	fmt.Println("testing", deployImage)
-	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile, "Dockerfile", namespace, false)
+	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile, "Dockerfile", namespace, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Parse and pytest on deploy  create a project with same name as your dev start. This causes astro deploy to kill local proejcts when ran

## 🎟 Issue(s)


## 🧪 Functional Testing

Tested commands manually

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
