### PR TITLE
remove `--worker-au` flag from deployment commands

### DIFF
--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -91,7 +91,6 @@ type DeploymentSpec struct {
 	Image                       Image                        `json:"image,omitempty"`
 	Webserver                   Webserver                    `json:"webserver,omitempty"`
 	Executor                    string                       `json:"executor"`
-	Workers                     Workers                      `json:"workers"`
 	Scheduler                   Scheduler                    `json:"scheduler"`
 	EnvironmentVariablesObjects []EnvironmentVariablesObject `json:"environmentVariablesObjects"`
 }
@@ -210,11 +209,6 @@ type Webserver struct {
 	URL string `json:"url"`
 }
 
-type Workers struct {
-	AU                            int `json:"au"`
-	TerminationGracePeriodSeconds int `json:"terminationGracePeriodSeconds"`
-}
-
 type Scheduler struct {
 	AU       int `json:"au"`
 	Replicas int `json:"replicas"`
@@ -269,7 +263,6 @@ type CreateDeploymentInput struct {
 
 type DeploymentCreateSpec struct {
 	Executor  string    `json:"executor"`
-	Workers   Workers   `json:"workers"`
 	Scheduler Scheduler `json:"scheduler"`
 }
 

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -36,10 +36,8 @@ const (
 // TODO: get these values from the Astrohub API
 var (
 	SchedulerAuMin       = 5
-	WorkerAuMin          = 10
 	SchedulerReplicasMin = 1
 	schedulerAuMax       = 30
-	workerAuMax          = 175
 	schedulerReplicasMax = 4
 	sleepTime            = 180
 	tickNum              = 10
@@ -134,7 +132,7 @@ func Logs(deploymentID, ws, deploymentName string, warnLogs, errorLogs, infoLogs
 	return nil
 }
 
-func Create(label, workspaceID, description, clusterID, runtimeVersion string, schedulerAU, schedulerReplicas, workerAU int, client astro.Client, waitForStatus bool) error {
+func Create(label, workspaceID, description, clusterID, runtimeVersion string, schedulerAU, schedulerReplicas int, client astro.Client, waitForStatus bool) error {
 	var organizationID string
 	var currentWorkspace astro.Workspace
 
@@ -144,7 +142,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion string, s
 	}
 
 	// validate resources requests
-	resourcesValid := validateResources(workerAU, schedulerAU, schedulerReplicas)
+	resourcesValid := validateResources(schedulerAU, schedulerReplicas)
 	if !resourcesValid {
 		return nil
 	}
@@ -201,11 +199,6 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion string, s
 		return err
 	}
 
-	workers := astro.Workers{
-		AU:                            workerAU,
-		TerminationGracePeriodSeconds: 86400,
-	}
-
 	scheduler := astro.Scheduler{
 		AU:       schedulerAU,
 		Replicas: schedulerReplicas,
@@ -213,7 +206,6 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion string, s
 
 	spec := astro.DeploymentCreateSpec{
 		Executor:  "CeleryExecutor",
-		Workers:   workers,
 		Scheduler: scheduler,
 	}
 
@@ -279,12 +271,7 @@ func createOutput(organizationID, workspaceID string, d *astro.Deployment) error
 	return nil
 }
 
-func validateResources(workerAU, schedulerAU, schedulerReplicas int) bool {
-	// TODO will be deprecating this when removing the --worker-au flag
-	if workerAU > workerAuMax || workerAU < WorkerAuMin {
-		fmt.Printf("\nWorker AUs must be between a min of %d and a max of %d AUs", WorkerAuMin, workerAuMax)
-		return false
-	}
+func validateResources(schedulerAU, schedulerReplicas int) bool {
 	if schedulerAU > schedulerAuMax || schedulerAU < SchedulerAuMin {
 		fmt.Printf("\nScheduler AUs must be between a min of %d and a max of %d AUs", SchedulerAuMin, schedulerAuMax)
 		return false
@@ -405,7 +392,7 @@ func healthPoll(deploymentID, ws string, client astro.Client) error {
 	}
 }
 
-func Update(deploymentID, label, ws, description, deploymentName string, schedulerAU, schedulerReplicas, workerAU int, wQueueList []astro.WorkerQueue, forceDeploy bool, client astro.Client) error {
+func Update(deploymentID, label, ws, description, deploymentName string, schedulerAU, schedulerReplicas int, wQueueList []astro.WorkerQueue, forceDeploy bool, client astro.Client) error {
 	// get deployment
 	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, client)
 	if err != nil {
@@ -424,15 +411,6 @@ func Update(deploymentID, label, ws, description, deploymentName string, schedul
 	}
 
 	// build query input
-	workers := astro.Workers{}
-
-	if workerAU != 0 {
-		workers.AU = workerAU
-	} else {
-		workerAU = currentDeployment.DeploymentSpec.Workers.AU
-		workers.AU = currentDeployment.DeploymentSpec.Workers.AU
-	}
-
 	scheduler := astro.Scheduler{}
 
 	if schedulerAU != 0 {
@@ -450,7 +428,6 @@ func Update(deploymentID, label, ws, description, deploymentName string, schedul
 	}
 
 	spec := astro.DeploymentCreateSpec{
-		Workers:   workers,
 		Scheduler: scheduler,
 		Executor:  "CeleryExecutor",
 	}
@@ -476,7 +453,7 @@ func Update(deploymentID, label, ws, description, deploymentName string, schedul
 		deploymentUpdate.WorkerQueues = wQueueList
 	}
 	// validate resources requests
-	resourcesValid := validateResources(workerAU, schedulerAU, schedulerReplicas)
+	resourcesValid := validateResources(schedulerAU, schedulerReplicas)
 	if !resourcesValid {
 		return nil
 	}
@@ -664,7 +641,7 @@ func deploymentSelectionProcess(ws string, deployments []astro.Deployment, clien
 		}
 
 		// walk user through creating a deployment
-		err = createDeployment("", ws, "", "", runtimeVersion, SchedulerAuMin, SchedulerReplicasMin, WorkerAuMin, client, false)
+		err = createDeployment("", ws, "", "", runtimeVersion, SchedulerAuMin, SchedulerReplicasMin, client, false)
 		if err != nil {
 			return astro.Deployment{}, err
 		}

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -112,7 +112,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	}
 
 	// update the deployment with the new list of worker queues
-	err = deployment.Update(requestedDeployment.ID, "", ws, "", "", 0, 0, 0, listToCreate, true, client)
+	err = deployment.Update(requestedDeployment.ID, "", ws, "", "", 0, 0, listToCreate, true, client)
 	if err != nil {
 		return err
 	}
@@ -315,7 +315,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, client as
 			}
 		}
 		// update the deployment with the new list
-		err = deployment.Update(requestedDeployment.ID, "", ws, "", "", 0, 0, 0, listToDelete, true, client)
+		err = deployment.Update(requestedDeployment.ID, "", ws, "", "", 0, 0, listToDelete, true, client)
 		if err != nil {
 			return err
 		}

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -53,9 +53,6 @@ func TestCreate(t *testing.T) {
 			},
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
-				Workers: astro.Workers{
-					AU: 12,
-				},
 				Scheduler: astro.Scheduler{
 					AU:       5,
 					Replicas: 3,
@@ -68,9 +65,6 @@ func TestCreate(t *testing.T) {
 			Label:          "test-deployment-label-1",
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
-				Workers: astro.Workers{
-					AU: 10,
-				},
 				Scheduler: astro.Scheduler{
 					AU:       9,
 					Replicas: 3,
@@ -102,9 +96,6 @@ func TestCreate(t *testing.T) {
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
 				Executor: "CeleryExecutor",
-				Workers: astro.Workers{
-					AU: 12,
-				},
 				Scheduler: astro.Scheduler{
 					AU:       5,
 					Replicas: 3,
@@ -136,9 +127,6 @@ func TestCreate(t *testing.T) {
 			Label:          "test-deployment-label-1",
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
-				Workers: astro.Workers{
-					AU: 10,
-				},
 				Scheduler: astro.Scheduler{
 					AU:       5,
 					Replicas: 3,
@@ -171,7 +159,6 @@ func TestCreate(t *testing.T) {
 		Label: deploymentRespWithQueues[0].Label,
 		DeploymentSpec: astro.DeploymentCreateSpec{
 			Executor:  deploymentRespWithQueues[0].DeploymentSpec.Executor,
-			Workers:   deploymentRespWithQueues[0].DeploymentSpec.Workers,
 			Scheduler: deploymentRespWithQueues[0].DeploymentSpec.Scheduler,
 		},
 		WorkerQueues: []astro.WorkerQueue{
@@ -360,9 +347,6 @@ func TestUpdate(t *testing.T) {
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
 				Executor: "CeleryExecutor",
-				Workers: astro.Workers{
-					AU: 12,
-				},
 				Scheduler: astro.Scheduler{
 					AU:       5,
 					Replicas: 3,
@@ -415,7 +399,6 @@ func TestUpdate(t *testing.T) {
 		Label: deploymentRespWithQueues[0].Label,
 		DeploymentSpec: astro.DeploymentCreateSpec{
 			Executor:  deploymentRespWithQueues[0].DeploymentSpec.Executor,
-			Workers:   deploymentRespWithQueues[0].DeploymentSpec.Workers,
 			Scheduler: deploymentRespWithQueues[0].DeploymentSpec.Scheduler,
 		},
 		WorkerQueues: listToUpdate,
@@ -588,9 +571,6 @@ func TestDelete(t *testing.T) {
 			Label: "test-deployment-label",
 			DeploymentSpec: astro.DeploymentSpec{
 				Executor: "CeleryExecutor",
-				Workers: astro.Workers{
-					AU: 12,
-				},
 				Scheduler: astro.Scheduler{
 					AU:       5,
 					Replicas: 3,
@@ -635,7 +615,6 @@ func TestDelete(t *testing.T) {
 		Label: deploymentRespWithQueues[0].Label,
 		DeploymentSpec: astro.DeploymentCreateSpec{
 			Executor:  deploymentRespWithQueues[0].DeploymentSpec.Executor,
-			Workers:   deploymentRespWithQueues[0].DeploymentSpec.Workers,
 			Scheduler: deploymentRespWithQueues[0].DeploymentSpec.Scheduler,
 		},
 		WorkerQueues: listToDelete,

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -21,8 +21,6 @@ var (
 	clusterID                     string
 	schedulerAU                   int
 	schedulerReplicas             int
-	workerAU                      int
-	updateWorkerAU                int
 	updateSchedulerReplicas       int
 	updateSchedulerAU             int
 	forceUpdate                   bool
@@ -122,7 +120,6 @@ func newDeploymentCreateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "v", "", "Runtime version for the Deployment")
 	cmd.Flags().IntVarP(&schedulerAU, "scheduler-au", "s", deployment.SchedulerAuMin, "The Deployment's Scheduler resources in AUs")
 	cmd.Flags().IntVarP(&schedulerReplicas, "scheduler-replicas", "r", deployment.SchedulerReplicasMin, "The number of Scheduler replicas for the Deployment")
-	cmd.Flags().IntVarP(&workerAU, "worker-au", "a", deployment.WorkerAuMin, "The Deployment's Worker resources in AUs")
 	cmd.Flags().BoolVarP(&waitForStatus, "wait", "i", false, "Wait for the Deployment to become healthy before ending the command")
 	return cmd
 }
@@ -140,7 +137,6 @@ func newDeploymentUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Description of the Deployment. If the description contains a space, specify the entire description in quotes \"\"")
 	cmd.Flags().IntVarP(&updateSchedulerAU, "scheduler-au", "s", 0, "The Deployment's Scheduler resources in AUs")
 	cmd.Flags().IntVarP(&updateSchedulerReplicas, "scheduler-replicas", "r", 0, "The number of Scheduler replicas for the Deployment")
-	cmd.Flags().IntVarP(&updateWorkerAU, "worker-au", "a", 0, "The Deployment's Worker resources in AUs")
 	cmd.Flags().BoolVarP(&forceUpdate, "force", "f", false, "Force update: Don't prompt a user before Deployment update")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment to update")
 	return cmd
@@ -293,7 +289,7 @@ func deploymentCreate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	return deployment.Create(label, workspaceID, description, clusterID, runtimeVersion, schedulerAU, schedulerReplicas, workerAU, astroClient, waitForStatus)
+	return deployment.Create(label, workspaceID, description, clusterID, runtimeVersion, schedulerAU, schedulerReplicas, astroClient, waitForStatus)
 }
 
 func deploymentUpdate(cmd *cobra.Command, args []string) error {
@@ -311,7 +307,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string) error {
 		deploymentID = args[0]
 	}
 
-	return deployment.Update(deploymentID, label, ws, description, deploymentName, updateSchedulerAU, updateSchedulerReplicas, updateWorkerAU, []astro.WorkerQueue{}, forceUpdate, astroClient)
+	return deployment.Update(deploymentID, label, ws, description, deploymentName, updateSchedulerAU, updateSchedulerReplicas, []astro.WorkerQueue{}, forceUpdate, astroClient)
 }
 
 func deploymentDelete(cmd *cobra.Command, args []string) error {

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -80,11 +80,25 @@ func TestDeploymentCreate(t *testing.T) {
 	ws := "test-ws-id"
 	csID := "test-cluster-id"
 
+	deploymentCreateInput := astro.CreateDeploymentInput{
+		WorkspaceID:           ws,
+		ClusterID:             csID,
+		Label:                 "test-name",
+		Description:           "",
+		RuntimeReleaseVersion: "4.2.5",
+		DeploymentSpec: astro.DeploymentCreateSpec{
+			Executor: "CeleryExecutor",
+			Scheduler: astro.Scheduler{
+				AU:       5,
+				Replicas: 1,
+			},
+		},
+	}
 	mockClient := new(astro_mocks.Client)
 	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Once()
 	mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
 	mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Once()
-	mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{ID: "test-id"}, nil).Once()
+	mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 	astroClient = mockClient
 
 	mockResponse := &airflowversions.Response{
@@ -117,12 +131,23 @@ func TestDeploymentUpdate(t *testing.T) {
 		ID:             "test-id",
 		Label:          "test-name",
 		RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
-		DeploymentSpec: astro.DeploymentSpec{Workers: astro.Workers{AU: 10}, Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
+		DeploymentSpec: astro.DeploymentSpec{Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
+	}
+	deploymentUpdateInput := astro.DeploymentUpdateInput{
+		ID:          "test-id",
+		ClusterID:   "",
+		Label:       "test-name",
+		Description: "",
+		DeploymentSpec: astro.DeploymentCreateSpec{
+			Executor:  "CeleryExecutor",
+			Scheduler: astro.Scheduler{AU: 5, Replicas: 3},
+		},
+		WorkerQueues: nil,
 	}
 
 	mockClient := new(astro_mocks.Client)
 	mockClient.On("ListDeployments", astro.DeploymentsInput{WorkspaceID: ws}).Return([]astro.Deployment{deploymentResp}, nil).Once()
-	mockClient.On("UpdateDeployment", mock.Anything).Return(astro.Deployment{ID: "test-id"}, nil).Once()
+	mockClient.On("UpdateDeployment", &deploymentUpdateInput).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 	astroClient = mockClient
 
 	cmdArgs := []string{"update", "test-id", "--name", "test-name", "--workspace-id", ws, "--force"}
@@ -137,7 +162,7 @@ func TestDeploymentDelete(t *testing.T) {
 	deploymentResp := astro.Deployment{
 		ID:             "test-id",
 		RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
-		DeploymentSpec: astro.DeploymentSpec{Workers: astro.Workers{AU: 10}, Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
+		DeploymentSpec: astro.DeploymentSpec{Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
 	}
 
 	mockClient := new(astro_mocks.Client)

--- a/cmd/cloud/deployment_workerqueue_test.go
+++ b/cmd/cloud/deployment_workerqueue_test.go
@@ -63,9 +63,6 @@ func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 			},
 			DeploymentSpec: astro.DeploymentSpec{
 				Executor: "CeleryExecutor",
-				Workers: astro.Workers{
-					AU: 10,
-				},
 				Scheduler: astro.Scheduler{
 					AU:       5,
 					Replicas: 3,
@@ -97,9 +94,6 @@ func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 			Label:          "test-deployment-label-1",
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
-				Workers: astro.Workers{
-					AU: 10,
-				},
 				Scheduler: astro.Scheduler{
 					AU:       5,
 					Replicas: 3,
@@ -158,7 +152,6 @@ func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 		Label: deploymentRespDefaultQueue[0].Label,
 		DeploymentSpec: astro.DeploymentCreateSpec{
 			Executor:  deploymentRespDefaultQueue[0].DeploymentSpec.Executor,
-			Workers:   deploymentRespDefaultQueue[0].DeploymentSpec.Workers,
 			Scheduler: deploymentRespDefaultQueue[0].DeploymentSpec.Scheduler,
 		},
 		WorkerQueues: listToCreate,
@@ -291,9 +284,6 @@ func TestNewDeploymentWorkerQueueDeleteCmd(t *testing.T) {
 				Label: "test-deployment-label",
 				DeploymentSpec: astro.DeploymentSpec{
 					Executor: "CeleryExecutor",
-					Workers: astro.Workers{
-						AU: 12,
-					},
 					Scheduler: astro.Scheduler{
 						AU:       5,
 						Replicas: 3,
@@ -338,7 +328,6 @@ func TestNewDeploymentWorkerQueueDeleteCmd(t *testing.T) {
 			Label: deploymentRespWithQueues[0].Label,
 			DeploymentSpec: astro.DeploymentCreateSpec{
 				Executor:  deploymentRespWithQueues[0].DeploymentSpec.Executor,
-				Workers:   deploymentRespWithQueues[0].DeploymentSpec.Workers,
 				Scheduler: deploymentRespWithQueues[0].DeploymentSpec.Scheduler,
 			},
 			WorkerQueues: listToDelete,
@@ -398,9 +387,6 @@ func TestNewDeploymentWorkerQueueUpdateCmd(t *testing.T) {
 				},
 				DeploymentSpec: astro.DeploymentSpec{
 					Executor: "CeleryExecutor",
-					Workers: astro.Workers{
-						AU: 10,
-					},
 					Scheduler: astro.Scheduler{
 						AU:       5,
 						Replicas: 3,
@@ -453,7 +439,6 @@ func TestNewDeploymentWorkerQueueUpdateCmd(t *testing.T) {
 			Label: deploymentRespWithQueues[0].Label,
 			DeploymentSpec: astro.DeploymentCreateSpec{
 				Executor:  deploymentRespWithQueues[0].DeploymentSpec.Executor,
-				Workers:   deploymentRespWithQueues[0].DeploymentSpec.Workers,
 				Scheduler: deploymentRespWithQueues[0].DeploymentSpec.Scheduler,
 			},
 			WorkerQueues: listToUpdate,


### PR DESCRIPTION
## Description
This PR removes the `--worker-au` flag from deployment create and update commands.


## 🎟 Issue(s)
#639
#705 

Related #639, #705 

## 🧪 Functional Testing

### flag no longer exists for creating deployments
```bash
$ astro deployment create -n jp-test --worker-au 5
Error: unknown flag: --worker-au
Usage:
  astro deployment create [flags]

Aliases:
  create, cr

Flags:
  -c, --cluster-id string        Cluster to create the Deployment in
  -d, --description string       Description of the Deployment. If the description contains a space, specify the entire description in quotes ""
  -h, --help                     help for create
  -n, --name string              The Deployment's name. If the name contains a space, specify the entire name within quotes ""
  -v, --runtime-version string   Runtime version for the Deployment
  -s, --scheduler-au int         The Deployment's Scheduler resources in AUs (default 5)
  -r, --scheduler-replicas int   The number of Scheduler replicas for the Deployment (default 1)
  -i, --wait                     Wait for the Deployment to become healthy before ending the command

Global Flags:
      --workspace-id string   workspace assigned to deployment
```

### flag no longer exists for deployment update
```bash
$ astro deployment update -h
Update the configuration for an Astro Deployment. All flags are optional

Current Context: Astro

Usage:
  astro deployment update [DEPLOYMENT-ID] [flags]

Aliases:
  update, up

Flags:
      --deployment-name string   Name of the deployment to update
  -d, --description string       Description of the Deployment. If the description contains a space, specify the entire description in quotes ""
  -f, --force                    Force update: Don't prompt a user before Deployment update
  -h, --help                     help for update
  -n, --name string              Update the Deployment's name. If the new name contains a space, specify the entire name within quotes ""
  -s, --scheduler-au int         The Deployment's Scheduler resources in AUs
  -r, --scheduler-replicas int   The number of Scheduler replicas for the Deployment

Global Flags:
      --workspace-id string   workspace assigned to deployment
```
### worker queue commands do not print deployment output
```bash
$ astro deployment wq update
Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME                 DEPLOYMENT ID
 1     neel-dev-test       advanced-precession-1762     cl60i43ye406311hvr3amdaxvy
 2     jp-test-queues      new-phase-7131               cl7fcde9x90222d3wrsd9l0wp

> 2
No worker type was specified. Select the worker type to use
 #     WORKER TYPE      ISDEFAULT     ID
 1     t3.2xlarge       true          cl1y87zxz00046dywhzh50k9a
 2     c6i.12xlarge     false         cl639x2u6114361hx0cqw9oehw

> 1

 #     WORKER QUEUE     ISDEFAULT     ID
 1     astro-q1         false         cl7i2v6w1713812cwev6l0hhh0
 2     default          true          cl7fcde9x90252d3wy8eveugs
 3     test-q           false         cl7fer8zl321452cqavlm961wp
 4     test-q3          false         cl7i2uveq709512cwemp2z2sr1

> 4
worker queue test-q3 for jp-test-queues in cl0v1p6lc728255byzyfs7lw21 workspace updated
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
