### PR TITLE
Fix check for case when deployment is on AC in runtime upgrade cmd

### DIFF
--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -457,7 +457,7 @@ func RuntimeUpgrade(id, desiredRuntimeVersion string, client houston.ClientInter
 		return err
 	}
 
-	if deployment.RuntimeVersion == "" || deployment.AirflowVersion != "" {
+	if deployment.RuntimeVersion == "" && deployment.AirflowVersion != "" {
 		return errDeploymentNotOnRuntime
 	}
 

--- a/software/deployment/deployment_test.go
+++ b/software/deployment/deployment_test.go
@@ -1127,15 +1127,41 @@ func TestRuntimeUpgrade(t *testing.T) {
 		Label:                 "test123",
 		ReleaseName:           "burning-terrestrial-5940",
 		Version:               "0.0.0",
+		AirflowVersion:        "2.2.0",
+		DesiredAirflowVersion: "2.2.0",
 		RuntimeVersion:        "4.2.4",
 		RuntimeAirflowVersion: "2.2.4",
 		DesiredRuntimeVersion: "4.2.5",
 	}
 
-	t.Run("upgrade runtime success", func(t *testing.T) {
+	t.Run("upgrade runtime success when deployment is coming from AC migration", func(t *testing.T) {
 		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": mockDeployment.DesiredRuntimeVersion}
 
 		api := new(mocks.ClientInterface)
+		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
+		api.On("UpdateDeploymentRuntime", expectedVars).Return(mockDeployment, nil)
+		buf := new(bytes.Buffer)
+		err := RuntimeUpgrade(mockDeployment.ID, mockDeployment.DesiredRuntimeVersion, api, buf)
+		assert.NoError(t, err)
+		expected := ` NAME        DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 IMAGE VERSION     
+ test123     burning-terrestrial-5940     v0.0.0     ckbv818oa00r107606ywhoqtw     Runtime-4.2.5     
+
+The upgrade from Runtime 4.2.4 to 4.2.5 has been started. To complete this process, add an Runtime 4.2.5 image to your Dockerfile and deploy to Astronomer.
+To cancel, run: 
+ $ astro deployment runtime upgrade --cancel
+
+`
+
+		assert.Equal(t, expected, buf.String())
+		api.AssertExpectations(t)
+	})
+
+	t.Run("upgrade runtime success if deployment was always using runtime", func(t *testing.T) {
+		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": mockDeployment.DesiredRuntimeVersion}
+
+		api := new(mocks.ClientInterface)
+		mockDeployment.AirflowVersion = ""
+		mockDeployment.DesiredAirflowVersion = ""
 		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
 		api.On("UpdateDeploymentRuntime", expectedVars).Return(mockDeployment, nil)
 		buf := new(bytes.Buffer)


### PR DESCRIPTION
## Description
Changes:
- Fixed the AC deployment check in runtime upgrade cmd to ensure it only restricts when runtime version is not set and airflow version is set

## 🎟 Issue(s)

Related https://github.com/astronomer/issues/issues/4969

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
