### PR TITLE
Migrate teams related commands from 0.x to the new main

### DIFF
--- a/astro-client/mocks/Client.go
+++ b/astro-client/mocks/Client.go
@@ -142,13 +142,13 @@ func (_m *Client) GetDeploymentHistory(vars map[string]interface{}) (astro.Deplo
 	return r0, r1
 }
 
-// ListClusters provides a mock function with given fields: organizationId
-func (_m *Client) ListClusters(organizationId string) ([]astro.Cluster, error) {
-	ret := _m.Called(organizationId)
+// ListClusters provides a mock function with given fields: organizationID
+func (_m *Client) ListClusters(organizationID string) ([]astro.Cluster, error) {
+	ret := _m.Called(organizationID)
 
 	var r0 []astro.Cluster
 	if rf, ok := ret.Get(0).(func(string) []astro.Cluster); ok {
-		r0 = rf(organizationId)
+		r0 = rf(organizationID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]astro.Cluster)
@@ -157,7 +157,7 @@ func (_m *Client) ListClusters(organizationId string) ([]astro.Cluster, error) {
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(organizationId)
+		r1 = rf(organizationID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/cmd/software/root.go
+++ b/cmd/software/root.go
@@ -14,9 +14,12 @@ import (
 var (
 	// init debug logs should be used only for logs produced during the CLI-initialization, before the SetUpLogs Method has been called
 	initDebugLogs = []string{}
+
 	houstonClient houston.ClientInterface
-	workspaceID   string
 	appConfig     *houston.AppConfig
+
+	workspaceID string
+	teamID      string
 )
 
 // AddCmds adds all the command initialized in this package for the cmd package to import
@@ -34,6 +37,7 @@ func AddCmds(client houston.ClientInterface, out io.Writer) []*cobra.Command {
 		newWorkspaceCmd(out),
 		newDeployCmd(),
 		newUserCmd(out),
+		newTeamCmd(out),
 	}
 }
 

--- a/cmd/software/root_test.go
+++ b/cmd/software/root_test.go
@@ -25,7 +25,7 @@ func TestAddCmds(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmds := AddCmds(houstonMock, buf)
 	for cmdIdx := range cmds {
-		assert.Contains(t, []string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace"}, cmds[cmdIdx].Use)
+		assert.Contains(t, []string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace", "team"}, cmds[cmdIdx].Use)
 	}
 	houstonMock.AssertExpectations(t)
 }
@@ -36,7 +36,7 @@ func TestAppConfigFailure(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmds := AddCmds(houstonMock, buf)
 	for cmdIdx := range cmds {
-		assert.Contains(t, []string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace"}, cmds[cmdIdx].Use)
+		assert.Contains(t, []string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace", "team"}, cmds[cmdIdx].Use)
 	}
 	houstonMock.AssertExpectations(t)
 	assert.Contains(t, initDebugLogs, fmt.Sprintf("Error checking feature flag: %s", errMock))

--- a/cmd/software/teams.go
+++ b/cmd/software/teams.go
@@ -1,0 +1,37 @@
+package software
+
+import (
+	"io"
+
+	"github.com/astronomer/astro-cli/software/teams"
+	"github.com/spf13/cobra"
+)
+
+func newTeamCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "team",
+		Short: "Manage Astronomer Teams",
+		Long:  "Teams represents a team or a group from an IDP in the Astronomer Platform",
+	}
+	cmd.AddCommand(
+		newTeamGetCmd(out),
+	)
+	return cmd
+}
+
+func newTeamGetCmd(out io.Writer) *cobra.Command {
+	var usersEnabled bool
+	cmd := &cobra.Command{
+		Use:     "get",
+		Aliases: []string{"g"},
+		Short:   "Get a team in the Astronomer Platform",
+		Long:    "Get a team in the Astronomer Platform",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			return teams.Get(args[0], usersEnabled, houstonClient, out)
+		},
+	}
+	cmd.Flags().BoolVarP(&usersEnabled, "users", "u", false, "add team Users")
+	return cmd
+}

--- a/cmd/software/teams_test.go
+++ b/cmd/software/teams_test.go
@@ -1,0 +1,65 @@
+package software
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/astronomer/astro-cli/houston"
+	mocks "github.com/astronomer/astro-cli/houston/mocks"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func execTeamCmd(args ...string) (string, error) {
+	buf := new(bytes.Buffer)
+	cmd := newTeamCmd(buf)
+	cmd.SetOut(buf)
+	cmd.SetArgs(args)
+	_, err := cmd.ExecuteC()
+	return buf.String(), err
+}
+
+func TestNewGetTeamCmd(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	team := &houston.Team{
+		Name: "Everyone",
+		ID:   "blah-id",
+	}
+
+	api := new(mocks.ClientInterface)
+	api.On("GetTeam", mock.Anything).Return(team, nil)
+	houstonClient = api
+
+	output, err := execTeamCmd("get", "test-id")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "")
+	api.AssertExpectations(t)
+}
+
+func TestNewGetTeamUsersCmd(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	team := &houston.Team{
+		Name: "Everyone",
+		ID:   "blah-id",
+	}
+	users := []houston.User{
+		{
+			Username: "email@email.com",
+			ID:       "test-id",
+		},
+	}
+
+	api := new(mocks.ClientInterface)
+	api.On("GetTeam", mock.Anything).Return(team, nil)
+	api.On("GetTeamUsers", mock.Anything).Return(users, nil)
+	houstonClient = api
+
+	output, err := execTeamCmd("get", "-u", "test-id")
+	assert.NoError(t, err)
+	assert.Contains(t, output, "USERNAME            ID          \n email@email.com     test-id")
+	api.AssertExpectations(t)
+}

--- a/cmd/software/workspace.go
+++ b/cmd/software/workspace.go
@@ -38,6 +38,7 @@ func newWorkspaceCmd(out io.Writer) *cobra.Command {
 		newWorkspaceUpdateCmd(out),
 		newWorkspaceUserRootCmd(out),
 		newWorkspaceSaRootCmd(out),
+		newWorkspaceTeamRootCmd(out),
 	)
 	return cmd
 }

--- a/cmd/software/workspace_teams.go
+++ b/cmd/software/workspace_teams.go
@@ -1,0 +1,156 @@
+package software
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/software/workspace"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	workspaceTeamRole string
+
+	workspaceTeamAddExample = `
+$ astro workspace team add --workspace-id=<workspace-id> --team-id=<team-id> --role=ROLE
+`
+	workspaceTeamRemoveExample = `
+$ astro workspace team remove cl0ck2snm0064jexu3ljfn9um --workspace-id ckwwb09aj0048u8xuts287erj
+`
+	workspaceTeamUpdateExample = `
+$ astro workspace team update cl0ck2snm0064jexu3ljfn9um --workspace-id ckwwb09aj0048u8xuts287erj --role WORKSPACE_EDITOR
+`
+	workspaceTeamsListExample = `
+$ astro workspace team list --workspace-id ckwwb09aj0048u8xuts287erj`
+)
+
+func newWorkspaceTeamRootCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "team",
+		Short: "Manage Workspace Team resources",
+		Long:  "Teams can be added or removed from Workspaces",
+	}
+	cmd.PersistentFlags().StringVar(&workspaceID, "workspace-id", "", "workspace to associate team to")
+	cmd.AddCommand(
+		newWorkspaceTeamAddCmd(out),
+		newWorkspaceTeamUpdateCmd(out),
+		newWorkspaceTeamRemoveCmd(out),
+		newWorkspaceTeamsListCmd(out),
+	)
+	return cmd
+}
+
+func newWorkspaceTeamAddCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "add",
+		Short:   "Add a Team to a Workspace",
+		Long:    "Add a Team to a Workspace",
+		Example: workspaceTeamAddExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return workspaceTeamAdd(cmd, out, args)
+		},
+	}
+	cmd.PersistentFlags().StringVar(&teamID, "team-id", "", "team id to be assigned to workspace")
+	_ = cmd.MarkFlagRequired("team-id")
+	cmd.PersistentFlags().StringVar(&workspaceTeamRole, "role", houston.WorkspaceViewerRole, "workspace role assigned to team")
+	return cmd
+}
+
+func newWorkspaceTeamUpdateCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "update",
+		Short:   "Update a Team inside a workspace",
+		Long:    "Update a Team inside a workspace",
+		Example: workspaceTeamUpdateExample,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return workspaceTeamUpdate(cmd, out, args)
+		},
+	}
+	cmd.PersistentFlags().StringVar(&workspaceTeamRole, "role", houston.WorkspaceViewerRole, "workspace role assigned to team")
+	return cmd
+}
+
+func newWorkspaceTeamRemoveCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "remove TEAM",
+		Aliases: []string{"rm"},
+		Short:   "Remove a Team from a Workspace",
+		Long:    "Remove a Team from a Workspace",
+		Example: workspaceTeamRemoveExample,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return workspaceTeamRm(cmd, out, args)
+		},
+	}
+	return cmd
+}
+
+func newWorkspaceTeamsListCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List Teams inside an Astronomer Workspace",
+		Long:    "List Teams inside an Astronomer Workspace",
+		Example: workspaceTeamsListExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return workspaceTeamsList(cmd, out, args)
+		},
+	}
+	return cmd
+}
+
+func workspaceTeamAdd(cmd *cobra.Command, out io.Writer, _ []string) error {
+	ws, err := coalesceWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
+	}
+
+	if err := validateWorkspaceRole(workspaceTeamRole); err != nil {
+		return fmt.Errorf("failed to find a valid role: %w", err)
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+	return workspace.AddTeam(ws, teamID, workspaceTeamRole, houstonClient, out)
+}
+
+func workspaceTeamUpdate(cmd *cobra.Command, out io.Writer, args []string) error {
+	ws, err := coalesceWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
+	}
+
+	if err := validateWorkspaceRole(workspaceTeamRole); err != nil {
+		return fmt.Errorf("failed to find a valid role: %w", err)
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+	return workspace.UpdateTeamRole(ws, args[0], workspaceTeamRole, houstonClient, out)
+}
+
+func workspaceTeamRm(cmd *cobra.Command, out io.Writer, args []string) error {
+	ws, err := coalesceWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+
+	return workspace.RemoveTeam(ws, args[0], houstonClient, out)
+}
+
+func workspaceTeamsList(cmd *cobra.Command, out io.Writer, _ []string) error {
+	ws, err := coalesceWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+	return workspace.ListTeamRoles(ws, houstonClient, out)
+}

