### PR TITLE
CLI Pagination: astro workspace switch command is throwing an error

### DIFF
--- a/software/workspace/workspace_test.go
+++ b/software/workspace/workspace_test.go
@@ -215,7 +215,7 @@ func TestGetWorkspaceSelectionError(t *testing.T) {
 	api.On("ListWorkspaces").Return(nil, errMock)
 
 	buf := new(bytes.Buffer)
-	_, err := getWorkspaceSelection(0, 0, api, buf)
+	_, _, err := getWorkspaceSelection(0, 0, api, buf)
 	assert.EqualError(t, err, errMock.Error())
 	api.AssertExpectations(t)
 }
@@ -324,7 +324,7 @@ func TestGetWorkspaceSelection(t *testing.T) {
 		err := config.ResetCurrentContext()
 		assert.NoError(t, err)
 		out := new(bytes.Buffer)
-		resp, err := getWorkspaceSelection(0, 0, api, out)
+		resp, _, err := getWorkspaceSelection(0, 0, api, out)
 
 		assert.Contains(t, err.Error(), "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 		assert.Equal(t, "", resp)
@@ -335,7 +335,7 @@ func TestGetWorkspaceSelection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		defer testUtil.MockUserInput(t, "1")()
-		resp, err := getWorkspaceSelection(0, 0, api, out)
+		resp, _, err := getWorkspaceSelection(0, 0, api, out)
 
 		assert.NoError(t, err)
 		assert.Equal(t, "ck05r3bor07h40d02y2hw4n4v", resp)
@@ -344,7 +344,7 @@ func TestGetWorkspaceSelection(t *testing.T) {
 	t.Run("success with pagination", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		defer testUtil.MockUserInput(t, "1")()
-		resp, err := getWorkspaceSelection(10, 0, api, out)
+		resp, _, err := getWorkspaceSelection(10, 0, api, out)
 
 		assert.NoError(t, err)
 		assert.Equal(t, "ck05r3bor07h40d02y2hw4n4v", resp)
@@ -353,7 +353,7 @@ func TestGetWorkspaceSelection(t *testing.T) {
 	t.Run("invalid selection", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		defer testUtil.MockUserInput(t, "y")()
-		resp, err := getWorkspaceSelection(0, 0, api, out)
+		resp, _, err := getWorkspaceSelection(0, 0, api, out)
 
 		assert.Contains(t, err.Error(), "cannot parse y to int")
 		assert.Equal(t, "", resp)
@@ -362,9 +362,10 @@ func TestGetWorkspaceSelection(t *testing.T) {
 	t.Run("quit selection when paginated", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		defer testUtil.MockUserInput(t, "q")()
-		resp, err := getWorkspaceSelection(10, 0, api, out)
+		resp, quit, err := getWorkspaceSelection(10, 0, api, out)
 		assert.Nil(t, err)
 		assert.Equal(t, "", resp)
+		assert.Equal(t, true, quit)
 	})
 }
 

--- a/software/workspace/workspace_test.go
+++ b/software/workspace/workspace_test.go
@@ -215,8 +215,8 @@ func TestGetWorkspaceSelectionError(t *testing.T) {
 	api.On("ListWorkspaces").Return(nil, errMock)
 
 	buf := new(bytes.Buffer)
-	_, _, err := getWorkspaceSelection(0, 0, api, buf)
-	assert.EqualError(t, err, errMock.Error())
+	workspaceSelection := getWorkspaceSelection(0, 0, api, buf)
+	assert.EqualError(t, workspaceSelection.err, errMock.Error())
 	api.AssertExpectations(t)
 }
 
@@ -324,10 +324,10 @@ func TestGetWorkspaceSelection(t *testing.T) {
 		err := config.ResetCurrentContext()
 		assert.NoError(t, err)
 		out := new(bytes.Buffer)
-		resp, _, err := getWorkspaceSelection(0, 0, api, out)
+		workspaceSelection := getWorkspaceSelection(0, 0, api, out)
 
-		assert.Contains(t, err.Error(), "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
-		assert.Equal(t, "", resp)
+		assert.Contains(t, workspaceSelection.err.Error(), "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
+		assert.Equal(t, "", workspaceSelection.id)
 	})
 
 	testUtil.InitTestConfig("software")
@@ -335,37 +335,37 @@ func TestGetWorkspaceSelection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		defer testUtil.MockUserInput(t, "1")()
-		resp, _, err := getWorkspaceSelection(0, 0, api, out)
+		workspaceSelection := getWorkspaceSelection(0, 0, api, out)
 
-		assert.NoError(t, err)
-		assert.Equal(t, "ck05r3bor07h40d02y2hw4n4v", resp)
+		assert.NoError(t, workspaceSelection.err)
+		assert.Equal(t, "ck05r3bor07h40d02y2hw4n4v", workspaceSelection.id)
 	})
 
 	t.Run("success with pagination", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		defer testUtil.MockUserInput(t, "1")()
-		resp, _, err := getWorkspaceSelection(10, 0, api, out)
+		workspaceSelection := getWorkspaceSelection(10, 0, api, out)
 
-		assert.NoError(t, err)
-		assert.Equal(t, "ck05r3bor07h40d02y2hw4n4v", resp)
+		assert.NoError(t, workspaceSelection.err)
+		assert.Equal(t, "ck05r3bor07h40d02y2hw4n4v", workspaceSelection.id)
 	})
 
 	t.Run("invalid selection", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		defer testUtil.MockUserInput(t, "y")()
-		resp, _, err := getWorkspaceSelection(0, 0, api, out)
+		workspaceSelection := getWorkspaceSelection(0, 0, api, out)
 
-		assert.Contains(t, err.Error(), "cannot parse y to int")
-		assert.Equal(t, "", resp)
+		assert.Contains(t, workspaceSelection.err.Error(), "cannot parse y to int")
+		assert.Equal(t, "", workspaceSelection.id)
 	})
 
 	t.Run("quit selection when paginated", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		defer testUtil.MockUserInput(t, "q")()
-		resp, quit, err := getWorkspaceSelection(10, 0, api, out)
-		assert.Nil(t, err)
-		assert.Equal(t, "", resp)
-		assert.Equal(t, true, quit)
+		workspaceSelection := getWorkspaceSelection(10, 0, api, out)
+		assert.Nil(t, workspaceSelection.err)
+		assert.Equal(t, "", workspaceSelection.id)
+		assert.Equal(t, true, workspaceSelection.quit)
 	})
 }
 


### PR DESCRIPTION
## Description

> fixed workspace switch pagination on quit selection throws an error

## 🎟 Issue(s)

Related
- https://github.com/astronomer/issues/issues/4985

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.
<img width="797" alt="Screen Shot 2022-08-30 at 10 48 18 AM" src="https://user-images.githubusercontent.com/5626812/187468518-6f1191d4-632f-481e-b715-df8dcbb43d3b.png">



## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
