### PR TITLE
Update golangci-lint to 1.50.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -87,6 +86,8 @@ linters:
     - gofumpt
     - goimports
     - revive
+    - gocognit
+    - goerr113
     - gomnd
     - goprintffuncname
     - gosec
@@ -97,20 +98,15 @@ linters:
     - nakedret
     - noctx
     - nolintlint
-    - rowserrcheck
+    - prealloc
+    - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
-    - goerr113
-    - prealloc
-    - revive
-    - gocognit
 
   # don't enable:
   # - asciicheck

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 
 OUTPUT ?= astro
 # golangci-lint version
-GOLANGCI_LINT_VERSION ?=v1.46.2
+GOLANGCI_LINT_VERSION ?=v1.50.1
 
 lint:
 	@test -f ${ENVTEST_ASSETS_DIR}/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${ENVTEST_ASSETS_DIR} ${GOLANGCI_LINT_VERSION}

--- a/airflow/airflow_test.go
+++ b/airflow/airflow_test.go
@@ -1,7 +1,6 @@
 package airflow
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestInitDirs(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "temp")
+	tmpDir, err := os.MkdirTemp("", "temp")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +28,7 @@ func TestInitDirs(t *testing.T) {
 }
 
 func TestInitDirsEmpty(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "temp")
+	tmpDir, err := os.MkdirTemp("", "temp")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +39,7 @@ func TestInitDirsEmpty(t *testing.T) {
 }
 
 func TestInitFiles(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "temp")