--- a/cmd/software/workspace_teams_test.go
+++ b/cmd/software/workspace_teams_test.go
@@ -1,0 +1,112 @@
+package software
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/astronomer/astro-cli/houston"
+	mocks "github.com/astronomer/astro-cli/houston/mocks"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	mockWorkspaceTeamRole = &houston.RoleBinding{
+		Role: houston.WorkspaceViewerRole,
+		Team: houston.Team{
+			ID:   "cl0evnxfl0120dxxu1s4nbnk7",
+			Name: "test-team",
+		},
+		Workspace: houston.Workspace{
+			ID:    "ck05r3bor07h40d02y2hw4n4v",
+			Label: "airflow",
+		},
+	}
+	mockWorkspaceTeam = &houston.Team{
+		RoleBindings: []houston.RoleBinding{
+			*mockWorkspaceTeamRole,
+		},
+	}
+)
+
+func TestWorkspaceTeamAddCommand(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	expectedOut := ` NAME        WORKSPACE ID                  TEAM ID                       ROLE                 
+ airflow     ck05r3bor07h40d02y2hw4n4v     cl0evnxfl0120dxxu1s4nbnk7     WORKSPACE_VIEWER     
+Successfully added cl0evnxfl0120dxxu1s4nbnk7 to airflow
+`
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig").Return(mockAppConfig, nil)
+	api.On("AddWorkspaceTeam", mockWorkspace.ID, mockWorkspaceTeamRole.Team.ID, mockWorkspaceTeamRole.Role).Return(mockWorkspace, nil)
+	houstonClient = api
+
+	output, err := execWorkspaceCmd(
+		"team",
+		"add",
+		"--workspace-id="+mockWorkspace.ID,
+		"--team-id="+mockWorkspaceTeamRole.Team.ID,
+		"--role="+mockWorkspaceTeamRole.Role,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOut, output)
+}
+
+func TestWorkspaceTeamRm(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	mockTeamID := "ckc0eir8e01gj07608ajmvia1"
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig").Return(mockAppConfig, nil)
+	api.On("DeleteWorkspaceTeam", mockWorkspace.ID, mockTeamID).Return(mockWorkspace, nil)
+	houstonClient = api
+
+	expected := ` NAME                          WORKSPACE ID                                      TEAM ID                                           
+ airflow                       ck05r3bor07h40d02y2hw4n4v                         ckc0eir8e01gj07608ajmvia1                         
+Successfully removed team from workspace
+`
+
+	buf := new(bytes.Buffer)
+	cmd := newWorkspaceTeamRemoveCmd(buf)
+	err := cmd.RunE(cmd, []string{mockTeamID})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, buf.String())
+}
+
+func TestWorkspaceTeamUpdateCommand(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig").Return(mockAppConfig, nil)
+	api.On("GetWorkspaceTeamRole", mockWorkspace.ID, mockWorkspaceTeamRole.Team.ID).Return(mockWorkspaceTeam, nil)
+	api.On("UpdateWorkspaceTeamRole", mockWorkspace.ID, mockWorkspaceTeamRole.Team.ID, mockWorkspaceTeamRole.Role).Return(mockWorkspace.Label, nil)
+	houstonClient = api
+
+	_, err := execWorkspaceCmd(
+		"team",
+		"update",
+		mockWorkspaceTeamRole.Team.ID,
+		"--workspace-id="+mockWorkspace.ID,
+		"--role="+mockWorkspaceTeamRole.Role,
+	)
+	assert.NoError(t, err)
+}
+
+func TestWorkspaceTeamsListCmd(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString("")),
+			Header:     make(http.Header),
+		}
+	})
+	houstonClient = houston.NewClient(client)
+	buf := new(bytes.Buffer)
+	cmd := newWorkspaceTeamsListCmd(buf)
+	assert.NotNil(t, cmd)
+	assert.Nil(t, cmd.Args)
+}

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -67,6 +67,15 @@ type ClientInterface interface {
 	GetAvailableNamespaces() ([]Namespace, error)
 	// runtime
 	GetRuntimeReleases(airflowVersion string) (RuntimeReleases, error)
+	// teams
+	GetTeam(teamID string) (*Team, error)
+	GetTeamUsers(teamID string) ([]User, error)
+	// workspace teams and roles
+	AddWorkspaceTeam(workspaceID, teamID, role string) (*Workspace, error)
+	DeleteWorkspaceTeam(workspaceID, teamID string) (*Workspace, error)
+	ListWorkspaceTeamsAndRoles(workspaceID string) ([]Team, error)
+	UpdateWorkspaceTeamRole(workspaceID, teamID, role string) (string, error)
+	GetWorkspaceTeamRole(workspaceID, teamID string) (*Team, error)
 }
 
 // ClientImplementation - implementation of the Houston Client Interface

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -37,6 +37,29 @@ func (_m *ClientInterface) AddDeploymentUser(variables houston.UpdateDeploymentU
 	return r0, r1
 }
 
