### PR TITLE
Reset patch commit codecov target to auto

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,6 @@ coverage:
     patch:
       default:
         enabled: yes
-        target: 85 # TODO Set it back to "auto" once PR: https://github.com/astronomer/astro-cli/pull/819 is merged
+        target: auto
         threshold: 1%  # allowed to drop X% and still result in a "success" commit status
         base: auto


### PR DESCRIPTION
We had lowered the minimum value to 85% with 1% threshold for Codecov commit patch check to pass for the PR
https://github.com/astronomer/astro-cli/pull/819 which involves implementation for SQL CLI integration with Astro CLI. Since, the PR is merged now, we're resetting it to the previous value of "auto".