### PR TITLE
Move from zip to exe for windows binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ archives:
   - format: tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        format: exe
     name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     files:
       - licence*


### PR DESCRIPTION
## Description
Changes:
- Updated the format for windows binaries to `.exe` format as we plan to add support for the `winget` package manager, which requires a `.exe` format


## 🎟 Issue(s)

Related #716

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

<img width="963" alt="Screenshot 2022-09-08 at 1 16 15 PM" src="https://user-images.githubusercontent.com/92356010/189065303-7060179e-c5de-438d-8542-a089c5cde67a.png">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
