### PR TITLE
Ran Python code dagintegritytest.go through black

### DIFF
--- a/airflow/include/dagintegritytest.go
+++ b/airflow/include/dagintegritytest.go
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 import pytest
 from airflow.models import DagBag
 
+
 @contextmanager
 def suppress_logging(namespace):
     logger = logging.getLogger(namespace)
@@ -22,55 +23,70 @@ def suppress_logging(namespace):
     finally:
         logger.disabled = old_value
 
+
 def get_import_errors():
-	"""
-	Generate a tuple for import errors in the dag bag
-	"""
-	with suppress_logging('airflow') :
-		dag_bag = DagBag(include_examples=False)
+    """
+    Generate a tuple for import errors in the dag bag
+    """
+    with suppress_logging("airflow"):
+        dag_bag = DagBag(include_examples=False)
 
-		def strip_path_prefix(path):
-			return os.path.relpath(path ,os.environ.get('AIRFLOW_HOME'))
+        def strip_path_prefix(path):
+            return os.path.relpath(path, os.environ.get("AIRFLOW_HOME"))
 
-		# we prepend "(None,None)" to ensure that a test object is always created even if its a no op.
-		return [(None,None)] +[ ( strip_path_prefix(k) , v.strip() ) for k,v in dag_bag.import_errors.items()]
+        # we prepend "(None,None)" to ensure that a test object is always created even if its a no op.
+        return [(None, None)] + [
+            (strip_path_prefix(k), v.strip()) for k, v in dag_bag.import_errors.items()
+        ]
+
 
 def get_dags():
-	"""
-	Generate a tuple of dag_id, <DAG objects> in the DagBag
-	"""
-	with suppress_logging('airflow') :
-		dag_bag = DagBag(include_examples=False)
-	def strip_path_prefix(path):
-		return os.path.relpath(path ,os.environ.get('AIRFLOW_HOME'))
-	return [ (k,v,strip_path_prefix(v.fileloc)) for k,v in dag_bag.dags.items()]
+    """
+    Generate a tuple of dag_id, <DAG objects> in the DagBag
+    """
+    with suppress_logging("airflow"):
+        dag_bag = DagBag(include_examples=False)
 
-@pytest.mark.parametrize("rel_path,rv", get_import_errors(), ids=[x[0] for x in get_import_errors()])
-def test_file_imports(rel_path,rv):
-	""" Test for import errors on a file """
-	if rel_path and rv :
-			raise Exception(f"{rel_path} failed to import with message \n {rv}")
+    def strip_path_prefix(path):
+        return os.path.relpath(path, os.environ.get("AIRFLOW_HOME"))
 
+    return [(k, v, strip_path_prefix(v.fileloc)) for k, v in dag_bag.dags.items()]
+
+
+@pytest.mark.parametrize(
+    "rel_path,rv", get_import_errors(), ids=[x[0] for x in get_import_errors()]
+)
+def test_file_imports(rel_path, rv):
+    """Test for import errors on a file"""
+    if rel_path and rv:
+        raise Exception(f"{rel_path} failed to import with message \n {rv}")
 
 
 APPROVED_TAGS = {}
 
-@pytest.mark.parametrize("dag_id,dag,fileloc", get_dags(), ids=[x[2] for x in get_dags()])
-def test_dag_tags(dag_id,dag, fileloc):
-	"""
-	test if a DAG is tagged and if those TAGs are in the approved list
-	"""
-	assert dag.tags, f"{dag_id} in {fileloc} has no tags"
-	if APPROVED_TAGS:
-		assert not set(dag.tags) - APPROVED_TAGS
+
+@pytest.mark.parametrize(
+    "dag_id,dag,fileloc", get_dags(), ids=[x[2] for x in get_dags()]
+)
+def test_dag_tags(dag_id, dag, fileloc):
+    """
+    test if a DAG is tagged and if those TAGs are in the approved list
+    """
+    assert dag.tags, f"{dag_id} in {fileloc} has no tags"
+    if APPROVED_TAGS:
+        assert not set(dag.tags) - APPROVED_TAGS
 
 
+@pytest.mark.parametrize(
+    "dag_id,dag, fileloc", get_dags(), ids=[x[2] for x in get_dags()]
+)
+def test_dag_retries(dag_id, dag, fileloc):
+    """
+    test if a DAG has retries set
+    """
+    assert (
+        dag.default_args.get("retries", None) >= 2
+    ), f"{dag_id} in {fileloc} does not have retries not set to 2."
 
-@pytest.mark.parametrize("dag_id,dag, fileloc", get_dags(), ids=[x[2] for x in get_dags()])
-def test_dag_retries(dag_id,dag, fileloc):
-	"""
-	test if a DAG has retries set
-	"""
-	assert dag.default_args.get('retries', None) >= 2 , f"{dag_id} in {fileloc} does not have retries not set to 2."
 
 `)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.
The Python code doesn't conform to pep8

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
