### PR TITLE
Enable --login-link for organization switch

### DIFF
--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -138,7 +138,7 @@ func getOrganizationSelection(out io.Writer) (string, error) {
 }
 
 // Switch switches organizations
-func Switch(orgNameOrID string, client astro.Client, out io.Writer) error {
+func Switch(orgNameOrID string, client astro.Client, out io.Writer, shouldDisplayLoginLink bool) error {
 	// get current context
 	c, err := config.GetCurrentContext()
 	if err != nil {
@@ -170,7 +170,7 @@ func Switch(orgNameOrID string, client astro.Client, out io.Writer) error {
 	}
 
 	// log user into new organization
-	err = AuthLogin(c.Domain, id, "", client, out, false)
+	err = AuthLogin(c.Domain, id, "", client, out, shouldDisplayLoginLink)
 	if err != nil {
 		return err
 	}

--- a/cloud/organization/organization_test.go
+++ b/cloud/organization/organization_test.go
@@ -160,7 +160,7 @@ func TestSwitch(t *testing.T) {
 			return nil
 		}
 		buf := new(bytes.Buffer)
-		err := Switch("name", mockClient, buf)
+		err := Switch("name", mockClient, buf, false)
 		assert.NoError(t, err)
 	})
 
@@ -194,7 +194,7 @@ func TestSwitch(t *testing.T) {
 			return nil
 		}
 		buf := new(bytes.Buffer)
-		err = Switch("", mockClient, buf)
+		err = Switch("", mockClient, buf, false)
 		assert.NoError(t, err)
 	})
 
@@ -212,7 +212,7 @@ func TestSwitch(t *testing.T) {
 			return nil
 		}
 		buf := new(bytes.Buffer)
-		err := Switch("name-wrong", mockClient, buf)
+		err := Switch("name-wrong", mockClient, buf, false)
 		assert.ErrorIs(t, err, errInvalidOrganizationName)
 	})
 
@@ -246,7 +246,7 @@ func TestSwitch(t *testing.T) {
 			return nil
 		}
 		buf := new(bytes.Buffer)
-		err = Switch("", mockClient, buf)
+		err = Switch("", mockClient, buf, false)
 		assert.ErrorIs(t, err, errInvalidOrganizationKey)
 	})
 
@@ -264,7 +264,7 @@ func TestSwitch(t *testing.T) {
 			return errMock
 		}
 		buf := new(bytes.Buffer)
-		err := Switch("name", mockClient, buf)
+		err := Switch("name", mockClient, buf, false)
 		assert.ErrorIs(t, err, errMock)
 	})
 }

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -9,6 +9,8 @@ import (
 )
 
 var (
+	shouldDisplayLoginLink bool
+
 	orgList   = organization.List
 	orgSwitch = organization.Switch
 )
@@ -51,6 +53,8 @@ func newOrganizationSwitchCmd(out io.Writer) *cobra.Command {
 			return organizationSwitch(cmd, out, args)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&shouldDisplayLoginLink, "login-link", "l", false, "Get login link to login on a separate device for organization switch")
 	return cmd
 }
 
@@ -70,5 +74,5 @@ func organizationSwitch(cmd *cobra.Command, out io.Writer, args []string) error 
 		organizationNameOrID = args[0]
 	}
 
-	return orgSwitch(organizationNameOrID, astroClient, out)
+	return orgSwitch(organizationNameOrID, astroClient, out, shouldDisplayLoginLink)
 }

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -41,7 +41,7 @@ func TestOrganizationList(t *testing.T) {
 }
 
 func TestOrganizationSwitch(t *testing.T) {
-	orgSwitch = func(orgName string, client astro.Client, out io.Writer) error {
+	orgSwitch = func(orgName string, client astro.Client, out io.Writer, shouldDisplayLoginLink bool) error {
 		return nil
 	}
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related #838 

to unblock cli e2e tests from switching orgs issue.

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
