### PR TITLE
Airflow webserver auto opens

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -33,6 +33,7 @@ import (
 	docker_types "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
+	"github.com/pkg/browser"
 )
 
 const (
@@ -67,6 +68,8 @@ var (
 
 	inspectContainer = inspect.Inspect
 	initSettings     = settings.ConfigSettings
+
+	openURL = browser.OpenURL
 )
 
 // ComposeConfig is input data to docker compose yaml template
@@ -610,10 +613,16 @@ var checkWebserverHealth = func(project *types.Project, composeService api.Servi
 
 				fmt.Println("\nProject is running! All components are now available.")
 				parts := strings.Split(config.CFG.WebserverPort.GetString(), ":")
-				fmt.Printf("\n"+composeLinkWebserverMsg+"\n", ansi.Bold("http://localhost:"+parts[len(parts)-1]))
+				webserverURL := "http://localhost:"+parts[len(parts)-1]
+				fmt.Printf("\n"+composeLinkWebserverMsg+"\n", ansi.Bold(webserverURL))
 				fmt.Printf(composeLinkPostgresMsg+"\n", ansi.Bold("localhost:"+config.CFG.PostgresPort.GetString()+"/postgres"))
 				fmt.Printf(composeUserPasswordMsg+"\n", ansi.Bold("admin:admin"))
 				fmt.Printf(postgresUserPasswordMsg+"\n", ansi.Bold("postgres:postgres"))
+
+				err = openURL(webserverURL)
+				if err != nil {
+					fmt.Println("\nUnable to open the webserver URL, please visit the following link: " + webserverURL)
+				}
 				return errComposeProjectRunning
 			}
 			return nil

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -32,8 +32,8 @@ import (
 	"github.com/docker/compose/v2/pkg/compose"
 	docker_types "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/pkg/errors"
 	"github.com/pkg/browser"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -613,7 +613,7 @@ var checkWebserverHealth = func(project *types.Project, composeService api.Servi
 
 				fmt.Println("\nProject is running! All components are now available.")
 				parts := strings.Split(config.CFG.WebserverPort.GetString(), ":")
-				webserverURL := "http://localhost:"+parts[len(parts)-1]
+				webserverURL := "http://localhost:" + parts[len(parts)-1]
 				fmt.Printf("\n"+composeLinkWebserverMsg+"\n", ansi.Bold(webserverURL))
 				fmt.Printf(composeLinkPostgresMsg+"\n", ansi.Bold("localhost:"+config.CFG.PostgresPort.GetString()+"/postgres"))
 				fmt.Printf(composeUserPasswordMsg+"\n", ansi.Bold("admin:admin"))


### PR DESCRIPTION
## Description

This PR makes it so the local airflow webserver automatically opens at the end of the astro dev start process. This will make it easier for users to find the webserver located at localhost:whatever-port

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/651

## 🧪 Functional Testing



## 📸 Screenshots



## 📋 Checklist

- [X] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
