### PR TITLE
fix api keys with dev

### DIFF
--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -189,26 +189,28 @@ func checkAPIKeys(astroClient astro.Client, args []string) (bool, error) {
 		return false, nil
 	}
 	fmt.Println("Using an Astro API key")
-	// set context
-	domain := "astronomer.io"
-
-	if !context.Exists(domain) {
-		err := context.SetContext(domain)
-		if err != nil {
-			return false, err
-		}
-
-		// Switch context
-		err = context.Switch(domain)
-		if err != nil {
-			return false, err
-		}
-	}
 
 	// get authConfig
 	c, err := context.GetCurrentContext() // get current context
 	if err != nil {
-		return false, err
+		// set context
+		domain := "astronomer.io"
+		if !context.Exists(domain) {
+			err := context.SetContext(domain)
+			if err != nil {
+				return false, err
+			}
+
+			// Switch context
+			err = context.Switch(domain)
+			if err != nil {
+				return false, err
+			}
+		}
+		c, err = context.GetContext(domain) // get current context
+		if err != nil {
+			return false, err
+		}
 	}
 
 	authConfig, err := auth.ValidateDomain(c.Domain)

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	astro "github.com/astronomer/astro-cli/astro-client"
-	"github.com/astronomer/astro-cli/context"
 	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
+	"github.com/astronomer/astro-cli/context"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -203,7 +203,7 @@ func TestSetup(t *testing.T) {
 
 func TestCheckAPIKeys(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	t.Run("test context switch", func(t *testing.T) { 
+	t.Run("test context switch", func(t *testing.T) {
 		mockDeplyResp := []astro.Deployment{
 			{
 				ID:        "test-id",
@@ -254,4 +254,3 @@ func TestCheckAPIKeys(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
-

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	astro "github.com/astronomer/astro-cli/astro-client"
+	"github.com/astronomer/astro-cli/context"
 	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/spf13/cobra"
@@ -199,3 +200,58 @@ func TestSetup(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 }
+
+func TestCheckAPIKeys(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	t.Run("test context switch", func(t *testing.T) { 
+		mockDeplyResp := []astro.Deployment{
+			{
+				ID:        "test-id",
+				Workspace: astro.Workspace{ID: "workspace-id"},
+			},
+		}
+
+		mockOrgResp := []astro.Organization{
+			{
+				ID:   "test-org-id",
+				Name: "test-org-name",
+			},
+		}
+
+		mockClient := new(astro_mocks.Client)
+		mockClient.On("GetOrganizations").Return(mockOrgResp, nil).Once()
+		mockClient.On("ListDeployments", mockOrgResp[0].ID, "").Return(mockDeplyResp, nil).Once()
+
+		authLogin = func(domain, id, token string, client astro.Client, out io.Writer, shouldDisplayLoginLink bool) error {
+			return nil
+		}
+
+		t.Setenv("ASTRONOMER_KEY_ID", "key")
+		t.Setenv("ASTRONOMER_KEY_SECRET", "secret")
+
+		mockResp := TokenResponse{
+			AccessToken: "test-token",
+			IDToken:     "test-id",
+		}
+		jsonResponse, err := json.Marshal(mockResp)
+		assert.NoError(t, err)
+
+		client = testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+
+		// Switch context
+		domain := "astronomer-dev.io"
+		err = context.Switch(domain)
+		assert.NoError(t, err)
+
+		// run CheckAPIKeys
+		_, err = checkAPIKeys(mockClient, []string{})
+		assert.NoError(t, err)
+	})
+}
+


### PR DESCRIPTION
## Description

The QA team found that the still cannot push to dev with api keys in 1.7. I found that we are setting the domain to prod no matter what context they are switched too

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
