### PR TITLE
worker queue delete command

### DIFF
--- a/cmd/cloud/deployment_workerqueue.go
+++ b/cmd/cloud/deployment_workerqueue.go
@@ -14,6 +14,7 @@ var (
 	maxWorkerCount int
 	workerType     string
 	name           string
+	force          bool
 )
 
 func newDeploymentWorkerQueueRootCmd(out io.Writer) *cobra.Command {
@@ -25,6 +26,7 @@ func newDeploymentWorkerQueueRootCmd(out io.Writer) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newDeploymentWorkerQueueCreateCmd(out),
+		newDeploymentWorkerQueueDeleteCmd(out),
 	)
 	return cmd
 }
@@ -39,14 +41,31 @@ func newDeploymentWorkerQueueCreateCmd(out io.Writer) *cobra.Command {
 			return deploymentWorkerQueueCreate(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be created.")
-	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment where the worker queue should be created.")
-	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue. Queue names must not exceed 63 characters and contain only lowercase alphanumeric characters or '-' and start with an alphabetical character.")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be deleted.")
+	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment where the worker queue should be deleted.")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue to delete.")
 	cmd.Flags().IntVarP(&minWorkerCount, "min-count", "", 0, "The min worker count of the worker queue.")
 	cmd.Flags().IntVarP(&maxWorkerCount, "max-count", "", 0, "The max worker count of the worker queue.")
 	cmd.Flags().IntVarP(&concurrency, "concurrency", "", 0, "The concurrency(number of slots) of the worker queue.")
 	cmd.Flags().StringVarP(&workerType, "worker-type", "t", "", "The worker type of the default worker queue.")
 
+	return cmd
+}
+
+func newDeploymentWorkerQueueDeleteCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Aliases: []string{"de"},
+		Short:   "Delete a Deployment's worker queue",
+		Long:    "Delete a worker queue from an Astro Deployment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentWorkerQueueDelete(cmd, args, out)
+		},
+	}
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be created.")
+	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment where the worker queue should be created.")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue. Queue names must not exceed 63 characters and contain only lowercase alphanumeric characters or '-' and start with an alphabetical character.")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force delete: Don't prompt a user for confirmation")
 	return cmd
 }
 
@@ -59,4 +78,14 @@ func deploymentWorkerQueueCreate(cmd *cobra.Command, _ []string, out io.Writer) 
 	}
 
 	return workerqueue.Create(ws, deploymentID, deploymentName, name, workerType, minWorkerCount, maxWorkerCount, concurrency, astroClient, out)
+}
+
+func deploymentWorkerQueueDelete(cmd *cobra.Command, _ []string, out io.Writer) error {
+	cmd.SilenceUsage = true
+
+	ws, err := coalesceWorkspace()
+	if err != nil {
+		return err
+	}
+	return workerqueue.Delete(ws, deploymentID, deploymentName, name, force, astroClient, out)
 }


### PR DESCRIPTION
## Description

This command allows users to delete a worker queue from a deployment. It prompts for a deployment and name of the queue to delete if none were provided. It prevents users from deleting a default worker queue.

Deletion is confirmed using the `--force` flag.

## 🎟 Issue(s)

Related #671

## 🧪 Functional Testing

### worker queue is deleted
>
### default queue can not be deleted
```bash
$ astro deployment worker-queue delete -n default
Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME                 DEPLOYMENT ID
 1     neel-dev-test       advanced-precession-1762     cl60i43ye406311hvr3amdaxvy
 2     jp-test-queues      new-phase-7131               cl7fcde9x90222d3wrsd9l0wp

> 2
Error: default queue can not be deleted
```
### prompts for a queue name
```bash
$ astro deployment worker-queue delete --deployment-name jp-test-queues

 #     WORKER QUEUE     ISDEFAULT     ID
 1     default          true          cl7fcde9x90252d3wy8eveugs
 2     test-q           false         cl7fer8zl321452cqavlm961wp

> ...
```
### prompts for confirmation before deletion
```bash
$ astro deployment worker-queue delete --deployment-name jp-test-queues -n test-q

Are you sure you want to delete the test-q worker queue? (y/n) n
Canceling worker queue deletion
```

### skips delete confirmation
```bash
$ astro deployment worker-queue delete --deployment-name jp-test-queues -n test-q2 --force
cl7fcde9x90222d3wrsd9l0wp
 NAME               NAMESPACE          WORKSPACE ID                   CLUSTER ID                    DEPLOYMENT ID                 DOCKER IMAGE TAG     RUNTIME VERSION
 jp-test-queues     new-phase-7131     cl0v1p6lc728255byzyfs7lw21     ckt3779dp00000rvx94xucbx7     cl7fcde9x90222d3wrsd9l0wp     5.0.8                5.0.8 (based on Airflow 2.3.4)

 Successfully updated Deployment
worker queue test-q2 for jp-test-queues in cl0v1p6lc728255byzyfs7lw21 workspace deleted
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
