### PR TITLE
Multiple key=value pairs to variable create and update

### DIFF
--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -196,9 +196,9 @@ func addVariableFromFlag(oldKeyList []string, oldEnvironmentVariables []astro.En
 	exist, num := contains(oldKeyList, variableKey)
 	switch {
 	case exist && !updateVars: // don't update variable
-		fmt.Fprintln(out, "key %s already exists, skipping creation. Use the update command to update existing variables\n", variableKey)
+		fmt.Fprintf(out, "key %s already exists, skipping creation. Use the update command to update existing variables\n", variableKey)
 	case exist && updateVars: // update variable
-		fmt.Fprintln(out, "updating variable %s \n", variableKey)
+		fmt.Fprintf(out, "updating variable %s \n", variableKey)
 		secret := makeSecret
 		if !makeSecret { // you can only make variables secret a user can't make them not secret
 			secret = oldEnvironmentVariables[num].IsSecret

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -91,7 +91,7 @@ func VariableModify(deploymentID, variableKey, variableValue, ws, envFile string
 
 	// add new variable from flag
 	if variableKey != "" && variableValue != "" {
-		newEnvironmentVariables = addVariableFromFlag(oldKeyList, oldEnvironmentVariables, newEnvironmentVariables, variableKey, variableValue, updateVars, makeSecret)
+		newEnvironmentVariables = addVariableFromFlag(oldKeyList, oldEnvironmentVariables, newEnvironmentVariables, variableKey, variableValue, updateVars, makeSecret, out)
 	}
 	if variableValue == "" && variableKey != "" {
 		fmt.Fprintf(out, "Variable with key %s not created or updated\nYou must provide a variable value", variableKey)
@@ -191,14 +191,14 @@ func writeVarToFile(environmentVariablesObjects []astro.EnvironmentVariablesObje
 }
 
 // Add variables from flag
-func addVariableFromFlag(oldKeyList []string, oldEnvironmentVariables []astro.EnvironmentVariablesObject, newEnvironmentVariables []astro.EnvironmentVariable, variableKey, variableValue string, updateVars, makeSecret bool) []astro.EnvironmentVariable {
+func addVariableFromFlag(oldKeyList []string, oldEnvironmentVariables []astro.EnvironmentVariablesObject, newEnvironmentVariables []astro.EnvironmentVariable, variableKey, variableValue string, updateVars, makeSecret bool, out io.Writer) []astro.EnvironmentVariable {
 	var newEnvironmentVariable astro.EnvironmentVariable
 	exist, num := contains(oldKeyList, variableKey)
 	switch {
 	case exist && !updateVars: // don't update variable
-		fmt.Printf("key %s already exists, skipping creation. Use the update command to update existing variables\n", variableKey)
+		fmt.Fprintln(out, "key %s already exists, skipping creation. Use the update command to update existing variables\n", variableKey)
 	case exist && updateVars: // update variable
-		fmt.Printf("updating variable %s \n", variableKey)
+		fmt.Fprintln(out, "updating variable %s \n", variableKey)
 		secret := makeSecret
 		if !makeSecret { // you can only make variables secret a user can't make them not secret
 			secret = oldEnvironmentVariables[num].IsSecret

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -279,9 +279,9 @@ func TestWriteVarToFile(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestAddVariableFromFlag(t *testing.T) {
+func TestAddVariable(t *testing.T) {
 	buf := new(bytes.Buffer)
-	resp := addVariableFromFlag([]string{"test-key-1"},
+	resp := addVariable([]string{"test-key-1"},
 		[]astro.EnvironmentVariablesObject{{Key: "test-key-1", Value: "test-value-1"}},
 		[]astro.EnvironmentVariable{{Key: "test-key-1", Value: "test-value-2"}},
 		"test-key-1", "test-value-3", true, false, buf,
@@ -289,7 +289,7 @@ func TestAddVariableFromFlag(t *testing.T) {
 	assert.Equal(t, []astro.EnvironmentVariable{{Key: "test-key-1", Value: "test-value-3"}}, resp)
 
 	buf = new(bytes.Buffer)
-	resp = addVariableFromFlag([]string{"test-key-1"},
+	resp = addVariable([]string{"test-key-1"},
 		[]astro.EnvironmentVariablesObject{{Key: "test-key-1", Value: "test-value-1"}},
 		[]astro.EnvironmentVariable{{Key: "test-key-1", Value: "test-value-2"}},
 		"test-key-1", "test-value-3", false, false, buf,
@@ -298,24 +298,25 @@ func TestAddVariableFromFlag(t *testing.T) {
 }
 
 func TestAddVariablesFromArgs(t *testing.T) {
+	buf := new(bytes.Buffer)
 	resp := addVariablesFromArgs([]string{"test-key-1"},
 		[]astro.EnvironmentVariablesObject{{Key: "test-key-1", Value: "test-value-1"}},
 		[]astro.EnvironmentVariable{{Key: "test-key-1", Value: "test-value-2"}},
-		[]string{"test-key-1=test-value-3"}, true, false,
+		[]string{"test-key-1=test-value-3"}, true, false, buf,
 	)
 	assert.Equal(t, []astro.EnvironmentVariable{{Key: "test-key-1", Value: "test-value-3"}}, resp)
 
 	resp = addVariablesFromArgs([]string{"test-key-1"},
 		[]astro.EnvironmentVariablesObject{{Key: "test-key-1", Value: "test-value-1"}},
 		[]astro.EnvironmentVariable{{Key: "test-key-1", Value: "test-value-2"}},
-		[]string{"test-key-1=test-value-3"}, false, false,
+		[]string{"test-key-1=test-value-3"}, false, false, buf,
 	)
 	assert.Equal(t, []astro.EnvironmentVariable{{Key: "test-key-1", Value: "test-value-2"}}, resp)
 
 	resp = addVariablesFromArgs([]string{"test-key-1"},
 		[]astro.EnvironmentVariablesObject{},
 		[]astro.EnvironmentVariable{},
-		[]string{"test-key-2=test-value-3", "test-key-3=", "test-key-3"}, false, false,
+		[]string{"test-key-2=test-value-3", "test-key-3=", "test-key-3"}, false, false, buf,
 	)
 	assert.Equal(t, []astro.EnvironmentVariable{{Key: "test-key-2", Value: "test-value-3"}}, resp)
 }

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -210,23 +210,23 @@ func TestVariableModify(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
-	t.Run("missing var key or value from arg list", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockListResponse, nil).Once()
-		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Once()
+	// t.Run("missing var key or value from arg list", func(t *testing.T) {
+	// 	mockClient := new(astro_mocks.Client)
+	// 	mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockListResponse, nil).Once()
+	// 	mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Once()
 
-		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "", "", ws, "", []string{"test-key-2="}, false, false, false, mockClient, buf)
-		assert.NoError(t, err)
-		assert.Contains(t, buf.String(), "Input test-key-2= has blank key or value")
-		mockClient.AssertExpectations(t)
+	// 	buf := new(bytes.Buffer)
+	// 	err := VariableModify("test-id-1", "", "", ws, "", []string{"test-key-2="}, false, false, false, mockClient, buf)
+	// 	assert.NoError(t, err)
+	// 	assert.Contains(t, buf.String(), "Input test-key-2= has blank key or value")
+	// 	mockClient.AssertExpectations(t)
 
-		buf = new(bytes.Buffer)
-		err = VariableModify("test-id-1", "", "", ws, "", []string{"test-key-2"}, false, false, false, mockClient, buf)
-		assert.NoError(t, err)
-		assert.Contains(t, buf.String(), "Input test-key-2 is not a valid key value pair")
-		mockClient.AssertExpectations(t)
-	})
+	// 	buf = new(bytes.Buffer)
+	// 	err = VariableModify("test-id-1", "", "", ws, "", []string{"test-key-2"}, false, false, false, mockClient, buf)
+	// 	assert.NoError(t, err)
+	// 	assert.Contains(t, buf.String(), "Input test-key-2 is not a valid key value pair")
+	// 	mockClient.AssertExpectations(t)
+	// })
 
 	t.Run("create env var failure", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -145,7 +145,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", true, false, false, mockClient, buf)
+		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", []string{}, true, false, false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "test-key-1")
 		assert.Contains(t, buf.String(), "test-key-2")
@@ -159,7 +159,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{}, errMock).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", false, false, false, mockClient, buf)
+		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -169,7 +169,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockListResponse, nil).Twice()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-invalid-id", "test-key-2", "test-value-2", ws, "", false, false, false, mockClient, buf)
+		err := VariableModify("test-invalid-id", "test-key-2", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
 		assert.ErrorIs(t, err, errInvalidDeployment)
 
 		// mock os.Stdin
@@ -188,7 +188,7 @@ func TestVariableModify(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = VariableModify("", "test-key-2", "test-value-2", ws, "", false, false, false, mockClient, buf)
+		err = VariableModify("", "test-key-2", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
 		assert.ErrorIs(t, err, errInvalidDeploymentKey)
 		mockClient.AssertExpectations(t)
 	})
@@ -199,12 +199,12 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Twice()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "", "test-value-2", ws, "", false, false, false, mockClient, buf)
+		err := VariableModify("test-id-1", "", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "You must provide a variable key")
 
 		buf = new(bytes.Buffer)
-		err = VariableModify("test-id-1", "test-key-2", "", ws, "", false, false, false, mockClient, buf)
+		err = VariableModify("test-id-1", "test-key-2", "", ws, "", []string{}, false, false, false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "You must provide a variable value")
 		mockClient.AssertExpectations(t)
@@ -216,7 +216,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, errMock).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", false, false, false, mockClient, buf)
+		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -227,7 +227,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, nil).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-2", "", "", ws, "", false, false, false, mockClient, buf)
+		err := VariableModify("test-id-2", "", "", ws, "", []string{}, false, false, false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "No variables for this Deployment")
 	})

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -212,19 +212,19 @@ func TestVariableModify(t *testing.T) {
 
 	// t.Run("missing var key or value from arg list", func(t *testing.T) {
 	// 	mockClient := new(astro_mocks.Client)
-	// 	mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockListResponse, nil).Once()
-	// 	mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Once()
+	// 	mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockListResponse, nil).Twice()
+	// 	mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Twice()
+
+	// 	// buf := new(bytes.Buffer)
+	// 	// err := VariableModify("test-id-1", "", "", ws, "", []string{"test-key-3="}, false, false, false, mockClient, buf)
+	// 	// assert.NoError(t, err)
+	// 	// assert.Contains(t, buf.String(), "test-key-2")
+	// 	// mockClient.AssertExpectations(t)
 
 	// 	buf := new(bytes.Buffer)
-	// 	err := VariableModify("test-id-1", "", "", ws, "", []string{"test-key-2="}, false, false, false, mockClient, buf)
+	// 	err := VariableModify("test-id-1", "", "", ws, "", []string{"test-key-3"}, false, false, false, mockClient, buf)
 	// 	assert.NoError(t, err)
-	// 	assert.Contains(t, buf.String(), "Input test-key-2= has blank key or value")
-	// 	mockClient.AssertExpectations(t)
-
-	// 	buf = new(bytes.Buffer)
-	// 	err = VariableModify("test-id-1", "", "", ws, "", []string{"test-key-2"}, false, false, false, mockClient, buf)
-	// 	assert.NoError(t, err)
-	// 	assert.Contains(t, buf.String(), "Input test-key-2 is not a valid key value pair")
+	// 	assert.Contains(t, buf.String(), "test-key-2")
 	// 	mockClient.AssertExpectations(t)
 	// })
 
@@ -329,4 +329,11 @@ func TestAddVariablesFromArgs(t *testing.T) {
 		[]string{"test-key-1=test-value-3"}, false, false,
 	)
 	assert.Equal(t, []astro.EnvironmentVariable{{Key: "test-key-1", Value: "test-value-2"}}, resp)
+
+	resp = addVariablesFromArgs([]string{"test-key-1"},
+		[]astro.EnvironmentVariablesObject{},
+		[]astro.EnvironmentVariable{},
+		[]string{"test-key-2=test-value-3", "test-key-3=", "test-key-3"}, false, false,
+	)
+	assert.Equal(t, []astro.EnvironmentVariable{{Key: "test-key-2", Value: "test-value-3"}}, resp)
 }

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -210,24 +210,6 @@ func TestVariableModify(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
-	// t.Run("missing var key or value from arg list", func(t *testing.T) {
-	// 	mockClient := new(astro_mocks.Client)
-	// 	mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockListResponse, nil).Twice()
-	// 	mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Twice()
-
-	// 	// buf := new(bytes.Buffer)
-	// 	// err := VariableModify("test-id-1", "", "", ws, "", []string{"test-key-3="}, false, false, false, mockClient, buf)
-	// 	// assert.NoError(t, err)
-	// 	// assert.Contains(t, buf.String(), "test-key-2")
-	// 	// mockClient.AssertExpectations(t)
-
-	// 	buf := new(bytes.Buffer)
-	// 	err := VariableModify("test-id-1", "", "", ws, "", []string{"test-key-3"}, false, false, false, mockClient, buf)
-	// 	assert.NoError(t, err)
-	// 	assert.Contains(t, buf.String(), "test-key-2")
-	// 	mockClient.AssertExpectations(t)
-	// })
-
 	t.Run("create env var failure", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockListResponse, nil).Once()

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -230,7 +230,6 @@ func newDeploymentVariableUpdateCmd(out io.Writer) *cobra.Command {
 	_ = cmd.Flags().MarkHidden("key")
 	_ = cmd.Flags().MarkHidden("value")
 
-
 	return cmd
 }
 

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -41,15 +41,15 @@ var (
 		`
 	deploymentVariableCreateExample = `
 		# Create a deployment variable
-		$ astro deployment variable create --deployment-id <deployment-id> --key FOO --value BAR --secret
+		$ astro deployment variable create FOO=BAR FOO2=BAR2 --deployment-id <deployment-id> --secret
 		# Create a deployment variables from a file
-		$ astro deployment variable create  --deployment-id <deployment-id> --load --env .env.my-deployment
+		$ astro deployment variable create --deployment-id <deployment-id> --load --env .env.my-deployment
 		`
 	deploymentVariableUpdateExample = `
 		# Update a deployment variable
-		$ astro deployment variable update --deployment-id <deployment-id> --key KEY --value NEWVALUE --secret
+		$ astro deployment variable update FOO=NEWBAR FOO2=NEWBAR2 --deployment-id <deployment-id> --secret
 		# Update a deployment variables from a file
-		$ astro deployment variable update  --deployment-id <deployment-id> --load --env .env.my-deployment
+		$ astro deployment variable update --deployment-id <deployment-id> --load --env .env.my-deployment
 		`
 
 	httpClient = httputil.NewHTTPClient()
@@ -204,6 +204,8 @@ func newDeploymentVariableCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&useEnvFile, "load", "l", false, "Create environment variables loaded from an environment file")
 	cmd.Flags().BoolVarP(&makeSecret, "secret", "s", false, "Set the new environment variables as secrets")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file to load environment variables from")
+	_ = cmd.Flags().MarkHidden("key")
+	_ = cmd.Flags().MarkHidden("value")
 
 	return cmd
 }
@@ -225,6 +227,9 @@ func newDeploymentVariableUpdateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&useEnvFile, "load", "l", false, "Update environment variables loaded from an environment file")
 	cmd.Flags().BoolVarP(&makeSecret, "secret", "s", false, "Set updated environment variables as secrets")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file to load environment variables to update from")
+	_ = cmd.Flags().MarkHidden("key")
+	_ = cmd.Flags().MarkHidden("value")
+
 
 	return cmd
 }

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -189,10 +189,10 @@ func newDeploymentVariableListCmd(out io.Writer) *cobra.Command {
 // nolint:dupl
 func newDeploymentVariableCreateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "create",
-		Short:   "Create Deployment-level environment variables",
-		Long:    "Create Deployment-level environment variables by supplying either a key and value or an environment file with a list of keys and values",
-		Args:    cobra.NoArgs,
+		Use:   "create [key1=val1 key2=val2]",
+		Short: "Create Deployment-level environment variables",
+		Long:  "Create Deployment-level environment variables by supplying either a key and value or an environment file with a list of keys and values",
+		// Args:    cobra.NoArgs,
 		Example: deploymentVariableCreateExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentVariableCreate(cmd, args, out)
@@ -211,10 +211,9 @@ func newDeploymentVariableCreateCmd(out io.Writer) *cobra.Command {
 // nolint:dupl
 func newDeploymentVariableUpdateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "update",
+		Use:     "update [key1=update_val1 key2=update_val2]",
 		Short:   "Update Deployment-level environment variables",
 		Long:    "Update Deployment-level environment variables by supplying either a key and value or an environment file with a list of keys and values, variables that don't already exist will be created",
-		Args:    cobra.NoArgs,
 		Example: deploymentVariableUpdateExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentVariableUpdate(cmd, args, out)
@@ -330,26 +329,30 @@ func deploymentVariableList(cmd *cobra.Command, _ []string, out io.Writer) error
 	return deployment.VariableList(deploymentID, variableKey, ws, envFile, useEnvFile, astroClient, out)
 }
 
-func deploymentVariableCreate(cmd *cobra.Command, _ []string, out io.Writer) error {
+func deploymentVariableCreate(cmd *cobra.Command, args []string, out io.Writer) error {
 	ws, err := coalesceWorkspace()
 	if err != nil {
 		return errors.Wrap(err, "failed to find a valid workspace")
 	}
 
+	variableList := args
+
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	return deployment.VariableModify(deploymentID, variableKey, variableValue, ws, envFile, useEnvFile, makeSecret, false, astroClient, out)
+	return deployment.VariableModify(deploymentID, variableKey, variableValue, ws, envFile, variableList, useEnvFile, makeSecret, false, astroClient, out)
 }
 
-func deploymentVariableUpdate(cmd *cobra.Command, _ []string, out io.Writer) error {
+func deploymentVariableUpdate(cmd *cobra.Command, args []string, out io.Writer) error {
 	ws, err := coalesceWorkspace()
 	if err != nil {
 		return errors.Wrap(err, "failed to find a valid workspace")
 	}
 
+	variableList := args
+
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	return deployment.VariableModify(deploymentID, variableKey, variableValue, ws, envFile, useEnvFile, makeSecret, true, astroClient, out)
+	return deployment.VariableModify(deploymentID, variableKey, variableValue, ws, envFile, variableList, useEnvFile, makeSecret, true, astroClient, out)
 }

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -208,6 +208,10 @@ func TestDeploymentVariableModify(t *testing.T) {
 			Key:   "test-key-2",
 			Value: "test-value-2",
 		},
+		{
+			Key:   "test-key-3",
+			Value: "test-value-3",
+		},
 	}
 
 	mockClient := new(astro_mocks.Client)
@@ -215,13 +219,15 @@ func TestDeploymentVariableModify(t *testing.T) {
 	mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Once()
 	astroClient = mockClient
 
-	cmdArgs := []string{"variable", "create", "--deployment-id", "test-id-1", "--key", "test-key-2", "--value", "test-value-2"}
+	cmdArgs := []string{"variable", "create","test-key-3=test-value-3", "--deployment-id", "test-id-1", "--key", "test-key-2", "--value", "test-value-2"}
 	resp, err := execDeploymentCmd(cmdArgs...)
 	assert.NoError(t, err)
 	assert.Contains(t, resp, "test-key-1")
 	assert.Contains(t, resp, "test-value-1")
 	assert.Contains(t, resp, "test-key-2")
 	assert.Contains(t, resp, "test-value-2")
+	assert.Contains(t, resp, "test-key-3")
+	assert.Contains(t, resp, "test-value-3")
 	mockClient.AssertExpectations(t)
 }
 
@@ -248,6 +254,10 @@ func TestDeploymentVariableUpdate(t *testing.T) {
 			Key:   "test-key-1",
 			Value: "test-value-update",
 		},
+		{
+			Key:   "test-key-2",
+			Value: "test-value-2-update",
+		},
 	}
 
 	mockClient := new(astro_mocks.Client)
@@ -255,10 +265,12 @@ func TestDeploymentVariableUpdate(t *testing.T) {
 	mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockUpdateResponse, nil).Once()
 	astroClient = mockClient
 
-	cmdArgs := []string{"variable", "update", "--deployment-id", "test-id-1", "--key", "test-key-1", "--value", "test-value-update"}
+	cmdArgs := []string{"variable", "update","test-key-2=test-value-2-update", "--deployment-id", "test-id-1", "--key", "test-key-1", "--value", "test-value-update"}
 	resp, err := execDeploymentCmd(cmdArgs...)
 	assert.NoError(t, err)
 	assert.Contains(t, resp, "test-key-1")
 	assert.Contains(t, resp, "test-value-update")
+	assert.Contains(t, resp, "test-key-2")
+	assert.Contains(t, resp, "test-value-2-update")
 	mockClient.AssertExpectations(t)
 }


### PR DESCRIPTION
## Description

Allow users to pass multiple key=value pairs to variable create and update

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/663

## 🧪 Functional Testing

- added unit tests
- Tested manually

## 📸 Screenshots

![Screen Shot 2022-07-26 at 2 31 40 PM](https://user-images.githubusercontent.com/63181127/181084437-55964f0a-7a04-48ff-94bf-eeaa7fffc94f.png)

## 📋 Checklist

- [X] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [X] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [X] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [X] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
