### PR TITLE
org switch works with both org id and name

### DIFF
--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -138,7 +138,7 @@ func getOrganizationSelection(out io.Writer) (string, error) {
 }
 
 // Switch switches organizations
-func Switch(orgName string, client astro.Client, out io.Writer) error {
+func Switch(orgNameOrID string, client astro.Client, out io.Writer) error {
 	// get current context
 	c, err := config.GetCurrentContext()
 	if err != nil {
@@ -146,7 +146,7 @@ func Switch(orgName string, client astro.Client, out io.Writer) error {
 	}
 	// get auth id
 	var id string
-	if orgName == "" {
+	if orgNameOrID == "" {
 		id, err = getOrganizationSelection(out)
 		if err != nil {
 			return err
@@ -157,7 +157,10 @@ func Switch(orgName string, client astro.Client, out io.Writer) error {
 			return errors.Wrap(err, astro.AstronomerConnectionErrMsg)
 		}
 		for i := range or {
-			if or[i].Name == orgName {
+			if or[i].Name == orgNameOrID {
+				id = or[i].AuthServiceID
+			}
+			if or[i].ID == orgNameOrID {
 				id = or[i].AuthServiceID
 			}
 		}

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -42,7 +42,7 @@ func newOrganizationListCmd(out io.Writer) *cobra.Command {
 
 func newOrganizationSwitchCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "switch [organization_id]",
+		Use:     "switch [organization name/id]",
 		Aliases: []string{"sw"},
 		Short:   "Switch to a different Organization",
 		Long:    "Switch to a different Organization",
@@ -64,11 +64,11 @@ func organizationSwitch(cmd *cobra.Command, out io.Writer, args []string) error 
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	organizationName := ""
+	organizationNameOrID := ""
 
 	if len(args) == 1 {
-		organizationName = args[0]
+		organizationNameOrID = args[0]
 	}
 
-	return orgSwitch(organizationName, astroClient, out)
+	return orgSwitch(organizationNameOrID, astroClient, out)
 }


### PR DESCRIPTION
## Description

This PR makes it so you can use both org id and name to switch organizations

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/811

## 🧪 Functional Testing


## 📸 Screenshots


## 📋 Checklist

- [X] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
