### PR TITLE
Deployment Name Flag

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -229,7 +229,7 @@ func getDeploymentInfo(deploymentID, wsID, deploymentName string, prompt bool, c
 	}
 
 	if deploymentID != "" && deploymentName != "" {
-		fmt.Printf("Both a Deployment ID and Deployment Name have been supplied. The Deploymnet ID %s will be used for the Deploy\n", deploymentID)
+		fmt.Printf("Both a Deployment ID and Deployment name have been supplied. The Deployment ID %s will be used for the Deploy\n", deploymentID)
 	}
 
 	// check if deploymentID or if force prompt was requested was given by user

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -132,7 +132,7 @@ func deployDags(path, domain string, deployInfo *deploymentInfo, client astro.Cl
 }
 
 // Deploy pushes a new docker image
-func Deploy(path, deploymentID, wsID, pytest, envFile, imageName string, prompt, dags bool, client astro.Client) error {
+func Deploy(path, deploymentID, wsID, pytest, envFile, imageName, deploymentName string, prompt, dags bool, client astro.Client) error {
 	// Get cloud domain
 	c, err := config.GetCurrentContext()
 	if err != nil {
@@ -149,7 +149,7 @@ func Deploy(path, deploymentID, wsID, pytest, envFile, imageName string, prompt,
 		domain = splitDomain[1]
 	}
 
-	deployInfo, err := getDeploymentInfo(deploymentID, wsID, prompt, domain, client)
+	deployInfo, err := getDeploymentInfo(deploymentID, wsID, deploymentName, prompt, domain, client)
 	if err != nil {
 		return err
 	}
@@ -219,15 +219,22 @@ func Deploy(path, deploymentID, wsID, pytest, envFile, imageName string, prompt,
 	return nil
 }
 
-func getDeploymentInfo(deploymentID, wsID string, prompt bool, cloudDomain string, client astro.Client) (deploymentInfo, error) {
+func getDeploymentInfo(deploymentID, wsID, deploymentName string, prompt bool, cloudDomain string, client astro.Client) (deploymentInfo, error) {
 	// Use config deployment if provided
 	if deploymentID == "" {
 		deploymentID = config.CFG.ProjectDeployment.GetProjectString()
+		if deploymentID != "" {
+			fmt.Printf("Deployment ID found in the config file. This Deployment ID will be used for the deploy\n")
+		}
+	}
+
+	if deploymentID != "" && deploymentName != "" {
+		fmt.Printf("Both a Deployment ID and Deployment Name have been supplied. The Deploymnet ID %s will be used for the Deploy\n", deploymentID)
 	}
 
 	// check if deploymentID or if force prompt was requested was given by user
 	if deploymentID == "" || prompt {
-		currentDeployment, err := deployment.GetDeployment(wsID, deploymentID, client)
+		currentDeployment, err := deployment.GetDeployment(wsID, deploymentID, deploymentName, client)
 		if err != nil {
 			return deploymentInfo{}, err
 		}

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -88,7 +88,6 @@ func TestDeploySuccess(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-<<<<<<< HEAD
 	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, false, mockClient)
 	assert.NoError(t, err)
 
@@ -97,16 +96,6 @@ func TestDeploySuccess(t *testing.T) {
 
 	// test custom image
 	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", false, false, mockClient)
-=======
-	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, mockClient)
-	assert.NoError(t, err)
-
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", false, mockClient)
-	assert.NoError(t, err)
-
-	// test custom image
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", false, mockClient)
->>>>>>> fix tests
 	assert.NoError(t, err)
 
 	mockClient.AssertExpectations(t)
@@ -119,11 +108,7 @@ func TestDeployFailure(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	err := config.ResetCurrentContext()
 	assert.NoError(t, err)
-<<<<<<< HEAD
 	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", true, false, nil)
-=======
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", true, nil)
->>>>>>> fix tests
 	assert.EqualError(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 
 	// airflow parse failure
@@ -171,11 +156,7 @@ func TestDeployFailure(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-<<<<<<< HEAD
 	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, false, mockClient)
-=======
-	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, mockClient)
->>>>>>> fix tests
 	assert.ErrorIs(t, err, errDagsParseFailed)
 
 	mockClient.AssertExpectations(t)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -88,6 +88,7 @@ func TestDeploySuccess(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
+<<<<<<< HEAD
 	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, false, mockClient)
 	assert.NoError(t, err)
 
@@ -96,6 +97,16 @@ func TestDeploySuccess(t *testing.T) {
 
 	// test custom image
 	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", false, false, mockClient)
+=======
+	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, mockClient)
+	assert.NoError(t, err)
+
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", false, mockClient)
+	assert.NoError(t, err)
+
+	// test custom image
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", false, mockClient)
+>>>>>>> fix tests
 	assert.NoError(t, err)
 
 	mockClient.AssertExpectations(t)
@@ -108,7 +119,11 @@ func TestDeployFailure(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	err := config.ResetCurrentContext()
 	assert.NoError(t, err)
+<<<<<<< HEAD
 	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", true, false, nil)
+=======
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", true, nil)
+>>>>>>> fix tests
 	assert.EqualError(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 
 	// airflow parse failure
@@ -156,7 +171,11 @@ func TestDeployFailure(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
+<<<<<<< HEAD
 	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, false, mockClient)
+=======
+	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, mockClient)
+>>>>>>> fix tests
 	assert.ErrorIs(t, err, errDagsParseFailed)
 
 	mockClient.AssertExpectations(t)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -45,10 +45,10 @@ func TestDeploySuccess(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
-	mockClient.On("ListDeployments", mock.Anything).Return(mockDeplyResp, nil).Times(3)
-	mockClient.On("ListPublicRuntimeReleases").Return([]astro.RuntimeRelease{{Version: "4.2.5", AirflowVersion: "2.2.5"}}, nil).Times(3)
-	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(3)
-	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(3)
+	mockClient.On("ListDeployments", mock.Anything).Return(mockDeplyResp, nil).Times(4)
+	mockClient.On("ListPublicRuntimeReleases").Return([]astro.RuntimeRelease{{Version: "4.2.5", AirflowVersion: "2.2.5"}}, nil).Times(4)
+	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(4)
+	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(4)
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
@@ -96,6 +96,11 @@ func TestDeploySuccess(t *testing.T) {
 
 	// test custom image
 	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", false, false, mockClient)
+	assert.NoError(t, err)
+
+	config.CFG.ProjectDeployment.SetProjectString("test-id")
+	// test both deploymentID and name used
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "test-name", false, false, mockClient)
 	assert.NoError(t, err)
 
 	mockClient.AssertExpectations(t)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -88,14 +88,14 @@ func TestDeploySuccess(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", true, false, mockClient)
+	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, false, mockClient)
 	assert.NoError(t, err)
 
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", false, false, mockClient)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", false, false, mockClient)
 	assert.NoError(t, err)
 
 	// test custom image
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", false, false, mockClient)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", false, false, mockClient)
 	assert.NoError(t, err)
 
 	mockClient.AssertExpectations(t)
@@ -108,7 +108,7 @@ func TestDeployFailure(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	err := config.ResetCurrentContext()
 	assert.NoError(t, err)
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", true, false, nil)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", true, false, nil)
 	assert.EqualError(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 
 	// airflow parse failure
@@ -156,7 +156,7 @@ func TestDeployFailure(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
-	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", true, false, mockClient)
+	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, false, mockClient)
 	assert.ErrorIs(t, err, errDagsParseFailed)
 
 	mockClient.AssertExpectations(t)

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -550,11 +550,11 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 			}
 		}
 		if len(stageDeployments) > 1 {
-			fmt.Printf("More than one Deployment with the name %s was found\n")
+			fmt.Printf("More than one Deployment with the name %s was found\n", deploymentName)
 		} else if len(stageDeployments) == 1 {
 			return stageDeployments[0], nil
 		} else if len(stageDeployments) < 1 {
-			fmt.Printf("No Deployment with the name %s was found\n")
+			fmt.Printf("No Deployment with the name %s was found\n", deploymentName)
 		}
 	}
 

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -24,8 +24,6 @@ var (
 	noDeployments           = "No Deployments found in this Workspace. Would you like to create one now?"
 	// Monkey patched to write unit tests
 	createDeployment = Create
-	// deploymentSelect = selectDeployment
-
 )
 
 const (

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -541,7 +541,7 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 	if deploymentID != "" && deploymentName != "" {
 		fmt.Printf("Both a Deployment ID and Deployment Name have been supplied. The Deploymnet ID %s will be used\n", deploymentID)
 	}
-
+	// find deployment by name
 	if deploymentID == "" && deploymentName != "" {
 		var stageDeployments []astro.Deployment
 		for i := range deployments {
@@ -593,6 +593,7 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 	if deploymentID == "" {
 		return deploymentSelectionProcess(ws, deployments, client)
 	}
+	// find deployment by ID
 	for i := range deployments {
 		if deployments[i].ID == deploymentID {
 			currentDeployment = deployments[i]

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -566,33 +566,6 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 
 	// select deployment if deploymentID is empty
 	if deploymentID == "" {
-		currentDeployment, err = selectDeployment(deployments, "Select a Deployment")
-		if err != nil {
-			return astro.Deployment{}, err
-		}
-		if currentDeployment.ID == "" {
-			// get latest runtime veresion
-			airflowVersionClient := airflowversions.NewClient(httputil.NewHTTPClient(), false)
-			runtimeVersion, err := airflowversions.GetDefaultImageTag(airflowVersionClient, "")
-			if err != nil {
-				return astro.Deployment{}, err
-			}
-		}
-		if len(stageDeployments) > 1 {
-			fmt.Printf("More than one Deployment with the name %s was found\n", deploymentName)
-		}
-		if len(stageDeployments) == 1 {
-			return stageDeployments[0], nil
-		}
-		if len(stageDeployments) < 1 {
-			fmt.Printf("No Deployment with the name %s was found\n", deploymentName)
-		}
-	}
-
-	var currentDeployment astro.Deployment
-
-	// select deployment if deploymentID is empty
-	if deploymentID == "" {
 		return deploymentSelectionProcess(ws, deployments, client)
 	}
 	// find deployment by ID

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -550,6 +550,31 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 			}
 		}
 		if len(stageDeployments) > 1 {
+			fmt.Printf("More than one Deployment with the name %s was found\n")
+		} else if len(stageDeployments) == 1 {
+			return stageDeployments[0], nil
+		} else if len(stageDeployments) < 1 {
+			fmt.Printf("No Deployment with the name %s was found\n")
+		}
+	}
+
+	var currentDeployment astro.Deployment
+
+	// select deployment if deploymentID is empty
+	if deploymentID == "" {
+		currentDeployment, err = selectDeployment(deployments, "Select a Deployment")
+		if err != nil {
+			return astro.Deployment{}, err
+		}
+		if currentDeployment.ID == "" {
+			// get latest runtime veresion
+			airflowVersionClient := airflowversions.NewClient(httputil.NewHTTPClient(), false)
+			runtimeVersion, err := airflowversions.GetDefaultImageTag(airflowVersionClient, "")
+			if err != nil {
+				return astro.Deployment{}, err
+			}
+		}
+		if len(stageDeployments) > 1 {
 			fmt.Printf("More than one Deployment with the name %s was found\n", deploymentName)
 		}
 		if len(stageDeployments) == 1 {

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -78,7 +78,7 @@ func List(ws string, all bool, client astro.Client, out io.Writer) error {
 	return tab.Print(out)
 }
 
-func Logs(deploymentID, ws string, warnLogs, errorLogs, infoLogs bool, logCount int, client astro.Client) error {
+func Logs(deploymentID, ws, deploymentName string, warnLogs, errorLogs, infoLogs bool, logCount int, client astro.Client) error {
 	logLevels := []string{}
 
 	// log level
@@ -96,7 +96,7 @@ func Logs(deploymentID, ws string, warnLogs, errorLogs, infoLogs bool, logCount 
 	}
 
 	// get deployment
-	deployment, err := GetDeployment(ws, deploymentID, client)
+	deployment, err := GetDeployment(ws, deploymentID, deploymentName, client)
 	if err != nil {
 		return err
 	}
@@ -170,6 +170,16 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion string, s
 		label = input.Text(ansi.Bold("\nDeployment name: "))
 		if label == "" {
 			return errors.New("you must give your Deployment a name")
+		}
+		deployments, err := getDeployments(workspaceID, client)
+		if err != nil {
+			return errors.Wrap(err, errInvalidDeployment.Error())
+		}
+
+		for i := range deployments {
+			if deployments[i].Label == label {
+				return errors.New("A Deployment with that name already exists")
+			}
 		}
 	}
 
@@ -328,9 +338,9 @@ func selectCluster(clusterID, organizationID string, client astro.Client) (newCl
 	return clusterID, nil
 }
 
-func Update(deploymentID, label, ws, description string, schedulerAU, schedulerReplicas, workerAU int, forceDeploy bool, client astro.Client) error {
+func Update(deploymentID, label, ws, description, deploymentName string, schedulerAU, schedulerReplicas, workerAU int, forceDeploy bool, client astro.Client) error {
 	// get deployment
-	currentDeployment, err := GetDeployment(ws, deploymentID, client)
+	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, client)
 	if err != nil {
 		return err
 	}
@@ -425,9 +435,9 @@ func Update(deploymentID, label, ws, description string, schedulerAU, schedulerR
 	return nil
 }
 
-func Delete(deploymentID, ws string, forceDelete bool, client astro.Client) error {
+func Delete(deploymentID, ws, deploymentName string, forceDelete bool, client astro.Client) error {
 	// get deployment
-	currentDeployment, err := GetDeployment(ws, deploymentID, client)
+	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, client)
 	if err != nil {
 		return err
 	}
@@ -522,17 +532,37 @@ func selectDeployment(deployments []astro.Deployment, message string) (astro.Dep
 	return selected, nil
 }
 
-func GetDeployment(ws, deploymentID string, client astro.Client) (astro.Deployment, error) {
+func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client) (astro.Deployment, error) {
 	deployments, err := getDeployments(ws, client)
 	if err != nil {
 		return astro.Deployment{}, errors.Wrap(err, errInvalidDeployment.Error())
+	}
+
+	if deploymentID != "" && deploymentName != "" {
+		fmt.Printf("Both a Deployment ID and Deployment Name have been supplied. The Deploymnet ID %s will be used\n", deploymentID)
+	}
+
+	if deploymentID == "" && deploymentName != "" {
+		var stageDeployments []astro.Deployment
+		for i := range deployments {
+			if deployments[i].Label == deploymentName {
+				stageDeployments = append(stageDeployments, deployments[i])
+			}
+		}
+		if len(stageDeployments) > 1 {
+			fmt.Printf("More than one Deployment with the name %s was found\n")
+		} else if len(stageDeployments) == 1 {
+			return stageDeployments[0], nil
+		} else if len(stageDeployments) < 1 {
+			fmt.Printf("No Deployment with the name %s was found\n")
+		}
 	}
 
 	var currentDeployment astro.Deployment
 
 	// select deployment if deploymentID is empty
 	if deploymentID == "" {
-		currentDeployment, err = selectDeployment(deployments, "Select which Deployment you want to update")
+		currentDeployment, err = selectDeployment(deployments, "Select a Deployment")
 		if err != nil {
 			return astro.Deployment{}, err
 		}

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -24,6 +24,8 @@ var (
 	noDeployments           = "No Deployments found in this Workspace. Would you like to create one now?"
 	// Monkey patched to write unit tests
 	createDeployment = Create
+	// deploymentSelect = selectDeployment
+
 )
 
 const (

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -539,7 +539,7 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 	}
 
 	if deploymentID != "" && deploymentName != "" {
-		fmt.Printf("Both a Deployment ID and Deployment Name have been supplied. The Deploymnet ID %s will be used\n", deploymentID)
+		fmt.Printf("Both a Deployment ID and Deployment name have been supplied. The Deployment ID %s will be used\n", deploymentID)
 	}
 	// find deployment by name
 	if deploymentID == "" && deploymentName != "" {

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -551,9 +551,11 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 		}
 		if len(stageDeployments) > 1 {
 			fmt.Printf("More than one Deployment with the name %s was found\n", deploymentName)
-		} else if len(stageDeployments) == 1 {
+		}
+		if len(stageDeployments) == 1 {
 			return stageDeployments[0], nil
-		} else if len(stageDeployments) < 1 {
+		}
+		if len(stageDeployments) < 1 {
 			fmt.Printf("No Deployment with the name %s was found\n", deploymentName)
 		}
 	}

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -148,7 +148,6 @@ func TestGetDeployment(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
-
 	// t.Run("select deployment error", func(t *testing.T) {
 	// 	mockClient := new(astro_mocks.Client)
 	// 	mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{}, nil).Once()
@@ -211,8 +210,6 @@ func TestGetDeployment(t *testing.T) {
 		assert.Equal(t, deploymentID, deployment.ID)
 		mockClient.AssertExpectations(t)
 	})
-
-
 }
 
 func TestLogs(t *testing.T) {

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -210,10 +210,6 @@ func TestGetDeployment(t *testing.T) {
 		assert.Equal(t, deploymentID, deployment.ID)
 		mockClient.AssertExpectations(t)
 	})
-<<<<<<< HEAD
-=======
-
->>>>>>> 1c11e8153a5f05289958f1a11a3b9546aa91ed51
 }
 
 func TestLogs(t *testing.T) {

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -85,7 +85,6 @@ func TestGetDeployment(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
-
 	t.Run("test automatic deployment selection", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -49,7 +49,7 @@ func TestGetDeployment(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
-		_, err := GetDeployment(ws, deploymentID, mockClient)
+		_, err := GetDeployment(ws, deploymentID, "", mockClient)
 		assert.ErrorIs(t, err, errInvalidDeployment)
 		mockClient.AssertExpectations(t)
 	})
@@ -59,7 +59,7 @@ func TestGetDeployment(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
-		deployment, err := GetDeployment(ws, deploymentID, mockClient)
+		deployment, err := GetDeployment(ws, deploymentID, "", mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, deploymentID, deployment.ID)
 		mockClient.AssertExpectations(t)
@@ -69,7 +69,7 @@ func TestGetDeployment(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
-		deployment, err := GetDeployment(ws, "", mockClient)
+		deployment, err := GetDeployment(ws, "", "", mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, deploymentID, deployment.ID)
 		mockClient.AssertExpectations(t)
@@ -99,7 +99,7 @@ func TestGetDeployment(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		deployment, err := GetDeployment(ws, "", mockClient)
+		deployment, err := GetDeployment(ws, "", "", mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, deploymentID, deployment.ID)
 		mockClient.AssertExpectations(t)
@@ -123,7 +123,7 @@ func TestLogs(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 		mockClient.On("GetDeploymentHistory", mockInput).Return(astro.DeploymentHistory{DeploymentID: deploymentID, SchedulerLogs: []astro.SchedulerLog{{Raw: "test log line"}}}, nil).Once()
 
-		err := Logs(deploymentID, ws, true, true, true, logCount, mockClient)
+		err := Logs(deploymentID, ws, "", true, true, true, logCount, mockClient)
 		assert.NoError(t, err)
 
 		mockClient.AssertExpectations(t)
@@ -150,7 +150,7 @@ func TestLogs(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Logs("", ws, false, false, false, logCount, mockClient)
+		err = Logs("", ws, "", false, false, false, logCount, mockClient)
 		assert.NoError(t, err)
 
 		mockClient.AssertExpectations(t)
@@ -161,7 +161,7 @@ func TestLogs(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 		mockClient.On("GetDeploymentHistory", mockInput).Return(astro.DeploymentHistory{}, errMock).Once()
 
-		err := Logs(deploymentID, ws, true, true, true, logCount, mockClient)
+		err := Logs(deploymentID, ws, "", true, true, true, logCount, mockClient)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -179,6 +179,7 @@ func TestCreate(t *testing.T) {
 		mockClient.On("ListWorkspaces").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
 		mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Once()
 		mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{ID: "test-id"}, nil).Once()
+		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
 		// mock os.Stdin
 		input := []byte("test-name")
@@ -363,7 +364,7 @@ func TestUpdate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Update("test-id", "", ws, "", 0, 0, 0, false, mockClient)
+		err = Update("test-id", "", ws, "", "", 0, 0, 0, false, mockClient)
 		assert.NoError(t, err)
 
 		// mock os.Stdin
@@ -382,7 +383,7 @@ func TestUpdate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Update("test-id", "test-label", ws, "test description", 5, 3, 10, false, mockClient)
+		err = Update("test-id", "test-label", ws, "test description", "", 5, 3, 10, false, mockClient)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -391,7 +392,7 @@ func TestUpdate(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{}, errMock).Once()
 
-		err := Update("test-id", "test-label", ws, "test description", 5, 3, 10, false, mockClient)
+		err := Update("test-id", "test-label", ws, "test description", "", 5, 3, 10, false, mockClient)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -416,10 +417,10 @@ func TestUpdate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Update("", "test-label", ws, "test description", 5, 3, 10, false, mockClient)
+		err = Update("", "test-label", ws, "test description", "", 5, 3, 10, false, mockClient)
 		assert.ErrorIs(t, err, errInvalidDeploymentKey)
 
-		err = Update("test-invalid-id", "test-label", ws, "test description", 5, 3, 10, false, mockClient)
+		err = Update("test-invalid-id", "test-label", ws, "test description", "", 5, 3, 10, false, mockClient)
 		assert.ErrorIs(t, err, errInvalidDeployment)
 		mockClient.AssertExpectations(t)
 	})
@@ -444,7 +445,7 @@ func TestUpdate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Update("test-id", "test-label", ws, "test description", 5, 3, 10, false, mockClient)
+		err = Update("test-id", "test-label", ws, "test description", "", 5, 3, 10, false, mockClient)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -454,7 +455,7 @@ func TestUpdate(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{deploymentResp}, nil).Once()
 		mockClient.On("UpdateDeployment", mock.Anything).Return(astro.Deployment{}, errMock).Once()
 
-		err := Update("test-id", "", ws, "", 0, 0, 0, true, mockClient)
+		err := Update("test-id", "", ws, "", "", 0, 0, 0, true, mockClient)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -491,7 +492,7 @@ func TestDelete(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Delete("test-id", ws, false, mockClient)
+		err = Delete("test-id", ws, "", false, mockClient)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -500,7 +501,7 @@ func TestDelete(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{}, errMock).Once()
 
-		err := Delete("test-id", ws, false, mockClient)
+		err := Delete("test-id", ws, "", false, mockClient)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -525,10 +526,10 @@ func TestDelete(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Delete("", ws, false, mockClient)
+		err = Delete("", ws, "", false, mockClient)
 		assert.ErrorIs(t, err, errInvalidDeploymentKey)
 
-		err = Delete("test-invalid-id", ws, false, mockClient)
+		err = Delete("test-invalid-id", ws, "", false, mockClient)
 		assert.ErrorIs(t, err, errInvalidDeployment)
 		mockClient.AssertExpectations(t)
 	})
@@ -553,7 +554,7 @@ func TestDelete(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Delete("test-id", ws, false, mockClient)
+		err = Delete("test-id", ws, "", false, mockClient)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -563,7 +564,7 @@ func TestDelete(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{deploymentResp}, nil).Once()
 		mockClient.On("DeleteDeployment", mock.Anything).Return(astro.Deployment{}, errMock).Once()
 
-		err := Delete("test-id", ws, true, mockClient)
+		err := Delete("test-id", ws, "", true, mockClient)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -139,8 +139,24 @@ func TestGetDeployment(t *testing.T) {
 			return errMock
 		}
 
-		_, err := GetDeployment(ws, "", "", mockClient)
-		assert.ErrorIs(t, err, errInvalidDeployment)
+		// mock os.Stdin
+		input := []byte("y")
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = w.Write(input)
+		if err != nil {
+			t.Error(err)
+		}
+		w.Close()
+		stdin := os.Stdin
+		// Restore stdin right after the test.
+		defer func() { os.Stdin = stdin }()
+		os.Stdin = r
+
+		_, err = GetDeployment(ws, "", "", mockClient)
+		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
 

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -190,39 +190,6 @@ func TestGetDeployment(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
-	// t.Run("select deployment error", func(t *testing.T) {
-	// 	mockClient := new(astro_mocks.Client)
-	// 	mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{}, nil).Once()
-	// 	// mock createDeployment
-	// 	createDeployment = func(label, workspaceID, description, clusterID, runtimeVersion string, schedulerAU, schedulerReplicas, workerAU int, client astro.Client) error {
-	// 		return nil
-	// 	}
-	// 	mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
-	// 	// mock selectDeployment
-	// 	deploymentSelect = func(deployments []astro.Deployment, message string) (astro.Deployment, error) {
-	// 		return astro.Deployment{}, errMock
-	// 	}
-	// 	// mock os.Stdin
-	// 	input := []byte("y")
-	// 	r, w, err := os.Pipe()
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
-	// 	_, err = w.Write(input)
-	// 	if err != nil {
-	// 		t.Error(err)
-	// 	}
-	// 	w.Close()
-	// 	stdin := os.Stdin
-	// 	// Restore stdin right after the test.
-	// 	defer func() { os.Stdin = stdin }()
-	// 	os.Stdin = r
-
-	// 	_, err = GetDeployment(ws, "", "", mockClient)
-	// 	assert.ErrorIs(t, err, errMock)
-	// 	mockClient.AssertExpectations(t)
-	// })
-
 	t.Run("test automatic deployment creation", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{}, nil).Once()

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func VariableList(deploymentID, variableKey, ws, envFile string, useEnvFile bool, client astro.Client, out io.Writer) error {
+func VariableList(deploymentID, variableKey, ws, envFile, deploymentName string, useEnvFile bool, client astro.Client, out io.Writer) error {
 	varTab := printutil.Table{
 		Padding:        []int{5, 30, 30, 50},
 		DynamicPadding: true,
@@ -21,7 +21,7 @@ func VariableList(deploymentID, variableKey, ws, envFile string, useEnvFile bool
 	}
 
 	// get deployment
-	currentDeployment, err := GetDeployment(ws, deploymentID, client)
+	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, client)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func VariableList(deploymentID, variableKey, ws, envFile string, useEnvFile bool
 
 // this function modifies a deployment's environment variable object
 // it is used to create and update deployment's environment variables
-func VariableModify(deploymentID, variableKey, variableValue, ws, envFile string, variableList []string, useEnvFile, makeSecret, updateVars bool, client astro.Client, out io.Writer) error {
+func VariableModify(deploymentID, variableKey, variableValue, ws, envFile, deploymentName string, variableList []string, useEnvFile, makeSecret, updateVars bool, client astro.Client, out io.Writer) error {
 	varTab := printutil.Table{
 		Padding:        []int{5, 30, 30, 50},
 		DynamicPadding: true,
@@ -67,7 +67,7 @@ func VariableModify(deploymentID, variableKey, variableValue, ws, envFile string
 	}
 
 	// get deployment
-	currentDeployment, err := GetDeployment(ws, deploymentID, client)
+	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, client)
 	if err != nil {
 		return err
 	}

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -227,7 +227,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, nil).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-2", "", "", ws, "", "",  []string{}, false, false, false, mockClient, buf)
+		err := VariableModify("test-id-2", "", "", ws, "", "", []string{}, false, false, false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "No variables for this Deployment")
 	})

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -36,12 +36,12 @@ func TestVariableList(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockResponse, nil).Twice()
 
 		buf := new(bytes.Buffer)
-		err := VariableList("test-id-1", "test-key-1", ws, "", false, mockClient, buf)
+		err := VariableList("test-id-1", "test-key-1", ws, "", "", false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "test-key-1")
 		assert.Contains(t, buf.String(), "test-value-1")
 
-		err = VariableList("test-id-1", "", ws, "", false, mockClient, buf)
+		err = VariableList("test-id-1", "", ws, "", "", false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "test-key-1")
 		assert.Contains(t, buf.String(), "test-value-1")
@@ -53,7 +53,7 @@ func TestVariableList(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockResponse, nil).Twice()
 
 		buf := new(bytes.Buffer)
-		err := VariableList("test-invalid-id", "test-key-1", ws, "", false, mockClient, buf)
+		err := VariableList("test-invalid-id", "test-key-1", ws, "", "", false, mockClient, buf)
 		assert.ErrorIs(t, err, errInvalidDeployment)
 
 		// mock os.Stdin
@@ -72,7 +72,7 @@ func TestVariableList(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = VariableList("", "test-key-1", ws, "", false, mockClient, buf)
+		err = VariableList("", "test-key-1", ws, "", "", false, mockClient, buf)
 		assert.ErrorIs(t, err, errInvalidDeploymentKey)
 		mockClient.AssertExpectations(t)
 	})
@@ -82,7 +82,7 @@ func TestVariableList(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockResponse, nil).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableList("test-id-1", "test-invalid-key", ws, "", false, mockClient, buf)
+		err := VariableList("test-id-1", "test-invalid-key", ws, "", "", false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "No variables found")
 		mockClient.AssertExpectations(t)
@@ -93,7 +93,7 @@ func TestVariableList(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{}, errMock).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableList("test-id-1", "test-key-1", ws, "", false, mockClient, buf)
+		err := VariableList("test-id-1", "test-key-1", ws, "", "", false, mockClient, buf)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -103,7 +103,7 @@ func TestVariableList(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockResponse, nil).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableList("test-id-1", "test-key-1", ws, "\000x", true, mockClient, buf)
+		err := VariableList("test-id-1", "test-key-1", ws, "\000x", "", true, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "unable to write environment variables to file")
 	})
@@ -145,7 +145,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", []string{}, true, false, false, mockClient, buf)
+		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", "", []string{}, true, false, false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "test-key-1")
 		assert.Contains(t, buf.String(), "test-key-2")
@@ -159,7 +159,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{}, errMock).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
+		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", "", []string{}, false, false, false, mockClient, buf)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -169,7 +169,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return(mockListResponse, nil).Twice()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-invalid-id", "test-key-2", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
+		err := VariableModify("test-invalid-id", "test-key-2", "test-value-2", ws, "", "", []string{}, false, false, false, mockClient, buf)
 		assert.ErrorIs(t, err, errInvalidDeployment)
 
 		// mock os.Stdin
@@ -188,7 +188,7 @@ func TestVariableModify(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = VariableModify("", "test-key-2", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
+		err = VariableModify("", "test-key-2", "test-value-2", ws, "", "", []string{}, false, false, false, mockClient, buf)
 		assert.ErrorIs(t, err, errInvalidDeploymentKey)
 		mockClient.AssertExpectations(t)
 	})
@@ -199,12 +199,12 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockCreateResponse, nil).Twice()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
+		err := VariableModify("test-id-1", "", "test-value-2", ws, "", "", []string{}, false, false, false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "You must provide a variable key")
 
 		buf = new(bytes.Buffer)
-		err = VariableModify("test-id-1", "test-key-2", "", ws, "", []string{}, false, false, false, mockClient, buf)
+		err = VariableModify("test-id-1", "test-key-2", "", ws, "", "", []string{}, false, false, false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "You must provide a variable value")
 		mockClient.AssertExpectations(t)
@@ -216,7 +216,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, errMock).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", []string{}, false, false, false, mockClient, buf)
+		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", "", []string{}, false, false, false, mockClient, buf)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -227,7 +227,7 @@ func TestVariableModify(t *testing.T) {
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, nil).Once()
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-2", "", "", ws, "", []string{}, false, false, false, mockClient, buf)
+		err := VariableModify("test-id-2", "", "", ws, "", "",  []string{}, false, false, false, mockClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "No variables for this Deployment")
 	})

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -33,21 +33,9 @@ Menu will be presented if you do not specify a deployment ID:
 )
 
 var (
-<<<<<<< HEAD
-<<<<<<< HEAD
 	pytestFile     string
 	envFile        string
 	imageName      string
-=======
-	pytestFile string
-	envFile    string
-	imageName  string
->>>>>>> add deployment name flag
-=======
-	pytestFile     string
-	envFile        string
-	imageName      string
->>>>>>> fix tests
 	deploymentName string
 )
 
@@ -73,11 +61,8 @@ func newDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables for Pytests")
 	cmd.Flags().StringVarP(&pytestFile, "test", "t", "", "Location of Pytests or specific Pytest file. All Pytest files must be located in the tests directory")
 	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom image to deploy")
-<<<<<<< HEAD
 	cmd.Flags().BoolVarP(&dags, "dags", "d", false, "To push dags to your airflow deployment")
 	_ = cmd.Flags().MarkHidden("dags")
-=======
->>>>>>> add deployment name flag
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to deploy to")
 	return cmd
 }

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -36,6 +36,7 @@ var (
 	pytestFile string
 	envFile    string
 	imageName  string
+	deploymentName string
 )
 
 const (
@@ -62,6 +63,7 @@ func newDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom image to deploy")
 	cmd.Flags().BoolVarP(&dags, "dags", "d", false, "To push dags to your airflow deployment")
 	_ = cmd.Flags().MarkHidden("dags")
+	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to deploy to")
 	return cmd
 }
 
@@ -106,5 +108,5 @@ func deploy(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	return deployImage(config.WorkingPath, deploymentID, ws, pytestFile, envFile, imageName, forcePrompt, dags, astroClient)
+	return deployImage(config.WorkingPath, deploymentID, ws, pytestFile, envFile, imageName, deploymentName, forcePrompt, dags, astroClient)
 }

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -33,9 +33,15 @@ Menu will be presented if you do not specify a deployment ID:
 )
 
 var (
+<<<<<<< HEAD
 	pytestFile     string
 	envFile        string
 	imageName      string
+=======
+	pytestFile string
+	envFile    string
+	imageName  string
+>>>>>>> add deployment name flag
 	deploymentName string
 )
 
@@ -61,8 +67,11 @@ func newDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables for Pytests")
 	cmd.Flags().StringVarP(&pytestFile, "test", "t", "", "Location of Pytests or specific Pytest file. All Pytest files must be located in the tests directory")
 	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom image to deploy")
+<<<<<<< HEAD
 	cmd.Flags().BoolVarP(&dags, "dags", "d", false, "To push dags to your airflow deployment")
 	_ = cmd.Flags().MarkHidden("dags")
+=======
+>>>>>>> add deployment name flag
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to deploy to")
 	return cmd
 }

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -34,6 +34,7 @@ Menu will be presented if you do not specify a deployment ID:
 
 var (
 <<<<<<< HEAD
+<<<<<<< HEAD
 	pytestFile     string
 	envFile        string
 	imageName      string
@@ -42,6 +43,11 @@ var (
 	envFile    string
 	imageName  string
 >>>>>>> add deployment name flag
+=======
+	pytestFile     string
+	envFile        string
+	imageName      string
+>>>>>>> fix tests
 	deploymentName string
 )
 

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -33,9 +33,9 @@ Menu will be presented if you do not specify a deployment ID:
 )
 
 var (
-	pytestFile string
-	envFile    string
-	imageName  string
+	pytestFile     string
+	envFile        string
+	imageName      string
 	deploymentName string
 )
 

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -23,7 +23,7 @@ func TestDeployImage(t *testing.T) {
 		return nil
 	}
 
-	deployImage = func(path, deploymentID, wsID, pytest, envFile, imageName string, prompt, dags bool, client astro.Client) error {
+	deployImage = func(path, deploymentID, wsID, pytest, envFile, imageName, deploymentName string, prompt, dags bool, client astro.Client) error {
 		return nil
 	}
 

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -208,11 +208,8 @@ func newDeploymentVariableCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&useEnvFile, "load", "l", false, "Create environment variables loaded from an environment file")
 	cmd.Flags().BoolVarP(&makeSecret, "secret", "s", false, "Set the new environment variables as secrets")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file to load environment variables from")
-<<<<<<< HEAD
 	_ = cmd.Flags().MarkHidden("key")
 	_ = cmd.Flags().MarkHidden("value")
-=======
->>>>>>> add deployment name flag
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to create variables from")
 
 	return cmd
@@ -235,11 +232,8 @@ func newDeploymentVariableUpdateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&useEnvFile, "load", "l", false, "Update environment variables loaded from an environment file")
 	cmd.Flags().BoolVarP(&makeSecret, "secret", "s", false, "Set updated environment variables as secrets")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file to load environment variables to update from")
-<<<<<<< HEAD
 	_ = cmd.Flags().MarkHidden("key")
 	_ = cmd.Flags().MarkHidden("value")
-=======
->>>>>>> add deployment name flag
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to update varibles from")
 
 	return cmd

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -208,8 +208,11 @@ func newDeploymentVariableCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&useEnvFile, "load", "l", false, "Create environment variables loaded from an environment file")
 	cmd.Flags().BoolVarP(&makeSecret, "secret", "s", false, "Set the new environment variables as secrets")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file to load environment variables from")
+<<<<<<< HEAD
 	_ = cmd.Flags().MarkHidden("key")
 	_ = cmd.Flags().MarkHidden("value")
+=======
+>>>>>>> add deployment name flag
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to create variables from")
 
 	return cmd
@@ -232,8 +235,11 @@ func newDeploymentVariableUpdateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&useEnvFile, "load", "l", false, "Update environment variables loaded from an environment file")
 	cmd.Flags().BoolVarP(&makeSecret, "secret", "s", false, "Set updated environment variables as secrets")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file to load environment variables to update from")
+<<<<<<< HEAD
 	_ = cmd.Flags().MarkHidden("key")
 	_ = cmd.Flags().MarkHidden("value")
+=======
+>>>>>>> add deployment name flag
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to update varibles from")
 
 	return cmd


### PR DESCRIPTION
## Description

Allows users to specify a deployment with the deployments name on commands: astro deployment delete, update, logs, and variable list, create, update

## 🎟 Issue(s)

-  https://github.com/astronomer/astro-cli/issues/668

## 🧪 Functional Testing

- added tests

## 📸 Screenshots



## 📋 Checklist

- [X] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [X] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
