### PR TITLE
fix expire time

### DIFF
--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -394,7 +394,7 @@ func Login(domain, orgID, token string, client astro.Client, out io.Writer, shou
 		fmt.Println("You are logging into Astro via an OAuth token\nThis token will expire in 24 hours and will not refresh")
 		res = Result{
 			AccessToken: token,
-			ExpiresIn:   time.Now().Add(24 * time.Hour).Unix(), // nolint:gomnd
+			ExpiresIn:   86400, // nolint:gomnd
 		}
 	}
 


### PR DESCRIPTION
## Description

Token expire time is set to a time 75 years in the future during `astro login -t`. It should be 24hours after the token is pasted. This PR fixes that

## 🎟 Issue(s)

Related #781 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
