### PR TITLE
Adding support for virtual runtime api keys

### DIFF
--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -68,7 +68,7 @@ func newDeployCmd() *cobra.Command {
 	return cmd
 }
 
-func deployTests(pars, pytest, forceDeploy bool, pytestFile string) string {
+func deployTests(parse, pytest, forceDeploy bool, pytestFile string) string {
 	if pytest && pytestFile == "" {
 		pytestFile = "all-tests"
 	}


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Adding support for virtual runtime api keys

## 🎟 Issue(s)

Related astronomer/astro#5145

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screen Shot 2022-10-24 at 18 20 23](https://user-images.githubusercontent.com/65428224/197661576-71d3df41-7964-4b14-9246-75a6718887a0.png)

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
