### PR TITLE
Fix user role update in Software 

### DIFF
--- a/houston/queries.go
+++ b/houston/queries.go
@@ -526,8 +526,8 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 	}`
 
 	WorkspaceUserUpdateRequest = `
-	mutation workspaceUpdateUserRole($workspaceUuid: Uuid!, $email: String!, $role: Role!) {
-		workspaceUpdateUserRole(
+	mutation workspaceUpsertUserRole($workspaceUuid: Uuid!, $email: String!, $role: Role!) {
+		workspaceUpsertUserRole(
         	workspaceUuid: $workspaceUuid
             email: $email
             role: $role

--- a/houston/types.go
+++ b/houston/types.go
@@ -44,7 +44,7 @@ type ResponseData struct {
 	CancelUpdateDeploymentRuntime  *Deployment                 `json:"cancelRuntimeUpdate,omitempty"`
 	UpdateWorkspace                *Workspace                  `json:"updateWorkspace,omitempty"`
 	DeploymentLog                  []DeploymentLog             `json:"logs,omitempty"`
-	WorkspaceUpdateUserRole        string                      `json:"workspaceUpdateUserRole,omitempty"`
+	WorkspaceUpdateUserRole        string                      `json:"workspaceUpsertUserRole,omitempty"`
 	WorkspaceGetUser               WorkspaceUserRoleBindings   `json:"workspaceUser,omitempty"`
 	WorkspaceGetUsers              []WorkspaceUserRoleBindings `json:"workspaceUsers,omitempty"`
 	DeploymentConfig               DeploymentConfig            `json:"deploymentConfig,omitempty"`

--- a/houston/types.go
+++ b/houston/types.go
@@ -44,7 +44,7 @@ type ResponseData struct {
 	CancelUpdateDeploymentRuntime  *Deployment                 `json:"cancelRuntimeUpdate,omitempty"`
 	UpdateWorkspace                *Workspace                  `json:"updateWorkspace,omitempty"`
 	DeploymentLog                  []DeploymentLog             `json:"logs,omitempty"`
-	WorkspaceUpdateUserRole        string                      `json:"workspaceUpsertUserRole,omitempty"`
+	WorkspaceUpsertUserRole        string                      `json:"workspaceUpsertUserRole,omitempty"`
 	WorkspaceGetUser               WorkspaceUserRoleBindings   `json:"workspaceUser,omitempty"`
 	WorkspaceGetUsers              []WorkspaceUserRoleBindings `json:"workspaceUsers,omitempty"`
 	DeploymentConfig               DeploymentConfig            `json:"deploymentConfig,omitempty"`

--- a/houston/workspace_users.go
+++ b/houston/workspace_users.go
@@ -57,7 +57,7 @@ func (h ClientImplementation) UpdateWorkspaceUserRole(workspaceID, email, role s
 		return "", handleAPIErr(err)
 	}
 
-	return r.Data.WorkspaceUpdateUserRole, nil
+	return r.Data.WorkspaceUpsertUserRole, nil
 }
 
 // GetUserRoleInWorkspace - get a user role in a workspace

--- a/houston/workspace_users_test.go
+++ b/houston/workspace_users_test.go
@@ -181,7 +181,7 @@ func TestUpdateWorkspaceUserAndRole(t *testing.T) {
 
 	mockResponse := &Response{
 		Data: ResponseData{
-			WorkspaceUpdateUserRole: DeploymentAdminRole,
+			WorkspaceUpsertUserRole: DeploymentAdminRole,
 		},
 	}
 	jsonResponse, err := json.Marshal(mockResponse)
@@ -199,7 +199,7 @@ func TestUpdateWorkspaceUserAndRole(t *testing.T) {
 
 		response, err := api.UpdateWorkspaceUserRole("workspace-id", "email", DeploymentAdminRole)
 		assert.NoError(t, err)
-		assert.Equal(t, response, mockResponse.Data.WorkspaceUpdateUserRole)
+		assert.Equal(t, response, mockResponse.Data.WorkspaceUpsertUserRole)
 	})
 
 	t.Run("error", func(t *testing.T) {


### PR DESCRIPTION
## Description
Changes:
- Moved from using `workspaceUpdateUserRole` to `workspaceUpsertUserRole` query to update user role, this new query would allow us to cover the case when a user is added to a workspace implicitly via team added to a workspace and then someone tries to update that user role. The original query won't work because it won't find the record which needs to be updated corresponding to that user, which would be needed to be created and is covered as part of the upsert query.

## 🎟 Issue(s)

Related https://github.com/astronomer/issues/issues/4913

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
