### PR TITLE
Deploy large dags

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -15,3 +15,6 @@ rules:
   line-length: disable
   truthy: disable
   comments-indentation: disable
+  indentation:
+    spaces: 2
+    indent-sequences: whatever

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -91,23 +91,23 @@ type InputDeploy struct {
 }
 
 func deployDags(path, runtimeID string, client astro.Client) error {
-	dagDeployment, err := deployment.Initiate(runtimeID, client)
-	if err != nil {
-		return err
-	}
-
 	// Check the dags directory
 	dagsPath := path + "/dags"
 	monitoringDagPath := filepath.Join(dagsPath, "astronomer_monitoring_dag.py")
 
 	// Create monitoring dag file
-	err = fileutil.WriteStringToFile(monitoringDagPath, include.MonitoringDag)
+	err := fileutil.WriteStringToFile(monitoringDagPath, include.MonitoringDag)
 	if err != nil {
 		return err
 	}
 
 	// Generate the dags tar
 	err = fileutil.Tar(dagsPath, path)
+	if err != nil {
+		return err
+	}
+
+	dagDeployment, err := deployment.Initiate(runtimeID, client)
 	if err != nil {
 		return err
 	}
@@ -212,6 +212,10 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 					return err
 				}
 			}
+		}
+
+		if !deployInfo.dagDeployEnabled {
+			return fmt.Errorf(enableDagDeployMsg, deployInfo.deploymentID) //nolint
 		}
 
 		fmt.Println("Initiating DAGs Deployment for: " + deployInfo.deploymentID)

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -46,6 +46,7 @@ const (
 	message            = "Dags uploaded successfully"
 	action             = "UPLOAD"
 	allTests           = "all-tests"
+	parseAndPytest     = "parse-and-all-tests"
 	enableDagDeployMsg = "Dag Deploy is not enabled for deployment. Run 'astro deployment update %s --dag-deploy enable' to enable dags deploy"
 	dagDeployDisabled  = "dag deploy is not enabled for deployment"
 )
