### PR TITLE
deployment inspect command

### DIFF
--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -46,6 +46,8 @@ var (
 				maxWorkerCount
 			}
 			createdAt
+			updatedAt
+			alertEmails
 			status
 			runtimeRelease {
 				version

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -64,13 +64,14 @@ type Deployment struct {
 	ReleaseName      string         `json:"releaseName"`
 	Version          string         `json:"version"`
 	DagDeployEnabled bool           `json:"dagDeployEnabled"`
+	AlertEmails      []string       `json:"alertEmails"`
 	Cluster          Cluster        `json:"cluster"`
 	Workspace        Workspace      `json:"workspace"`
 	RuntimeRelease   RuntimeRelease `json:"runtimeRelease"`
 	DeploymentSpec   DeploymentSpec `json:"deploymentSpec"`
 	WorkerQueues     []WorkerQueue  `json:"workerQueues"`
 	CreatedAt        time.Time      `json:"createdAt"`
-	UpdatedAt        string         `json:"updatedAt"`
+	UpdatedAt        time.Time      `json:"updatedAt"`
 }
 
 // Cluster contains all components of an Astronomer Cluster

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -692,3 +692,20 @@ func deploymentSelectionProcess(ws string, deployments []astro.Deployment, clien
 	}
 	return currentDeployment, nil
 }
+
+// GetDeploymentURL takes a deploymentID, WorkspaceID as parameters
+// and returns a deploymentURL
+func GetDeploymentURL(deploymentID, workspaceID string) (string, error) {
+	var (
+		deploymentURL string
+		ctx           config.Context
+		err           error
+	)
+
+	ctx, err = config.GetCurrentContext()
+	if err != nil {
+		return "", err
+	}
+	deploymentURL = "cloud." + ctx.Domain + "/" + workspaceID + "/deployments/" + deploymentID + "/analytics"
+	return deploymentURL, nil
+}

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -879,3 +879,51 @@ func TestDelete(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 }
+
+func TestGetDeploymentURL(t *testing.T) {
+	deploymentID := "deployment-id"
+	workspaceID := "workspace-id"
+
+	t.Run("returns deploymentURL for dev environment", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudDevPlatform)
+		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id/analytics"
+		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns deploymentURL for stage environment", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudStagePlatform)
+		expectedURL := "cloud.astronomer-stage.io/workspace-id/deployments/deployment-id/analytics"
+		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns deploymentURL for perf environment", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPerfPlatform)
+		expectedURL := "cloud.astronomer-perf.io/workspace-id/deployments/deployment-id/analytics"
+		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns deploymentURL for cloud (prod) environment", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		expectedURL := "cloud.astronomer.io/workspace-id/deployments/deployment-id/analytics"
+		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns deploymentURL for local environment", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		expectedURL := "cloud.localhost/workspace-id/deployments/deployment-id/analytics"
+		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns an error if getting current context fails", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.ErrorReturningContext)
+		expectedURL := ""
+		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
+		assert.ErrorContains(t, err, "no context set")
+		assert.Equal(t, expectedURL, actualURL)
+	})
+}

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -1,0 +1,158 @@
+package inspect
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/astronomer/astro-cli/astro-client"
+	"github.com/astronomer/astro-cli/cloud/deployment"
+	"github.com/astronomer/astro-cli/config"
+)
+
+var (
+	jsonMarshal = json.MarshalIndent
+	yamlMarshal = yaml.Marshal
+)
+
+const (
+	jsonFormat = "json"
+)
+
+func Inspect(wsID, deploymentName, deploymentID, outputFormat string, client astro.Client, out io.Writer) error {
+	var (
+		requestedDeployment                                   astro.Deployment
+		err                                                   error
+		infoToPrint                                           []byte
+		deploymentInfoMap, deploymentConfigMap, additionalMap map[string]interface{}
+	)
+	// get or select the deployment
+	requestedDeployment, err = deployment.GetDeployment(wsID, deploymentID, deploymentName, client)
+	if err != nil {
+		return err
+	}
+
+	deploymentInfoMap, err = getDeploymentInspectInfo(&requestedDeployment)
+	if err != nil {
+		return err
+	}
+
+	deploymentConfigMap = getDeploymentConfig(&requestedDeployment)
+
+	additionalMap = getAdditional(&requestedDeployment)
+
+	infoToPrint, err = formatPrintableDeployment(deploymentInfoMap, deploymentConfigMap, additionalMap, outputFormat)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(out, string(infoToPrint))
+	return nil
+}
+
+func getDeploymentInspectInfo(sourceDeployment *astro.Deployment) (map[string]interface{}, error) {
+	var (
+		deploymentURL string
+		c             config.Context
+		err           error
+	)
+	c, err = config.GetCurrentContext()
+	if err != nil {
+		return nil, err
+	}
+
+	deploymentURL = "cloud." + c.Domain + "/" + sourceDeployment.Workspace.ID + "/deployments/" + sourceDeployment.ID + "/analytics"
+
+	return map[string]interface{}{
+		"deployment_id":   sourceDeployment.ID,
+		"workspace_id":    sourceDeployment.Workspace.ID,
+		"cluster_id":      sourceDeployment.Cluster.ID,
+		"airflow_version": sourceDeployment.RuntimeRelease.AirflowVersion,
+		"release_name":    sourceDeployment.ReleaseName,
+		"deployment_url":  deploymentURL,
+		"webserver_url":   sourceDeployment.DeploymentSpec.Webserver.URL,
+		"created_at":      sourceDeployment.CreatedAt,
+		"updated_at":      sourceDeployment.UpdatedAt,
+		"status":          sourceDeployment.Status,
+	}, nil
+}
+
+func getDeploymentConfig(sourceDeployment *astro.Deployment) map[string]interface{} {
+	return map[string]interface{}{
+		"name":               sourceDeployment.Label,
+		"description":        sourceDeployment.Description,
+		"cluster_id":         sourceDeployment.Cluster.ID,
+		"runtime_version":    sourceDeployment.RuntimeRelease.Version,
+		"scheduler_au":       sourceDeployment.DeploymentSpec.Scheduler.AU,
+		"scheduler_replicas": sourceDeployment.DeploymentSpec.Scheduler.Replicas,
+	}
+}
+
+func getAdditional(sourceDeployment *astro.Deployment) map[string]interface{} {
+	return map[string]interface{}{
+		"alert_emails":         sourceDeployment.AlertEmails,
+		"worker_queues":        getQMap(sourceDeployment.WorkerQueues),
+		"astronomer_variables": getVariablesMap(sourceDeployment.DeploymentSpec.EnvironmentVariablesObjects), // API only returns values when !EnvironmentVariablesObject.isSecret
+	}
+}
+
+func getQMap(sourceDeploymentQs []astro.WorkerQueue) []map[string]interface{} {
+	queueMap := make([]map[string]interface{}, 0, len(sourceDeploymentQs))
+	for _, queue := range sourceDeploymentQs {
+		newQ := map[string]interface{}{
+			"id":                 queue.ID,
+			"name":               queue.Name,
+			"is_default":         queue.IsDefault,
+			"max_worker_count":   queue.MaxWorkerCount,
+			"min_worker_count":   queue.MinWorkerCount,
+			"worker_concurrency": queue.WorkerConcurrency,
+			"node_pool_id":       queue.NodePoolID,
+		}
+		queueMap = append(queueMap, newQ)
+	}
+	return queueMap
+}
+
+func getVariablesMap(sourceDeploymentVars []astro.EnvironmentVariablesObject) []map[string]interface{} {
+	variablesMap := make([]map[string]interface{}, 0, len(sourceDeploymentVars))
+	for _, variable := range sourceDeploymentVars {
+		newVar := map[string]interface{}{
+			"key":        variable.Key,
+			"value":      variable.Value,
+			"is_secret":  variable.IsSecret,
+			"updated_at": variable.UpdatedAt,
+		}
+		variablesMap = append(variablesMap, newVar)
+	}
+	return variablesMap
+}
+
+func formatPrintableDeployment(information, configuration, additional map[string]interface{}, outputFormat string) ([]byte, error) {
+	var (
+		printableDeployment map[string]interface{}
+		infoToPrint         []byte
+		err                 error
+	)
+	printableDeployment = map[string]interface{}{
+		"deployment": map[string]interface{}{
+			"information":          information,
+			"configuration":        configuration,
+			"alert_emails":         additional["alert_emails"],
+			"worker_queues":        additional["worker_queues"],
+			"astronomer_variables": additional["astronomer_variables"],
+		},
+	}
+	switch outputFormat {
+	case jsonFormat:
+		if infoToPrint, err = jsonMarshal(printableDeployment, "", "    "); err != nil {
+			return []byte{}, err
+		}
+	default:
+		// always yaml by default
+		if infoToPrint, err = yamlMarshal(printableDeployment); err != nil {
+			return []byte{}, err
+		}
+	}
+	return infoToPrint, nil
+}

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/astronomer/astro-cli/astro-client"
 	"github.com/astronomer/astro-cli/cloud/deployment"
