### PR TITLE
Custom image deploy with dag deploy when enabled

### DIFF
--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -158,10 +158,10 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 
 	mockClient.On("GetDeployment", mock.Anything).Return(mockDeplyResp, nil).Times(5)
 	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: true}}, nil).Times(1)
-	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(5)
-	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(5)
-	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(5)
-	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(5)
+	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(6)
+	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(6)
+	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(6)
+	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(6)
 
 	azureUploader = func(sasLink string, file io.Reader) (string, error) {
 		return "version-id", nil
@@ -175,13 +175,14 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 		Status:                   "SUCCEEDED",
 		Message:                  "Dags uploaded successfully",
 	}
-	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Times(5)
+	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Times(6)
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("", nil)
+		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
 	}
 
@@ -246,7 +247,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	defer testUtil.MockUserInput(t, "y")()
 	deployInput.ImageName = "custom-image"
 	err = Deploy(deployInput, mockClient)
-	assert.ErrorIs(t, err, customDeployError)
+	assert.NoError(t, err)
 
 	defer os.RemoveAll("./testfiles/dags/")
 

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -462,8 +462,8 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy stri
 	}
 
 	if dagDeploy == "enable" {
-		fmt.Println("\nYou enabled DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled." +
-			"\nRun `astro deploy --dags` after this command to push new changes. It may take a few minutes for the Airflow UI to update..")
+		fmt.Printf("\nYou enabled DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled." +
+			"\nRun `astro deploy --dags` after this command to push new changes. It may take a few minutes for the Airflow UI to update..\n\n")
 		deploymentUpdate.DagDeployEnabled = true
 	} else if dagDeploy == "disable" {
 		if config.CFG.ShowWarnings.GetBool() {


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Custom image deploy with dag deploy when enabled

## 🎟 Issue(s)

Related #826 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

**Custom Image Deploy with dag deploy disabled**
![Screen Shot 2022-10-20 at 14 19 02](https://user-images.githubusercontent.com/65428224/197063109-a4152754-55d5-4926-bcf5-1d5cb8bbc2e3.png)

**Enable Dag Deploy**
![Screen Shot 2022-10-20 at 14 20 28](https://user-images.githubusercontent.com/65428224/197063114-5ebebe39-3848-484a-8943-316aa77e3539.png)

**Custom Image Deploy with dag deploy enabled**
![Screen Shot 2022-10-20 at 14 22 39](https://user-images.githubusercontent.com/65428224/197063120-8f840e55-91fd-44b9-9680-ae8c92bdf27a.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
