### PR TITLE
get organizations for api key

### DIFF
--- a/astro-client/astro.go
+++ b/astro-client/astro.go
@@ -30,6 +30,8 @@ type Client interface {
 	CreateUserInvite(input CreateUserInviteInput) (UserInvite, error)
 	// WorkerQueues
 	GetWorkerQueueOptions() (WorkerQueueDefaultOptions, error)
+	// Organizations
+	GetOrganizations() ([]Organization, error)
 }
 
 func (c *HTTPClient) GetUserInfo() (*Self, error) {
@@ -270,4 +272,17 @@ func (c *HTTPClient) GetWorkerQueueOptions() (WorkerQueueDefaultOptions, error) 
 		return WorkerQueueDefaultOptions{}, err
 	}
 	return wqResp.Data.GetWorkerQueueOptions, nil
+}
+
+// Gets a list of Organizations
+func (c *HTTPClient) GetOrganizations() ([]Organization, error) {
+	req := Request{
+		Query: GetOrganizations,
+	}
+
+	resp, err := req.DoWithPublicClient(c)
+	if err != nil {
+		return []Organization{}, err
+	}
+	return resp.Data.GetOrganizations, nil
 }

--- a/astro-client/astro_test.go
+++ b/astro-client/astro_test.go
@@ -907,3 +907,48 @@ func TestWorkerQueueOptions(t *testing.T) {
 		assert.Contains(t, err.Error(), "Internal Server Error")
 	})
 }
+
+func TestGetOrganizations(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	mockResponse := &Response{
+		Data: ResponseData{
+			GetOrganizations: []Organization{
+				{
+					ID:   "test-org-id",
+					Name: "test-org-name",
+				},
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("happy path", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		astroClient := NewAstroClient(client)
+
+		resp, err := astroClient.GetOrganizations()
+		assert.NoError(t, err)
+		assert.Equal(t, resp, mockResponse.Data.GetOrganizations)
+	})
+
+	t.Run("error path", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		astroClient := NewAstroClient(client)
+
+		_, err := astroClient.GetOrganizations()
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}

--- a/astro-client/mocks/Client.go
+++ b/astro-client/mocks/Client.go
@@ -184,6 +184,29 @@ func (_m *Client) GetDeploymentHistory(vars map[string]interface{}) (astro.Deplo
 	return r0, r1
 }
 
+// GetOrganizations provides a mock function with given fields:
+func (_m *Client) GetOrganizations() ([]astro.Organization, error) {
+	ret := _m.Called()
+
+	var r0 []astro.Organization
+	if rf, ok := ret.Get(0).(func() []astro.Organization); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]astro.Organization)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetUserInfo provides a mock function with given fields:
 func (_m *Client) GetUserInfo() (*astro.Self, error) {
 	ret := _m.Called()

--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -212,4 +212,13 @@ var (
 			}
 		}
 	}`
+
+	GetOrganizations = `
+	query Query {
+		organizations {
+		  id
+		  name
+		}
+	  }
+	`
 )

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -28,6 +28,7 @@ type ResponseData struct {
 	InitiateDagDeployment     InitiateDagDeployment        `json:"initiateDagDeployment,omitempty"`
 	ReportDagDeploymentStatus DagDeploymentStatus          `json:"reportDagDeploymentStatus,omitempty"`
 	GetWorkerQueueOptions     WorkerQueueDefaultOptions    `json:"workerQueueOptions,omitempty"`
+	GetOrganizations          []Organization               `json:"organizations,omitempty"`
 }
 
 type Self struct {

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -267,8 +267,14 @@ func checkAPIKeys(astroClient astro.Client) (bool, error) {
 		fmt.Println("admin settings incorrectly set you may experince permissions issues")
 	}
 
+	organizations, err := astroClient.GetOrganizations()
+	if err != nil {
+		return false, errors.Wrap(err, astro.AstronomerConnectionErrMsg)
+	}
+	organizationID := organizations[0].ID
+
 	// get workspace ID
-	deployments, err := astroClient.ListDeployments(c.Organization, "")
+	deployments, err := astroClient.ListDeployments(organizationID, "")
 	if err != nil {
 		return false, errors.Wrap(err, astro.AstronomerConnectionErrMsg)
 	}
@@ -278,7 +284,7 @@ func checkAPIKeys(astroClient astro.Client) (bool, error) {
 	if err != nil {
 		fmt.Println("no workspace set")
 	}
-	err = c.SetContextKey("organization", c.Organization) // c.Organization
+	err = c.SetContextKey("organization", organizationID) // c.Organization
 	if err != nil {
 		fmt.Println("no organization set")
 	}

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -12,7 +12,6 @@ import (
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestSetup(t *testing.T) {
@@ -110,8 +109,16 @@ func TestSetup(t *testing.T) {
 			},
 		}
 
+		mockOrgResp := []astro.Organization{
+			{
+				ID:   "test-org-id",
+				Name: "test-org-name",
+			},
+		}
+
 		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListDeployments", mock.Anything, "").Return(mockDeplyResp, nil).Once()
+		mockClient.On("GetOrganizations").Return(mockOrgResp, nil).Once()
+		mockClient.On("ListDeployments", mockOrgResp[0].ID, "").Return(mockDeplyResp, nil).Once()
 
 		cmd := &cobra.Command{Use: "deploy"}
 		cmd, err := cmd.ExecuteC()


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.
get organizations for api key

## 🎟 Issue(s)

Related astronomer/astro#3822

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
