### PR TITLE
Fix deploy error message from deployment name to deployment id

### DIFF
--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -30,7 +30,7 @@ var (
 var (
 	errNoWorkspaceID             = errors.New("no workspace id provided")
 	errNoDomainSet               = errors.New("no domain set, re-authenticate")
-	errInvalidDeploymentName     = errors.New("please specify a valid deployment name")
+	errInvalidDeploymentID       = errors.New("please specify a valid deployment ID")
 	errDeploymentNotFound        = errors.New("no airflow deployments found")
 	errInvalidDeploymentSelected = errors.New("invalid deployment selection\n") //nolint
 )
@@ -93,7 +93,7 @@ func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, by
 	}
 
 	if deploymentID != "" && !deploymentExists(deploymentID, deployments) {
-		return errInvalidDeploymentName
+		return errInvalidDeploymentID
 	}
 
 	// Prompt user for deployment if no deployment passed in

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -298,7 +298,7 @@ func TestAirflowFailure(t *testing.T) {
 
 	// Invalid deployment name case
 	err = Airflow(houstonMock, "", "test-deployment-id", "test-workspace-id", "", false, false, false)
-	assert.ErrorIs(t, err, errInvalidDeploymentName)
+	assert.ErrorIs(t, err, errInvalidDeploymentID)
 
 	// No deployment in the current workspace case
 	err = Airflow(houstonMock, "", "", "test-workspace-id", "", false, false, false)


### PR DESCRIPTION
## Description
Changes:
- Fixed deploy error message when invalid deployment ID is passed

## 🎟 Issue(s)

Related #691 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
