### PR TITLE
deploy deprecated runtime versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ packages.txt
 requirements.txt
 testbin/golangci-lint
 vendor/github.com/theupdateframework/notary/Dockerfile
+airflow_settings_dev.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .vscode/
 airflow/pod-config.yml
 airflow_settings_dev.yaml
+airflow_settings_dev.yaml
 astro
 astro-cli
 cover.out
@@ -15,4 +16,3 @@ packages.txt
 requirements.txt
 testbin/golangci-lint
 vendor/github.com/theupdateframework/notary/Dockerfile
-airflow_settings_dev.yaml

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -37,7 +37,7 @@ const (
 	deploymentHeaderMsg           = "Authenticated to %s \n\n"
 
 	warningInvaildImageNameMsg = "WARNING! The image in your Dockerfile '%s' is not based on Astro Runtime and is not supported. Change your Dockerfile with an image that pulls from 'quay.io/astronomer/astro-runtime' to proceed.\n"
-	warningInvalidImageTagMsg  = "WARNING! You are about to push an image using the '%s' runtime tag. This is not supported.\nPlease use one of the following supported tags: %s"
+	warningInvalidImageTagMsg  = "WARNING! You are about to push an image using the '%s' runtime tag. This is not supported.\nConsider using one of the following supported tags: %s"
 
 	message = "Dags uploaded successfully"
 	action  = "UPLOAD"
@@ -399,8 +399,6 @@ func buildImage(c *config.Context, path, currentVersion, deployImage, imageName 
 
 	if !isTagValid {
 		fmt.Println(fmt.Sprintf(warningInvalidImageTagMsg, version, isValidRuntimeVersions))
-		fmt.Println("Canceling deploy...")
-		os.Exit(1)
 	}
 
 	return version, nil


### PR DESCRIPTION
## Description

This PR makes it so you can push an image that is based on a deprecated version of runtime. It gives the user a warning but does not stop a deploy

## 🎟 Issue(s)

- 

## 🧪 Functional Testing

I can test this with mocks but there is no way for me to create a deployment with a depreciated version of runtime so I can't test it with an actual deployment

## 📸 Screenshots

## 📋 Checklist

- [X] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
