### PR TITLE
redo image-name feature

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -24,8 +24,8 @@ type ContainerHandler interface {
 	Kill() error
 	Logs(follow bool, containerNames ...string) error
 	Run(args []string, user string) error
-	Pytest(pytestFile, projectImageName string) (string, error)
-	Parse(buildImage string) error
+	Pytest(imageName, pytestFile, projectImageName string) (string, error)
+	Parse(imageName, buildImage string) error
 }
 
 // RegistryHandler defines methods require to handle all operations with registry
@@ -35,11 +35,10 @@ type RegistryHandler interface {
 
 // ImageHandler defines methods require to handle all operations on/for container images
 type ImageHandler interface {
-	Build(config types.ImageBuildConfig) error
+	Build(localImage string, config types.ImageBuildConfig) error
 	Push(registry, username, token, remoteImage string) error
 	GetLabel(labelName string) (string, error)
 	ListLabels() (map[string]string, error)
-	TagLocalImage(localImage string) error
 }
 
 type DockerComposeAPI interface {

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -155,19 +155,10 @@ func (d *DockerCompose) Start(imageName string, noCache bool) error {
 		}
 	}
 
-	// Build this project image
-	// if imageName == "" {
 	err = d.imageHandler.Build(imageName, airflowTypes.ImageBuildConfig{Path: d.airflowHome, Output: true, NoCache: noCache})
 	if err != nil {
 		return err
 	}
-	// } else {
-	// 	// skip build if an imageName is passed
-	// 	err := d.imageHandler.TagLocalImage(imageName)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
 
 	imageLabels, err := d.imageHandler.ListLabels()
 	if err != nil {

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -39,8 +39,17 @@ func DockerImageInit(image string) *DockerImage {
 	return &DockerImage{imageName: image}
 }
 
-func (d *DockerImage) Build(config airflowTypes.ImageBuildConfig) error {
+func (d *DockerImage) Build(localImage string, config airflowTypes.ImageBuildConfig) error {
 	// Change to location of Dockerfile
+	if localImage != "" {
+		// skip build if an local image is passed
+		err := cmdExec(DockerCmd, nil, nil, "tag", localImage, d.imageName)
+		if err != nil {
+			return fmt.Errorf("command 'docker tag %s %s' failed: %w", localImage, d.imageName, err)
+		}
+		return nil
+	}
+
 	err := os.Chdir(config.Path)
 	if err != nil {
 		return err
@@ -185,14 +194,6 @@ func (d *DockerImage) ListLabels() (map[string]string, error) {
 		return labels, err
 	}
 	return labels, nil
-}
-
-func (d *DockerImage) TagLocalImage(localImage string) error {
-	err := cmdExec(DockerCmd, nil, nil, "tag", localImage, d.imageName)
-	if err != nil {
-		return fmt.Errorf("command 'docker tag %s %s' failed: %w", localImage, d.imageName, err)
-	}
-	return nil
 }
 
 // Exec executes a docker command

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -34,7 +34,7 @@ func TestDockerImageBuild(t *testing.T) {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 			return nil
 		}
-		err = handler.Build(options)
+		err = handler.Build("", options)
 		assert.NoError(t, err)
 	})
 
@@ -44,7 +44,7 @@ func TestDockerImageBuild(t *testing.T) {
 			assert.Contains(t, args, "--no-cache")
 			return nil
 		}
-		err = handler.Build(options)
+		err = handler.Build("", options)
 		assert.NoError(t, err)
 	})
 
@@ -52,7 +52,7 @@ func TestDockerImageBuild(t *testing.T) {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 			return errMock
 		}
-		err = handler.Build(options)
+		err = handler.Build("", options)
 		assert.Contains(t, err.Error(), errMock.Error())
 	})
 
@@ -195,31 +195,31 @@ func TestDockerImageListLabel(t *testing.T) {
 	})
 }
 
