### PR TITLE
Remove dag deploy enable/disable from astro deploy

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -137,7 +137,7 @@ func deployDags(path, runtimeID string, client astro.Client) error {
 }
 
 // Deploy pushes a new docker image
-func Deploy(path, runtimeID, wsID, pytest, envFile, imageName, deploymentName, dagDeploy string, prompt, dags bool, client astro.Client) error { //nolint: gocognit, gocyclo
+func Deploy(path, runtimeID, wsID, pytest, envFile, imageName, deploymentName string, prompt, dags bool, client astro.Client) error { //nolint: gocognit, gocyclo
 	// Get cloud domain
 	c, err := config.GetCurrentContext()
 	if err != nil {
@@ -174,52 +174,6 @@ func Deploy(path, runtimeID, wsID, pytest, envFile, imageName, deploymentName, d
 
 		fmt.Println("\nSuccessfully uploaded DAGs to Astro. Go to the Astro UI to view your data pipeline. The Astro UI takes about 1 minute to update.")
 		return nil
-	}
-
-	if dagDeploy != "" {
-		currentDeployment, err := deployment.GetDeployment(wsID, runtimeID, deploymentName, client)
-		if err != nil {
-			return err
-		}
-
-		runtimeID = currentDeployment.ID
-		scheduler := astro.Scheduler{}
-		scheduler.AU = currentDeployment.DeploymentSpec.Scheduler.AU
-		scheduler.Replicas = currentDeployment.DeploymentSpec.Scheduler.Replicas
-		spec := astro.DeploymentCreateSpec{
-			Executor:  "CeleryExecutor",
-			Scheduler: scheduler,
-		}
-
-		deploymentUpdate := &astro.UpdateDeploymentInput{
-			ID:             currentDeployment.ID,
-			Label:          currentDeployment.Label,
-			Description:    currentDeployment.Description,
-			ClusterID:      currentDeployment.Cluster.ID,
-			DeploymentSpec: spec,
-		}
-		if dagDeploy == "enable" {
-			fmt.Println("\nYou enabled DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled." +
-				"\nRun `astro deploy --dags` after this command to push new changes. It may take a few minutes for the Airflow UI to update..")
-			deploymentUpdate.DagDeployEnabled = true
-		} else if dagDeploy == "disable" {
-			if config.CFG.ShowWarnings.GetBool() {
-				i, _ := input.Confirm("\nWarning: This command will disable DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled" +
-					"\nRun `astro deploy` after this command to restart your DAGs. It may take a few minutes for the Airflow UI to update." +
-					"\nAre you sure you want to continue?")
-				if !i {
-					fmt.Println("Canceling deploy...")
-					return nil
-				}
-			}
-			deploymentUpdate.DagDeployEnabled = false
-		}
-
-		// update deployment
-		_, err = client.UpdateDeployment(deploymentUpdate)
-		if err != nil {
-			return errors.Wrap(err, astro.AstronomerConnectionErrMsg)
-		}
 	}
 
 	deployInfo, err := getDeploymentInfo(runtimeID, wsID, deploymentName, prompt, domain, client)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/astronomer/astro-cli/astro-client"
 	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
 	"github.com/astronomer/astro-cli/config"
-	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/spf13/afero"
@@ -92,227 +91,27 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 	os.Stdin = r
 
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", "", true, false, mockClient)
+	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, false, mockClient)
 	assert.NoError(t, err)
 
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", "", false, false, mockClient)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", false, false, mockClient)
 	assert.NoError(t, err)
 
 	// test custom image
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", "", false, false, mockClient)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", false, false, mockClient)
 	assert.NoError(t, err)
 
 	config.CFG.ProjectDeployment.SetProjectString("test-id")
 	// test both deploymentID and name used
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "test-name", "", false, false, mockClient)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "test-name", false, false, mockClient)
 	assert.NoError(t, err)
 
 	mockClient.AssertExpectations(t)
 	mockImageHandler.AssertExpectations(t)
 	mockContainerHandler.AssertExpectations(t)
