### PR TITLE
remove system admin role

### DIFF
--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -305,22 +305,6 @@ func checkToken(c *config.Context, client astro.Client, out io.Writer) error {
 		return err
 	}
 	organizationID := self.AuthenticatedOrganizationID
-	roleBindings := self.User.RoleBindings
-
-	err = c.SetSystemAdmin(false)
-	if err != nil {
-		return err
-	}
-
-	for i := range roleBindings {
-		if roleBindings[i].Role == "SYSTEM_ADMIN" {
-			err = c.SetSystemAdmin(true)
-			if err != nil {
-				return err
-			}
-			break
-		}
-	}
 
 	if organizationID != "" {
 		err = c.SetContextKey("organization", organizationID)
@@ -431,10 +415,6 @@ func Logout(domain string, out io.Writer) {
 	c, _ := context.GetContext(domain)
 
 	err = c.SetContextKey("token", "")
-	if err != nil {
-		return
-	}
-	err = c.SetContextKey("isSystemAdmin", "")
 	if err != nil {
 		return
 	}

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -29,7 +29,7 @@ var (
 		User: astro.User{
 			RoleBindings: []astro.RoleBinding{
 				{
-					Role: "SYSTEM_ADMIN",
+					Role: "WORKSPACE_ADMIN",
 				},
 			},
 		},

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -580,28 +580,24 @@ func TestLogout(t *testing.T) {
 	})
 
 	t.Run("success_with_email", func(t *testing.T) {
-		assertions := func(expIsSystemAdmin bool, expUserEmail string, expToken string) {
+		assertions := func(expUserEmail string, expToken string) {
 			contexts, err := config.GetContexts()
 			assert.NoError(t, err)
 			context := contexts.Contexts["localhost"]
 
-			isSystemAdmin, err := context.GetSystemAdmin()
 			assert.NoError(t, err)
-			assert.Equal(t, expIsSystemAdmin, isSystemAdmin)
 			assert.Equal(t, expUserEmail, context.UserEmail)
 			assert.Equal(t, expToken, context.Token)
 		}
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		err = c.SetSystemAdmin(true)
-		assert.NoError(t, err)
 		err = c.SetContextKey("user_email", "test.user@astronomer.io")
 		assert.NoError(t, err)
 		err = c.SetContextKey("token", "Bearer some-token")
 		assert.NoError(t, err)
 		// test before
-		assertions(true, "test.user@astronomer.io", "Bearer some-token")
+		assertions("test.user@astronomer.io", "Bearer some-token")
 
 		// log out
 		c, err = config.GetCurrentContext()
@@ -609,7 +605,7 @@ func TestLogout(t *testing.T) {
 		Logout(c.Domain, os.Stdout)
 
 		// test after logout
-		assertions(false, "", "")
+		assertions("", "")
 	})
 }
 

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -643,7 +643,6 @@ func TestBuildImageFailure(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.SetSystemAdmin(true)
 
 	mockImageHandler := new(mocks.ImageHandler)
 

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -262,11 +262,6 @@ func checkAPIKeys(astroClient astro.Client) (bool, error) {
 		return false, err
 	}
 
-	err = c.SetSystemAdmin(false)
-	if err != nil {
-		fmt.Println("admin settings incorrectly set you may experince permissions issues")
-	}
-
 	organizations, err := astroClient.GetOrganizations()
 	if err != nil {
 		return false, errors.Wrap(err, astro.AstronomerConnectionErrMsg)

--- a/config/context.go
+++ b/config/context.go
@@ -200,32 +200,6 @@ func (c *Context) DeleteContext() error {
 	return nil
 }
 
-func (c *Context) SetSystemAdmin(value bool) error {
-	cKey, err := c.GetContextKey()
-	if err != nil {
-		return err
-	}
-
-	cfgPath := fmt.Sprintf("contexts.%s.%s", cKey, "isSystemAdmin")
-	viperHome.Set(cfgPath, value)
-	err = saveConfig(viperHome, HomeConfigFile)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *Context) GetSystemAdmin() (bool, error) {
-	cKey, err := c.GetContextKey()
-	if err != nil {
-		return false, err
-	}
-
-	cfgPath := fmt.Sprintf("contexts.%s.%s", cKey, "isSystemAdmin")
-	return viperHome.GetBool(cfgPath), nil
-}
-
 func (c *Context) SetExpiresIn(value int64) error {
 	cKey, err := c.GetContextKey()
 	if err != nil {

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -183,32 +183,6 @@ func TestSetContextKey(t *testing.T) {
 	assert.Equal(t, "test", outCtx.Token)
 }
 
-func TestSystemAdmin(t *testing.T) {
-	initTestConfig()
-	ctx := Context{Domain: "localhost"}
-	err := ctx.SetSystemAdmin(true)
-	assert.NoError(t, err)
-
-	outCtx, err := ctx.GetContext()
-	assert.NoError(t, err)
-
-	val, err := outCtx.GetSystemAdmin()
-	assert.NoError(t, err)
-	assert.Equal(t, "localhost", outCtx.Domain)
-	assert.Equal(t, true, val)
-}
-
-func TestSystemAdminFailure(t *testing.T) {
-	initTestConfig()
-	ctx := Context{}
-	err := ctx.SetSystemAdmin(true)
-	assert.ErrorIs(t, err, ErrCtxConfigErr)
-
-	val, err := ctx.GetSystemAdmin()
-	assert.ErrorIs(t, err, ErrCtxConfigErr)
-	assert.Equal(t, false, val)
-}
-
 func TestExpiresIn(t *testing.T) {
 	initTestConfig()
 	ctx := Context{Domain: "localhost"}


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

remove system admin role since this is going to be deprecated and with moving to public endpoints in CLI 1.6, we removed the dependency of a SYSTEM ADMIN role. This is a clean up

## 🎟 Issue(s)

Related #793 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
