### PR TITLE
fix wq command usage

### DIFF
--- a/cmd/cloud/deployment_workerqueue.go
+++ b/cmd/cloud/deployment_workerqueue.go
@@ -44,7 +44,7 @@ func newDeploymentWorkerQueueCreateCmd(out io.Writer) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be deleted.")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment where the worker queue should be deleted.")
-	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue to delete.")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue. Queue names must not exceed 63 characters and contain only lowercase alphanumeric characters or '-' and start with an alphabetical character.")
 	cmd.Flags().IntVarP(&minWorkerCount, "min-count", "", 0, "The min worker count of the worker queue.")
 	cmd.Flags().IntVarP(&maxWorkerCount, "max-count", "", 0, "The max worker count of the worker queue.")
 	cmd.Flags().IntVarP(&concurrency, "concurrency", "", 0, "The concurrency(number of slots) of the worker queue.")
@@ -87,7 +87,7 @@ func newDeploymentWorkerQueueDeleteCmd(out io.Writer) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be created.")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment where the worker queue should be created.")
-	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue. Queue names must not exceed 63 characters and contain only lowercase alphanumeric characters or '-' and start with an alphabetical character.")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue to delete.")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force delete: Don't prompt a user for confirmation")
 	return cmd
 }


### PR DESCRIPTION
## Description

This PR fixes worker-queue create and delete command usage. 

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

### Prints correct usage for create

```
$ astro deployment worker-queue create -h
Create a worker queue for an Astro Deployment

Current Context: Astro

Usage:
  astro deployment worker-queue create [flags]

Aliases:
  create, cr

Flags:
      --concurrency int          The concurrency(number of slots) of the worker queue.
  -d, --deployment-id string     The deployment where the worker queue should be deleted.
      --deployment-name string   Name of the deployment where the worker queue should be deleted.
  -h, --help                     help for create
      --max-count int            The max worker count of the worker queue.
      --min-count int            The min worker count of the worker queue.
  -n, --name string              The name of the worker queue. Queue names must not exceed 63 characters and contain only lowercase alphanumeric characters or '-' and start with an alphabetical character.
  -t, --worker-type string       The worker type of the worker queue.

Global Flags:
      --verbosity string      Log level (debug, info, warn, error, fatal, panic (default "warning")
      --workspace-id string   workspace assigned to deployment
```

### prints correct usage for delete

```
$ astro deployment worker-queue delete -h
Delete a worker queue from an Astro Deployment

Current Context: Astro

Usage:
  astro deployment worker-queue delete [flags]

Aliases:
  delete, de

Flags:
  -d, --deployment-id string     The deployment where the worker queue should be created.
      --deployment-name string   Name of the deployment where the worker queue should be created.
  -f, --force                    Force delete: Don't prompt a user for confirmation
  -h, --help                     help for delete
  -n, --name string              The name of the worker queue to delete.

Global Flags:
      --verbosity string      Log level (debug, info, warn, error, fatal, panic (default "warning")
      --workspace-id string   workspace assigned to deployment```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)