### PR TITLE
fixed circle golang image reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - commit-next-tag
   release:
     docker:
-      - image: circleci/golang:1.18
+      - image: cimg/go:1.18.3
     working_directory: /go/src/github.com/astronomer/astro-cli
     steps:
       - checkout


### PR DESCRIPTION
## Description
Changes:
- Fixed unknown reference from `circle/golang` to `cimp/golang` as `cimp` has superseded the earlier docker image naming convention.
Reference: https://circleci.com/developer/images/image/cimg/go