-}
-
-func TestEnableDagsDeploySuccess(t *testing.T) {
-	deploymentUpdateInput := astro.UpdateDeploymentInput{
-		ID:               "test-id",
-		ClusterID:        "",
-		DagDeployEnabled: true,
-		DeploymentSpec: astro.DeploymentCreateSpec{
-			Executor: "CeleryExecutor",
-		},
-	}
-
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	config.CFG.ShowWarnings.SetHomeString("false")
-	mockClient := new(astro_mocks.Client)
-
-	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: false}}, nil).Once()
-	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: true}}, nil).Once()
-	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{}, errMock).Once()
-	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: false}}, nil).Once()
-	mockClient.On("UpdateDeployment", &deploymentUpdateInput).Return(astro.Deployment{ID: "test-id", DagDeployEnabled: true}, nil).Once()
-	mockClient.On("UpdateDeployment", &deploymentUpdateInput).Return(astro.Deployment{}, errMock).Once()
-	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Once()
-	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Once()
-	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Once()
-	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Once()
-
-	azureUploader = func(sasLink string, file io.Reader) (string, error) {
-		return "version-id", nil
-	}
-
-	reportDagDeploymentStatusInput := &astro.ReportDagDeploymentStatusInput{
-		InitiatedDagDeploymentID: initiatedDagDeploymentID,
-		RuntimeID:                runtimeID,
-		Action:                   "UPLOAD",
-		VersionID:                "version-id",
-		Status:                   "SUCCEEDED",
-		Message:                  "Dags uploaded successfully",
-	}
-	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Once()
-
-	mockImageHandler := new(mocks.ImageHandler)
-	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("", nil)
-		return mockImageHandler
-	}
-
-	mockContainerHandler := new(mocks.ContainerHandler)
-	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(nil)
-		return mockContainerHandler, nil
-	}
-
-	ctx, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	ctx.Token = "test testing"
-	err = ctx.SetContext()
-	assert.NoError(t, err)
-
-	// mock os.Stdin
-	input := []byte("1")
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = w.Write(input)
-	if err != nil {
-		t.Error(err)
-	}
-	w.Close()
-	stdin := os.Stdin
-	// Restore stdin right after the test.
-	defer func() { os.Stdin = stdin }()
-	os.Stdin = r
-
-	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", ws, "parse", "", "", "", "enable", true, false, mockClient)
-	assert.NoError(t, err)
-
-	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", ws, "parse", "", "", "", "enable", true, false, mockClient)
-	assert.Contains(t, err.Error(), errMock.Error())
-
-	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", ws, "parse", "", "", "", "enable", true, false, mockClient)
-	assert.Contains(t, err.Error(), errMock.Error())
-
-	defer os.RemoveAll("./testfiles/dags/")
-
-	mockClient.AssertExpectations(t)
-	mockImageHandler.AssertExpectations(t)
-	mockContainerHandler.AssertExpectations(t)
-}
-
-func TestDisableDagsDeploySuccess(t *testing.T) {
-	deploymentUpdateInput := astro.UpdateDeploymentInput{
-		ID:               "test-id",
-		ClusterID:        "",
-		DagDeployEnabled: false,
-		DeploymentSpec: astro.DeploymentCreateSpec{
-			Executor: "CeleryExecutor",
-		},
-	}
-
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	config.CFG.ShowWarnings.SetHomeString("false")
-	mockClient := new(astro_mocks.Client)
-
-	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: true}}, nil).Once()
-	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: false}}, nil).Once()
-	mockClient.On("UpdateDeployment", &deploymentUpdateInput).Return(astro.Deployment{ID: "test-id", DagDeployEnabled: false}, nil).Once()
-	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Once()
-	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Once()
-	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Once()
-
-	mockImageHandler := new(mocks.ImageHandler)
-	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("", nil)
-		return mockImageHandler
-	}
-
-	mockContainerHandler := new(mocks.ContainerHandler)
-	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(nil)
-		return mockContainerHandler, nil
-	}
-
-	ctx, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	ctx.Token = "test testing"
-	err = ctx.SetContext()
-	assert.NoError(t, err)
-
-	// mock os.Stdin
-	input := []byte("1")
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = w.Write(input)
-	if err != nil {
-		t.Error(err)
-	}
-	w.Close()
-	stdin := os.Stdin
-	// Restore stdin right after the test.
-	defer func() { os.Stdin = stdin }()
-	os.Stdin = r
-
-	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", ws, "parse", "", "", "", "disable", true, false, mockClient)
-	assert.NoError(t, err)
-
-	mockClient.AssertExpectations(t)
-	mockImageHandler.AssertExpectations(t)
-	mockContainerHandler.AssertExpectations(t)
-}
-
-func TestCancelDisableDagsDeploySuccess(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	config.CFG.ShowWarnings.SetHomeString("true")
-	defer testUtil.MockUserInput(t, "n")()
-	mockClient := new(astro_mocks.Client)
-
-	os.Mkdir("./testfiles/dags", 0o755)
-	fileutil.WriteStringToFile("./testfiles/dags/dags.py", "test")
-	defer os.RemoveAll("./testfiles/dags/")
-
-	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: true}}, nil).Once()
-
-	ctx, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	ctx.Token = "test testing"
-	err = ctx.SetContext()
-	assert.NoError(t, err)
-
-	// mock os.Stdin
-	input := []byte("1")
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = w.Write(input)
-	if err != nil {
-		t.Error(err)
-	}
-	w.Close()
-	stdin := os.Stdin
-	// Restore stdin right after the test.
-	defer func() { os.Stdin = stdin }()
-	os.Stdin = r
-
-	err = Deploy("./testfiles/", "test-id", ws, "parse", "", "", "", "disable", true, false, mockClient)
-	assert.NoError(t, err)
-
-	mockClient.AssertExpectations(t)
 }
 
 func TestDeployWithDagsDeploySuccess(t *testing.T) {
@@ -390,22 +189,22 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	os.Stdin = r
 
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", "", true, false, mockClient)
+	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, false, mockClient)
 	assert.NoError(t, err)
 
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", "", false, false, mockClient)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", false, false, mockClient)
 	assert.NoError(t, err)
 
 	// test custom image
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", "", false, false, mockClient)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "", false, false, mockClient)
 	assert.NoError(t, err)
 
 	config.CFG.ProjectDeployment.SetProjectString("test-id")
 	// test both deploymentID and name used
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "test-name", "", false, false, mockClient)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "custom-image", "test-name", false, false, mockClient)
 	assert.NoError(t, err)
 
 	defer os.RemoveAll("./testfiles/dags/")
