### PR TITLE
Fix boolean logic for checking nobrowser setting

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -631,7 +631,7 @@ var checkWebserverHealth = func(project *types.Project, composeService api.Servi
 				fmt.Printf(composeLinkPostgresMsg+"\n", ansi.Bold("localhost:"+config.CFG.PostgresPort.GetString()+"/postgres"))
 				fmt.Printf(composeUserPasswordMsg+"\n", ansi.Bold("admin:admin"))
 				fmt.Printf(postgresUserPasswordMsg+"\n", ansi.Bold("postgres:postgres"))
-				if !noBrowser || !util.CheckEnvBool(os.Getenv("ASTRONOMER_NO_BROWSER")) {
+				if !(noBrowser || util.CheckEnvBool(os.Getenv("ASTRONOMER_NO_BROWSER"))) {
 					err = openURL(webserverURL)
 					if err != nil {
 						fmt.Println("\nUnable to open the webserver URL, please visit the following link: " + webserverURL)


### PR DESCRIPTION
## Description

The boolean logic to check for the `noBrowser` setting is currently such that both the `--no-browser` flag AND the `ASTRONOMER_NO_BROWSER` env var are required. This PR changes that behaviour to OR, so that either the flag or the env var (or both) will not open the browser.

Verified by building the CLI and running `astro dev start --no-browser`, and running `ASTRONOMER_NO_BROWSER=true astro dev start`, which both did not open the browser.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