+// AddWorkspaceTeam provides a mock function with given fields: workspaceID, teamID, role
+func (_m *ClientInterface) AddWorkspaceTeam(workspaceID string, teamID string, role string) (*houston.Workspace, error) {
+	ret := _m.Called(workspaceID, teamID, role)
+
+	var r0 *houston.Workspace
+	if rf, ok := ret.Get(0).(func(string, string, string) *houston.Workspace); ok {
+		r0 = rf(workspaceID, teamID, role)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Workspace)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(workspaceID, teamID, role)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // AddWorkspaceUser provides a mock function with given fields: workspaceID, email, role
 func (_m *ClientInterface) AddWorkspaceUser(workspaceID string, email string, role string) (*houston.Workspace, error) {
 	ret := _m.Called(workspaceID, email, role)
@@ -334,6 +357,29 @@ func (_m *ClientInterface) DeleteWorkspaceServiceAccount(workspaceID string, ser
 	return r0, r1
 }
 
+// DeleteWorkspaceTeam provides a mock function with given fields: workspaceID, teamID
+func (_m *ClientInterface) DeleteWorkspaceTeam(workspaceID string, teamID string) (*houston.Workspace, error) {
+	ret := _m.Called(workspaceID, teamID)
+
+	var r0 *houston.Workspace
+	if rf, ok := ret.Get(0).(func(string, string) *houston.Workspace); ok {
+		r0 = rf(workspaceID, teamID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Workspace)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(workspaceID, teamID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // DeleteWorkspaceUser provides a mock function with given fields: workspaceID, userID
 func (_m *ClientInterface) DeleteWorkspaceUser(workspaceID string, userID string) (*houston.Workspace, error) {
 	ret := _m.Called(workspaceID, userID)
@@ -495,6 +541,52 @@ func (_m *ClientInterface) GetRuntimeReleases(airflowVersion string) (houston.Ru
 	return r0, r1
 }
 
+// GetTeam provides a mock function with given fields: teamID
+func (_m *ClientInterface) GetTeam(teamID string) (*houston.Team, error) {
+	ret := _m.Called(teamID)
+
+	var r0 *houston.Team
+	if rf, ok := ret.Get(0).(func(string) *houston.Team); ok {
+		r0 = rf(teamID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Team)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(teamID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetTeamUsers provides a mock function with given fields: teamID
+func (_m *ClientInterface) GetTeamUsers(teamID string) ([]houston.User, error) {
+	ret := _m.Called(teamID)
+
+	var r0 []houston.User
+	if rf, ok := ret.Get(0).(func(string) []houston.User); ok {
+		r0 = rf(teamID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]houston.User)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(teamID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetWorkspace provides a mock function with given fields: workspaceID
 func (_m *ClientInterface) GetWorkspace(workspaceID string) (*houston.Workspace, error) {
 	ret := _m.Called(workspaceID)
@@ -511,6 +603,29 @@ func (_m *ClientInterface) GetWorkspace(workspaceID string) (*houston.Workspace,
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(workspaceID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetWorkspaceTeamRole provides a mock function with given fields: workspaceID, teamID
+func (_m *ClientInterface) GetWorkspaceTeamRole(workspaceID string, teamID string) (*houston.Team, error) {
+	ret := _m.Called(workspaceID, teamID)
+
+	var r0 *houston.Team
+	if rf, ok := ret.Get(0).(func(string, string) *houston.Team); ok {
+		r0 = rf(workspaceID, teamID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Team)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(workspaceID, teamID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -641,6 +756,29 @@ func (_m *ClientInterface) ListWorkspaceServiceAccounts(workspaceID string) ([]h
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]houston.ServiceAccount)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(workspaceID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListWorkspaceTeamsAndRoles provides a mock function with given fields: workspaceID
+func (_m *ClientInterface) ListWorkspaceTeamsAndRoles(workspaceID string) ([]houston.Team, error) {
+	ret := _m.Called(workspaceID)
+
+	var r0 []houston.Team
+	if rf, ok := ret.Get(0).(func(string) []houston.Team); ok {
+		r0 = rf(workspaceID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]houston.Team)
 		}
 	}
 
@@ -808,6 +946,27 @@ func (_m *ClientInterface) UpdateWorkspace(workspaceID string, args map[string]s
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, map[string]string) error); ok {
 		r1 = rf(workspaceID, args)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UpdateWorkspaceTeamRole provides a mock function with given fields: workspaceID, teamID, role
+func (_m *ClientInterface) UpdateWorkspaceTeamRole(workspaceID string, teamID string, role string) (string, error) {
+	ret := _m.Called(workspaceID, teamID, role)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string, string) string); ok {
+		r0 = rf(workspaceID, teamID, role)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(workspaceID, teamID, role)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -670,4 +670,112 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 		  	airflowDatabaseMigrations
 		}
 	}`
+
+	TeamGetRequest = `
+	query team($teamUuid: Uuid!, $workspaceUuid: Uuid) {
+		team(teamUuid: $teamUuid, workspaceUuid: $workspaceUuid) {
+			name
+			id
+			createdAt
+			roleBindings {
+				id
+				role
+				workspace {
+					id
+					label
+				}
+				deployment {
+					id
+					label
+					releaseName
+				}
+			}
+		}
+	}
+	`
+
+	TeamGetUsersRequest = `
+	query GetTeamUsers(
+		$teamUuid: Uuid!
+	){
+		teamUsers(
+			teamUuid: $teamUuid
+		){
+			username
+			id
+			emails {
+				address
+				verified
+				primary
+			}
+			status
+		}
+	}
+	`
+
+	WorkspaceTeamAddRequest = `
+	mutation AddWorkspaceTeam(
+		$workspaceUuid: Uuid!
+		$teamUuid: Uuid!
+		$role: Role! = WORKSPACE_VIEWER
+		$deploymentRoles: [DeploymentRoles!] = []
+	){
+		workspaceAddTeam(
+			workspaceUuid: $workspaceUuid
+			teamUuid: $teamUuid
+			role: $role
+			deploymentRoles: $deploymentRoles) {
+			id
+			label
+			description
+			createdAt
+			updatedAt
+		}
+	}`
+
+	WorkspaceTeamUpdateRequest = `
+	mutation workspaceUpdateTeamRole(
+		$workspaceUuid: Uuid!
+		$teamUuid: Uuid!
+		$role: Role!
+	){
+		workspaceUpdateTeamRole(
+      		workspaceUuid: $workspaceUuid
+      		teamUuid: $teamUuid
+      		role: $role
+    	)
+	}`
+
+	WorkspaceGetTeamsRequest = `
+	query workspaceGetTeams($workspaceUuid: Uuid!) {
+		workspaceTeams(
+			workspaceUuid: $workspaceUuid
+		){
+			id
+      		name
+			roleBindings {
+				role
+				workspace {
+					id
+					label
+				}
+				deployment {
+					id
+					label
+				}
+			}
+		}
+	}
+	`
+
+	WorkspaceTeamRemoveRequest = `
+	mutation workspaceRemoveTeam(
+		$workspaceUuid: Uuid!,
+		$teamUuid: Uuid!
+	){
+		workspaceRemoveTeam(workspaceUuid: $workspaceUuid, teamUuid: $teamUuid) {
+			id
+		}
+	}
+	`
 )

--- a/houston/teams.go
+++ b/houston/teams.go
@@ -1,0 +1,29 @@
+package houston
+
+// GetTeam - return a specific team
+func (h ClientImplementation) GetTeam(teamID string) (*Team, error) {
+	req := Request{
+		Query:     TeamGetRequest,
+		Variables: map[string]interface{}{"teamUuid": teamID},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+	return r.Data.GetTeam, nil
+}
+
+// GetTeamUsers - return a specific teams Users
+func (h ClientImplementation) GetTeamUsers(teamID string) ([]User, error) {
+	req := Request{
+		Query:     TeamGetUsersRequest,
+		Variables: map[string]interface{}{"teamUuid": teamID},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+	return r.Data.GetTeamUsers, nil
+}

--- a/houston/teams_test.go
+++ b/houston/teams_test.go
@@ -1,0 +1,100 @@
+package houston
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTeam(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	mockResponse := &Response{
+		Data: ResponseData{
+			GetTeam: &Team{
+				Name: "Everyone",
+				ID:   "blah-id",
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.GetTeam("team-id")
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.GetTeam)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.GetTeam("team-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestGetTeamUsers(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	mockResponse := &Response{
+		Data: ResponseData{
+			GetTeamUsers: []User{
+				{
+					Username: "email@email.com",
+					ID:       "test-id",
+				},
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.GetTeamUsers("team-id")
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.GetTeamUsers)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.GetTeamUsers("team-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}

--- a/houston/types.go
+++ b/houston/types.go
@@ -50,6 +50,12 @@ type ResponseData struct {
 	DeploymentConfig               DeploymentConfig            `json:"deploymentConfig,omitempty"`
 	GetDeploymentNamespaces        []Namespace                 `json:"availableNamespaces,omitempty"`
 	RuntimeReleases                RuntimeReleases             `json:"runtimeReleases,omitempty"`
+	GetTeam                        *Team                       `json:"team,omitempty"`
+	GetTeamUsers                   []User                      `json:"teamUsers,omitempty"`
+	AddWorkspaceTeam               *Workspace                  `json:"workspaceAddTeam,omitempty"`
+	RemoveWorkspaceTeam            *Workspace                  `json:"workspaceRemoveTeam,omitempty"`
+	WorkspaceUpdateTeamRole        string                      `json:"workspaceUpdateTeamRole,omitempty"`
+	WorkspaceGetTeams              []Team                      `json:"workspaceTeams,omitempty"`
 }
 
 type Namespace struct {
@@ -205,9 +211,20 @@ type User struct {
 	Emails   []Email `json:"emails"`
 	Username string  `json:"username"`
 	Status   string  `json:"status"`
+	Teams    []Team  `json:"teams"`
 	// created at
 	// updated at
 	// profile
+}
+
+// Team contains all components of an Astronomer Team
+type Team struct {
+	ID           string        `json:"id"`
+	Name         string        `json:"name"`
+	SortID       int           `json:"sortId"`
+	CreatedAt    string        `json:"createdAt"`
+	UpdatedAt    string        `json:"updatedAt"`
+	RoleBindings []RoleBinding `json:"roleBindings"`
 }
 
 type RoleBindingWorkspace struct {
@@ -225,11 +242,17 @@ type WorkspaceUserRoleBindings struct {
 	RoleBindings []RoleBindingWorkspace `json:"roleBindings"`
 }
 
+type WorkspaceTeamRoleBindings struct {
+	RoleBindings []RoleBindingWorkspace `json:"roleBindings"`
+}
+
 type RoleBinding struct {
 	Role           string                  `json:"role"`
 	User           RoleBindingUser         `json:"user"`
 	ServiceAccount WorkspaceServiceAccount `json:"serviceAccount"`
 	Deployment     Deployment              `json:"deployment"`
+	Team           Team                    `json:"team"`
+	Workspace      Workspace               `json:"workspace"`
 }
 
 type RoleBindingUser struct {

--- a/houston/workspace_teams.go
+++ b/houston/workspace_teams.go
@@ -1,0 +1,76 @@
+package houston
+
+// AddTeamToWorkspace - add a team to a workspace
+func (h ClientImplementation) AddWorkspaceTeam(workspaceID, teamID, role string) (*Workspace, error) {
+	req := Request{
+		Query:     WorkspaceTeamAddRequest,
+		Variables: map[string]interface{}{"workspaceUuid": workspaceID, "teamUuid": teamID, "role": role},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return r.Data.AddWorkspaceTeam, nil
+}
+
+// RemoveTeamFromWorkspace - remove a team from a workspace
+func (h ClientImplementation) DeleteWorkspaceTeam(workspaceID, teamID string) (*Workspace, error) {
+	req := Request{
+		Query:     WorkspaceTeamRemoveRequest,
+		Variables: map[string]interface{}{"workspaceUuid": workspaceID, "teamUuid": teamID},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return r.Data.RemoveWorkspaceTeam, nil
+}
+
+// ListTeamAndRolesFromWorkspace - list teams and roles from a workspace
+func (h ClientImplementation) ListWorkspaceTeamsAndRoles(workspaceID string) ([]Team, error) {
+	req := Request{
+		Query:     WorkspaceGetTeamsRequest,
+		Variables: map[string]interface{}{"workspaceUuid": workspaceID},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return r.Data.WorkspaceGetTeams, nil
+}
+
+// UpdateTeamRoleInWorkspace - update a team role in a workspace
+func (h ClientImplementation) UpdateWorkspaceTeamRole(workspaceID, teamID, role string) (string, error) {
+	req := Request{
+		Query:     WorkspaceTeamUpdateRequest,
+		Variables: map[string]interface{}{"workspaceUuid": workspaceID, "teamUuid": teamID, "role": role},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return "", handleAPIErr(err)
+	}
+
+	return r.Data.WorkspaceUpdateTeamRole, nil
+}
+
+// GetTeamRoleInWorkspace - get a team role in a workspace
+func (h ClientImplementation) GetWorkspaceTeamRole(workspaceID, teamID string) (*Team, error) {
+	req := Request{
+		Query:     TeamGetRequest,
+		Variables: map[string]interface{}{"workspaceUuid": workspaceID, "teamUuid": teamID},
+	}
+
+	r, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return r.Data.GetTeam, nil
+}

--- a/houston/workspace_teams_test.go
+++ b/houston/workspace_teams_test.go
@@ -1,0 +1,231 @@
+package houston
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddWorkspaceTeam(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	mockResponse := &Response{
+		Data: ResponseData{
+			AddWorkspaceTeam: &Workspace{
+				ID:          "workspace-id",
+				Label:       "label",
+				Description: "description",
+				CreatedAt:   "2020-06-25T22:10:42.385Z",
+				UpdatedAt:   "2020-06-25T22:10:42.385Z",
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.AddWorkspaceTeam("workspace-id", "team-id", "role")
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.AddWorkspaceTeam)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.AddWorkspaceTeam("workspace-id", "team-id", "role")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestDeleteWorkspaceTeam(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	mockResponse := &Response{
+		Data: ResponseData{
+			RemoveWorkspaceTeam: &Workspace{
+				ID:          "workspace-id",
+				Label:       "label",
+				Description: "description",
+				CreatedAt:   "2020-06-25T22:10:42.385Z",
+				UpdatedAt:   "2020-06-25T22:10:42.385Z",
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.DeleteWorkspaceTeam("workspace-id", "user-id")
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.RemoveWorkspaceTeam)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.DeleteWorkspaceTeam("workspace-id", "user-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestListWorkspaceTeamsAndRoles(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	mockResponse := []Team{
+		{
+			ID: "test-id",
+		},
+	}
+	jsonResponse, err := json.Marshal(Response{Data: ResponseData{
+		WorkspaceGetTeams: []Team{
+			{
+				ID: "test-id",
+			},
+		},
+	}})
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.ListWorkspaceTeamsAndRoles("workspace-id")
+		assert.NoError(t, err)
+		assert.Equal(t, mockResponse, response)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.ListWorkspaceTeamsAndRoles("workspace-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestUpdateWorkspaceTeamAndRole(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	mockResponse := &Response{
+		Data: ResponseData{
+			WorkspaceUpdateTeamRole: WorkspaceAdminRole,
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.UpdateWorkspaceTeamRole("workspace-id", "team-id", WorkspaceAdminRole)
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.WorkspaceUpdateTeamRole)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.UpdateWorkspaceTeamRole("workspace-id", "team-id", "role")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
+func TestGetWorkspaceTeamRole(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	var mockResponse *Team
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.GetWorkspaceTeamRole("workspace-id", "team-id")
+		assert.NoError(t, err)
+		assert.Equal(t, mockResponse, response)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.GetWorkspaceTeamRole("workspace-id", "team-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}

--- a/software/teams/teams.go
+++ b/software/teams/teams.go
@@ -1,0 +1,48 @@
+package teams
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/printutil"
+	"github.com/sirupsen/logrus"
+)
+
+var errMissingTeamID = errors.New("missing team ID")
+
+// retrieves a team and all of its users if passed optional param
+func Get(teamID string, usersEnabled bool, client houston.ClientInterface, out io.Writer) error {
+	if teamID == "" {
+		return errMissingTeamID
+	}
+	team, err := client.GetTeam(teamID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("\n Team Name: %s and team id: %s \n", team.Name, team.ID)
+
+	if usersEnabled {
+		logrus.Debug("retrieving users part of team")
+		fmt.Println("Users part of Team:")
+		users, err := client.GetTeamUsers(teamID)
+		if err != nil {
+			return err
+		}
+		teamUsersTable := printutil.Table{
+			Padding:        []int{44, 50},
+			DynamicPadding: true,
+			Header:         []string{"USERNAME", "ID"},
+			ColorRowCode:   [2]string{"\033[1;32m", "\033[0m"},
+		}
+		for i := range users {
+			user := users[i]
+			teamUsersTable.AddRow([]string{user.Username, user.ID}, false)
+		}
+		return teamUsersTable.Print(out)
+	}
+
+	return nil
+}

--- a/software/workspace/teams.go
+++ b/software/workspace/teams.go
@@ -1,0 +1,105 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/printutil"
+)
+
+var errTeamNotInWorkspace = errors.New("the team you are trying to change is not part of this workspace")
+
+// Add a team to a workspace with specified role
+// nolint: dupl
+func AddTeam(workspaceID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
+	w, err := client.AddWorkspaceTeam(workspaceID, teamID, role)
+	if err != nil {
+		return err
+	}
+
+	tab := printutil.Table{
+		Padding:        []int{44, 50},
+		DynamicPadding: true,
+		Header:         []string{"NAME", "WORKSPACE ID", "TEAM ID", "ROLE"},
+	}
+
+	tab.AddRow([]string{w.Label, w.ID, teamID, role}, false)
+	tab.SuccessMsg = fmt.Sprintf("Successfully added %s to %s", teamID, w.Label)
+	tab.Print(out)
+
+	return nil
+}
+
+// Remove a team from a workspace
+func RemoveTeam(workspaceID, teamID string, client houston.ClientInterface, out io.Writer) error {
+	w, err := client.DeleteWorkspaceTeam(workspaceID, teamID)
+	if err != nil {
+		return err
+	}
+
+	utab := printutil.Table{
+		Padding: []int{30, 50, 50},
+		Header:  []string{"NAME", "WORKSPACE ID", "TEAM ID"},
+	}
+
+	utab.AddRow([]string{w.Label, w.ID, teamID}, false)
+	utab.SuccessMsg = "Successfully removed team from workspace"
+	utab.Print(out)
+	return nil
+}
+
+// ListRoles print teams and roles from a workspace
+func ListTeamRoles(workspaceID string, client houston.ClientInterface, out io.Writer) error {
+	workspaceTeams, err := client.ListWorkspaceTeamsAndRoles(workspaceID)
+	if err != nil {
+		return err
+	}
+
+	tab := printutil.Table{
+		Padding:        []int{44, 50},
+		DynamicPadding: true,
+		Header:         []string{"WORKSPACE ID", "TEAM ID", "TEAM NAME", "ROLE"},
+	}
+	for i := range workspaceTeams {
+		for j := range workspaceTeams[i].RoleBindings {
+			tab.AddRow([]string{workspaceID, workspaceTeams[i].ID, workspaceTeams[i].Name, workspaceTeams[i].RoleBindings[j].Role}, false)
+		}
+	}
+	tab.Print(out)
+	return nil
+}
+
+// Update workspace team role
+// nolint: dupl
+func UpdateTeamRole(workspaceID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
+	// get team you are updating to show role from before change
+	teams, err := client.GetWorkspaceTeamRole(workspaceID, teamID)
+
+	if teams == nil || err != nil {
+		return errTeamNotInWorkspace
+	}
+
+	var rb *houston.RoleBinding
+	roles := teams.RoleBindings
+	for i := range roles {
+		if roles[i].Workspace.ID == workspaceID && strings.Contains(roles[i].Role, "WORKSPACE") {
+			rb = &roles[i]
+			break
+		}
+	}
+	// check if rolebinding is an empty structure
+	if rb == nil {
+		return errTeamNotInWorkspace
+	}
+
+	newRole, err := client.UpdateWorkspaceTeamRole(workspaceID, teamID, role)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Role has been changed from %s to %s for team %s", rb.Role, newRole, teamID)
+	return nil
+}

--- a/software/workspace/teams_test.go
+++ b/software/workspace/teams_test.go
@@ -1,0 +1,150 @@
+package workspace
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/astronomer/astro-cli/houston"
+	houston_mocks "github.com/astronomer/astro-cli/houston/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddTeam(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("AddWorkspaceTeam", "workspace-id", "team-id", "role").Return(&houston.Workspace{ID: "workspace-id", Label: "label"}, nil)
+
+		buf := new(bytes.Buffer)
+		err := AddTeam("workspace-id", "team-id", "role", mock, buf)
+
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "workspace-id")
+		assert.Contains(t, buf.String(), "team-id")
+		mock.AssertExpectations(t)
+	})
+
+	t.Run("houston failure", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("AddWorkspaceTeam", "workspace-id", "team-id", "role").Return(nil, errMock)
+
+		buf := new(bytes.Buffer)
+		err := AddTeam("workspace-id", "team-id", "role", mock, buf)
+
+		assert.ErrorIs(t, err, errMock)
+		mock.AssertExpectations(t)
+	})
+}
+
+func TestRemoveTeam(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("DeleteWorkspaceTeam", "workspace-id", "team-id").Return(&houston.Workspace{ID: "workspace-id", Label: "label"}, nil)
+
+		buf := new(bytes.Buffer)
+		err := RemoveTeam("workspace-id", "team-id", mock, buf)
+
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "workspace-id")
+		assert.Contains(t, buf.String(), "team-id")
+		mock.AssertExpectations(t)
+	})
+
+	t.Run("houston failure", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("DeleteWorkspaceTeam", "workspace-id", "team-id").Return(nil, errMock)
+
+		buf := new(bytes.Buffer)
+		err := RemoveTeam("workspace-id", "team-id", mock, buf)
+
+		assert.ErrorIs(t, err, errMock)
+		mock.AssertExpectations(t)
+	})
+}
+
+func TestListTeamRoles(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("ListWorkspaceTeamsAndRoles", "workspace-id").Return([]houston.Team{{ID: "test-id-1", Name: "test-name-1", RoleBindings: []houston.RoleBinding{{Role: "test-role-1"}}}, {ID: "test-id-2", Name: "test-name-2", RoleBindings: []houston.RoleBinding{{Role: "test-role-2"}}}}, nil)
+
+		buf := new(bytes.Buffer)
+		err := ListTeamRoles("workspace-id", mock, buf)
+
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "workspace-id")
+		assert.Contains(t, buf.String(), "test-id-1")
+		assert.Contains(t, buf.String(), "test-id-2")
+		mock.AssertExpectations(t)
+	})
+
+	t.Run("houston failure", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("ListWorkspaceTeamsAndRoles", "workspace-id").Return([]houston.Team{}, errMock)
+
+		buf := new(bytes.Buffer)
+		err := ListTeamRoles("workspace-id", mock, buf)
+
+		assert.ErrorIs(t, err, errMock)
+		mock.AssertExpectations(t)
+	})
+}
+
+func TestUpdateTeamRole(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("GetWorkspaceTeamRole", "workspace-id", "team-id").Return(&houston.Team{ID: "test-id", RoleBindings: []houston.RoleBinding{{Workspace: houston.Workspace{ID: "workspace-id"}, Role: houston.WorkspaceAdminRole}}}, nil)
+		mock.On("UpdateWorkspaceTeamRole", "workspace-id", "team-id", "role-id").Return("role-id", nil)
+
+		buf := new(bytes.Buffer)
+		err := UpdateTeamRole("workspace-id", "team-id", "role-id", mock, buf)
+
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "team-id")
+		assert.Contains(t, buf.String(), "role-id")
+		mock.AssertExpectations(t)
+	})
+
+	t.Run("teams not in workspace", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("GetWorkspaceTeamRole", "workspace-id", "team-id").Return(nil, nil)
+
+		buf := new(bytes.Buffer)
+		err := UpdateTeamRole("workspace-id", "team-id", "role-id", mock, buf)
+
+		assert.ErrorIs(t, err, errTeamNotInWorkspace)
+		mock.AssertExpectations(t)
+	})
+
+	t.Run("GetWorkspaceTeamRole failure", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("GetWorkspaceTeamRole", "workspace-id", "team-id").Return(nil, errMock)
+
+		buf := new(bytes.Buffer)
+		err := UpdateTeamRole("workspace-id", "team-id", "role-id", mock, buf)
+
+		assert.ErrorIs(t, err, errTeamNotInWorkspace)
+		mock.AssertExpectations(t)
+	})
+
+	t.Run("rolebinding not present", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("GetWorkspaceTeamRole", "workspace-id", "team-id").Return(&houston.Team{ID: "test-id", RoleBindings: []houston.RoleBinding{}}, nil)
+
+		buf := new(bytes.Buffer)
+		err := UpdateTeamRole("workspace-id", "team-id", "role-id", mock, buf)
+
+		assert.ErrorIs(t, err, errTeamNotInWorkspace)
+		mock.AssertExpectations(t)
+	})
+
+	t.Run("UpdateWorkspaceTeamRole failure", func(t *testing.T) {
+		mock := new(houston_mocks.ClientInterface)
+		mock.On("GetWorkspaceTeamRole", "workspace-id", "team-id").Return(&houston.Team{ID: "test-id", RoleBindings: []houston.RoleBinding{{Workspace: houston.Workspace{ID: "workspace-id"}, Role: houston.WorkspaceAdminRole}}}, nil)
+		mock.On("UpdateWorkspaceTeamRole", "workspace-id", "team-id", "role-id").Return("", errMock)
+
+		buf := new(bytes.Buffer)
+		err := UpdateTeamRole("workspace-id", "team-id", "role-id", mock, buf)
+
+		assert.ErrorIs(t, err, errMock)
+		mock.AssertExpectations(t)
+	})
+}

--- a/software/workspace/user.go
+++ b/software/workspace/user.go
@@ -13,6 +13,7 @@ import (
 var errUserNotInWorkspace = errors.New("the user you are trying to change is not part of this workspace")
 
 // Add a user to a workspace with specified role
+// nolint: dupl
 func Add(workspaceID, email, role string, client houston.ClientInterface, out io.Writer) error {
 	w, err := client.AddWorkspaceUser(workspaceID, email, role)
 	if err != nil {
@@ -33,6 +34,7 @@ func Add(workspaceID, email, role string, client houston.ClientInterface, out io
 }
 
 // Remove a user from a workspace
+// nolint: dupl
 func Remove(workspaceID, userID string, client houston.ClientInterface, out io.Writer) error {
 	w, err := client.DeleteWorkspaceUser(workspaceID, userID)
 	if err != nil {


### PR DESCRIPTION
## Description
Changes:
- Migrated existing PRs present in `software-v0` to the `main` branch.
- Added more tests to bring up the coverage
PRs migrated:
- https://github.com/astronomer/astro-cli/pull/518
- https://github.com/astronomer/astro-cli/pull/524
- https://github.com/astronomer/astro-cli/pull/526
- https://github.com/astronomer/astro-cli/pull/527

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-cli/issues/545

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
