### PR TITLE
Update software qa domain in unit tests

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -58,7 +58,7 @@ func TestIsCloudContext(t *testing.T) {
 		{"cloud-perf-domain", "cloud.astronomer-perf.io", config.CloudPlatform, true},
 		{"local-cloud", "localhost", config.CloudPlatform, true},
 		{"software-domain", "dev.astrodev.com", config.SoftwarePlatform, false},
-		{"software-domain", "qa.astronomer.io", config.SoftwarePlatform, false},
+		{"software-domain", "software.astronomer-test.io", config.SoftwarePlatform, false},
 		{"local-software", "localhost", config.SoftwarePlatform, false},
 	}
 


### PR DESCRIPTION
## Description
Changes:
- Update the Software QA env domain from `qa.astronomer.io` to `software.astronomer-test.io` in CLI codebase

## 🎟 Issue(s)

Related https://github.com/astronomer/issues/issues/4979

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
