### PR TITLE
Throw error on custom deploy when dag deploy is enabled

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -63,7 +63,10 @@ var (
 	azureUploader        = azure.Upload
 )
 
-var errDagsParseFailed = errors.New("your local DAGs did not parse. Fix the listed errors or use `astro deploy [deployment-id] -f` to force deploy") //nolint:revive
+var (
+	errDagsParseFailed = errors.New("your local DAGs did not parse. Fix the listed errors or use `astro deploy [deployment-id] -f` to force deploy")            //nolint:revive
+	customDeployError  = errors.New("Dag Deploy is enabled. To perform custom image deploy, you will need to contact Astronomer Support to disable dag deploy") //nolint:revive
+)
 
 type deploymentInfo struct {
 	deploymentID     string
@@ -525,6 +528,9 @@ func buildImage(c *config.Context, path, currentVersion, deployImage, imageName 
 			}
 		}
 	} else {
+		if dagDeployEnabled {
+			return "", customDeployError
+		}
 		// skip build if an imageName is passed
 		fmt.Println(composeSkipImageBuildingPromptMsg)
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Throw error on custom deploy when dag deploy is enabled

## 🎟 Issue(s)

Related #822 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
