### PR TITLE
updating existing astro deploy flow

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -1,6 +1,7 @@
 package airflow
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -10,8 +11,10 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
+	"github.com/astronomer/astro-cli/pkg/fileutil"
 	cliCommand "github.com/docker/cli/cli/command"
 	cliConfig "github.com/docker/cli/cli/config"
 	cliTypes "github.com/docker/cli/cli/config/types"
@@ -46,6 +49,30 @@ func (d *DockerImage) Build(config airflowTypes.ImageBuildConfig) error {
 		return err
 	}
 
+	// flag to determine if we are setting the dags folder in the ignore path
+	dagsIgnoreSet := false
+	fullpath := filepath.Join(config.Path, ".dockerignore")
+
+	lines, err := fileutil.Read(fullpath)
+	if err != nil {
+		return err
+	}
+	contains, _ := fileutil.Contains(lines, "dags/")
+	if !contains {
+		f, err := os.OpenFile(fullpath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gomnd
+		if err != nil {
+			return err
+		}
+
+		defer f.Close()
+
+		if _, err := f.WriteString("\ndags/"); err != nil {
+			return err
+		}
+
+		dagsIgnoreSet = true
+	}
+
 	args := []string{
 		"build",
 		"-t",
@@ -69,6 +96,39 @@ func (d *DockerImage) Build(config airflowTypes.ImageBuildConfig) error {
 		stderr = nil
 	}
 	err = cmdExec(DockerCmd, stdout, stderr, args...)
+
+	// remove dags from .dockerignore file if we set it
+	if dagsIgnoreSet {
+		f, err := os.Open(fullpath)
+		if err != nil {
+			return err
+		}
+
+		defer f.Close()
+
+		var bs []byte
+		buf := bytes.NewBuffer(bs)
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			text := scanner.Text()
+			if text != "dags/" {
+				_, err = buf.WriteString(text + "\n")
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+		err = os.WriteFile(fullpath, bytes.Trim(buf.Bytes(), "\n"), 0o666) //nolint:gosec, gomnd
+		if err != nil {
+			return err
+		}
+	}
+
 	if err != nil {
 		return fmt.Errorf("command 'docker build -t %s failed: %w", d.imageName, err)
 	}

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -96,6 +96,9 @@ func (d *DockerImage) Build(config airflowTypes.ImageBuildConfig) error {
 		stderr = nil
 	}
 	err = cmdExec(DockerCmd, stdout, stderr, args...)
+	if err != nil {
+		return fmt.Errorf("command 'docker build -t %s failed: %w", d.imageName, err)
+	}
 
 	// remove dags from .dockerignore file if we set it
 	if dagsIgnoreSet {
@@ -127,10 +130,6 @@ func (d *DockerImage) Build(config airflowTypes.ImageBuildConfig) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if err != nil {
-		return fmt.Errorf("command 'docker build -t %s failed: %w", d.imageName, err)
 	}
 
 	return nil

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -63,6 +63,17 @@ func TestDockerImageBuild(t *testing.T) {
 		assert.Contains(t, err.Error(), errMock.Error())
 	})
 
+	t.Run("unable to read file error", func(t *testing.T) {
+		options := airflowTypes.ImageBuildConfig{
+			Path:            "incorrect-path",
+			TargetPlatforms: []string{"linux/amd64"},
+			NoCache:         false,
+		}
+
+		err = handler.Build(options)
+		assert.Error(t, err)
+	})
+
 	cmdExec = previousCmdExec
 }
 

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	airflowTypes "github.com/astronomer/astro-cli/airflow/types"
+	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,6 +24,10 @@ func TestDockerImageBuild(t *testing.T) {
 
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
+
+	dockerIgnoreFile := cwd + "/.dockerignore"
+	fileutil.WriteStringToFile(dockerIgnoreFile, "")
+	defer afero.NewOsFs().Remove(dockerIgnoreFile)
 
 	options := airflowTypes.ImageBuildConfig{
 		Path:            cwd,

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -253,10 +253,11 @@ type CreateImageInput struct {
 }
 
 type DeployImageInput struct {
-	ImageID      string `json:"imageId"`
-	DeploymentID string `json:"deploymentId"`
-	Tag          string `json:"tag"`
-	Repository   string `json:"repository"`
+	ImageID          string `json:"imageId"`
+	DeploymentID     string `json:"deploymentId"`
+	Tag              string `json:"tag"`
+	Repository       string `json:"repository"`
+	DagDeployEnabled bool   `json:"dagDeployEnabled"`
 }
 
 type CreateDeploymentInput struct {

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -33,8 +33,9 @@ const (
 	defaultRuntimeVersion  = "4.2.5"
 	dagParseAllowedVersion = "4.1.0"
 
-	composeImageBuildingPromptMsg = "Building image..."
-	deploymentHeaderMsg           = "Authenticated to %s \n\n"
+	composeImageBuildingPromptMsg     = "Building image..."
+	composeSkipImageBuildingPromptMsg = "Skipping building image..."
+	deploymentHeaderMsg               = "Authenticated to %s \n\n"
 
 	warningInvaildImageNameMsg = "WARNING! The image in your Dockerfile '%s' is not based on Astro Runtime and is not supported. Change your Dockerfile with an image that pulls from 'quay.io/astronomer/astro-runtime' to proceed.\n"
 	warningInvalidImageTagMsg  = "WARNING! You are about to push an image using the '%s' runtime tag. This is not supported.\nPlease use one of the following supported tags: %s"
@@ -68,8 +69,7 @@ type deploymentInfo struct {
 	webserverURL   string
 }
 
-func deployDags(path, domain string, deployInfo *deploymentInfo, client astro.Client) error {
-	fmt.Println("Initiating DAGs Deployment for: " + deployInfo.deploymentID)
+func deployDags(path string, deployInfo *deploymentInfo, client astro.Client) error {
 	dagDeployment, err := deployment.Initiate(deployInfo.deploymentID, client)
 	if err != nil {
 		return err
@@ -108,13 +108,6 @@ func deployDags(path, domain string, deployInfo *deploymentInfo, client astro.Cl
 		return err
 	}
 
-	deploymentURL := "cloud." + domain + "/" + deployInfo.workspaceID + "/deployments/" + deployInfo.deploymentID + "/analytics"
-
-	fmt.Println("Successfully uploaded DAGs to Astro. Navigate to the Airflow UI to confirm that your deploy was successful. The Airflow UI takes about 1 minute to update." +
-		"\n\nDeployment can be accessed at the following URLs: \n" +
-		fmt.Sprintf("\nDeployment Dashboard: %s", ansi.Bold(deploymentURL)) +
-		fmt.Sprintf("\nAirflow Dashboard: %s", ansi.Bold(deployInfo.webserverURL)))
-
 	// Delete the tar file
 	defer func() {
 		dagFile.Close()
@@ -151,14 +144,22 @@ func Deploy(path, deploymentID, wsID, pytest, envFile, imageName, deploymentName
 		return err
 	}
 
+	deploymentURL := "cloud." + domain + "/" + deployInfo.workspaceID + "/deployments/" + deployInfo.deploymentID + "/analytics"
+
 	if dags {
-		err = deployDags(path, domain, &deployInfo, client)
+		fmt.Println("Initiating DAGs Deployment for: " + deployInfo.deploymentID)
+		err = deployDags(path, &deployInfo, client)
 		if err != nil {
 			return err
 		}
+
+		fmt.Println("Successfully uploaded DAGs to Astro. Navigate to the Airflow UI to confirm that your deploy was successful. The Airflow UI takes about 1 minute to update." +
+			"\n\nDeployment can be accessed at the following URLs: \n" +
+			fmt.Sprintf("\nDeployment Dashboard: %s", ansi.Bold(deploymentURL)) +
+			fmt.Sprintf("\nAirflow Dashboard: %s", ansi.Bold(deployInfo.webserverURL)))
 	} else {
 		// Build our image
-		version, err := buildImage(&c, path, deployInfo.currentVersion, deployInfo.deployImage, imageName, client)
+		version, dagDeployEnabled, err := buildImage(&c, path, deployInfo.currentVersion, deployInfo.deployImage, imageName, client)
 		if err != nil {
 			return err
 		}
@@ -200,12 +201,17 @@ func Deploy(path, deploymentID, wsID, pytest, envFile, imageName, deploymentName
 		}
 
 		// Deploy the image
-		err = imageDeploy(imageCreateRes.ID, deployInfo.deploymentID, repository, nextTag, client)
+		err = imageDeploy(imageCreateRes.ID, deployInfo.deploymentID, repository, nextTag, dagDeployEnabled, client)
 		if err != nil {
 			return err
 		}
 
-		deploymentURL := "cloud." + domain + "/" + deployInfo.workspaceID + "/deployments/" + deployInfo.deploymentID + "/analytics"
+		if dagDeployEnabled {
+			err = deployDags(path, &deployInfo, client)
+			if err != nil {
+				return err
+			}
+		}
 
 		fmt.Println("Successfully pushed Docker image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful." +
 			"\n\n Deployment can be accessed at the following URLs: \n" +
@@ -331,34 +337,38 @@ func getImageName(cloudDomain, deploymentID string, client astro.Client) (deploy
 	return deploymentInfo{namespace: namespace, deployImage: deployImage, currentVersion: currentVersion, organizationID: organizationID, workspaceID: workspaceID, webserverURL: webserverURL}, nil
 }
 
-func buildImage(c *config.Context, path, currentVersion, deployImage, imageName string, client astro.Client) (string, error) {
-	// Build our image
-	fmt.Println(composeImageBuildingPromptMsg)
-
+func buildImage(c *config.Context, path, currentVersion, deployImage, imageName string, client astro.Client) (version string, dagDeployEnabled bool, err error) {
 	imageHandler := airflowImageHandler(deployImage)
+	dagDeployEnabled = false
 
 	if imageName == "" {
+		// Build our image
+		fmt.Println(composeImageBuildingPromptMsg)
+
 		err := imageHandler.Build(types.ImageBuildConfig{Path: path, Output: true, TargetPlatforms: deployImagePlatformSupport})
 		if err != nil {
-			return "", err
+			return "", dagDeployEnabled, err
 		}
+		dagDeployEnabled = true
 	} else {
 		// skip build if an imageName is passed
+		fmt.Println(composeSkipImageBuildingPromptMsg)
+
 		err := imageHandler.TagLocalImage(imageName)
 		if err != nil {
-			return "", err
+			return "", dagDeployEnabled, err
 		}
 	}
 
 	// parse dockerfile
 	cmds, err := docker.ParseFile(filepath.Join(path, dockerfile))
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse dockerfile: %s", filepath.Join(path, dockerfile))
+		return "", false, errors.Wrapf(err, "failed to parse dockerfile: %s", filepath.Join(path, dockerfile))
 	}
 
 	DockerfileImage := docker.GetImageFromParsedFile(cmds)
 
-	version, err := imageHandler.GetLabel(runtimeImageLabel)
+	version, err = imageHandler.GetLabel(runtimeImageLabel)
 	if err != nil {
 		fmt.Println("unable get runtime version from image")
 	}
@@ -375,7 +385,7 @@ func buildImage(c *config.Context, path, currentVersion, deployImage, imageName 
 
 	ConfigOptions, err := client.GetDeploymentConfig()
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	runtimeReleases := ConfigOptions.RuntimeReleases
 	runtimeVersions := []string{}
@@ -403,16 +413,17 @@ func buildImage(c *config.Context, path, currentVersion, deployImage, imageName 
 		os.Exit(1)
 	}
 
-	return version, nil
+	return version, dagDeployEnabled, nil
 }
 
 // Deploy the image
-func imageDeploy(imageCreateResID, deploymentID, repository, nextTag string, client astro.Client) error {
+func imageDeploy(imageCreateResID, deploymentID, repository, nextTag string, dagDeployEnabled bool, client astro.Client) error {
 	imageDeployInput := astro.DeployImageInput{
-		ImageID:      imageCreateResID,
-		DeploymentID: deploymentID,
-		Repository:   repository,
-		Tag:          nextTag,
+		ImageID:          imageCreateResID,
+		DeploymentID:     deploymentID,
+		Repository:       repository,
+		Tag:              nextTag,
+		DagDeployEnabled: dagDeployEnabled,
 	}
 	resp, err := client.DeployImage(imageDeployInput)
 	if err != nil {

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -2,6 +2,7 @@ package fileutil
 
 import (
 	"archive/tar"
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -119,4 +120,29 @@ func Tar(source, target string) error {
 			_, err = io.Copy(tarball, file)
 			return err
 		})
+}
+
+// this functions reads a whole file into memory and returns a slice of its lines.
+func Read(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, scanner.Err()
+}
+
+func Contains(elems []string, param string) (exist bool, position int) {
+	for index, elem := range elems {
+		if param == elem {
+			return true, index
+		}
+	}
+	return false, 0
 }

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -159,3 +159,77 @@ func TestTar(t *testing.T) {
 		})
 	}
 }
+
+func TestContains(t *testing.T) {
+	type args struct {
+		elems []string
+		param string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		expectedResp bool
+		expectedPos  int
+	}{
+		{
+			name:         "should contain element case",
+			args:         args{elems: []string{"sample.yaml", "test.yaml"}, param: "test.yaml"},
+			expectedResp: true,
+			expectedPos:  1,
+		},
+		{
+			name:         "should not contain element case",
+			args:         args{elems: []string{"sample.yaml", "test.yaml"}, param: "random.yaml"},
+			expectedResp: false,
+			expectedPos:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exist, index := Contains(tt.args.elems, tt.args.param)
+			assert.Equal(t, exist, tt.expectedResp)
+			assert.Equal(t, index, tt.expectedPos)
+		})
+	}
+}
+
+func TestRead(t *testing.T) {
+	filePath := "./test.out"
+	content := "testing"
+	WriteStringToFile(filePath, content)
+	defer afero.NewOsFs().Remove(filePath)
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		expectedResp []string
+		errResp      string
+	}{
+		{
+			name:         "should read file contents successfully",
+			args:         args{path: filePath},
+			expectedResp: []string{content},
+			errResp:      "",
+		},
+		{
+			name:         "error on read file content",
+			args:         args{path: "incorrect-file"},
+			expectedResp: nil,
+			errResp:      "no such file or directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualResp, actualErr := Read(tt.args.path)
+			if tt.errResp != "" && actualErr != nil {
+				assert.Contains(t, actualErr.Error(), tt.errResp)
+			} else {
+				assert.NoError(t, actualErr)
+			}
+			assert.Equal(t, tt.expectedResp, actualResp)
+		})
+	}
+}


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

updating existing astro deploy flow, to push dags and image without dags on `astro deploy`

## 🎟 Issue(s)

Related #547 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

**astro deploy**
![Screen Shot 2022-09-22 at 13 39 40](https://user-images.githubusercontent.com/65428224/191846665-9d685141-8702-4715-ad97-046dbdb33d03.png)


**astro deploy --dags**
![Screen Shot 2022-09-22 at 13 36 25](https://user-images.githubusercontent.com/65428224/191846190-ed64ca8a-2c18-46a9-bbc3-ad8d8026c08b.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