-	"github.com/astronomer/astro-cli/config"
 )
 
 var (
@@ -54,16 +53,13 @@ func Inspect(wsID, deploymentName, deploymentID, outputFormat string, client ast
 func getDeploymentInspectInfo(sourceDeployment *astro.Deployment) (map[string]interface{}, error) {
 	var (
 		deploymentURL string
-		c             config.Context
 		err           error
 	)
-	c, err = config.GetCurrentContext()
+
+	deploymentURL, err = deployment.GetDeploymentURL(sourceDeployment.ID, sourceDeployment.Workspace.ID)
 	if err != nil {
 		return nil, err
 	}
-
-	deploymentURL = "cloud." + c.Domain + "/" + sourceDeployment.Workspace.ID + "/deployments/" + sourceDeployment.ID + "/analytics"
-
 	return map[string]interface{}{
 		"deployment_id":   sourceDeployment.ID,
 		"workspace_id":    sourceDeployment.Workspace.ID,

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -1,0 +1,647 @@
+package inspect
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/astronomer/astro-cli/astro-client"
+	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var (
+	errGetDeployment = errors.New("test get deployment error")
+	errMarshal       = errors.New("test error")
+)
+
+type deploymentInfo struct {
+	DeploymentID   string    `mapstructure:"deployment_id"`
+	WorkspaceID    string    `mapstructure:"workspace_id"`
+	ClusterID      string    `mapstructure:"cluster_id"`
+	AirflowVersion string    `mapstructure:"airflow_version"`
+	ReleaseName    string    `mapstructure:"release_name"`
+	DeploymentURL  string    `mapstructure:"deployment_url"`
+	WebserverURL   string    `mapstructure:"webserver_url"`
+	UpdatedAt      time.Time `mapstructure:"updated_at"`
+	CreatedAt      time.Time `mapstructure:"created_at"`
+	Status         string    `mapstructure:"status"`
+}
+
+type deploymentConfig struct {
+	Name              string                   `mapstructure:"name"`
+	Description       string                   `mapstructure:"description"`
+	ClusterID         string                   `mapstructure:"cluster_id"` // this is also in deploymentInfo
+	RunTimeVersion    string                   `mapstructure:"runtime_version"`
+	SchedulerAU       int                      `mapstructure:"scheduler_au"`
+	SchedulerReplicas int                      `mapstructure:"scheduler_replicas"`
+	AlertEmails       []string                 `mapstructure:"alert_emails"`
+	WorkerQueues      []map[string]interface{} `mapstructure:"worker_queues"`
+	AstroVariables    []map[string]interface{} `mapstructure:"astronomer_variables"`
+}
+
+func errReturningYAMLMarshal(v interface{}) ([]byte, error) {
+	return []byte{}, errMarshal
+}
+
+func errReturningJSONMarshal(v interface{}, prefix, indent string) ([]byte, error) {
+	return []byte{}, errMarshal
+}
+
+func restoreJSONMarshal(replace func(v interface{}, prefix, indent string) ([]byte, error)) {
+	jsonMarshal = replace
+}
+
+func restoreYAMLMarshal(replace func(v interface{}) ([]byte, error)) {
+	yamlMarshal = replace
+}
+
+func TestInspect(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	workspaceID := "test-ws-id"
+	deploymentID := "test-deployment-id"
+	deploymentName := "test-deployment-label"
+	deploymentResponse := []astro.Deployment{
+		{
+			ID:          deploymentID,
+			Label:       deploymentName,
+			ReleaseName: "great-release-name",
+			Workspace:   astro.Workspace{ID: workspaceID},
+			Cluster: astro.Cluster{
+				ID: "cluster-id",
+				NodePools: []astro.NodePool{
+					{
+						ID:               "test-pool-id",
+						IsDefault:        false,
+						NodeInstanceType: "test-instance-type",
+						CreatedAt:        time.Now(),
+					},
+					{
+						ID:               "test-pool-id-1",
+						IsDefault:        true,
+						NodeInstanceType: "test-instance-type-1",
+						CreatedAt:        time.Now(),
+					},
+				},
+			},
+			RuntimeRelease: astro.RuntimeRelease{Version: "6.0.0", AirflowVersion: "2.4.0"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Executor: "CeleryExecutor",
+				Scheduler: astro.Scheduler{
+					AU:       5,
+					Replicas: 3,
+				},
+				Webserver: astro.Webserver{URL: "some-url"},
+			},
+			WorkerQueues: []astro.WorkerQueue{
+				{
+					ID:                "test-wq-id",
+					Name:              "default",
+					IsDefault:         true,
+					MaxWorkerCount:    130,
+					MinWorkerCount:    12,
+					WorkerConcurrency: 110,
+					NodePoolID:        "test-pool-id",
+				},
+				{
+					ID:                "test-wq-id-1",
+					Name:              "test-queue-1",
+					IsDefault:         false,
+					MaxWorkerCount:    175,
+					MinWorkerCount:    8,
+					WorkerConcurrency: 150,
+					NodePoolID:        "test-pool-id-1",
+				},
+			},
+			UpdatedAt: time.Now(),
+			Status:    "HEALTHY",
+		},
+		{
+			ID:             "test-deployment-id-1",
+			Label:          "test-deployment-label-1",
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Scheduler: astro.Scheduler{
+					AU:       5,
+					Replicas: 3,
+				},
+			},
+			WorkerQueues: []astro.WorkerQueue{
+				{
+					ID:                "test-wq-id-2",
+					Name:              "test-queue-2",
+					IsDefault:         false,
+					MaxWorkerCount:    130,
+					MinWorkerCount:    12,
+					WorkerConcurrency: 110,
+					NodePoolID:        "test-nodepool-id-2",
+				},
+				{
+					ID:                "test-wq-id-3",
+					Name:              "test-queue-3",
+					IsDefault:         true,
+					MaxWorkerCount:    175,
+					MinWorkerCount:    8,
+					WorkerConcurrency: 150,
+					NodePoolID:        "test-nodepool-id-3",
+				},
+			},
+		},
+	}
+	t.Run("prints a deployment's info and configuration to stdout", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockClient := new(astro_mocks.Client)
+		mockClient.On("ListDeployments", mock.Anything, workspaceID).Return(deploymentResponse, nil).Once()
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockClient, out)
+		assert.NoError(t, err)
+		assert.Contains(t, out.String(), deploymentResponse[0].ReleaseName)
+		assert.Contains(t, out.String(), deploymentName)
+		assert.Contains(t, out.String(), deploymentResponse[0].RuntimeRelease.Version)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("prompts for a deployment to inspect if no deployment name or id was provided", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockClient := new(astro_mocks.Client)
+		defer testUtil.MockUserInput(t, "1")() // selecting test-deployment-id
+		mockClient.On("ListDeployments", mock.Anything, workspaceID).Return(deploymentResponse, nil).Once()
+		err := Inspect(workspaceID, "", "", "yaml", mockClient, out)
+		assert.NoError(t, err)
+		assert.Contains(t, out.String(), deploymentName)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("returns an error if listing deployment fails", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockClient := new(astro_mocks.Client)
+		mockClient.On("ListDeployments", mock.Anything, workspaceID).Return([]astro.Deployment{}, errGetDeployment).Once()
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockClient, out)
+		assert.ErrorIs(t, err, errGetDeployment)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("returns an error if formatting deployment fails", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockClient := new(astro_mocks.Client)
+		originalMarshal := yamlMarshal
+		yamlMarshal = errReturningYAMLMarshal
+		defer restoreYAMLMarshal(originalMarshal)
+		mockClient.On("ListDeployments", mock.Anything, workspaceID).Return(deploymentResponse, nil).Once()
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockClient, out)
+		assert.ErrorIs(t, err, errMarshal)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("returns an error if getting context fails", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.ErrorReturningContext)
+		out := new(bytes.Buffer)
+		mockClient := new(astro_mocks.Client)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockClient, out)
+		assert.ErrorContains(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestGetDeploymentInspectInfo(t *testing.T) {
+	sourceDeployment := astro.Deployment{
+		ID:          "test-deployment-id",
+		Label:       "test-deployment-label",
+		Workspace:   astro.Workspace{ID: "test-ws-id"},
+		ReleaseName: "great-release-name",
+		Cluster: astro.Cluster{
+			ID: "cluster-id",
+			NodePools: []astro.NodePool{
+				{
+					ID:               "test-pool-id",
+					IsDefault:        false,
+					NodeInstanceType: "test-instance-type",
+					CreatedAt:        time.Now(),
+				},
+				{
+					ID:               "test-pool-id-1",
+					IsDefault:        true,
+					NodeInstanceType: "test-instance-type-1",
+					CreatedAt:        time.Now(),
+				},
+			},
+		},
+		RuntimeRelease: astro.RuntimeRelease{Version: "6.0.0", AirflowVersion: "2.4.0"},
+		DeploymentSpec: astro.DeploymentSpec{
+			Executor: "CeleryExecutor",
+			Scheduler: astro.Scheduler{
+				AU:       5,
+				Replicas: 3,
+			},
+			Webserver: astro.Webserver{URL: "some-url"},
+		},
+		WorkerQueues: []astro.WorkerQueue{
+			{
+				ID:                "test-wq-id",
+				Name:              "default",
+				IsDefault:         true,
+				MaxWorkerCount:    130,
+				MinWorkerCount:    12,
+				WorkerConcurrency: 110,
+				NodePoolID:        "test-pool-id",
+			},
+			{
+				ID:                "test-wq-id-1",
+				Name:              "test-queue-1",
+				IsDefault:         false,
+				MaxWorkerCount:    175,
+				MinWorkerCount:    8,
+				WorkerConcurrency: 150,
+				NodePoolID:        "test-pool-id-1",
+			},
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Status:    "HEALTHY",
+	}
+
+	t.Run("returns deployment Info for the requested cloud deployment", func(t *testing.T) {
+		var actualDeploymentInfo deploymentInfo
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		expectedCloudDomainURL := "cloud.astronomer.io/" + sourceDeployment.Workspace.ID +
+			"/deployments/" + sourceDeployment.ID + "/analytics"
+		expectedDeploymentInfo := deploymentInfo{
+			DeploymentID:   sourceDeployment.ID,
+			WorkspaceID:    sourceDeployment.Workspace.ID,
+			ClusterID:      sourceDeployment.Cluster.ID,
+			AirflowVersion: sourceDeployment.RuntimeRelease.AirflowVersion,
+			ReleaseName:    sourceDeployment.ReleaseName,
+			DeploymentURL:  expectedCloudDomainURL,
+			WebserverURL:   sourceDeployment.DeploymentSpec.Webserver.URL,
+			CreatedAt:      sourceDeployment.CreatedAt,
+			UpdatedAt:      sourceDeployment.UpdatedAt,
+			Status:         sourceDeployment.Status,
+		}
+		rawDeploymentInfo, err := getDeploymentInspectInfo(&sourceDeployment)
+		assert.NoError(t, err)
+		err = mapstructure.Decode(rawDeploymentInfo, &actualDeploymentInfo)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedDeploymentInfo, actualDeploymentInfo)
+	})
+	t.Run("returns deployment Info for the requested local deployment", func(t *testing.T) {
+		var actualDeploymentInfo deploymentInfo
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		expectedCloudDomainURL := "cloud.localhost/" + sourceDeployment.Workspace.ID +
+			"/deployments/" + sourceDeployment.ID + "/analytics"
+		expectedDeploymentInfo := deploymentInfo{
+			DeploymentID:   sourceDeployment.ID,
+			WorkspaceID:    sourceDeployment.Workspace.ID,
+			ClusterID:      sourceDeployment.Cluster.ID,
+			AirflowVersion: sourceDeployment.RuntimeRelease.AirflowVersion,
+			ReleaseName:    sourceDeployment.ReleaseName,
+			DeploymentURL:  expectedCloudDomainURL,
+			WebserverURL:   sourceDeployment.DeploymentSpec.Webserver.URL,
+			CreatedAt:      sourceDeployment.CreatedAt,
+			UpdatedAt:      sourceDeployment.UpdatedAt,
+			Status:         sourceDeployment.Status,
+		}
+		rawDeploymentInfo, err := getDeploymentInspectInfo(&sourceDeployment)
+		assert.NoError(t, err)
+		err = mapstructure.Decode(rawDeploymentInfo, &actualDeploymentInfo)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedDeploymentInfo, actualDeploymentInfo)
+	})
+	t.Run("returns error if getting context fails", func(t *testing.T) {
+		var actualDeploymentInfo deploymentInfo
+		// get an error from GetCurrentContext()
+		testUtil.InitTestConfig(testUtil.ErrorReturningContext)
+		expectedDeploymentInfo := deploymentInfo{}
+		rawDeploymentInfo, err := getDeploymentInspectInfo(&sourceDeployment)
+		assert.ErrorContains(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
+		err = mapstructure.Decode(rawDeploymentInfo, &actualDeploymentInfo)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedDeploymentInfo, actualDeploymentInfo)
+	})
+}
+
+func TestGetDeploymentConfig(t *testing.T) {
+	sourceDeployment := astro.Deployment{
+		ID:          "test-deployment-id",
+		Label:       "test-deployment-label",
+		Description: "description",
+		Workspace:   astro.Workspace{ID: "test-ws-id"},
+		ReleaseName: "great-release-name",
+		AlertEmails: []string{"email1", "email2"},
+		Cluster: astro.Cluster{
+			ID: "cluster-id",
+			NodePools: []astro.NodePool{
+				{
+					ID:               "test-pool-id",
+					IsDefault:        false,
+					NodeInstanceType: "test-instance-type",
+					CreatedAt:        time.Now(),
+				},
+				{
+					ID:               "test-pool-id-1",
+					IsDefault:        true,
+					NodeInstanceType: "test-instance-type-1",
+					CreatedAt:        time.Now(),
+				},
+			},
+		},
+		RuntimeRelease: astro.RuntimeRelease{Version: "6.0.0", AirflowVersion: "2.4.0"},
+		DeploymentSpec: astro.DeploymentSpec{
+			Executor: "CeleryExecutor",
+			Scheduler: astro.Scheduler{
+				AU:       5,
+				Replicas: 3,
+			},
+			Webserver: astro.Webserver{URL: "some-url"},
+			EnvironmentVariablesObjects: []astro.EnvironmentVariablesObject{
+				{
+					Key:       "foo",
+					Value:     "bar",
+					IsSecret:  false,
+					UpdatedAt: "NOW",
+				},
+				{
+					Key:       "bar",
+					Value:     "baz",
+					IsSecret:  true,
+					UpdatedAt: "NOW+1",
+				},
+			},
+		},
+		WorkerQueues: []astro.WorkerQueue{
+			{
+				ID:                "test-wq-id",
+				Name:              "default",
+				IsDefault:         true,
+				MaxWorkerCount:    130,
+				MinWorkerCount:    12,
+				WorkerConcurrency: 110,
+				NodePoolID:        "test-pool-id",
+			},
+			{
+				ID:                "test-wq-id-1",
+				Name:              "test-queue-1",
+				IsDefault:         false,
+				MaxWorkerCount:    175,
+				MinWorkerCount:    8,
+				WorkerConcurrency: 150,
+				NodePoolID:        "test-pool-id-1",
+			},
+		},
+		UpdatedAt: time.Now(),
+		Status:    "UNHEALTHY",
+	}
+
+	t.Run("returns deployment config for the requested cloud deployment", func(t *testing.T) {
+		var actualDeploymentConfig deploymentConfig
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		expectedDeploymentConfig := deploymentConfig{
+			Name:              sourceDeployment.Label,
+			Description:       sourceDeployment.Description,
+			ClusterID:         sourceDeployment.Cluster.ID,
+			RunTimeVersion:    sourceDeployment.RuntimeRelease.Version,
+			SchedulerAU:       sourceDeployment.DeploymentSpec.Scheduler.AU,
+			SchedulerReplicas: sourceDeployment.DeploymentSpec.Scheduler.Replicas,
+			AlertEmails:       nil,
+			WorkerQueues:      nil,
+			AstroVariables:    nil,
+		}
+		rawDeploymentConfig := getDeploymentConfig(&sourceDeployment)
+		err := mapstructure.Decode(rawDeploymentConfig, &actualDeploymentConfig)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedDeploymentConfig, actualDeploymentConfig)
+	})
+}
+
+func TestGetAdditional(t *testing.T) {
+	sourceDeployment := astro.Deployment{
+		ID:          "test-deployment-id",
+		Label:       "test-deployment-label",
+		Description: "description",
+		Workspace:   astro.Workspace{ID: "test-ws-id"},
+		ReleaseName: "great-release-name",
+		AlertEmails: []string{"email1", "email2"},
+		Cluster: astro.Cluster{
+			ID: "cluster-id",
+			NodePools: []astro.NodePool{
+				{
+					ID:               "test-pool-id",
+					IsDefault:        false,
+					NodeInstanceType: "test-instance-type",
+					CreatedAt:        time.Now(),
+				},
+				{
+					ID:               "test-pool-id-1",
+					IsDefault:        true,
+					NodeInstanceType: "test-instance-type-1",
+					CreatedAt:        time.Now(),
+				},
+			},
+		},
+		RuntimeRelease: astro.RuntimeRelease{Version: "6.0.0", AirflowVersion: "2.4.0"},
+		DeploymentSpec: astro.DeploymentSpec{
+			Executor: "CeleryExecutor",
+			Scheduler: astro.Scheduler{
+				AU:       5,
+				Replicas: 3,
+			},
+			Webserver: astro.Webserver{URL: "some-url"},
+			EnvironmentVariablesObjects: []astro.EnvironmentVariablesObject{
+				{
+					Key:       "foo",
+					Value:     "bar",
+					IsSecret:  false,
+					UpdatedAt: "NOW",
+				},
+				{
+					Key:       "bar",
+					Value:     "baz",
+					IsSecret:  true,
+					UpdatedAt: "NOW+1",
+				},
+			},
+		},
+		WorkerQueues: []astro.WorkerQueue{
+			{
+				ID:                "test-wq-id",
+				Name:              "default",
+				IsDefault:         true,
+				MaxWorkerCount:    130,
+				MinWorkerCount:    12,
+				WorkerConcurrency: 110,
+				NodePoolID:        "test-pool-id",
+			},
+			{
+				ID:                "test-wq-id-1",
+				Name:              "test-queue-1",
+				IsDefault:         false,
+				MaxWorkerCount:    175,
+				MinWorkerCount:    8,
+				WorkerConcurrency: 150,
+				NodePoolID:        "test-pool-id-1",
+			},
+		},
+		UpdatedAt: time.Now(),
+		Status:    "UNHEALTHY",
+	}
+
+	t.Run("returns alert emails, queues and variables for the requested deployment", func(t *testing.T) {
+		var actualDeploymentConfig deploymentConfig
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		expectedDeploymentConfig := deploymentConfig{
+			Name:              "",
+			Description:       "",
+			ClusterID:         "",
+			RunTimeVersion:    "",
+			SchedulerAU:       0,
+			SchedulerReplicas: 0,
+			AlertEmails:       sourceDeployment.AlertEmails,
+			WorkerQueues:      getQMap(sourceDeployment.WorkerQueues),
+			AstroVariables:    getVariablesMap(sourceDeployment.DeploymentSpec.EnvironmentVariablesObjects),
+		}
+		rawDeploymentConfig := getAdditional(&sourceDeployment)
+		err := mapstructure.Decode(rawDeploymentConfig, &actualDeploymentConfig)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedDeploymentConfig, actualDeploymentConfig)
+	})
+}
+
+func TestFormatPrintableDeployment(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	sourceDeployment := astro.Deployment{
+		ID:          "test-deployment-id",
+		Label:       "test-deployment-label",
+		Description: "description",
+		Workspace:   astro.Workspace{ID: "test-ws-id"},
+		ReleaseName: "great-release-name",
+		AlertEmails: []string{"email1", "email2"},
+		Cluster: astro.Cluster{
+			ID: "cluster-id",
+			NodePools: []astro.NodePool{
+				{
+					ID:               "test-pool-id",
+					IsDefault:        false,
+					NodeInstanceType: "test-instance-type",
+					CreatedAt:        time.Now(),
+				},
+				{
+					ID:               "test-pool-id-1",
+					IsDefault:        true,
+					NodeInstanceType: "test-instance-type-1",
+					CreatedAt:        time.Now(),
+				},
+			},
+		},
+		RuntimeRelease: astro.RuntimeRelease{Version: "6.0.0", AirflowVersion: "2.4.0"},
+		DeploymentSpec: astro.DeploymentSpec{
+			Executor: "CeleryExecutor",
+			Scheduler: astro.Scheduler{
+				AU:       5,
+				Replicas: 3,
+			},
+			Webserver: astro.Webserver{URL: "some-url"},
+			EnvironmentVariablesObjects: []astro.EnvironmentVariablesObject{
+				{
+					Key:       "foo",
+					Value:     "bar",
+					IsSecret:  false,
+					UpdatedAt: "NOW",
+				},
+				{
+					Key:       "bar",
+					Value:     "baz",
+					IsSecret:  true,
+					UpdatedAt: "NOW+1",
+				},
+			},
+		},
+		WorkerQueues: []astro.WorkerQueue{
+			{
+				ID:                "test-wq-id",
+				Name:              "default",
+				IsDefault:         true,
+				MaxWorkerCount:    130,
+				MinWorkerCount:    12,
+				WorkerConcurrency: 110,
+				NodePoolID:        "test-pool-id",
+			},
+			{
+				ID:                "test-wq-id-1",
+				Name:              "test-queue-1",
+				IsDefault:         false,
+				MaxWorkerCount:    175,
+				MinWorkerCount:    8,
+				WorkerConcurrency: 150,
+				NodePoolID:        "test-pool-id-1",
+			},
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Status:    "UNHEALTHY",
+	}
+	var expectedPrintableDeployment []byte
+
+	t.Run("returns a yaml formatted printable deployment", func(t *testing.T) {
+		info, _ := getDeploymentInspectInfo(&sourceDeployment)
+		config := getDeploymentConfig(&sourceDeployment)
+		additional := getAdditional(&sourceDeployment)
+		expectedPrintableDeployment = []byte("\n    information:\n")
+		actualPrintableDeployment, err := formatPrintableDeployment(info, config, additional, "")
+		assert.NoError(t, err)
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+		expectedPrintableDeployment = []byte("\n    configuration:\n")
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+		expectedPrintableDeployment = []byte("\n    alert_emails:\n")
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+		expectedPrintableDeployment = []byte("\n    worker_queues:\n")
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+		expectedPrintableDeployment = []byte("\n    astronomer_variables:\n")
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+	})
+
+	t.Run("returns a json formatted printable deployment", func(t *testing.T) {
+		info, _ := getDeploymentInspectInfo(&sourceDeployment)
+		config := getDeploymentConfig(&sourceDeployment)
+		additional := getAdditional(&sourceDeployment)
+		expectedPrintableDeployment = []byte(",\n        \"information\":")
+		actualPrintableDeployment, err := formatPrintableDeployment(info, config, additional, "json")
+		assert.NoError(t, err)
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+		expectedPrintableDeployment = []byte("\n        \"configuration\": ")
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+		expectedPrintableDeployment = []byte("\n        \"alert_emails\": ")
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+		expectedPrintableDeployment = []byte("\n        \"worker_queues\": ")
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+		expectedPrintableDeployment = []byte("\n        \"astronomer_variables\": ")
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+	})
+	t.Run("returns an error if marshaling yaml fails", func(t *testing.T) {
+		originalMarshal := yamlMarshal
+		yamlMarshal = errReturningYAMLMarshal
+		defer restoreYAMLMarshal(originalMarshal)
+		info, _ := getDeploymentInspectInfo(&sourceDeployment)
+		config := getDeploymentConfig(&sourceDeployment)
+		additional := getAdditional(&sourceDeployment)
+		expectedPrintableDeployment = []byte{}
+		actualPrintableDeployment, err := formatPrintableDeployment(info, config, additional, "")
+		assert.ErrorIs(t, err, errMarshal)
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+	})
+	t.Run("returns an error if marshaling json fails", func(t *testing.T) {
+		originalMarshal := jsonMarshal
+		jsonMarshal = errReturningJSONMarshal
+		defer restoreJSONMarshal(originalMarshal)
+		info, _ := getDeploymentInspectInfo(&sourceDeployment)
+		config := getDeploymentConfig(&sourceDeployment)
+		additional := getAdditional(&sourceDeployment)
+		expectedPrintableDeployment = []byte{}
+		actualPrintableDeployment, err := formatPrintableDeployment(info, config, additional, "json")
+		assert.ErrorIs(t, err, errMarshal)
+		assert.Contains(t, string(actualPrintableDeployment), string(expectedPrintableDeployment))
+	})
+}

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -77,6 +77,7 @@ func newDeploymentRootCmd(out io.Writer) *cobra.Command {
 		newDeploymentUpdateCmd(),
 		newDeploymentVariableRootCmd(out),
 		newDeploymentWorkerQueueRootCmd(out),
+		newDeploymentInspectCmd(out),
 	)
 	return cmd
 }

--- a/cmd/cloud/deployment_inspect.go
+++ b/cmd/cloud/deployment_inspect.go
@@ -1,0 +1,37 @@
+package cloud
+
+import (
+	"io"
+
+	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
+
+	"github.com/spf13/cobra"
+)
+
+var outputFormat string
+
+func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "inspect",
+		Aliases: []string{"in"},
+		Short:   "Inspect a deployment",
+		Long:    "Inspect an Astro Deployment.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentInspect(cmd, args, out)
+		},
+	}
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment to inspect.")
+	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to inspect.")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format can be one of: yaml or json. By default the inspected deployment will be in YAML format.")
+	return cmd
+}
+
+func deploymentInspect(cmd *cobra.Command, _ []string, out io.Writer) error {
+	cmd.SilenceUsage = true
+
+	wsID, err := coalesceWorkspace()
+	if err != nil {
+		return err
+	}
+	return inspect.Inspect(wsID, deploymentName, deploymentID, outputFormat, astroClient, out)
+}

