### PR TITLE
Update gitignore.go

### DIFF
--- a/airflow/include/gitignore.go
+++ b/airflow/include/gitignore.go
@@ -6,6 +6,7 @@ import "strings"
 var Gitignore = strings.TrimSpace(`
 .git
 .env
+.DS_Store # macOS specific ignore
 airflow_settings.yaml
 astro
 `)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Default `.gitignore` should ignore `.DS_Store` files automatically genered by osx  to prevent them from getting uploaded to git projects