### PR TITLE
add no browser flag

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -631,7 +631,7 @@ var checkWebserverHealth = func(project *types.Project, composeService api.Servi
 				fmt.Printf(composeLinkPostgresMsg+"\n", ansi.Bold("localhost:"+config.CFG.PostgresPort.GetString()+"/postgres"))
 				fmt.Printf(composeUserPasswordMsg+"\n", ansi.Bold("admin:admin"))
 				fmt.Printf(postgresUserPasswordMsg+"\n", ansi.Bold("postgres:postgres"))
-				if !noBrowser {
+				if !noBrowser || !util.CheckEnvBool(os.Getenv("ASTRONOMER_NO_BROWSER")) {
 					err = openURL(webserverURL)
 					if err != nil {
 						fmt.Println("\nUnable to open the webserver URL, please visit the following link: " + webserverURL)


### PR DESCRIPTION
## Description

Add variable for users to use to make it so the web server doesn't automatically come up

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing



## 📸 Screenshots



## 📋 Checklist

- [X] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
