### PR TITLE
moved from cimg/golang to vanila golang image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - commit-next-tag
   release:
     docker:
-      - image: cimg/go:1.18.3
+      - image: golang:1.18.3
     working_directory: /go/src/github.com/astronomer/astro-cli
     steps:
       - checkout


### PR DESCRIPTION
## Description
Changes:
- Moved from `cimg/golang` to vanilla `golang` image. CircleCI's checkout step is failing on CircleCI's golang image itself.
Reference: https://app.circleci.com/pipelines/github/astronomer/astro-cli/1477/workflows/8542130b-47ba-4301-9bf1-2123fb717ff9/jobs/2075