@@ -460,7 +259,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Times(2)
 
 	defer testUtil.MockUserInput(t, "y")()
-	err := Deploy("./testfiles/", "test-id", "test-ws-id", "", "", "", "", "", true, true, mockClient)
+	err := Deploy("./testfiles/", "test-id", "test-ws-id", "", "", "", "", true, true, mockClient)
 	assert.NoError(t, err)
 
 	// Test pytest with dags deploy
@@ -481,7 +280,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 	}
 
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "all-tests", "", "", "", "", true, true, mockClient)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "all-tests", "", "", "", true, true, mockClient)
 	assert.NoError(t, err)
 
 	defer os.RemoveAll("./testfiles/dags/")
@@ -520,7 +319,7 @@ func TestDagsDeployFailed(t *testing.T) {
 	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, fmt.Errorf("%w", dagDeployErr)).Times(1)
 
 	defer testUtil.MockUserInput(t, "y")()
-	err := Deploy("./testfiles/", "test-id", "test-ws-id", "", "", "", "", "", true, true, mockClient)
+	err := Deploy("./testfiles/", "test-id", "test-ws-id", "", "", "", "", true, true, mockClient)
 	assert.Equal(t, err.Error(), "Dag Deploy is not enabled for deployment. Run 'astro deployment update test-id --dag-deploy enable' to enable dags deploy")
 
 	mockClient.AssertExpectations(t)
