### PR TITLE
worker queue update command

### DIFF
--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -15,6 +15,11 @@ import (
 	"github.com/astronomer/astro-cli/pkg/printutil"
 )
 
+const (
+	createAction = "create"
+	updateAction = "update"
+)
+
 var (
 	errWorkerQueueDefaultOptions = errors.New("failed to get worker queue default options")
 	errInvalidWorkerQueueOption  = errors.New("worker queue option is invalid")
@@ -66,7 +71,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	}
 
 	switch action {
-	case "create":
+	case createAction:
 		if name == "" {
 			// prompt for name if one was not provided
 			queueToCreateOrUpdate.Name = input.Text("Enter a name for the worker queue\n> ")
@@ -79,7 +84,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 		// queueToCreateOrUpdate does not exist
 		// user requested create, so we add queueToCreateOrUpdate to the list
 		listToCreate = append(requestedDeployment.WorkerQueues, *queueToCreateOrUpdate) //nolint
-	case "update":
+	case updateAction:
 		if name == "" {
 			// user selects a queue as no name was provided
 			queueToCreateOrUpdate.Name, err = selectQueue(requestedDeployment.WorkerQueues, out)

--- a/cmd/cloud/deployment_workerqueue.go
+++ b/cmd/cloud/deployment_workerqueue.go
@@ -66,7 +66,7 @@ func newDeploymentWorkerQueueUpdateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be created.")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment where the worker queue should be created.")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue. Queue names must not exceed 63 characters and contain only lowercase alphanumeric characters or '-' and start with an alphabetical character.")
-	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force delete: Don't prompt a user for confirmation")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force update: Don't prompt a user for confirmation")
 	cmd.Flags().IntVarP(&minWorkerCount, "min-count", "", 0, "The min worker count of the worker queue.")
 	cmd.Flags().IntVarP(&maxWorkerCount, "max-count", "", 0, "The max worker count of the worker queue.")
 	cmd.Flags().IntVarP(&concurrency, "concurrency", "", 0, "The concurrency(number of slots) of the worker queue.")


### PR DESCRIPTION
## Description

This PR adds a command to update a worker queue for a deployment discussed in #670. This command checks if the queue being requested exists and only allows for existing worker queues to be updated.  Only one worker queue at a time can be updated with this command. 

The command prompts the user to select a queue to update if the user did not specify a name. 
`--froce` can be used to avoid a confirmation before applying the update.
 

## 🎟 Issue(s)

Related #670 

## 🧪 Functional Testing

### update the default worker-queue
```bash
$ astro deployment worker-queue update -n default --max-count 16 --deployment-name jp-test-queues --worker-type t3.2xlarge
cl7fcde9x90222d3wrsd9l0wp
 NAME               NAMESPACE          WORKSPACE ID                   CLUSTER ID                    DEPLOYMENT ID                 DOCKER IMAGE TAG     RUNTIME VERSION
 jp-test-queues     new-phase-7131     cl0v1p6lc728255byzyfs7lw21     ckt3779dp00000rvx94xucbx7     cl7fcde9x90222d3wrsd9l0wp     5.0.8                5.0.8 (based on Airflow 2.3.4)

 Successfully updated Deployment
worker queue default for jp-test-queues in cl0v1p6lc728255byzyfs7lw21 workspace updated
```
### update non default default worker-queue
```bash
$ astro deployment worker-queue update -n test-q --min-count 5 --deployment-name jp-test-queues --worker-type t3.2xlarge
cl7fcde9x90222d3wrsd9l0wp
 NAME               NAMESPACE          WORKSPACE ID                   CLUSTER ID                    DEPLOYMENT ID                 DOCKER IMAGE TAG     RUNTIME VERSION
 jp-test-queues     new-phase-7131     cl0v1p6lc728255byzyfs7lw21     ckt3779dp00000rvx94xucbx7     cl7fcde9x90222d3wrsd9l0wp     5.0.8                5.0.8 (based on Airflow 2.3.4)

 Successfully updated Deployment
worker queue test-q for jp-test-queues in cl0v1p6lc728255byzyfs7lw21 workspace updated
```
### prompts for queue name if one was not specified

```bash
$ astro deployment worker-queue update --min-count 5 --deployment-name jp-test-queues --worker-type t3.2xlarge

 #     WORKER QUEUE     ISDEFAULT     ID
 1     astro-q1         false         cl7i2v6w1713812cwev6l0hhh0
 2     default          true          cl7fcde9x90252d3wy8eveugs
 3     test-q           false         cl7fer8zl321452cqavlm961wp
 4     test-q3          false         cl7i2uveq709512cwemp2z2sr1
...
```
### prompts for worker type if one was not specified

```bash
$ astro deployment worker-queue update -n test-q --min-count 5 --deployment-name jp-test-queues
No worker type was specified. Select the worker type to use
 #     WORKER TYPE      ISDEFAULT     ID
 1     t3.2xlarge       true          cl1y87zxz00046dywhzh50k9a
 2     c6i.12xlarge     false         cl639x2u6114361hx0cqw9oehw
...
```

### prompts for deployment if one was not specified

```bash
$ astro deployment worker-queue update --min-count 5  --worker-type t3.2xlarge
Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME                 DEPLOYMENT ID
 1     neel-dev-test       advanced-precession-1762     cl60i43ye406311hvr3amdaxvy
 2     jp-test-queues      new-phase-7131               cl7fcde9x90222d3wrsd9l0wp
...
```

### errors when non-existing queue is being modified

```bash
$ astro deployment worker-queue update -n test-q100 --min-count 5 --deployment-name jp-test-queues --worker-type t3.2xlarge
Error: worker queue does not exist: use worker queue create test-q100 instead
```

### errors when input values for min, max, concurrency are out of bounds

```bash
$ astro deployment worker-queue update -n test-q --min-count 50 --deployment-name jp-test-queues --worker-type t3.2xlarge
Error: worker queue option is invalid: min worker count must be between 0 and 32
```
### errors when worker type is incorrect

```bash
$ astro deployment worker-queue update -n test-q --min-count 5 --deployment-name jp-test-queues --worker-type doesnotexist
Error: node pool selection failed: workerType doesnotexist is not available for this deployment
```

### errors when min-count is > max-count

```bash
$ astro deployment worker-queue update -n test-q --deployment-name jp-test-queues --worker-type t3.2xlarge --min-count 32 --max-count 16
cl7fcde9x90222d3wrsd9l0wp
Error: Cannot connect to Astronomer. Try to log in with astro login or check your internet connection and user permissions.

Details: Requested minimum worker count 32 cannot be greater than requested maximum worker count 16.
```

### errors when any api call made to get workspace, deployments, get default values, etc. fails

```bash
$ astro deployment worker-queue update -n test-q --min-count 5 --deployment-name jp-test-queues --worker-type t3.2xlarge
Error: no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