-func TestDockerTagLocalImage(t *testing.T) {
-	handler := DockerImage{
-		imageName: "testing",
-	}
+// func TestDockerTagLocalImage(t *testing.T) {
+// 	handler := DockerImage{
+// 		imageName: "testing",
+// 	}
 
-	previousCmdExec := cmdExec
+// 	previousCmdExec := cmdExec
 
-	t.Run("rename local image success", func(t *testing.T) {
-		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
-			return nil
-		}
-		err := handler.TagLocalImage("custom-image")
-		assert.NoError(t, err)
-	})
+// 	t.Run("rename local image success", func(t *testing.T) {
+// 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+// 			return nil
+// 		}
+// 		err := handler.TagLocalImage("custom-image")
+// 		assert.NoError(t, err)
+// 	})
 
-	t.Run("rename local image error", func(t *testing.T) {
-		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
-			return errMock
-		}
-		err := handler.TagLocalImage("custom-image")
-		assert.Contains(t, err.Error(), errMock.Error())
-	})
+// 	t.Run("rename local image error", func(t *testing.T) {
+// 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+// 			return errMock
+// 		}
+// 		err := handler.TagLocalImage("custom-image")
+// 		assert.Contains(t, err.Error(), errMock.Error())
+// 	})
 
-	cmdExec = previousCmdExec
-}
+// 	cmdExec = previousCmdExec
+// }
 
 func TestExecCmd(t *testing.T) {
 	t.Run("success", func(t *testing.T) {

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -203,32 +203,6 @@ func TestDockerImageListLabel(t *testing.T) {
 	})
 }
 
-// func TestDockerTagLocalImage(t *testing.T) {
-// 	handler := DockerImage{
-// 		imageName: "testing",
-// 	}
-
-// 	previousCmdExec := cmdExec
-
-// 	t.Run("rename local image success", func(t *testing.T) {
-// 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
-// 			return nil
-// 		}
-// 		err := handler.TagLocalImage("custom-image")
-// 		assert.NoError(t, err)
-// 	})
-
-// 	t.Run("rename local image error", func(t *testing.T) {
-// 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
-// 			return errMock
-// 		}
-// 		err := handler.TagLocalImage("custom-image")
-// 		assert.Contains(t, err.Error(), errMock.Error())
-// 	})
-
-// 	cmdExec = previousCmdExec
-// }
-
 func TestExecCmd(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		stdout := new(bytes.Buffer)

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -38,6 +38,14 @@ func TestDockerImageBuild(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("build custom-image", func(t *testing.T) {
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			return nil
+		}
+		err = handler.Build("custom-image", options)
+		assert.NoError(t, err)
+	})
+
 	t.Run("build --no-cache", func(t *testing.T) {
 		options.NoCache = true
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -192,9 +192,9 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Twice()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Twice()
-		imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
+		// imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Twice()
@@ -246,7 +246,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("image build failure", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(errMockDocker).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Once()
@@ -270,7 +270,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("list label failure", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{}, errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -295,7 +295,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("compose up failure", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{}, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -321,7 +321,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("webserver health check failure", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -578,7 +578,7 @@ func TestDockerComposePytest(t *testing.T) {
 	mockDockerCompose := DockerCompose{projectName: "test"}
 	t.Run("success", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -595,7 +595,7 @@ func TestDockerComposePytest(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("test", "")
+		resp, err := mockDockerCompose.Pytest("", "test", "")
 		assert.NoError(t, err)
 		assert.Equal(t, "", resp)
 		composeMock.AssertExpectations(t)
@@ -604,7 +604,7 @@ func TestDockerComposePytest(t *testing.T) {
 
 	t.Run("unexpected exit code", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -621,7 +621,7 @@ func TestDockerComposePytest(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("test", "")
+		resp, err := mockDockerCompose.Pytest("", "test", "")
 		assert.Contains(t, err.Error(), "something went wrong while Pytesting your DAGs")
 		assert.Equal(t, mockResponse, resp)
 		composeMock.AssertExpectations(t)
@@ -630,7 +630,7 @@ func TestDockerComposePytest(t *testing.T) {
 
 	t.Run("inspect container failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -647,7 +647,7 @@ func TestDockerComposePytest(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		_, err := mockDockerCompose.Pytest("test", "")
+		_, err := mockDockerCompose.Pytest("", "test", "")
 		assert.ErrorIs(t, err, errMockDocker)
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -655,7 +655,7 @@ func TestDockerComposePytest(t *testing.T) {
 
 	t.Run("no test containers", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -666,7 +666,7 @@ func TestDockerComposePytest(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		_, err := mockDockerCompose.Pytest("test", "")
+		_, err := mockDockerCompose.Pytest("", "test", "")
 		assert.Contains(t, err.Error(), "error finding the testing container")
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -674,7 +674,7 @@ func TestDockerComposePytest(t *testing.T) {
 
 	t.Run("compose ps failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -685,7 +685,7 @@ func TestDockerComposePytest(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		_, err := mockDockerCompose.Pytest("test", "")
+		_, err := mockDockerCompose.Pytest("", "test", "")
 		assert.ErrorIs(t, err, errMockDocker)
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -693,7 +693,7 @@ func TestDockerComposePytest(t *testing.T) {
 
 	t.Run("compose up failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -702,7 +702,7 @@ func TestDockerComposePytest(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		_, err := mockDockerCompose.Pytest("test", "")
+		_, err := mockDockerCompose.Pytest("", "test", "")
 		assert.ErrorIs(t, err, errMockDocker)
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -710,23 +710,23 @@ func TestDockerComposePytest(t *testing.T) {
 
 	t.Run("list labels failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{}, errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		_, err := mockDockerCompose.Pytest("test", "")
+		_, err := mockDockerCompose.Pytest("", "test", "")
 		assert.ErrorIs(t, err, errMockDocker)
 		imageHandler.AssertExpectations(t)
 	})
 
 	t.Run("image build failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
+		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		_, err := mockDockerCompose.Pytest("test", "")
+		_, err := mockDockerCompose.Pytest("", "test", "")
 		assert.ErrorIs(t, err, errMockDocker)
 		imageHandler.AssertExpectations(t)
 	})
@@ -755,7 +755,7 @@ func TestDockerComposeParse(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("test")
+		err := mockDockerCompose.Parse("", "test")
 		assert.NoError(t, err)
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -781,7 +781,7 @@ func TestDockerComposeParse(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("test")
+		err := mockDockerCompose.Parse("", "test")
 		assert.Contains(t, err.Error(), "errors detected in your local DAGs are listed above")
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -807,7 +807,7 @@ func TestDockerComposeParse(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("test")
+		err := mockDockerCompose.Parse("", "test")
 		assert.Contains(t, err.Error(), "something went wrong while parsing your DAGs")
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -821,7 +821,7 @@ func TestDockerComposeParse(t *testing.T) {
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 
-		err := mockDockerCompose.Parse("test")
+		err := mockDockerCompose.Parse("", "test")
 		assert.NoError(t, err)
 
 		w.Close()
@@ -833,7 +833,7 @@ func TestDockerComposeParse(t *testing.T) {
 	t.Run("invalid file name", func(t *testing.T) {
 		DefaultTestPath = "\x0004"
 
-		err := mockDockerCompose.Parse("test")
+		err := mockDockerCompose.Parse("", "test")
 		assert.Contains(t, err.Error(), "invalid argument")
 	})
 }

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -194,7 +194,6 @@ func TestDockerComposeStart(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Twice()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Twice()
-		// imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Twice()

--- a/airflow/mocks/ContainerHandler.go
+++ b/airflow/mocks/ContainerHandler.go
@@ -58,13 +58,13 @@ func (_m *ContainerHandler) PS() error {
 	return r0
 }
 
-// Parse provides a mock function with given fields: buildImage
-func (_m *ContainerHandler) Parse(buildImage string) error {
-	ret := _m.Called(buildImage)
+// Parse provides a mock function with given fields: imageName, buildImage
+func (_m *ContainerHandler) Parse(imageName string, buildImage string) error {
+	ret := _m.Called(imageName, buildImage)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(buildImage)
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(imageName, buildImage)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -72,20 +72,20 @@ func (_m *ContainerHandler) Parse(buildImage string) error {
 	return r0
 }
 
-// Pytest provides a mock function with given fields: pytestFile, projectImageName
-func (_m *ContainerHandler) Pytest(pytestFile string, projectImageName string) (string, error) {
-	ret := _m.Called(pytestFile, projectImageName)
+// Pytest provides a mock function with given fields: imageName, pytestFile, projectImageName
+func (_m *ContainerHandler) Pytest(imageName string, pytestFile string, projectImageName string) (string, error) {
+	ret := _m.Called(imageName, pytestFile, projectImageName)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string, string) string); ok {
-		r0 = rf(pytestFile, projectImageName)
+	if rf, ok := ret.Get(0).(func(string, string, string) string); ok {
+		r0 = rf(imageName, pytestFile, projectImageName)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(pytestFile, projectImageName)
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(imageName, pytestFile, projectImageName)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/airflow/mocks/ImageHandler.go
+++ b/airflow/mocks/ImageHandler.go
@@ -12,13 +12,13 @@ type ImageHandler struct {
 	mock.Mock
 }
 
-// Build provides a mock function with given fields: config
-func (_m *ImageHandler) Build(config types.ImageBuildConfig) error {
-	ret := _m.Called(config)
+// Build provides a mock function with given fields: localImage, config
+func (_m *ImageHandler) Build(localImage string, config types.ImageBuildConfig) error {
+	ret := _m.Called(localImage, config)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(types.ImageBuildConfig) error); ok {
-		r0 = rf(config)
+	if rf, ok := ret.Get(0).(func(string, types.ImageBuildConfig) error); ok {
+		r0 = rf(localImage, config)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -77,20 +77,6 @@ func (_m *ImageHandler) Push(registry string, username string, token string, rem
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
 		r0 = rf(registry, username, token, remoteImage)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// TagLocalImage provides a mock function with given fields: localImage
-func (_m *ImageHandler) TagLocalImage(localImage string) error {
-	ret := _m.Called(localImage)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(localImage)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -260,18 +260,10 @@ func buildImage(c *config.Context, path, currentVersion, deployImage, imageName 
 
 	imageHandler := airflowImageHandler(deployImage)
 
-	// if imageName == "" {
 	err := imageHandler.Build(imageName, types.ImageBuildConfig{Path: path, Output: true})
 	if err != nil {
 		return "", err
 	}
-	// } else {
-	// 	// skip build if an imageName is passed
-	// 	err := imageHandler.TagLocalImage(imageName)
-	// 	if err != nil {
-	// 		return "", err
-	// 	}
-	// }
 
 	// parse dockerfile
 	cmds, err := docker.ParseFile(filepath.Join(path, dockerfile))

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -187,7 +187,7 @@ func parseDAG(pytest, version, envFile, deployImage, namespace string) error {
 	if pytest == parse && dagParseVersionCheck {
 		if !config.CFG.SkipParse.GetBool() && !util.CheckEnvBool(os.Getenv("ASTRONOMER_SKIP_PARSE")) {
 			fmt.Println("Testing image...")
-			err := containerHandler.Parse(deployImage)
+			err := containerHandler.Parse("", deployImage)
 			if err != nil {
 				fmt.Println(err)
 				return errDagsParseFailed
@@ -212,7 +212,7 @@ func checkPytest(pytest, deployImage string, containerHandler airflow.ContainerH
 		pytestFile = pytest
 	}
 
-	exitCode, err := containerHandler.Pytest(pytestFile, deployImage)
+	exitCode, err := containerHandler.Pytest("", pytestFile, deployImage)
 	if err != nil {
 		if strings.Contains(exitCode, "1") { // exit code is 1 meaning tests failed
 			return errors.New("at least 1 pytest in your tests directory failed. Fix the issues listed or rerun the command without the '--pytest' flag to deploy")
@@ -260,18 +260,18 @@ func buildImage(c *config.Context, path, currentVersion, deployImage, imageName 
 
 	imageHandler := airflowImageHandler(deployImage)
 
-	if imageName == "" {
-		err := imageHandler.Build(types.ImageBuildConfig{Path: path, Output: true})
-		if err != nil {
-			return "", err
-		}
-	} else {
-		// skip build if an imageName is passed
-		err := imageHandler.TagLocalImage(imageName)
-		if err != nil {
-			return "", err
-		}
+	// if imageName == "" {
+	err := imageHandler.Build(imageName, types.ImageBuildConfig{Path: path, Output: true})
+	if err != nil {
+		return "", err
 	}
+	// } else {
+	// 	// skip build if an imageName is passed
+	// 	err := imageHandler.TagLocalImage(imageName)
+	// 	if err != nil {
+	// 		return "", err
+	// 	}
+	// }
 
 	// parse dockerfile
 	cmds, err := docker.ParseFile(filepath.Join(path, dockerfile))

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -55,7 +55,6 @@ func TestDeploySuccess(t *testing.T) {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("", nil)
-		// mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
 	}
 

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -52,17 +52,17 @@ func TestDeploySuccess(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("", nil)
-		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
+		// mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
 	}
 
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string, isPyTestCompose bool) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything).Return(nil)
-		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything).Return("", nil)
+		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(nil)
+		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}
 
@@ -129,14 +129,14 @@ func TestDeployFailure(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("4.2.5", nil)
 		return mockImageHandler
 	}
 
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string, isPyTestCompose bool) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything).Return(errMock)
+		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(errMock)
 		return mockContainerHandler, nil
 	}
 
@@ -172,7 +172,7 @@ func TestBuildImageFailure(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("4.2.5", nil)
 		return mockImageHandler
 	}
@@ -238,7 +238,7 @@ func TestCheckPyTest(t *testing.T) {
 	mockDeployImage := "test-image"
 
 	mockContainerHandler := new(mocks.ContainerHandler)
-	mockContainerHandler.On("Pytest", "", mockDeployImage).Return("", errMock).Once()
+	mockContainerHandler.On("Pytest", mock.Anything, "", mockDeployImage).Return("", errMock).Once()
 
 	// random error on running airflow pytest
 	err := checkPytest("", mockDeployImage, mockContainerHandler)
@@ -246,7 +246,7 @@ func TestCheckPyTest(t *testing.T) {
 	mockContainerHandler.AssertExpectations(t)
 
 	// airflow pytest exited with status code 1
-	mockContainerHandler.On("Pytest", "", mockDeployImage).Return("exit code 1", errMock).Once()
+	mockContainerHandler.On("Pytest", mock.Anything, "", mockDeployImage).Return("exit code 1", errMock).Once()
 	err = checkPytest("", mockDeployImage, mockContainerHandler)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least 1 pytest in your tests directory failed. Fix the issues listed or rerun the command without the '--pytest' flag to deploy")

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -27,7 +27,7 @@ var (
 	airflowVersion         string
 	envFile                string
 	pytestFile             string
-	customImageName              string
+	customImageName        string
 	followLogs             bool
 	schedulerLogs          bool
 	webserverLogs          bool

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -27,7 +27,7 @@ var (
 	airflowVersion         string
 	envFile                string
 	pytestFile             string
-	imageName              string
+	customImageName              string
 	followLogs             bool
 	schedulerLogs          bool
 	webserverLogs          bool
@@ -147,7 +147,7 @@ func newAirflowStartCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "Do not use cache when building container image")
-	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom built image to start airflow with")
+	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to start airflow with")
 	return cmd
 }
 
@@ -245,7 +245,7 @@ func newAirflowRestartCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "Do not use cache when building container image")
-	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom built image to start airflow with")
+	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to restart airflow with")
 	return cmd
 }
 
@@ -263,6 +263,7 @@ func newAirflowPytestCmd() *cobra.Command {
 		RunE:    airflowPytest,
 	}
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
+	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to run pytest with")
 	return cmd
 }
 
@@ -280,6 +281,7 @@ func newAirflowParseCmd() *cobra.Command {
 		RunE:    airflowParse,
 	}
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
+	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to run parse with")
 	return cmd
 }
 
@@ -399,7 +401,7 @@ func airflowStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return containerHandler.Start(imageName, noCache)
+	return containerHandler.Start(customImageName, noCache)
 }
 
 // airflowRun
@@ -507,7 +509,7 @@ func airflowRestart(cmd *cobra.Command, args []string) error {
 		envFile = args[0]
 	}
 
-	return containerHandler.Start(imageName, noCache)
+	return containerHandler.Start(customImageName, noCache)
 }
 
 // run pytest on an airflow project
@@ -542,7 +544,7 @@ func airflowPytest(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	exitCode, err := containerHandler.Pytest(pytestFile, "")
+	exitCode, err := containerHandler.Pytest(customImageName, pytestFile, "")
 	if err != nil {
 		if strings.Contains(exitCode, "1") { // exit code is 1 meaning tests failed
 			return errors.New("pytests failed")
@@ -568,7 +570,7 @@ func airflowParse(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return containerHandler.Parse("")
+	return containerHandler.Parse(customImageName, "")
 }
 
 // airflowUpgradeCheck

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -13,6 +13,7 @@ import (
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 var errMock = errors.New("mock error")
@@ -706,7 +707,7 @@ func TestAirflowPytest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string, isPyTestCompose bool) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "").Return("0", nil).Once()
+			mockContainerHandler.On("Pytest", mock.Anything, "test-pytest-file", "").Return("0", nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -722,7 +723,7 @@ func TestAirflowPytest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string, isPyTestCompose bool) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "").Return("exit code 1", errMock).Once()
+			mockContainerHandler.On("Pytest", mock.Anything, "test-pytest-file", "").Return("exit code 1", errMock).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -738,7 +739,7 @@ func TestAirflowPytest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string, isPyTestCompose bool) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "").Return("0", nil).Once()
+			mockContainerHandler.On("Pytest", mock.Anything, "test-pytest-file", "").Return("0", nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -754,7 +755,7 @@ func TestAirflowPytest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string, isPyTestCompose bool) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "").Return("0", errMock).Once()
+			mockContainerHandler.On("Pytest", mock.Anything, "test-pytest-file", "").Return("0", errMock).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -797,7 +798,7 @@ func TestAirflowParse(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string, isPyTestCompose bool) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Parse", "").Return(nil).Once()
+			mockContainerHandler.On("Parse", mock.Anything, "").Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -812,7 +813,7 @@ func TestAirflowParse(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string, isPyTestCompose bool) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Parse", "").Return(errMock).Once()
+			mockContainerHandler.On("Parse", mock.Anything, "").Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -219,7 +219,7 @@ func buildPushDockerImage(houstonClient houston.ClientInterface, c *config.Conte
 		Path:    config.WorkingPath,
 		NoCache: ignoreCacheDeploy,
 	}
-	err = imageHandler.Build(buildConfig)
+	err = imageHandler.Build("", buildConfig)
 	if err != nil {
 		return err
 	}

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -99,7 +99,7 @@ func TestBuildPushDockerImageSuccessWithTagWarning(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		return mockImageHandler
 	}
@@ -130,7 +130,7 @@ func TestBuildPushDockerImageSuccessWithImageRepoWarning(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		return mockImageHandler
 	}
@@ -161,7 +161,7 @@ func TestBuildPushDockerImageSuccessWithBYORegistry(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("", nil).Once()
 		mockImageHandler.On("GetLabel", airflowImageLabel).Return("1.10.12", nil).Once()
@@ -208,7 +208,7 @@ func TestBuildPushDockerImageFailure(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(errSomeContainerIssue)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(errSomeContainerIssue)
 		return mockImageHandler
 	}
 
@@ -219,7 +219,7 @@ func TestBuildPushDockerImageFailure(t *testing.T) {
 
 	mockImageHandler = new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errSomeContainerIssue)
 		return mockImageHandler
 	}
@@ -327,7 +327,7 @@ func TestAirflowSuccess(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		return mockImageHandler
 	}


### PR DESCRIPTION
## Description

update --image-name feature to include pytest and parse commands

## 🎟 Issue(s)

-  https://github.com/astronomer/astro-cli/issues/627

## 🧪 Functional Testing

- added tests to increase coverage

## 📸 Screenshots



## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
