### PR TITLE
Move from MustParse to NewVersion of semver to avoid code panics

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -36,6 +36,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -209,8 +210,10 @@ func (d *DockerCompose) Start(imageName string, noCache, noBrowser bool) error {
 	airflowDockerVersion := defaultAirflowVersion
 	airflowVersion, ok := imageLabels[airflowVersionLabelName]
 	if ok {
-		if version := semver.MustParse(airflowVersion); version != nil {
+		if version, err := semver.NewVersion(airflowVersion); err == nil {
 			airflowDockerVersion = version.Major()
+		} else {
+			logrus.Debugf("unable to parse airflow version, defaulting to major version 2, error: %s", err.Error())
 		}
 	}
 

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -219,6 +219,36 @@ func TestDockerComposeStart(t *testing.T) {
 		composeMock.AssertExpectations(t)
 	})
 
+	t.Run("success with invalid airflow version label", func(t *testing.T) {
+		noCache := false
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: "2.3.4.dev+astro1"}, nil).Twice()
+		imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
+
+		composeMock := new(mocks.DockerComposeAPI)
+		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Twice()
+		composeMock.On("Up", mock.Anything, mock.Anything, api.UpOptions{Create: api.CreateOptions{}}).Return(nil).Twice()
+
+		orgCheckWebserverHealthFunc := checkWebserverHealth
+		checkWebserverHealth = func(project *types.Project, composeService api.Service, airflowDockerVersion uint64, noBrowser bool) error {
+			return nil
+		}
+		defer func() { checkWebserverHealth = orgCheckWebserverHealthFunc }()
+
+		mockDockerCompose.composeService = composeMock
+		mockDockerCompose.imageHandler = imageHandler
+
+		err := mockDockerCompose.Start("", noCache, false)
+		assert.NoError(t, err)
+
+		err = mockDockerCompose.Start("custom-image", noCache, false)
+		assert.NoError(t, err)
+
+		imageHandler.AssertExpectations(t)
+		composeMock.AssertExpectations(t)
+	})
+
 	t.Run("project already running", func(t *testing.T) {
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-webserver-id", State: "running"}}, nil).Once()

--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -143,7 +143,7 @@ func CheckTriggererEnabled(client houston.ClientInterface) bool {
 func addTriggererReplicasArg(vars map[string]interface{}, client houston.ClientInterface, airflowVersion string, triggererReplicas int) {
 	// reset triggerer count to zero in case airflowVersion < 2.2.0
 	if airflowVersion != "" {
-		if version := semver.MustParse(airflowVersion); version != nil && version.LessThan(triggererAllowedAirflowVersion) {
+		if version, _ := semver.NewVersion(airflowVersion); version != nil && version.LessThan(triggererAllowedAirflowVersion) {
 			triggererReplicas = 0
 		}
 	}
@@ -543,10 +543,11 @@ func RuntimeMigrate(deploymentID string, client houston.ClientInterface, out io.
 
 	var latestRuntimeRelease *semver.Version
 	for idx := range runtimeReleases {
+		runtimeVersion, _ := semver.NewVersion(runtimeReleases[idx].Version)
 		if latestRuntimeRelease == nil {
-			latestRuntimeRelease = semver.MustParse(runtimeReleases[idx].Version)
-		} else if !latestRuntimeRelease.GreaterThan(semver.MustParse(runtimeReleases[idx].Version)) {
-			latestRuntimeRelease = semver.MustParse(runtimeReleases[idx].Version)
+			latestRuntimeRelease = runtimeVersion
+		} else if runtimeVersion != nil && !latestRuntimeRelease.GreaterThan(runtimeVersion) {
+			latestRuntimeRelease = runtimeVersion
 		}
 	}
 

--- a/software/deployment/deployment_test.go
+++ b/software/deployment/deployment_test.go
@@ -1337,7 +1337,7 @@ func TestRuntimeMigrate(t *testing.T) {
 
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
-		api.On("GetRuntimeReleases", mockDeployment.AirflowVersion).Return(houston.RuntimeReleases{houston.RuntimeRelease{Version: "4.2.4", AirflowVersion: "2.2.4"}}, nil)
+		api.On("GetRuntimeReleases", mockDeployment.AirflowVersion).Return(houston.RuntimeReleases{houston.RuntimeRelease{Version: "4.2.3", AirflowVersion: "2.2.3"}, houston.RuntimeRelease{Version: "4.2.4", AirflowVersion: "2.2.4"}}, nil)
 		mockMigrateRuntimeResp := *mockDeployment
 		mockMigrateRuntimeResp.RuntimeVersion = "4.2.4"
 		api.On("UpdateDeploymentRuntime", expectedVars).Return(&mockMigrateRuntimeResp, nil)


### PR DESCRIPTION
## Description
Changes:
- Moved to `semver.NewVersion` from `semver.MustParse` as MustParse will panic in case version passed is invalid.

## 🎟 Issue(s)

Related #657 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
