### PR TITLE
Add support for multi arch runtime images

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -55,6 +55,10 @@ func (d *DockerImage) Build(config airflowTypes.ImageBuildConfig) error {
 	if config.NoCache {
 		args = append(args, "--no-cache")
 	}
+
+	if len(config.TargetPlatforms) > 0 {
+		args = append(args, fmt.Sprintf("--platform=%s", strings.Join(config.TargetPlatforms, ",")))
+	}
 	// Build image
 	var stdout, stderr io.Writer
 	if config.Output {

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -24,8 +24,9 @@ func TestDockerImageBuild(t *testing.T) {
 	assert.NoError(t, err)
 
 	options := airflowTypes.ImageBuildConfig{
-		Path:    cwd,
-		NoCache: false,
+		Path:            cwd,
+		TargetPlatforms: []string{"linux/amd64"},
+		NoCache:         false,
 	}
 
 	previousCmdExec := cmdExec

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -928,6 +928,10 @@ func TestCheckWebserverHealth(t *testing.T) {
 			mockEventsCall.ReturnArguments = mock.Arguments{err}
 		}
 
+		openURL = func(url string) error {
+			return nil
+		}
+
 		orgInitSetting := initSettings
 		initSettings = func(id string, version uint64) error {
 			return nil
@@ -963,6 +967,10 @@ func TestCheckWebserverHealth(t *testing.T) {
 			err = consumer(api.Event{Status: "health_status: healthy"})
 			assert.ErrorIs(t, err, errMockDocker)
 			mockEventsCall.ReturnArguments = mock.Arguments{err}
+		}
+
+		openURL = func(url string) error {
+			return nil
 		}
 
 		err := checkWebserverHealth(&types.Project{Name: "test"}, composeMock, 2)

--- a/airflow/types/types.go
+++ b/airflow/types/types.go
@@ -2,7 +2,8 @@ package types
 
 // ImageBuildConfig defines options when building a container image
 type ImageBuildConfig struct {
-	Path    string
-	NoCache bool
-	Output  bool
+	Path            string
+	TargetPlatforms []string
+	NoCache         bool
+	Output          bool
 }

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -43,6 +43,8 @@ var (
 	pytestFile string
 	dockerfile = "Dockerfile"
 
+	deployImagePlatformSupport = []string{"linux/amd64"}
+
 	// Monkey patched to write unit tests
 	airflowImageHandler  = airflow.ImageHandlerInit
 	containerHandlerInit = airflow.ContainerHandlerInit
@@ -261,7 +263,7 @@ func buildImage(c *config.Context, path, currentVersion, deployImage, imageName 
 	imageHandler := airflowImageHandler(deployImage)
 
 	if imageName == "" {
-		err := imageHandler.Build(types.ImageBuildConfig{Path: path, Output: true})
+		err := imageHandler.Build(types.ImageBuildConfig{Path: path, Output: true, TargetPlatforms: deployImagePlatformSupport})
 		if err != nil {
 			return "", err
 		}

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -171,6 +171,15 @@ func TestBuildImageFailure(t *testing.T) {
 	ctx.SetSystemAdmin(true)
 
 	mockImageHandler := new(mocks.ImageHandler)
+
+	// image build failure
+	airflowImageHandler = func(image string) airflow.ImageHandler {
+		mockImageHandler.On("Build", mock.Anything).Return(errMock).Once()
+		return mockImageHandler
+	}
+	_, err = buildImage(&ctx, "./testfiles/", "4.2.5", "", "", nil)
+	assert.ErrorIs(t, err, errMock)
+
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("4.2.5", nil)

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -23,6 +23,8 @@ var (
 	imageHandlerInit = airflow.ImageHandlerInit
 
 	dockerfile = "Dockerfile"
+
+	deployImagePlatformSupport = []string{"linux/amd64"}
 )
 
 var (
@@ -216,8 +218,10 @@ func buildPushDockerImage(houstonClient houston.ClientInterface, c *config.Conte
 	imageHandler := imageHandlerInit(imageName)
 
 	buildConfig := types.ImageBuildConfig{
-		Path:    config.WorkingPath,
-		NoCache: ignoreCacheDeploy,
+		Path:            config.WorkingPath,
+		NoCache:         ignoreCacheDeploy,
+		TargetPlatforms: deployImagePlatformSupport,
+		Output:          true,
 	}
 	err = imageHandler.Build(buildConfig)
 	if err != nil {


### PR DESCRIPTION
## Description
Changes:
- Added support in docker image build method to pass target platform list
- Updated logic of `astro deploy` for both cloud & software to build images for `linux/amd64` targeted platforms.
- Fixed unit test logic of `checkWebserverHealth` so that it doesn't end up redirecting to the browser when running tests locally

<img width="1131" alt="Screenshot 2022-07-20 at 3 54 04 PM" src="https://user-images.githubusercontent.com/92356010/180806236-7e3315f7-c7c1-4149-bd88-75d1b7c92671.png">

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-cli/issues/638

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
