### PR TITLE
Add checks on workspace & deployment roles and ids for team list

### DIFF
--- a/software/workspace/teams.go
+++ b/software/workspace/teams.go
@@ -64,8 +64,9 @@ func ListTeamRoles(workspaceID string, client houston.ClientInterface, out io.Wr
 		Header:         []string{"WORKSPACE ID", "TEAM ID", "TEAM NAME", "ROLE"},
 	}
 	for i := range workspaceTeams {
-		for j := range workspaceTeams[i].RoleBindings {
-			tab.AddRow([]string{workspaceID, workspaceTeams[i].ID, workspaceTeams[i].Name, workspaceTeams[i].RoleBindings[j].Role}, false)
+		role := getWorkspaceLevelRole(workspaceTeams[i].RoleBindings, workspaceID)
+		if role != houston.NoneTeamRole {
+			tab.AddRow([]string{workspaceID, workspaceTeams[i].ID, workspaceTeams[i].Name, role}, false)
 		}
 	}
 	tab.Print(out)
@@ -102,4 +103,23 @@ func UpdateTeamRole(workspaceID, teamID, role string, client houston.ClientInter
 
 	fmt.Fprintf(out, "Role has been changed from %s to %s for team %s\n", rb.Role, newRole, teamID)
 	return nil
+}
+
+// isValidWorkspaceLevelRole checks if the role is amongst valid workspace roles
+func isValidWorkspaceLevelRole(role string) bool {
+	switch role {
+	case houston.WorkspaceAdminRole, houston.WorkspaceEditorRole, houston.WorkspaceViewerRole, houston.NoneTeamRole:
+		return true
+	}
+	return false
+}
+
+// getWorkspaceLevelRole returns the first system level role from a slice of roles
+func getWorkspaceLevelRole(roles []houston.RoleBinding, workspaceID string) string {
+	for i := range roles {
+		if isValidWorkspaceLevelRole(roles[i].Role) && roles[i].Workspace.ID == workspaceID {
+			return roles[i].Role
+		}
+	}
+	return houston.NoneTeamRole
 }


### PR DESCRIPTION
## Description
Changes:
- Fixed the output of `astro deployment team list` & `astro workspace team list` command, where as of now it would output all the roles of all the teams associated with that deployment/workspace, which would mean it would return system-level role as well roles which are associated to other deployments/workspaces. The change is to filter out the Houston response based on deployment id or workspace id as well as role level.

Existing Response:
```
neel@Neels-MacBook-Pro astro-cli % ./astro deployment team list --deployment-id cl5tfvuxl9170314h9tn9czmrf
 DEPLOYMENT ID                  TEAM ID                        TEAM NAME         ROLE                  
 cl5tfvuxl9170314h9tn9czmrf     ckyampgud00286ll3efdkasb2      Everyone          DEPLOYMENT_VIEWER     
 cl5tfvuxl9170314h9tn9czmrf     ckyampgud00286ll3efdkasb2      Everyone          WORKSPACE_VIEWER      
 cl5tfvuxl9170314h9tn9czmrf     cl0vk7kl4302236lifcukic1mo     MovieWatchers     WORKSPACE_EDITOR      
 cl5tfvuxl9170314h9tn9czmrf     cl0vk7kl4302236lifcukic1mo     MovieWatchers     WORKSPACE_EDITOR      
 cl5tfvuxl9170314h9tn9czmrf     cl0vk7kl4302236lifcukic1mo     MovieWatchers     DEPLOYMENT_EDITOR   
```

New Response:
```
neel@Neels-MacBook-Pro astro-cli % ./astro deployment team list --deployment-id cl5tfvuxl9170314h9tn9czmrf
 DEPLOYMENT ID                  TEAM ID                        TEAM NAME         ROLE                  
 cl5tfvuxl9170314h9tn9czmrf     ckyampgud00286ll3efdkasb2      Everyone          DEPLOYMENT_VIEWER     
 cl5tfvuxl9170314h9tn9czmrf     cl0vk7kl4302236lifcukic1mo     MovieWatchers     DEPLOYMENT_EDITOR     
neel@Neels-MacBook-Pro astro-cli % 
```

## 🎟 Issue(s)

Related #681 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