--- a/cmd/cloud/deployment_inspect_test.go
+++ b/cmd/cloud/deployment_inspect_test.go
@@ -1,0 +1,132 @@
+package cloud
+
+import (
+	"testing"
+	"time"
+
+	"github.com/astronomer/astro-cli/astro-client"
+	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
+	"github.com/stretchr/testify/mock"
+
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDeploymentInspectCmd(t *testing.T) {
+	expectedHelp := "Inspect an Astro Deployment."
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	deploymentResponse := []astro.Deployment{
+		{
+			ID:          "test-deployment-id",
+			Label:       "test-deployment-label",
+			ReleaseName: "great-release-name",
+			Workspace:   astro.Workspace{ID: "test-ws-id"},
+			Cluster: astro.Cluster{
+				ID: "cluster-id",
+				NodePools: []astro.NodePool{
+					{
+						ID:               "test-pool-id",
+						IsDefault:        false,
+						NodeInstanceType: "test-instance-type",
+						CreatedAt:        time.Now(),
+					},
+					{
+						ID:               "test-pool-id-1",
+						IsDefault:        true,
+						NodeInstanceType: "test-instance-type-1",
+						CreatedAt:        time.Now(),
+					},
+				},
+			},
+			RuntimeRelease: astro.RuntimeRelease{Version: "6.0.0", AirflowVersion: "2.4.0"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Executor: "CeleryExecutor",
+				Scheduler: astro.Scheduler{
+					AU:       5,
+					Replicas: 3,
+				},
+				Webserver: astro.Webserver{URL: "some-url"},
+			},
+			WorkerQueues: []astro.WorkerQueue{
+				{
+					ID:                "test-wq-id",
+					Name:              "default",
+					IsDefault:         true,
+					MaxWorkerCount:    130,
+					MinWorkerCount:    12,
+					WorkerConcurrency: 110,
+					NodePoolID:        "test-pool-id",
+				},
+				{
+					ID:                "test-wq-id-1",
+					Name:              "test-queue-1",
+					IsDefault:         false,
+					MaxWorkerCount:    175,
+					MinWorkerCount:    8,
+					WorkerConcurrency: 150,
+					NodePoolID:        "test-pool-id-1",
+				},
+			},
+			UpdatedAt: time.Now(),
+			Status:    "HEALTHY",
+		},
+		{
+			ID:             "test-deployment-id-1",
+			Label:          "test-deployment-label-1",
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Scheduler: astro.Scheduler{
+					AU:       5,
+					Replicas: 3,
+				},
+			},
+			WorkerQueues: []astro.WorkerQueue{
+				{
+					ID:                "test-wq-id-2",
+					Name:              "test-queue-2",
+					IsDefault:         false,
+					MaxWorkerCount:    130,
+					MinWorkerCount:    12,
+					WorkerConcurrency: 110,
+					NodePoolID:        "test-nodepool-id-2",
+				},
+				{
+					ID:                "test-wq-id-3",
+					Name:              "test-queue-3",
+					IsDefault:         true,
+					MaxWorkerCount:    175,
+					MinWorkerCount:    8,
+					WorkerConcurrency: 150,
+					NodePoolID:        "test-nodepool-id-3",
+				},
+			},
+		},
+	}
+	mockClient := new(astro_mocks.Client)
+	astroClient = mockClient
+	t.Run("-h prints help", func(t *testing.T) {
+		cmdArgs := []string{"inspect", "-h"}
+		resp, err := execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, expectedHelp)
+	})
+
+	t.Run("returns info and config in yaml format for a deployment", func(t *testing.T) {
+		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Once()
+		cmdArgs := []string{"inspect", "-d", "test-deployment-id"}
+		resp, err := execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, deploymentResponse[0].ReleaseName)
+		assert.Contains(t, resp, deploymentName)
+		assert.Contains(t, resp, deploymentResponse[0].RuntimeRelease.Version)
+		mockClient.AssertExpectations(t)
+	})
+	t.Run("returns an error when getting workspace fails", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.Initial)
+		expectedOut := "Usage:\n"
+		cmdArgs := []string{"inspect", "-d", "doesnotexist"}
+		resp, err := execDeploymentCmd(cmdArgs...)
+		assert.Error(t, err)
+		assert.NotContains(t, resp, expectedOut)
+	})
+}

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	LocalPlatform    = "local"
-	CloudPlatform    = "cloud"
-	SoftwarePlatform = "software"
-	Initial          = "initial"
+	LocalPlatform         = "local"
+	CloudPlatform         = "cloud"
+	SoftwarePlatform      = "software"
+	Initial               = "initial"
+	ErrorReturningContext = "error"
 )
 
 var perm os.FileMode = 0o777