@@ -85,6 +86,8 @@ type InputDeploy struct {
 	DeploymentName string
 	Prompt         bool
 	Dags           bool
+	ForceDeploy    bool
+	Parse          bool
 }
 
 func deployDags(path, runtimeID string, client astro.Client) error {
@@ -190,15 +193,24 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 	deploymentURL := "cloud." + domain + "/" + deployInfo.workspaceID + "/deployments/" + deployInfo.deploymentID + "/analytics"
 
 	if deployInput.Dags {
-		if deployInput.Pytest == allTests {
+		if (deployInput.Pytest == allTests || deployInput.Parse) && !deployInput.ForceDeploy {
 			version, err := buildImage(&c, deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.dagDeployEnabled, client)
 			if err != nil {
 				return err
 			}
 
-			err = parseDAG(deployInput.Pytest, version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
-			if err != nil {
-				return err
+			if deployInput.Pytest == allTests {
+				err = parseOrPytestDAG(deployInput.Pytest, version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
+				if err != nil {
+					return err
+				}
+			}
+
+			if deployInput.Parse {
+				err = parseOrPytestDAG("parse", version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
+				if err != nil {
+					return err
+				}
 			}
 		}
 
@@ -223,7 +235,7 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 			return err
 		}
 
-		err = parseDAG(deployInput.Pytest, version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
+		err = parseOrPytestDAG(deployInput.Pytest, version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
 		if err != nil {
 			return err
 		}
@@ -325,7 +337,7 @@ func getDeploymentInfo(deploymentID, wsID, deploymentName string, prompt bool, c
 	return deployInfo, nil
 }
 
-func parseDAG(pytest, version, envFile, deployImage, namespace string) error {
+func parseOrPytestDAG(pytest, version, envFile, deployImage, namespace string) error {
 	dagParseVersionCheck := versions.GreaterThanOrEqualTo(version, dagParseAllowedVersion)
 	if !dagParseVersionCheck {
 		fmt.Println("\nruntime image is earlier than 4.1.0, this deploy will skip DAG parse...")
@@ -337,26 +349,48 @@ func parseDAG(pytest, version, envFile, deployImage, namespace string) error {
 		return err
 	}
 
-	// parse dags
-	if pytest == parse && dagParseVersionCheck {
-		if !config.CFG.SkipParse.GetBool() && !util.CheckEnvBool(os.Getenv("ASTRONOMER_SKIP_PARSE")) {
-			fmt.Println("Testing image...")
-			err := containerHandler.Parse("", deployImage)
-			if err != nil {
-				fmt.Println(err)
-				return errDagsParseFailed
-			}
-		} else {
-			fmt.Println("Skiping parsing dags due to skip parse being set to true in either the config.yaml or local environment variables")
+	switch {
+	case pytest == parse && dagParseVersionCheck:
+		// parse dags
+		fmt.Println("Testing image...")
+		err := parseDAGs(deployImage, containerHandler)
+		if err != nil {
+			return err
 		}
+	case pytest != "" && pytest != parse:
 		// check pytests
-	} else if pytest != "" && pytest != parse {
 		fmt.Println("Testing image...")
 		err := checkPytest(pytest, deployImage, containerHandler)
 		if err != nil {
 			return err
 		}
+	case pytest == parseAndPytest:
+		// parse dags and check pytests
+		fmt.Println("Testing image...")
+		err := parseDAGs(deployImage, containerHandler)
+		if err != nil {
+			return err
+		}
+
+		err = checkPytest(pytest, deployImage, containerHandler)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+func parseDAGs(deployImage string, containerHandler airflow.ContainerHandler) error {
+	if !config.CFG.SkipParse.GetBool() && !util.CheckEnvBool(os.Getenv("ASTRONOMER_SKIP_PARSE")) {
+		err := containerHandler.Parse("", deployImage)
+		if err != nil {
+			fmt.Println(err)
+			return errDagsParseFailed
+		}
+	} else {
+		fmt.Println("Skiping parsing dags due to skip parse being set to true in either the config.yaml or local environment variables")
+	}
+
 	return nil
 }
 

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -157,11 +157,11 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
 
-	mockClient.On("GetDeployment", mock.Anything).Return(mockDeplyResp, nil).Times(4)
+	mockClient.On("GetDeployment", mock.Anything).Return(mockDeplyResp, nil).Times(5)
 	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: true}}, nil).Times(1)
-	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(5)
-	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(5)
-	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(5)
+	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(6)
+	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(6)
+	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(6)
 	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(2)
 
 	azureUploader = func(sasLink string, file io.Reader) (string, error) {
@@ -244,6 +244,11 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 
 	defer testUtil.MockUserInput(t, "y")()
 	deployInput.Parse = true
+	err = Deploy(deployInput, mockClient)
+	assert.NoError(t, err)
+
+	defer testUtil.MockUserInput(t, "y")()
+	deployInput.Pytest = "parse-and-all-tests"
 	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -280,15 +280,16 @@ func TestDagsDeploySuccess(t *testing.T) {
 		ImageName:      "",
 		DeploymentName: "",
 		Prompt:         true,
+		Parse:          false,
 		Dags:           true,
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
 
-	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(1)
-	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(2)
-	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(2)
+	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(2)
+	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(3)
+	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(3)
 
 	azureUploader = func(sasLink string, file io.Reader) (string, error) {
 		return "version-id", nil
@@ -302,7 +303,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 		Status:                   "SUCCEEDED",
 		Message:                  "Dags uploaded successfully",
 	}
-	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Times(2)
+	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Times(3)
 
 	defer testUtil.MockUserInput(t, "y")()
 	err := Deploy(deployInput, mockClient)
@@ -327,6 +328,11 @@ func TestDagsDeploySuccess(t *testing.T) {
 
 	defer testUtil.MockUserInput(t, "y")()
 	deployInput.Pytest = "all-tests"
+	err = Deploy(deployInput, mockClient)
+	assert.NoError(t, err)
+
+	defer testUtil.MockUserInput(t, "y")()
+	deployInput.Parse = true
 	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -3,7 +3,6 @@ package deploy
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -268,7 +267,8 @@ func TestDagsDeploySuccess(t *testing.T) {
 			DeploymentSpec: astro.DeploymentSpec{
 				Webserver: astro.Webserver{URL: "test-url"},
 			},
-			CreatedAt: time.Now(),
+			CreatedAt:        time.Now(),
+			DagDeployEnabled: true,
 		},
 		{
 			ID:             "test-id-2",
@@ -277,7 +277,8 @@ func TestDagsDeploySuccess(t *testing.T) {
 			DeploymentSpec: astro.DeploymentSpec{
 				Webserver: astro.Webserver{URL: "test-url"},
 			},
-			CreatedAt: time.Now(),
+			CreatedAt:        time.Now(),
+			DagDeployEnabled: true,
 		},
 	}
 
@@ -371,7 +372,8 @@ func TestDagsDeployFailed(t *testing.T) {
 			DeploymentSpec: astro.DeploymentSpec{
 				Webserver: astro.Webserver{URL: "test-url"},
 			},
-			CreatedAt: time.Now(),
+			CreatedAt:        time.Now(),
+			DagDeployEnabled: false,
 		},
 		{
 			ID:             "test-id-2",
@@ -380,7 +382,8 @@ func TestDagsDeployFailed(t *testing.T) {
 			DeploymentSpec: astro.DeploymentSpec{
 				Webserver: astro.Webserver{URL: "test-url"},
 			},
-			CreatedAt: time.Now(),
+			CreatedAt:        time.Now(),
+			DagDeployEnabled: true,
 		},
 	}
 
@@ -396,8 +399,6 @@ func TestDagsDeployFailed(t *testing.T) {
 		Dags:           true,
 	}
 	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(1)
-	dagDeployErr := errors.New("dag deploy is not enabled for deployment") //nolint: goerr113
-	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, fmt.Errorf("%w", dagDeployErr)).Times(1)
 
 	defer testUtil.MockUserInput(t, "y")()
 	err := Deploy(deployInput, mockClient)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -150,17 +150,18 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 		ImageName:      "",
 		DeploymentName: "",
 		Prompt:         true,
+		Parse:          false,
 		Dags:           false,
 	}
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
 
-	mockClient.On("GetDeployment", mock.Anything).Return(mockDeplyResp, nil).Times(3)
+	mockClient.On("GetDeployment", mock.Anything).Return(mockDeplyResp, nil).Times(4)
 	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: true}}, nil).Times(1)
-	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(4)
-	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(4)
-	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(4)
+	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(5)
+	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(5)
+	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(5)
 	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(2)
 
 	azureUploader = func(sasLink string, file io.Reader) (string, error) {
@@ -239,7 +240,11 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	defer testUtil.MockUserInput(t, "y")()
 	deployInput.DeploymentName = "test-name"
 	err = Deploy(deployInput, mockClient)
+	assert.NoError(t, err)
 
+	defer testUtil.MockUserInput(t, "y")()
+	deployInput.Parse = true
+	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 
 	defer os.RemoveAll("./testfiles/dags/")
@@ -287,9 +292,9 @@ func TestDagsDeploySuccess(t *testing.T) {
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
 
-	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(2)
-	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(3)
-	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(3)
+	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(3)
+	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(4)
+	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(4)
 
 	azureUploader = func(sasLink string, file io.Reader) (string, error) {
 		return "version-id", nil
@@ -303,7 +308,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 		Status:                   "SUCCEEDED",
 		Message:                  "Dags uploaded successfully",
 	}
-	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Times(3)
+	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Times(4)
 
 	defer testUtil.MockUserInput(t, "y")()
 	err := Deploy(deployInput, mockClient)
@@ -327,12 +332,19 @@ func TestDagsDeploySuccess(t *testing.T) {
 	}
 
 	defer testUtil.MockUserInput(t, "y")()
+	deployInput.Parse = true
+	err = Deploy(deployInput, mockClient)
+	assert.NoError(t, err)
+
+	defer testUtil.MockUserInput(t, "y")()
+	deployInput.Parse = false
 	deployInput.Pytest = "all-tests"
 	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 
 	defer testUtil.MockUserInput(t, "y")()
 	deployInput.Parse = true
+	deployInput.Pytest = "all-tests"
 	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -17,6 +17,7 @@ var (
 	forcePrompt      bool
 	saveDeployConfig bool
 	pytest           bool
+	parse            bool
 	dags             bool
 	deployExample    = `
 Specify the ID of the Deployment on Astronomer you would like to deploy this project to:
@@ -63,6 +64,7 @@ func newDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom image to deploy")
 	cmd.Flags().BoolVarP(&dags, "dags", "d", false, "To push dags to your airflow deployment")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to deploy to")
+	cmd.Flags().BoolVar(&parse, "parse", false, "Deploy code to Astro only if all DAGs in your Astro project parse correctly")
 	return cmd
 }
 
@@ -96,12 +98,16 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if pytest && pytestFile == "" {
+	if pytest && pytestFile == "" && !forceDeploy {
 		pytestFile = "all-tests"
 	}
 
 	if !pytest && !forceDeploy {
 		pytestFile = "parse"
+	}
+
+	if parse && pytest && !forceDeploy {
+		pytestFile = "parse-and-all-tests"
 	}
 
 	// Silence Usage as we have now validated command input
@@ -117,6 +123,8 @@ func deploy(cmd *cobra.Command, args []string) error {
 		DeploymentName: deploymentName,
 		Prompt:         forcePrompt,
 		Dags:           dags,
+		ForceDeploy:    forceDeploy,
+		Parse:          parse,
 	}
 
 	return deployImage(deployInput, astroClient)

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -37,6 +37,18 @@ func TestDeployImage(t *testing.T) {
 	err = execDeployCmd([]string{"-f", "test-deployment-id", "--pytest"}...)
 	assert.NoError(t, err)
 
+	err = execDeployCmd([]string{"-f", "test-deployment-id", "--parse"}...)
+	assert.NoError(t, err)
+
 	err = execDeployCmd([]string{"-f", "test-deployment-id", "--parse", "--pytest"}...)
+	assert.NoError(t, err)
+
+	err = execDeployCmd([]string{"-f", "test-deployment-id", "--dags", "--pytest"}...)
+	assert.NoError(t, err)
+
+	err = execDeployCmd([]string{"-f", "test-deployment-id", "--dags", "--parse"}...)
+	assert.NoError(t, err)
+
+	err = execDeployCmd([]string{"-f", "test-deployment-id", "--dags", "--parse", "--pytest"}...)
 	assert.NoError(t, err)
 }

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -36,4 +36,7 @@ func TestDeployImage(t *testing.T) {
 
 	err = execDeployCmd([]string{"-f", "test-deployment-id", "--pytest"}...)
 	assert.NoError(t, err)
+
+	err = execDeployCmd([]string{"-f", "test-deployment-id", "--parse", "--pytest"}...)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

To be able to deploy large dags via dag deploy, we want to make the tar file before request the api for new sas link since the expiry time is only 10 mins and making a tar file with 1000s of dags and uploading the tar could exceed that time limit

## 🎟 Issue(s)

Related #809 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
