### PR TITLE
Support dag deploy tests

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -86,8 +86,6 @@ type InputDeploy struct {
 	DeploymentName string
 	Prompt         bool
 	Dags           bool
-	ForceDeploy    bool
-	Parse          bool
 }
 
 func deployDags(path, runtimeID string, client astro.Client) error {
@@ -193,24 +191,15 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 	deploymentURL := "cloud." + domain + "/" + deployInfo.workspaceID + "/deployments/" + deployInfo.deploymentID + "/analytics"
 
 	if deployInput.Dags {
-		if (deployInput.Pytest == allTests || deployInput.Parse) && !deployInput.ForceDeploy {
+		if deployInput.Pytest != "" {
 			version, err := buildImage(&c, deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.dagDeployEnabled, client)
 			if err != nil {
 				return err
 			}
 
-			if deployInput.Pytest == allTests {
-				err = parseOrPytestDAG(deployInput.Pytest, version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
-				if err != nil {
-					return err
-				}
-			}
-
-			if deployInput.Parse {
-				err = parseOrPytestDAG("parse", version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
-				if err != nil {
-					return err
-				}
+			err = parseOrPytestDAG(deployInput.Pytest, version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
+			if err != nil {
+				return err
 			}
 		}
 

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -149,7 +149,6 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 		ImageName:      "",
 		DeploymentName: "",
 		Prompt:         true,
-		Parse:          false,
 		Dags:           false,
 	}
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
@@ -234,12 +233,12 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	defer testUtil.MockUserInput(t, "y")()
-	deployInput.Parse = true
+	deployInput.Pytest = "parse"
 	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 
 	defer testUtil.MockUserInput(t, "y")()
-	deployInput.Pytest = "parse-and-all-tests"
+	deployInput.Pytest = parseAndPytest
 	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 
@@ -289,7 +288,6 @@ func TestDagsDeploySuccess(t *testing.T) {
 		ImageName:      "",
 		DeploymentName: "",
 		Prompt:         true,
-		Parse:          false,
 		Dags:           true,
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
@@ -336,19 +334,17 @@ func TestDagsDeploySuccess(t *testing.T) {
 	}
 
 	defer testUtil.MockUserInput(t, "y")()
-	deployInput.Parse = true
+	deployInput.Pytest = "parse"
 	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 
 	defer testUtil.MockUserInput(t, "y")()
-	deployInput.Parse = false
-	deployInput.Pytest = "all-tests"
+	deployInput.Pytest = allTests
 	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 
 	defer testUtil.MockUserInput(t, "y")()
-	deployInput.Parse = true
-	deployInput.Pytest = "all-tests"
+	deployInput.Pytest = parseAndPytest
 	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 
@@ -394,7 +390,6 @@ func TestDagsDeployFailed(t *testing.T) {
 		ImageName:      "",
 		DeploymentName: "",
 		Prompt:         true,
-		ForceDeploy:    false,
 		Dags:           true,
 	}
 	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(3)
@@ -419,7 +414,7 @@ func TestDagsDeployFailed(t *testing.T) {
 	}
 
 	defer testUtil.MockUserInput(t, "y")()
-	deployInput.Parse = true
+	deployInput.Pytest = "parse"
 	err = Deploy(deployInput, mockClient)
 	assert.Error(t, err)
 

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -158,10 +158,10 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 
 	mockClient.On("GetDeployment", mock.Anything).Return(mockDeplyResp, nil).Times(5)
 	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: true}}, nil).Times(1)
-	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(5)
-	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(5)
-	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(5)
-	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(5)
+	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(6)
+	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(6)
+	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(6)
+	mockClient.On("InitiateDagDeployment", astro.InitiateDagDeploymentInput{RuntimeID: runtimeID}).Return(astro.InitiateDagDeployment{ID: initiatedDagDeploymentID, DagURL: dagURL}, nil).Times(6)
 
 	azureUploader = func(sasLink string, file io.Reader) (string, error) {
 		return "version-id", nil
@@ -175,13 +175,14 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 		Status:                   "SUCCEEDED",
 		Message:                  "Dags uploaded successfully",
 	}
-	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Times(5)
+	mockClient.On("ReportDagDeploymentStatus", reportDagDeploymentStatusInput).Return(astro.DagDeploymentStatus{}, nil).Times(6)
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", runtimeImageLabel).Return("", nil)
+		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
 	}
 
@@ -246,7 +247,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	defer testUtil.MockUserInput(t, "y")()
 	deployInput.ImageName = "custom-image"
 	err = Deploy(deployInput, mockClient)
-	assert.ErrorIs(t, err, customDeployError)
+	assert.NoError(t, err)
 
 	defer os.RemoveAll("./testfiles/dags/")
 

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -462,8 +462,8 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy stri
 	}
 
 	if dagDeploy == "enable" {
-		fmt.Println("\nYou enabled DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled." +
-			"\nRun `astro deploy --dags` after this command to push new changes. It may take a few minutes for the Airflow UI to update..")
+		fmt.Printf("\nYou enabled DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled." +
+			"\nRun `astro deploy --dags` after this command to push new changes. It may take a few minutes for the Airflow UI to update..\n\n")
 		deploymentUpdate.DagDeployEnabled = true
 	} else if dagDeploy == "disable" {
 		if config.CFG.ShowWarnings.GetBool() {

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -46,6 +46,9 @@ func TestDeployImage(t *testing.T) {
 	err = execDeployCmd([]string{"test-deployment-id", "--parse", "--pytest"}...)
 	assert.NoError(t, err)
 
+	err = execDeployCmd([]string{"test-deployment-id", "--dags"}...)
+	assert.NoError(t, err)
+
 	err = execDeployCmd([]string{"-f", "test-deployment-id", "--dags", "--pytest"}...)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Add Support to run dag deploy tests. This should support the following

```
astro deploy (default parse)
astro deploy —parse (run parse)
astro deploy —pytest  (run pytest)
astro deploy —parse, —pytest (run both parse and pytest)
astro deploy -f (skips both parse and pytest)

astro deploy —dags (just dags deploy)
astro deploy —dags —parse (parse and dags deploy)
astro deploy —dags —parse -f (parse and dags deploy)
astro deploy —dags —pytest -f (pytest and dags deploy)
astro deploy —dags —parse —pytest (parse, pytest and dags deploy)
astro deploy —dags -f (dags deploy)
```

## 🎟 Issue(s)

Related #829 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