+	tmpDir, err := os.MkdirTemp("", "temp")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +59,7 @@ func TestInitFiles(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "temp")
+	tmpDir, err := os.MkdirTemp("", "temp")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/airflow/container.go
+++ b/airflow/container.go
@@ -2,7 +2,7 @@ package airflow
 
 import (
 	"bytes"
-	"crypto/md5" // nolint:gosec
+	"crypto/md5" //nolint:gosec
 	"fmt"
 	"html/template"
 	"regexp"

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -39,7 +39,7 @@ import (
 const (
 	componentName                  = "airflow"
 	dockerStateUp                  = "running"
-	defaultAirflowVersion          = uint64(0x2) // nolint:gomnd
+	defaultAirflowVersion          = uint64(0x2) //nolint:gomnd
 	triggererAllowedRuntimeVersion = "4.0.0"
 	triggererAllowedAirflowVersion = "2.2.0"
 	pytestDirectory                = "tests"

--- a/astro-client/client.go
+++ b/astro-client/client.go
@@ -71,7 +71,7 @@ func (c *HTTPClient) DoPublic(doOpts httputil.DoOptions) (*Response, error) {
 	if cl.Token != "" {
 		doOpts.Headers["authorization"] = cl.Token
 	}
-	doOpts.Headers["apollographql-client-name"] = "cli" // nolint: goconst
+	doOpts.Headers["apollographql-client-name"] = "cli" //nolint: goconst
 	doOpts.Headers["apollographql-client-version"] = version.CurrVersion
 
 	var response httputil.HTTPResponse

--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -143,7 +143,7 @@ func requestToken(authConfig astro.AuthConfig, verifier, code string) (Result, e
 
 func authorizeCallbackHandler() (string, error) {
 	m := http.NewServeMux()
-	s := http.Server{Addr: "localhost:12345", Handler: m}
+	s := http.Server{Addr: "localhost:12345", Handler: m, ReadHeaderTimeout: 0}
 	m.HandleFunc("/callback", func(w http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
 		if errorCode, ok := req.URL.Query()["error"]; ok {
@@ -223,7 +223,7 @@ func (a *Authenticator) authDeviceLogin(c config.Context, authConfig astro.AuthC
 
 	// Generate PKCE verifier and challenge
 	token := make([]byte, 32)                            //nolint:gomnd
-	r := rand.New(rand.NewSource(time.Now().UnixNano())) // nolint:gosec
+	r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
 	r.Read(token)
 	verifier := util.Base64URLEncode(token)
 	hash32 := sha256.Sum256([]byte(verifier)) // Sum256 returns a [32]byte
@@ -378,7 +378,7 @@ func Login(domain, orgID, token string, client astro.Client, out io.Writer, shou
 		fmt.Println("You are logging into Astro via an OAuth token\nThis token will expire in 24 hours and will not refresh")
 		res = Result{
 			AccessToken: token,
-			ExpiresIn:   86400, // nolint:gomnd
+			ExpiresIn:   86400, //nolint:gomnd
 		}
 	}
 

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -192,7 +192,7 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 
 	if deployInput.Dags {
 		if deployInput.Pytest != "" {
-			version, err := buildImage(&c, deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.dagDeployEnabled, client)
+			version, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.dagDeployEnabled, client)
 			if err != nil {
 				return err
 			}
@@ -223,7 +223,7 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 			fmt.Sprintf("\nAirflow Dashboard: %s", ansi.Bold(deployInfo.webserverURL)))
 	} else {
 		// Build our image
-		version, err := buildImage(&c, deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.dagDeployEnabled, client)
+		version, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.dagDeployEnabled, client)
 		if err != nil {
 			return err
 		}
@@ -490,7 +490,7 @@ func buildImageWithoutDags(path string, imageHandler airflow.ImageHandler) error
 	return nil
 }
 
-func buildImage(c *config.Context, path, currentVersion, deployImage, imageName string, dagDeployEnabled bool, client astro.Client) (version string, err error) {
+func buildImage(path, currentVersion, deployImage, imageName string, dagDeployEnabled bool, client astro.Client) (version string, err error) {
 	imageHandler := airflowImageHandler(deployImage)
 
 	if imageName == "" {

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -577,8 +577,6 @@ func TestDeployFailure(t *testing.T) {
 
 func TestBuildImageFailure(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	ctx, err := config.GetCurrentContext()
-	assert.NoError(t, err)
 
 	mockImageHandler := new(mocks.ImageHandler)
 
@@ -587,7 +585,7 @@ func TestBuildImageFailure(t *testing.T) {
 		mockImageHandler.On("Build", mock.Anything).Return(errMock).Once()
 		return mockImageHandler
 	}
-	_, err = buildImage("./testfiles/", "4.2.5", "", "", false, nil)
+	_, err := buildImage("./testfiles/", "4.2.5", "", "", false, nil)
 	assert.ErrorIs(t, err, errMock)
 
 	airflowImageHandler = func(image string) airflow.ImageHandler {

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -587,7 +587,7 @@ func TestBuildImageFailure(t *testing.T) {
 		mockImageHandler.On("Build", mock.Anything).Return(errMock).Once()
 		return mockImageHandler
 	}
-	_, err = buildImage(&ctx, "./testfiles/", "4.2.5", "", "", false, nil)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "", false, nil)
 	assert.ErrorIs(t, err, errMock)
 
 	airflowImageHandler = func(image string) airflow.ImageHandler {
@@ -598,7 +598,7 @@ func TestBuildImageFailure(t *testing.T) {
 
 	// dockerfile parsing error
 	dockerfile = "Dockerfile.invalid"
-	_, err = buildImage(&ctx, "./testfiles/", "4.2.5", "", "", false, nil)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "", false, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse dockerfile")
 
@@ -606,7 +606,7 @@ func TestBuildImageFailure(t *testing.T) {
 	dockerfile = "Dockerfile"
 	mockClient := new(astro_mocks.Client)
 	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{}, errMock).Once()
-	_, err = buildImage(&ctx, "./testfiles/", "4.2.5", "", "", false, mockClient)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "", false, mockClient)
 	assert.ErrorIs(t, err, errMock)
 	mockClient.AssertExpectations(t)
 	mockImageHandler.AssertExpectations(t)

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -175,7 +175,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 	}
 
 	if organizationID == "" {
-		return fmt.Errorf(noWorkspaceMsg, workspaceID) // nolint:goerr113
+		return fmt.Errorf(noWorkspaceMsg, workspaceID) //nolint:goerr113
 	}
 	fmt.Printf("Current Workspace: %s\n\n", currentWorkspace.Label)
 
@@ -239,7 +239,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 	if waitForStatus {
 		err = healthPoll(d.ID, workspaceID, client)
 		if err != nil {
-			errOutput := createOutput(organizationID, workspaceID, &d)
+			errOutput := createOutput(workspaceID, &d)
 			if errOutput != nil {
 				return errOutput
 			}
@@ -247,7 +247,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 		}
 	}
 
-	err = createOutput(organizationID, workspaceID, &d)
+	err = createOutput(workspaceID, &d)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 	return nil
 }
 
-func createOutput(organizationID, workspaceID string, d *astro.Deployment) error {
+func createOutput(workspaceID string, d *astro.Deployment) error {
 	tab := newTableOut()
 
 	currentTag := d.DeploymentSpec.Image.Tag

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -259,12 +259,12 @@ func addVariablesFromFile(envFile string, oldKeyList []string, oldEnvironmentVar
 		if vars[i] == "" {
 			continue
 		}
-		if len(strings.SplitN(vars[i], "=", 2)) == 1 { // nolint:gomnd
+		if len(strings.SplitN(vars[i], "=", 2)) == 1 { //nolint:gomnd
 			fmt.Printf("%s is an improperly formatted variable, no variable created\n", vars[i])
 			continue
 		}
-		key := strings.SplitN(vars[i], "=", 2)[0]   // nolint:gomnd
-		value := strings.SplitN(vars[i], "=", 2)[1] // nolint:gomnd
+		key := strings.SplitN(vars[i], "=", 2)[0]   //nolint:gomnd
+		value := strings.SplitN(vars[i], "=", 2)[1] //nolint:gomnd
 		if key == "" {
 			fmt.Printf("empty key! skipping creating variable with value: %s\n", value)
 			continue

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -60,6 +60,7 @@ func listOrganizations(c *config.Context) ([]OrgRes, error) {
 	if err != nil {
 		return []OrgRes{}, fmt.Errorf("could not retrieve organization list: %w", err)
 	}
+	defer res.Body.Close()
 	var orgResponse []OrgRes
 	err = json.NewDecoder(res.Body).Decode(&orgResponse)
 	if err != nil {

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -68,7 +68,7 @@ func newDeployCmd() *cobra.Command {
 	return cmd
 }
 
-func deployTests(pars, pytest, forceDeploy bool, pytestFile string) string {
+func deployTests(parse, pytest, forceDeploy bool, pytestFile string) string {
 	if pytest && pytestFile == "" {
 		pytestFile = "all-tests"
 	}

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -199,7 +199,7 @@ func newDeploymentVariableListCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newDeploymentVariableCreateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [key1=val1 key2=val2]",
@@ -224,7 +224,7 @@ func newDeploymentVariableCreateCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newDeploymentVariableUpdateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update [key1=update_val1 key2=update_val2]",

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func execOrganizationCmd(args ...string) (string, error) {
+func execOrganizationCmd(args ...string) error {
 	buf := new(bytes.Buffer)
 	cmd := newOrganizationCmd(buf)
 	cmd.SetOut(buf)
 	cmd.SetArgs(args)
 	_, err := cmd.ExecuteC()
-	return buf.String(), err
+	return err
 }
 
 func TestOrganizationRootCommand(t *testing.T) {
@@ -36,7 +36,7 @@ func TestOrganizationList(t *testing.T) {
 	}
 
 	cmdArgs := []string{"list"}
-	_, err := execOrganizationCmd(cmdArgs...)
+	err := execOrganizationCmd(cmdArgs...)
 	assert.NoError(t, err)
 }
 
@@ -46,6 +46,6 @@ func TestOrganizationSwitch(t *testing.T) {
 	}
 
 	cmdArgs := []string{"switch"}
-	_, err := execOrganizationCmd(cmdArgs...)
+	err := execOrganizationCmd(cmdArgs...)
 	assert.NoError(t, err)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -69,7 +69,7 @@ func ensureGlobalFlag(cmd *cobra.Command, args []string) error {
 
 	if !isProjectDir && !globalFlag {
 		c := "astro config " + cmd.Use + " " + args[0] + " -g"
-		return fmt.Errorf(configUseOutsideProjectDirMsg, cmd.Use, cmd.Use, c) // nolint
+		return fmt.Errorf(configUseOutsideProjectDirMsg, cmd.Use, cmd.Use, c) //nolint
 	}
 	return nil
 }
@@ -94,7 +94,7 @@ func configGet(cmd *cobra.Command, args []string) error {
 }
 
 func configSet(cmd *cobra.Command, args []string) error {
-	if len(args) != 2 { // nolint:gomnd
+	if len(args) != 2 { //nolint:gomnd
 		return errInvalidSetArgs
 	}
 

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -267,7 +267,7 @@ func newDeploymentAirflowRootCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newDeploymentAirflowUpgradeCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "upgrade",
@@ -303,7 +303,7 @@ func newDeploymentRuntimeRootCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newDeploymentRuntimeUpgradeCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "upgrade",

--- a/cmd/software/deployment_logs.go
+++ b/cmd/software/deployment_logs.go
@@ -56,7 +56,7 @@ func newLogsCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newWebserverLogsCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "webserver",
@@ -78,7 +78,7 @@ astro deployment logs webserver YOU_DEPLOYMENT_ID -s string-to-find
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newSchedulerLogsCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "scheduler",
@@ -100,7 +100,7 @@ astro deployment logs scheduler YOU_DEPLOYMENT_ID -s string-to-find
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newWorkersLogsCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "workers",
@@ -123,7 +123,7 @@ astro deployment logs workers YOU_DEPLOYMENT_ID -s string-to-find
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newTriggererLogsCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "triggerer",

--- a/cmd/software/deployment_service_account.go
+++ b/cmd/software/deployment_service_account.go
@@ -42,7 +42,7 @@ func newDeploymentSaRootCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newDeploymentSaCreateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",

--- a/cmd/software/deployment_user.go
+++ b/cmd/software/deployment_user.go
@@ -67,7 +67,7 @@ func newDeploymentUserListCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newDeploymentUserAddCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add",
@@ -88,7 +88,7 @@ func newDeploymentUserAddCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newDeploymentUserRemoveCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "remove [email]",
@@ -105,7 +105,7 @@ func newDeploymentUserRemoveCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newDeploymentUserUpdateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update [email]",

--- a/cmd/software/workspace_service_account.go
+++ b/cmd/software/workspace_service_account.go
@@ -40,7 +40,7 @@ func newWorkspaceSaRootCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-// nolint:dupl
+//nolint:dupl
 func newWorkspaceSaCreateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",

--- a/pkg/ansi/spinner.go
+++ b/pkg/ansi/spinner.go
@@ -34,7 +34,7 @@ func loading(initialMsg, doneMsg, failMsg string, fn func() error) error {
 		defer close(done)
 
 		spinnerSet := []string{"●   ", "●   ", " ●  ", "  ● ", "    ●", "  ● ", " ●  "}
-		s := spinner.New(spinnerSet, 100*time.Millisecond, spinner.WithWriter(Messages)) // nolint:gomnd
+		s := spinner.New(spinnerSet, 100*time.Millisecond, spinner.WithWriter(Messages)) //nolint:gomnd
 		s.Prefix = initialMsg
 		s.FinalMSG = doneMsg
 		s.HideCursor = true

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -32,7 +32,7 @@ func Confirm(promptText string) (bool, error) {
 // Password requests a users passord, does not print out what they entered, and returns it
 func Password(promptText string) (string, error) {
 	fmt.Print(promptText)
-	bytePassword, err := term.ReadPassword(int(syscall.Stdin)) // nolint: unconvert
+	bytePassword, err := term.ReadPassword(int(syscall.Stdin)) //nolint: unconvert
 	if err != nil {
 		return "", err
 	}

--- a/pkg/printutil/printutil.go
+++ b/pkg/printutil/printutil.go
@@ -169,7 +169,9 @@ func strSliceToInterSlice(ss []string) []interface{} {
 //
 // If the altPadding slice length is equivalent to the Values slice length,
 // then it should compare the length of the incoming value being evaluated
-//  to see if it longer than the value already stored in it's place in
+//
+//	to see if it longer than the value already stored in it's place in
+//
 // altPadding. If it is, replace it's value with the length of the
 // incoming value.
 //

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -358,7 +358,7 @@ func EnvExportConnections(id, envFile string) error {
 		defer f.Close()
 
 		for i := range vars {
-			varSplit := strings.SplitN(vars[i], "=", 2) // nolint:gomnd
+			varSplit := strings.SplitN(vars[i], "=", 2) //nolint:gomnd
 			if len(varSplit) > 1 {
 				fmt.Println("Exporting Connection: " + varSplit[0])
 				_, err := f.WriteString("\nAIRFLOW_CONN_" + strings.ToUpper(varSplit[0]) + "=" + varSplit[1])
@@ -423,7 +423,7 @@ func ExportConnections(id string) error {
 	// remove all color from output of the airflow command
 	plainOut := re.ReplaceAllString(out, "")
 	// remove extra warning text
-	yamlCons := "- conn_id:" + strings.SplitN(plainOut, "- conn_id:", 2)[1] // nolint:gomnd
+	yamlCons := "- conn_id:" + strings.SplitN(plainOut, "- conn_id:", 2)[1] //nolint:gomnd
 
 	var connections AirflowConnections
 

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	houstonOAuthRedirect     = "Please visit the following URL, authenticate and paste token in next prompt\n"
-	inputOAuthToken          = "oAuth Token: " // nolint:gosec // false positive
+	inputOAuthToken          = "oAuth Token: " //nolint:gosec // false positive
 	inputUsername            = "Username (leave blank for oAuth): "
 	inputPassword            = "Password: "
 	cliChooseWorkspace       = "Please choose a workspace:"

--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -500,7 +500,8 @@ func RuntimeUpgrade(id, desiredRuntimeVersion string, client houston.ClientInter
 }
 
 // RuntimeUpgradeCancel is to cancel an upgrade operation for a deployment
-// nolint:dupl
+//
+//nolint:dupl
 func RuntimeUpgradeCancel(id string, client houston.ClientInterface, out io.Writer) error {
 	deployment, err := client.GetDeployment(id)
 	if err != nil {

--- a/software/deployment/teams.go
+++ b/software/deployment/teams.go
@@ -41,8 +41,9 @@ func ListTeamRoles(deploymentID string, client houston.ClientInterface, out io.W
 	return nil
 }
 
-// nolint:dupl
 // AddTeam adds a team to a deployment with specified role
+//
+//nolint:dupl
 func AddTeam(deploymentID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
 	_, err := client.AddDeploymentTeam(deploymentID, teamID, role)
 	if err != nil {
@@ -61,8 +62,9 @@ func AddTeam(deploymentID, teamID, role string, client houston.ClientInterface, 
 	return nil
 }
 
-// nolint:dupl
 // UpdateTeam updates a team's deployment role
+//
+//nolint:dupl
 func UpdateTeamRole(deploymentID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
 	_, err := client.UpdateDeploymentTeamRole(deploymentID, teamID, role)
 	if err != nil {

--- a/software/deployment/user.go
+++ b/software/deployment/user.go
@@ -60,8 +60,9 @@ func UserList(deploymentID, email, userID, fullName string, client houston.Clien
 	return nil
 }
 
-// nolint:dupl
 // Add a user to a deployment with specified role
+//
+//nolint:dupl
 func Add(deploymentID, email, role string, client houston.ClientInterface, out io.Writer) error {
 	addUserRequest := houston.UpdateDeploymentUserRequest{
 		Email:        email,
@@ -80,8 +81,9 @@ func Add(deploymentID, email, role string, client houston.ClientInterface, out i
 	return nil
 }
 
-// nolint:dupl
 // UpdateUser updates a user's deployment role
+//
+//nolint:dupl
 func UpdateUser(deploymentID, email, role string, client houston.ClientInterface, out io.Writer) error {
 	updateUserRequest := houston.UpdateDeploymentUserRequest{
 		Email:        email,

--- a/software/service_account/service_account.go
+++ b/software/service_account/service_account.go
@@ -18,7 +18,7 @@ func newTableOut() *printutil.Table {
 	}
 }
 
-// nolint:dupl
+//nolint:dupl
 func CreateUsingDeploymentUUID(deploymentUUID, label, category, role string, client houston.ClientInterface, out io.Writer) error {
 	createServiceAccountRequest := &houston.CreateServiceAccountRequest{
 		DeploymentID: deploymentUUID,
@@ -38,7 +38,7 @@ func CreateUsingDeploymentUUID(deploymentUUID, label, category, role string, cli
 	return tab.Print(out)
 }
 
-// nolint:dupl
+//nolint:dupl
 func CreateUsingWorkspaceUUID(workspaceUUID, label, category, role string, client houston.ClientInterface, out io.Writer) error {
 	request := &houston.CreateServiceAccountRequest{
 		WorkspaceID: workspaceUUID,

--- a/software/workspace/teams.go
+++ b/software/workspace/teams.go
@@ -13,7 +13,8 @@ import (
 var errTeamNotInWorkspace = errors.New("the team you are trying to change is not part of this workspace")
 
 // Add a team to a workspace with specified role
-// nolint: dupl
+//
+//nolint:dupl
 func AddTeam(workspaceID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
 	w, err := client.AddWorkspaceTeam(workspaceID, teamID, role)
 	if err != nil {
@@ -74,7 +75,8 @@ func ListTeamRoles(workspaceID string, client houston.ClientInterface, out io.Wr
 }
 
 // Update workspace team role
-// nolint: dupl
+//
+//nolint:dupl
 func UpdateTeamRole(workspaceID, teamID, role string, client houston.ClientInterface, out io.Writer) error {
 	// get team you are updating to show role from before change
 	teams, err := client.GetWorkspaceTeamRole(workspaceID, teamID)

--- a/software/workspace/user.go
+++ b/software/workspace/user.go
@@ -19,7 +19,8 @@ var (
 )
 
 // Add a user to a workspace with specified role
-// nolint: dupl
+//
+//nolint:dupl
 func Add(workspaceID, email, role string, client houston.ClientInterface, out io.Writer) error {
 	w, err := client.AddWorkspaceUser(workspaceID, email, role)
 	if err != nil {
@@ -40,7 +41,8 @@ func Add(workspaceID, email, role string, client houston.ClientInterface, out io
 }
 
 // Remove a user from a workspace
-// nolint: dupl
+//
+//nolint:dupl
 func Remove(workspaceID, userID string, client houston.ClientInterface, out io.Writer) error {
 	w, err := client.DeleteWorkspaceUser(workspaceID, userID)
 	if err != nil {


### PR DESCRIPTION
## Description

The main purpose is to make golangcli-lint working on m1 machines. Additionally, the updated golangci-lint detects new issues in the code such as unused arguments, missing closing of http body and more.

- remove deprecated linters
- update code to be golangci-lint compliant
- fix typo in cmd/cloud/deploy.go

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-cli/pull/856

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