@@ -551,12 +350,12 @@ func TestDagsDeployVR(t *testing.T) {
 
 	defer testUtil.MockUserInput(t, "y")()
 	defer testUtil.MockUserInput(t, "y")()
-	err := Deploy("./testfiles//", runtimeID, "test-ws-id", "", "", "", "", "", true, true, mockClient)
+	err := Deploy("./testfiles//", runtimeID, "test-ws-id", "", "", "", "", true, true, mockClient)
 	assert.NoError(t, err)
 
 	defer testUtil.MockUserInput(t, "y")()
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles//", runtimeID, "test-ws-id", "", "", "", "", "", true, true, mockClient)
+	err = Deploy("./testfiles//", runtimeID, "test-ws-id", "", "", "", "", true, true, mockClient)
 	assert.ErrorIs(t, err, errMock)
 	defer afero.NewOsFs().Remove("./testfiles/dags.tar")
 	defer os.RemoveAll("./testfiles/dags/")
@@ -570,7 +369,7 @@ func TestNoDagsDeploy(t *testing.T) {
 	config.CFG.ShowWarnings.SetHomeString("true")
 	mockClient := new(astro_mocks.Client)
 
-	err := Deploy("./testfiles/", "test-id", "test-ws-id", "", "", "", "", "", true, true, mockClient)
+	err := Deploy("./testfiles/", "test-id", "test-ws-id", "", "", "", "", true, true, mockClient)
 	assert.NoError(t, err)
 
 	mockClient.AssertExpectations(t)
@@ -582,7 +381,7 @@ func TestDeployFailure(t *testing.T) {
 	err := config.ResetCurrentContext()
 	assert.NoError(t, err)
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", "", true, false, nil)
+	err = Deploy("./testfiles/", "test-id", "test-ws-id", "pytest", "", "", "", true, false, nil)
 	assert.EqualError(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 
 	// airflow parse failure
@@ -631,7 +430,7 @@ func TestDeployFailure(t *testing.T) {
 	os.Stdin = r
 
 	defer testUtil.MockUserInput(t, "y")()
-	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", "", true, false, mockClient)
+	err = Deploy("./testfiles/", "", "test-ws-id", "parse", "", "", "", true, false, mockClient)
 	assert.ErrorIs(t, err, errDagsParseFailed)
 
 	mockClient.AssertExpectations(t)

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -37,13 +37,10 @@ var (
 	envFile        string
 	imageName      string
 	deploymentName string
-	dagDeploy      string
 )
 
 const (
 	registryUncommitedChangesMsg = "Project directory has uncommitted changes, use `astro deploy [deployment-id] -f` to force deploy."
-	dagDeployEnabled             = "enable"
-	dagDeployDisabled            = "disable"
 )
 
 func newDeployCmd() *cobra.Command {
@@ -64,7 +61,6 @@ func newDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables for Pytests")
 	cmd.Flags().StringVarP(&pytestFile, "test", "t", "", "Location of Pytests or specific Pytest file. All Pytest files must be located in the tests directory")
 	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom image to deploy")
-	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "", "To enable or disable dag deploy for the Deployment")
 	cmd.Flags().BoolVarP(&dags, "dags", "d", false, "To push dags to your airflow deployment")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to deploy to")
 	return cmd
@@ -108,11 +104,8 @@ func deploy(cmd *cobra.Command, args []string) error {
 		pytestFile = "parse"
 	}
 
-	if dagDeploy != "" && !(dagDeploy == dagDeployEnabled || dagDeploy == dagDeployDisabled) {
-		return errors.New("Invalid --dag-deploy value. Possible values are (enable, disable)")
-	}
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	return deployImage(config.WorkingPath, deploymentID, ws, pytestFile, envFile, imageName, deploymentName, dagDeploy, forcePrompt, dags, astroClient)
+	return deployImage(config.WorkingPath, deploymentID, ws, pytestFile, envFile, imageName, deploymentName, forcePrompt, dags, astroClient)
 }

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -23,7 +23,7 @@ func TestDeployImage(t *testing.T) {
 		return nil
 	}
 
-	deployImage = func(path, deploymentID, wsID, pytest, envFile, imageName, deploymentName, dagDeploy string, prompt, dags bool, client astro.Client) error {
+	deployImage = func(path, deploymentID, wsID, pytest, envFile, imageName, deploymentName string, prompt, dags bool, client astro.Client) error {
 		return nil
 	}
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Remove dag deploy enable / disable from astro deploy

## 🎟 Issue(s)

Related #794 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