@@ -70,6 +71,10 @@ contexts:
 		testConfig = fmt.Sprintf(testConfig, "localhost", "localhost", "localhost")
 	case Initial:
 		testConfig = ""
+	case ErrorReturningContext:
+		// this is an error returning case
+		testConfig = fmt.Sprintf(testConfig, "error", "error", "error")
+		testConfig = strings.Replace(testConfig, "context: error", "context: ", 1)
 	default:
 		testConfig = fmt.Sprintf(testConfig, "localhost", "localhost", "localhost")
 	}

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -15,6 +15,9 @@ import (
 const (
 	LocalPlatform         = "local"
 	CloudPlatform         = "cloud"
+	CloudDevPlatform      = "dev"
+	CloudPerfPlatform     = "perf"
+	CloudStagePlatform    = "stage"
 	SoftwarePlatform      = "software"
 	Initial               = "initial"
 	ErrorReturningContext = "error"
@@ -65,6 +68,12 @@ contexts:
 	switch platform {
 	case CloudPlatform:
 		testConfig = fmt.Sprintf(testConfig, "astronomer.io", strings.Replace("astronomer.io", ".", "_", -1), "astronomer.io")
+	case CloudDevPlatform:
+		testConfig = fmt.Sprintf(testConfig, "astronomer-dev.io", strings.Replace("astronomer-dev.io", ".", "_", -1), "astronomer-dev.io")
+	case CloudStagePlatform:
+		testConfig = fmt.Sprintf(testConfig, "astronomer-stage.io", strings.Replace("astronomer-stage.io", ".", "_", -1), "astronomer-stage.io")
+	case CloudPerfPlatform:
+		testConfig = fmt.Sprintf(testConfig, "astronomer-perf.io", strings.Replace("astronomer-perf.io", ".", "_", -1), "astronomer-perf.io")
 	case SoftwarePlatform:
 		testConfig = fmt.Sprintf(testConfig, "astronomer_dev.com", strings.Replace("astronomer_dev.com", ".", "_", -1), "astronomer_dev.com")
 	case LocalPlatform:


### PR DESCRIPTION
- prints the entire deployment struct to terminal in YAML format
- add -o to format output as json/yaml
- add `alertEmails` & `updatedAt` to the `Deployments` query

## Description

The PR adds a `deployment inspect` command that users can use to get information about their deployments. It structures the output in 2 sections `information` and `configuration`. 

`-o` flag can be used to switch between yaml or json output formats. The default output format is YAML.


## 🎟 Issue(s)

Related #732

## 🧪 Functional Testing

### prints a deployment in yaml form
```bash
$ astro deployment inspect -d cl930qolz45611j184enlxzgg
deployment:
    alert_emails:
        - test1@test.com
        - test2@test.com
    astronomer_variables:
        - is_secret: true
          key: SUPERSECRET
          updated-at: "2022-10-11T19:38:27.538Z"
          value: ""
        - is_secret: false
          key: NOTSECRET
          updated-at: "2022-10-11T19:38:27.287Z"
          value: tester
    configuration:
        cluster_id: ckt3779dp00000rvx94xucbx7
        description: ""
        name: Test Deployment
        runtime_version: 6.0.2
        scheduler_au: 5
        scheduler_replicas: 1
    information:
        airflow_version: 2.4.1
        cluster_id: ckt3779dp00000rvx94xucbx7
        created_at: 2022-10-10T16:58:50.519Z
        deployment_id: cl930qolz45611j184enlxzgg
        deployment_url: cloud.astronomer-dev.io/cl0v1p6lc728255byzyfs7lw21/deployments/cl930qolz45611j184enlxzgg/analytics
        release_name: stellar-wormhole-1667
        status: HEALTHY
        updated_at: 2022-10-11T19:39:09.114Z
        webserver_url: astronomer.astronomer-dev.run/denlxzgg?orgId=org_dlgevirUCwI9vX10
        workspace_id: cl0v1p6lc728255byzyfs7lw21
    worker_queues:
        - id: cl930qolz45641j18r3ojsxba
          is_default: true
          max_worker_count: 10
          min_worker_count: 1
          name: default
          node_pool_id: cl1y87zxz00046dywhzh50k9a
          worker_concurrency: 16
```
### prints deployment in json form
```bash
$ astro deployment inspect -d cl930qolz45611j184enlxzgg -o json
{
    "deployment": {
        "alert_emails": [
            "test1@test.com",
            "test2@test.com"
        ],
        "astronomer_variables": [
            {
                "is_secret": true,
                "key": "SUPERSECRET",
                "updated-at": "2022-10-11T19:38:27.538Z",
                "value": ""
            },
            {
                "is_secret": false,
                "key": "NOTSECRET",
                "updated-at": "2022-10-11T19:38:27.287Z",
                "value": "tester"
            }
        ],
        "configuration": {
            "cluster_id": "ckt3779dp00000rvx94xucbx7",
            "description": "",
            "name": "Test Deployment",
            "runtime_version": "6.0.2",
            "scheduler_au": 5,
            "scheduler_replicas": 1
        },
        "information": {
            "airflow_version": "2.4.1",
            "cluster_id": "ckt3779dp00000rvx94xucbx7",
            "created_at": "2022-10-10T16:58:50.519Z",
            "deployment_id": "cl930qolz45611j184enlxzgg",
            "deployment_url": "cloud.astronomer-dev.io/cl0v1p6lc728255byzyfs7lw21/deployments/cl930qolz45611j184enlxzgg/analytics",
            "release_name": "stellar-wormhole-1667",
            "status": "HEALTHY",
            "updated_at": "2022-10-11T19:39:09.114Z",
            "webserver_url": "astronomer.astronomer-dev.run/denlxzgg?orgId=org_dlgevirUCwI9vX10",
            "workspace_id": "cl0v1p6lc728255byzyfs7lw21"
        },
        "worker_queues": [
            {
                "id": "cl930qolz45641j18r3ojsxba",
                "is_default": true,
                "max_worker_count": 10,
                "min_worker_count": 1,
                "name": "default",
                "node_pool_id": "cl1y87zxz00046dywhzh50k9a",
                "worker_concurrency": 16
            }
        ]
    }
}
```
### output can be redirected to a yaml or json file
```bash
$ astro deployment inspect -d cl60i43ye406311hvr3amdaxvy -o json > somefile.json
$ astro deployment inspect -d cl60i43ye406311hvr3amdaxvy -o yaml > somefile.yaml
```
### flags for the command
```bash
$ astro deployment inspect -h
Inspect an Astro Deployment.

Current Context: Astro

Usage:
  astro deployment inspect [flags]

Aliases:
  inspect, in

Flags:
  -d, --deployment-id string     The deployment to inspect.
  -n, --deployment-name string   Name of the deployment to inspect.
  -h, --help                     help for inspect
  -o, --output string            Output format can be one of: yaml or json. By default the inspected deployment will be in YAML format. (default "yaml")

Global Flags:
      --verbosity string      Log level (debug, info, warn, error, fatal, panic (default "warning")
      --workspace-id string   workspace assigned to deployment

```
## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
