### PR TITLE
Update triggerer replicas defaults in create & update deployment flows

### DIFF
--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -35,7 +35,8 @@ var (
 	releaseName             string
 	nfsLocation             string
 	dagDeploymentType       string
-	triggererReplicas       int
+	createTriggererReplicas int
+	updateTriggererReplicas int
 	gitRevision             string
 	gitRepoURL              string
 	gitBranchName           string
@@ -141,7 +142,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	}
 
 	if triggererEnabled {
-		cmd.Flags().IntVarP(&triggererReplicas, "triggerer-replicas", "", 0, "Number of replicas to use for triggerer airflow component, valid 0-2")
+		cmd.Flags().IntVarP(&createTriggererReplicas, "triggerer-replicas", "", 1, "Number of replicas to use for triggerer airflow component, valid 0-2")
 	}
 
 	if runtimeEnabled {
@@ -228,7 +229,7 @@ $ astro deployment update [deployment ID] --dag-deployment-type=volume --nfs-loc
 	}
 
 	if triggererEnabled {
-		cmd.Flags().IntVarP(&triggererReplicas, "triggerer-replicas", "", 0, "Number of replicas to use for triggerer airflow component, valid 0-2")
+		cmd.Flags().IntVarP(&updateTriggererReplicas, "triggerer-replicas", "", -1, "Number of replicas to use for triggerer airflow component, valid 0-2")
 	}
 
 	//noline:dupl
@@ -388,7 +389,7 @@ func deploymentCreate(cmd *cobra.Command, out io.Writer) error {
 		SSHKey:            sshKey,
 		KnownHosts:        knowHosts,
 		GitSyncInterval:   gitSyncInterval,
-		TriggererReplicas: triggererReplicas,
+		TriggererReplicas: createTriggererReplicas,
 	}
 	return deployment.Create(req, houstonClient, out)
 }
@@ -459,7 +460,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 		}
 	}
 
-	return deployment.Update(args[0], cloudRole, argsMap, dagDeploymentType, nfsLocation, gitRepoURL, gitRevision, gitBranchName, gitDAGDir, sshKey, knowHosts, executorType, gitSyncInterval, triggererReplicas, houstonClient, out)
+	return deployment.Update(args[0], cloudRole, argsMap, dagDeploymentType, nfsLocation, gitRepoURL, gitRevision, gitBranchName, gitDAGDir, sshKey, knowHosts, executorType, gitSyncInterval, updateTriggererReplicas, houstonClient, out)
 }
 
 func deploymentAirflowUpgrade(cmd *cobra.Command, out io.Writer) error {


### PR DESCRIPTION
## Description
Changes:
- Update default value for `triggerer-replicas` to 1 in create deployment workflow. Also if the airflow version passed is < 2.2.0 then triggerer-replicas will be passed as 0 to Houston
- Update default value for `triggerer-replicas` to -1 in update deployment workflow. Now only if `triggerer-replicas` != -1 is when the value is passed to Houston to update

## 🎟 Issue(s)

Related https://github.com/astronomer/issues/issues/4844

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
