### PR TITLE
fix colima deploy part2

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -300,7 +300,7 @@ func useBash(authConfig *cliTypes.AuthConfig, image string) error {
 	var err error
 	if authConfig.Username != "" { // Case for cloud image push where we have both registry user & pass, for software login happens during `astro login` itself
 		cmd := "echo \"" + authConfig.Password + "\"" + " | docker login " + authConfig.ServerAddress + " -u " + authConfig.Username + " --password-stdin"
-		err = cmdExec("bash", os.Stdout, os.Stderr, "-c", cmd) // This command will only work on machines that have bash
+		err = cmdExec("bash", os.Stdout, os.Stderr, "-c", cmd) // This command will only work on machines that have bash. If users have issues we will revist
 	}
 	if err != nil {
 		return err

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -299,7 +299,9 @@ var cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 func useBash(authConfig *cliTypes.AuthConfig, image string) error {
 	var err error
 	if authConfig.Username != "" { // Case for cloud image push where we have both registry user & pass, for software login happens during `astro login` itself
-		err = cmdExec(EchoCmd, nil, os.Stderr, fmt.Sprintf("%q", authConfig.Password), "|", DockerCmd, "login", authConfig.ServerAddress, "-u", authConfig.Username, "--password-stdin")
+		cmd := "echo \"" + authConfig.Password + "\"" + " | docker login " + authConfig.ServerAddress + " -u " + authConfig.Username + " --password-stdin"
+		// err = cmdExec(EchoCmd, os.Stdout, os.Stderr, fmt.Sprintf("%q", authConfig.Password), "|", DockerCmd, "login", authConfig.ServerAddress, "-u", authConfig.Username, "--password-stdin")
+		err = cmdExec("bash", os.Stdout, os.Stderr, "-c", cmd)
 	}
 	if err != nil {
 		return err

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -300,7 +300,6 @@ func useBash(authConfig *cliTypes.AuthConfig, image string) error {
 	var err error
 	if authConfig.Username != "" { // Case for cloud image push where we have both registry user & pass, for software login happens during `astro login` itself
 		cmd := "echo \"" + authConfig.Password + "\"" + " | docker login " + authConfig.ServerAddress + " -u " + authConfig.Username + " --password-stdin"
-		// err = cmdExec(EchoCmd, os.Stdout, os.Stderr, fmt.Sprintf("%q", authConfig.Password), "|", DockerCmd, "login", authConfig.ServerAddress, "-u", authConfig.Username, "--password-stdin")
 		err = cmdExec("bash", os.Stdout, os.Stderr, "-c", cmd)
 	}
 	if err != nil {

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -295,12 +295,12 @@ var cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 	return nil
 }
 
-// When login and push do not work use bash to run docker commands
+// When login and push do not work use bash to run docker commands, this function is for users using colima
 func useBash(authConfig *cliTypes.AuthConfig, image string) error {
 	var err error
 	if authConfig.Username != "" { // Case for cloud image push where we have both registry user & pass, for software login happens during `astro login` itself
 		cmd := "echo \"" + authConfig.Password + "\"" + " | docker login " + authConfig.ServerAddress + " -u " + authConfig.Username + " --password-stdin"
-		err = cmdExec("bash", os.Stdout, os.Stderr, "-c", cmd)
+		err = cmdExec("bash", os.Stdout, os.Stderr, "-c", cmd) // This command will only work on machines that have bash
 	}
 	if err != nil {
 		return err

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -321,7 +321,7 @@ func TestUseBash(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
-			assert.Contains(t, []string{"\"pass\"", "push", "rmi"}, args[0])
+			assert.Contains(t, []string{"-c", "push", "rmi"}, args[0])
 			return nil
 		}
 		err := useBash(&types.AuthConfig{Username: "testing", Password: "pass"}, "test")

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -339,7 +339,7 @@ func TestUseBash(t *testing.T) {
 
 	t.Run("login exec failure", func(t *testing.T) {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
-			assert.Contains(t, cmd, "echo")
+			assert.Contains(t, cmd, "bash")
 			return errMockDocker
 		}
 		err := useBash(&types.AuthConfig{Username: "testing"}, "test")


### PR DESCRIPTION
## Description

seems like the login command is still not working. This update get it to work and prints the result of running the command ( in this case "login succeeded")

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/615

## 🧪 Functional Testing

## 📸 Screenshots


## 📋 Checklist

- [X] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
