### PR TITLE
toggle dag deploy

### DIFF
--- a/astro-client/mutations.go
+++ b/astro-client/mutations.go
@@ -43,6 +43,7 @@ var (
 			id
 			label
 			releaseName
+			dagDeployEnabled
 			cluster {
 				id
 			}
@@ -72,6 +73,7 @@ var (
 			id
 			label
 			releaseName
+			dagDeployEnabled
 			cluster {
 				id
 			}

--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -19,6 +19,7 @@ var (
 			id
 			label
 			releaseName
+			dagDeployEnabled
 			cluster {
 				id
 			}
@@ -90,6 +91,7 @@ var (
 			}
 			createdAt
 			status
+			dagDeployEnabled
 			runtimeRelease {
 				version
 				airflowVersion

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -56,20 +56,21 @@ type AuthUser struct {
 
 // Deployment defines structure of a astrohub response Deployment object
 type Deployment struct {
-	ID              string         `json:"id"`
-	Label           string         `json:"label"`
-	Description     string         `json:"description"`
-	WebserverStatus string         `json:"webserverStatus"`
-	Status          string         `json:"status"`
-	ReleaseName     string         `json:"releaseName"`
-	Version         string         `json:"version"`
-	Cluster         Cluster        `json:"cluster"`
-	Workspace       Workspace      `json:"workspace"`
-	RuntimeRelease  RuntimeRelease `json:"runtimeRelease"`
-	DeploymentSpec  DeploymentSpec `json:"deploymentSpec"`
-	WorkerQueues    []WorkerQueue  `json:"workerQueues"`
-	CreatedAt       time.Time      `json:"createdAt"`
-	UpdatedAt       string         `json:"updatedAt"`
+	ID               string         `json:"id"`
+	Label            string         `json:"label"`
+	Description      string         `json:"description"`
+	WebserverStatus  string         `json:"webserverStatus"`
+	Status           string         `json:"status"`
+	ReleaseName      string         `json:"releaseName"`
+	Version          string         `json:"version"`
+	DagDeployEnabled bool           `json:"dagDeployEnabled"`
+	Cluster          Cluster        `json:"cluster"`
+	Workspace        Workspace      `json:"workspace"`
+	RuntimeRelease   RuntimeRelease `json:"runtimeRelease"`
+	DeploymentSpec   DeploymentSpec `json:"deploymentSpec"`
+	WorkerQueues     []WorkerQueue  `json:"workerQueues"`
+	CreatedAt        time.Time      `json:"createdAt"`
+	UpdatedAt        string         `json:"updatedAt"`
 }
 
 // Cluster contains all components of an Astronomer Cluster
@@ -266,6 +267,7 @@ type CreateDeploymentInput struct {
 	Label                 string               `json:"label"`
 	Description           string               `json:"description"`
 	RuntimeReleaseVersion string               `json:"runtimeReleaseVersion"`
+	DagDeployEnabled      bool                 `json:"dagDeployEnabled"`
 	DeploymentSpec        DeploymentCreateSpec `json:"deploymentSpec"`
 }
 
@@ -275,12 +277,13 @@ type DeploymentCreateSpec struct {
 }
 
 type UpdateDeploymentInput struct {
-	ID             string               `json:"id"`
-	ClusterID      string               `json:"clusterId"`
-	Label          string               `json:"label"`
-	Description    string               `json:"description"`
-	DeploymentSpec DeploymentCreateSpec `json:"deploymentSpec"`
-	WorkerQueues   []WorkerQueue        `json:"workerQueues"`
+	ID               string               `json:"id"`
+	ClusterID        string               `json:"clusterId"`
+	Label            string               `json:"label"`
+	Description      string               `json:"description"`
+	DagDeployEnabled bool                 `json:"dagDeployEnabled"`
+	DeploymentSpec   DeploymentCreateSpec `json:"deploymentSpec"`
+	WorkerQueues     []WorkerQueue        `json:"workerQueues"`
 }
 
 type DeleteDeploymentInput struct {

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -43,6 +43,7 @@ const (
 	message            = "Dags uploaded successfully"
 	action             = "UPLOAD"
 	enableDagDeployMsg = "Dag Deploy is not enabled for Deployment. Run 'astro deploy update <deployment-id> --dag-deploy enable' to enable dags deploy"
+	dagDeployDisabled  = "dag deploy is not enabled for deployment"
 )
 
 var (
@@ -173,7 +174,7 @@ func Deploy(path, runtimeID, wsID, pytest, envFile, imageName, deploymentName st
 		fmt.Println("Initiating DAGs Deployment for: " + deployInfo.deploymentID)
 		err = deployDags(path, deployInfo.deploymentID, client)
 		if err != nil {
-			if strings.Contains(err.Error(), "dag deploy is not enabled for deployment") {
+			if strings.Contains(err.Error(), dagDeployDisabled) {
 				return errors.New(enableDagDeployMsg)
 			}
 

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -176,8 +177,45 @@ func TestDagsDeploySuccess(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestDagsDeployFailed(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	config.CFG.ShowWarnings.SetHomeString("false")
+	mockClient := new(astro_mocks.Client)
+
+	mockDeplyResp := []astro.Deployment{
+		{
+			ID:             "test-id",
+			ReleaseName:    "test-name",
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Webserver: astro.Webserver{URL: "test-url"},
+			},
+			CreatedAt: time.Now(),
+		},
+		{
+			ID:             "test-id-2",
+			ReleaseName:    "test-name-2",
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Webserver: astro.Webserver{URL: "test-url"},
+			},
+			CreatedAt: time.Now(),
+		},
+	}
+
+	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(1)
+	dagDeployErr := errors.New("dag deploy is not enabled for deployment") //nolint: goerr113
+	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, fmt.Errorf("%w", dagDeployErr)).Times(1)
+
+	defer testUtil.MockUserInput(t, "y")()
+	err := Deploy("./testfiles/", "test-id", "test-ws-id", "", "", "", "", true, true, mockClient)
+	assert.Equal(t, err.Error(), "Dag Deploy is not enabled for Deployment. Run 'astro deploy update <deployment-id> --dag-deploy enable' to enable dags deploy")
+
+	mockClient.AssertExpectations(t)
+}
+
 func TestDagsDeployVR(t *testing.T) {
-	runtimeID = "vr-test-id"
+	runtimeID := "vr-test-id"
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
@@ -206,43 +244,6 @@ func TestDagsDeployVR(t *testing.T) {
 	defer testUtil.MockUserInput(t, "y")()
 	err = Deploy("./testfiles/", runtimeID, "test-ws-id", "", "", "", "", true, true, mockClient)
 	assert.ErrorIs(t, err, errMock)
-
-	mockClient.AssertExpectations(t)
-}
-
-func TestDagsDeployFailed(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	config.CFG.ShowWarnings.SetHomeString("false")
-	mockClient := new(astro_mocks.Client)
-
-	mockDeplyResp := []astro.Deployment{
-		{
-			ID:             "test-id",
-			ReleaseName:    "test-name",
-			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
-			DeploymentSpec: astro.DeploymentSpec{
-				Webserver: astro.Webserver{URL: "test-url"},
-			},
-			CreatedAt: time.Now(),
-		},
-		{
-			ID:             "test-id-2",
-			ReleaseName:    "test-name-2",
-			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
-			DeploymentSpec: astro.DeploymentSpec{
-				Webserver: astro.Webserver{URL: "test-url"},
-			},
-			CreatedAt: time.Now(),
-		},
-	}
-
-	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(1)
-	dagDeployErr := errors.New("dag deploy is not enabled for deployment")
-	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, fmt.Errorf("%w", dagDeployErr)).Times(1)
-
-	defer testUtil.MockUserInput(t, "y")()
-	err := Deploy("./testfiles/", "test-id", "test-ws-id", "", "", "", "", true, true, mockClient)
-	assert.Equal(t, err.Error(), "Dag Deploy is not enabled for Deployment. Run 'astro deploy update <deployment-id> --dag-deploy enable' to enable dags deploy")
 
 	mockClient.AssertExpectations(t)
 }

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -177,7 +177,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 }
 
 func TestDagsDeployVR(t *testing.T) {
-	runtimeID := "vr-test-id"
+	runtimeID = "vr-test-id"
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
@@ -206,6 +206,43 @@ func TestDagsDeployVR(t *testing.T) {
 	defer testUtil.MockUserInput(t, "y")()
 	err = Deploy("./testfiles/", runtimeID, "test-ws-id", "", "", "", "", true, true, mockClient)
 	assert.ErrorIs(t, err, errMock)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestDagsDeployFailed(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	config.CFG.ShowWarnings.SetHomeString("false")
+	mockClient := new(astro_mocks.Client)
+
+	mockDeplyResp := []astro.Deployment{
+		{
+			ID:             "test-id",
+			ReleaseName:    "test-name",
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Webserver: astro.Webserver{URL: "test-url"},
+			},
+			CreatedAt: time.Now(),
+		},
+		{
+			ID:             "test-id-2",
+			ReleaseName:    "test-name-2",
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Webserver: astro.Webserver{URL: "test-url"},
+			},
+			CreatedAt: time.Now(),
+		},
+	}
+
+	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(1)
+	dagDeployErr := errors.New("dag deploy is not enabled for deployment")
+	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, fmt.Errorf("%w", dagDeployErr)).Times(1)
+
+	defer testUtil.MockUserInput(t, "y")()
+	err := Deploy("./testfiles/", "test-id", "test-ws-id", "", "", "", "", true, true, mockClient)
+	assert.Equal(t, err.Error(), "Dag Deploy is not enabled for Deployment. Run 'astro deploy update <deployment-id> --dag-deploy enable' to enable dags deploy")
 
 	mockClient.AssertExpectations(t)
 }

--- a/cloud/deployment/dag_deployment.go
+++ b/cloud/deployment/dag_deployment.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	astro "github.com/astronomer/astro-cli/astro-client"
-	"github.com/pkg/errors"
 )
 
 // Initiates a Dag Deployment Request
@@ -15,7 +14,7 @@ func Initiate(runtimeID string, client astro.Client) (astro.InitiateDagDeploymen
 	// initiate dag deployment
 	dagDeployment, err := client.InitiateDagDeployment(initiateDagDeploymentInput)
 	if err != nil {
-		return astro.InitiateDagDeployment{}, errors.Wrap(err, astro.AstronomerConnectionErrMsg)
+		return astro.InitiateDagDeployment{}, err
 	}
 
 	return dagDeployment, nil
@@ -36,7 +35,7 @@ func ReportDagDeploymentStatus(initiatedDagDeploymentID, runtimeID, action, vers
 	// report dag deployment status
 	dagDeploymentStatus, err := client.ReportDagDeploymentStatus(reportDagDeploymentStatusInput)
 	if err != nil {
-		return astro.DagDeploymentStatus{}, errors.Wrap(err, astro.AstronomerConnectionErrMsg)
+		return astro.DagDeploymentStatus{}, err
 	}
 
 	return dagDeploymentStatus, nil

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -462,8 +462,19 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy stri
 	}
 
 	if dagDeploy == "enable" {
+		fmt.Println("\nYou enabled DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled." +
+			"\nRun `astro deploy --dags` after this command to push new changes. It may take a few minutes for the Airflow UI to update..")
 		deploymentUpdate.DagDeployEnabled = true
 	} else if dagDeploy == "disable" {
+		if config.CFG.ShowWarnings.GetBool() {
+			i, _ := input.Confirm("\nWarning: This command will disable DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled" +
+				"\nRun `astro deploy` after this command to restart your DAGs. It may take a few minutes for the Airflow UI to update." +
+				"\nAre you sure you want to continue?")
+			if !i {
+				fmt.Println("Canceling deployment update...")
+				return nil
+			}
+		}
 		deploymentUpdate.DagDeployEnabled = false
 	}
 

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -136,9 +136,10 @@ func Logs(deploymentID, ws, deploymentName string, warnLogs, errorLogs, infoLogs
 	return nil
 }
 
-func Create(label, workspaceID, description, clusterID, runtimeVersion string, schedulerAU, schedulerReplicas int, client astro.Client, waitForStatus bool) error {
+func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeploy string, schedulerAU, schedulerReplicas int, client astro.Client, waitForStatus bool) error {
 	var organizationID string
 	var currentWorkspace astro.Workspace
+	var dagDeployEnabled bool
 
 	c, err := config.GetCurrentContext()
 	if err != nil {
@@ -213,12 +214,18 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion string, s
 		Scheduler: scheduler,
 	}
 
+	if dagDeploy == "enable" { //nolint: goconst
+		dagDeployEnabled = true
+	} else {
+		dagDeployEnabled = false
+	}
+
 	createInput := &astro.CreateDeploymentInput{
 		WorkspaceID:           workspaceID,
 		ClusterID:             clusterID,
 		Label:                 label,
 		Description:           description,
-		DagDeployEnabled:      true,
+		DagDeployEnabled:      dagDeployEnabled,
 		RuntimeReleaseVersion: runtimeVersion,
 		DeploymentSpec:        spec,
 	}
@@ -657,7 +664,7 @@ func deploymentSelectionProcess(ws string, deployments []astro.Deployment, clien
 		}
 
 		// walk user through creating a deployment
-		err = createDeployment("", ws, "", "", runtimeVersion, SchedulerAuMin, SchedulerReplicasMin, client, false)
+		err = createDeployment("", ws, "", "", runtimeVersion, "disable", SchedulerAuMin, SchedulerReplicasMin, client, false)
 		if err != nil {
 			return astro.Deployment{}, err
 		}

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -719,6 +719,29 @@ func TestUpdate(t *testing.T) {
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
+
+	t.Run("update deployment to enable dag deploy", func(t *testing.T) {
+		mockClient := new(astro_mocks.Client)
+		deploymentUpdateInput := astro.UpdateDeploymentInput{
+			ID:               "test-id",
+			ClusterID:        "",
+			Label:            "",
+			Description:      "",
+			DagDeployEnabled: true,
+			DeploymentSpec: astro.DeploymentCreateSpec{
+				Executor:  "CeleryExecutor",
+				Scheduler: astro.Scheduler{AU: 5, Replicas: 3},
+			},
+			WorkerQueues: nil,
+		}
+		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{deploymentResp}, nil).Once()
+		mockClient.On("UpdateDeployment", &deploymentUpdateInput).Return(astro.Deployment{ID: "test-id"}, nil).Once()
+
+		err := Update("test-id", "", ws, "", "", "enable", 5, 3, []astro.WorkerQueue{}, true, mockClient)
+
+		assert.NoError(t, err)
+		mockClient.AssertExpectations(t)
+	})
 }
 
 func TestDelete(t *testing.T) {

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -297,6 +297,7 @@ func TestCreate(t *testing.T) {
 		Label:                 "test-name",
 		Description:           "test-desc",
 		RuntimeReleaseVersion: "4.2.5",
+		DagDeployEnabled:      true,
 		DeploymentSpec: astro.DeploymentCreateSpec{
 			Executor: "CeleryExecutor",
 			Scheduler: astro.Scheduler{
@@ -614,7 +615,7 @@ func TestUpdate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Update("test-id", "", ws, "", "", 0, 0, expectedQueue, false, mockClient)
+		err = Update("test-id", "", ws, "", "", "", 0, 0, expectedQueue, false, mockClient)
 		assert.NoError(t, err)
 
 		// mock os.Stdin
@@ -633,7 +634,7 @@ func TestUpdate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Update("test-id", "test-label", ws, "test description", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
+		err = Update("test-id", "test-label", ws, "test description", "", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -642,7 +643,7 @@ func TestUpdate(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{}, errMock).Once()
 
-		err := Update("test-id", "test-label", ws, "test description", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
+		err := Update("test-id", "test-label", ws, "test description", "", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -667,10 +668,10 @@ func TestUpdate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Update("", "test-label", ws, "test description", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
+		err = Update("", "test-label", ws, "test description", "", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
 		assert.ErrorIs(t, err, ErrInvalidDeploymentKey)
 
-		err = Update("test-invalid-id", "test-label", ws, "test description", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
+		err = Update("test-invalid-id", "test-label", ws, "test description", "", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
 		assert.ErrorIs(t, err, errInvalidDeployment)
 		mockClient.AssertExpectations(t)
 	})
@@ -678,7 +679,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("invalid resources", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{deploymentResp}, nil).Once()
-		err := Update("test-id", "test-label", ws, "test-description", "", 10, 5, []astro.WorkerQueue{}, true, mockClient)
+		err := Update("test-id", "test-label", ws, "test-description", "", "", 10, 5, []astro.WorkerQueue{}, true, mockClient)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -703,7 +704,7 @@ func TestUpdate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Update("test-id", "test-label", ws, "test description", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
+		err = Update("test-id", "test-label", ws, "test description", "", "", 5, 3, []astro.WorkerQueue{}, false, mockClient)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -713,7 +714,7 @@ func TestUpdate(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{deploymentResp}, nil).Once()
 		mockClient.On("UpdateDeployment", mock.Anything).Return(astro.Deployment{}, errMock).Once()
 
-		err := Update("test-id", "", ws, "", "", 0, 0, []astro.WorkerQueue{}, true, mockClient)
+		err := Update("test-id", "", ws, "", "", "", 0, 0, []astro.WorkerQueue{}, true, mockClient)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -112,7 +112,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	}
 
 	// update the deployment with the new list of worker queues
-	err = deployment.Update(requestedDeployment.ID, "", ws, "", "", 0, 0, listToCreate, true, client)
+	err = deployment.Update(requestedDeployment.ID, "", ws, "", "", "", 0, 0, listToCreate, true, client)
 	if err != nil {
 		return err
 	}
@@ -315,7 +315,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, client as
 			}
 		}
 		// update the deployment with the new list
-		err = deployment.Update(requestedDeployment.ID, "", ws, "", "", 0, 0, listToDelete, true, client)
+		err = deployment.Update(requestedDeployment.ID, "", ws, "", "", "", 0, 0, listToDelete, true, client)
 		if err != nil {
 			return err
 		}

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -62,7 +62,6 @@ func newDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&pytestFile, "test", "t", "", "Location of Pytests or specific Pytest file. All Pytest files must be located in the tests directory")
 	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom image to deploy")
 	cmd.Flags().BoolVarP(&dags, "dags", "d", false, "To push dags to your airflow deployment")
-	_ = cmd.Flags().MarkHidden("dags")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to deploy to")
 	return cmd
 }

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -62,6 +62,7 @@ func newDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&pytestFile, "test", "t", "", "Location of Pytests or specific Pytest file. All Pytest files must be located in the tests directory")
 	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom image to deploy")
 	cmd.Flags().BoolVarP(&dags, "dags", "d", false, "To push dags to your airflow deployment")
+	_ = cmd.Flags().MarkHidden("dags")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to deploy to")
 	return cmd
 }

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -19,6 +19,7 @@ var (
 	forceDelete                   bool
 	description                   string
 	clusterID                     string
+	dagDeploy                     string
 	schedulerAU                   int
 	schedulerReplicas             int
 	updateSchedulerReplicas       int
@@ -137,6 +138,7 @@ func newDeploymentUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Description of the Deployment. If the description contains a space, specify the entire description in quotes \"\"")
 	cmd.Flags().IntVarP(&updateSchedulerAU, "scheduler-au", "s", 0, "The Deployment's Scheduler resources in AUs")
 	cmd.Flags().IntVarP(&updateSchedulerReplicas, "scheduler-replicas", "r", 0, "The number of Scheduler replicas for the Deployment")
+	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "", "To enable or disable dag deploy for the Deployment")
 	cmd.Flags().BoolVarP(&forceUpdate, "force", "f", false, "Force update: Don't prompt a user before Deployment update")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment to update")
 	return cmd
@@ -307,7 +309,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string) error {
 		deploymentID = args[0]
 	}
 
-	return deployment.Update(deploymentID, label, ws, description, deploymentName, updateSchedulerAU, updateSchedulerReplicas, []astro.WorkerQueue{}, forceUpdate, astroClient)
+	return deployment.Update(deploymentID, label, ws, description, deploymentName, dagDeploy, updateSchedulerAU, updateSchedulerReplicas, []astro.WorkerQueue{}, forceUpdate, astroClient)
 }
 
 func deploymentDelete(cmd *cobra.Command, args []string) error {

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -119,6 +119,7 @@ func newDeploymentCreateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Description of the Deployment. If the description contains a space, specify the entire description in quotes \"\"")
 	cmd.Flags().StringVarP(&clusterID, "cluster-id", "c", "", "Cluster to create the Deployment in")
 	cmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "v", "", "Runtime version for the Deployment")
+	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "disable", "To enable or disable dag deploy for the Deployment")
 	cmd.Flags().IntVarP(&schedulerAU, "scheduler-au", "s", deployment.SchedulerAuMin, "The Deployment's Scheduler resources in AUs")
 	cmd.Flags().IntVarP(&schedulerReplicas, "scheduler-replicas", "r", deployment.SchedulerReplicasMin, "The number of Scheduler replicas for the Deployment")
 	cmd.Flags().BoolVarP(&waitForStatus, "wait", "i", false, "Wait for the Deployment to become healthy before ending the command")
@@ -291,7 +292,7 @@ func deploymentCreate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	return deployment.Create(label, workspaceID, description, clusterID, runtimeVersion, schedulerAU, schedulerReplicas, astroClient, waitForStatus)
+	return deployment.Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeploy, schedulerAU, schedulerReplicas, astroClient, waitForStatus)
 }
 
 func deploymentUpdate(cmd *cobra.Command, args []string) error {

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -86,6 +86,7 @@ func TestDeploymentCreate(t *testing.T) {
 		Label:                 "test-name",
 		Description:           "",
 		RuntimeReleaseVersion: "4.2.5",
+		DagDeployEnabled:      true,
 		DeploymentSpec: astro.DeploymentCreateSpec{
 			Executor: "CeleryExecutor",
 			Scheduler: astro.Scheduler{

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -118,7 +118,7 @@ func TestDeploymentCreate(t *testing.T) {
 		}
 	})
 
-	cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID}
+	cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "enable"}
 	_, err = execDeploymentCmd(cmdArgs...)
 	assert.NoError(t, err)
 	mockClient.AssertExpectations(t)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

toggle dag deploy on update deployment and enabling dags deploy on creating new deployments

## 🎟 Issue(s)

Related #773 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

**Deployment List (Add new column to tell if a deployment is dag deploy enabled)**
<img width="1634" alt="Screen Shot 2022-09-29 at 23 16 28" src="https://user-images.githubusercontent.com/65428224/193203408-eada84f8-1023-4717-9c7e-a1fa97fe2e45.png">

**Enable Dag Deploy only if flag is passed on new deployment creation**
![Screen Shot 2022-09-30 at 15 06 01](https://user-images.githubusercontent.com/65428224/193363670-1b3504d9-fb41-4a0c-9437-464f8c132d75.png)

![Screen Shot 2022-09-30 at 15 16 02](https://user-images.githubusercontent.com/65428224/193363756-cf35dcfd-41b1-4b26-97bf-29d0b5a7e336.png)

**Disable Dag Deploy**
![Screen Shot 2022-09-30 at 16 44 49](https://user-images.githubusercontent.com/65428224/193369921-b203ea0a-aa75-4015-b234-1611979f14c2.png)


**Throws Error on `astro deploy --dags` and suggest to run update command to enable dags deploy**
<img width="1638" alt="Screen Shot 2022-09-29 at 23 17 52" src="https://user-images.githubusercontent.com/65428224/193203419-19bb1a08-a8a6-4f4b-95b0-0240586bec2a.png">

**Enable Dag Deploy**
![Screen Shot 2022-09-30 at 16 45 00](https://user-images.githubusercontent.com/65428224/193369939-9a0c7c11-2596-49a7-9db6-98bf96e57ab1.png)

**Successfully deploy dags via `astro deploy --dags` after enabling dags deploy**
<img width="1635" alt="Screen Shot 2022-09-29 at 23 18 04" src="https://user-images.githubusercontent.com/65428224/193203425-1852a08d-476b-4408-bb9d-3dfa27193ef8.png">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
