### PR TITLE
Fix flow commands

### DIFF
--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -122,8 +122,6 @@ func executeInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	args = mountDirs
-
 	return executeCmd(cmd, args, vars, mountDirs)
 }
 
@@ -209,8 +207,8 @@ func initCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.SetHelpFunc(executeHelp)
-	cmd.Flags().StringVarP(&airflowHome, "airflow_home", "a", "", "")
-	cmd.Flags().StringVarP(&airflowDagsFolder, "airflow_dags_folder", "d", "", "")
+	cmd.Flags().StringVarP(&airflowHome, "airflow-home", "a", "", "")
+	cmd.Flags().StringVarP(&airflowDagsFolder, "airflow-dags-folder", "d", "", "")
 	return cmd
 }
 

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -65,7 +65,7 @@ func getBaseMountDirs(projectDir string) ([]string, error) {
 	return mountDirs, nil
 }
 
-func buildflagsAndMountDirs(projectDir string, setProjectDir, setAirflowHome, setAirflowDagsFolder bool) (flags map[string]string, mountDirs []string, err error) {
+func buildFlagsAndMountDirs(projectDir string, setProjectDir, setAirflowHome, setAirflowDagsFolder bool) (flags map[string]string, mountDirs []string, err error) {
 	flags = buildCommonFlags()
 	mountDirs, err = getBaseMountDirs(projectDir)
 	if err != nil {
@@ -112,7 +112,7 @@ func executeCmd(cmd *cobra.Command, args []string, flags map[string]string, moun
 }
 
 func executeBase(cmd *cobra.Command, args []string) error {
-	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, false, false, false)
+	flags, mountDirs, err := buildFlagsAndMountDirs(projectDir, false, false, false)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func executeInit(cmd *cobra.Command, args []string) error {
 		projectDir = args[0]
 	}
 
-	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, false, true, true)
+	flags, mountDirs, err := buildFlagsAndMountDirs(projectDir, false, true, true)
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func executeValidate(cmd *cobra.Command, args []string) error {
 		projectDir = args[0]
 	}
 
-	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, false, false, false)
+	flags, mountDirs, err := buildFlagsAndMountDirs(projectDir, false, false, false)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func executeGenerate(cmd *cobra.Command, args []string) error {
 		return sql.ArgNotSetError("workflow_name")
 	}
 
-	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, true, false, false)
+	flags, mountDirs, err := buildFlagsAndMountDirs(projectDir, true, false, false)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func executeRun(cmd *cobra.Command, args []string) error {
 		return sql.ArgNotSetError("workflow_name")
 	}
 
-	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, true, false, false)
+	flags, mountDirs, err := buildFlagsAndMountDirs(projectDir, true, false, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -129,7 +129,8 @@ func executeInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	args = []string{mountDirs[0]}
+	projectDirAbsolute := mountDirs[0]
+	args = []string{projectDirAbsolute}
 
 	return executeCmd(cmd, args, flags, mountDirs)
 }
@@ -144,7 +145,8 @@ func executeValidate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	args = []string{mountDirs[0]}
+	projectDirAbsolute := mountDirs[0]
+	args = []string{projectDirAbsolute}
 
 	return executeCmd(cmd, args, flags, mountDirs)
 }

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -96,7 +96,6 @@ func buildflagsAndMountDirs(projectDir string, setProjectDir, setAirflowHome, se
 		}
 		flags["airflow-dags-folder"] = airflowDagsFolderAbs
 		mountDirs = append(mountDirs, airflowDagsFolderAbs)
-
 	}
 
 	return flags, mountDirs, nil

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -45,15 +45,15 @@ func createProjectDir(projectDir string) (mountDir string, err error) {
 	return projectDir, nil
 }
 
-func buildCommonVars() map[string]string {
-	vars := make(map[string]string)
+func buildCommonFlags() map[string]string {
+	flags := make(map[string]string)
 	if environment != "" {
-		vars["env"] = environment
+		flags["env"] = environment
 	}
 	if connection != "" {
-		vars["connection"] = connection
+		flags["connection"] = connection
 	}
-	return vars
+	return flags
 }
 
 func getBaseMountDirs(projectDir string) ([]string, error) {
@@ -65,8 +65,8 @@ func getBaseMountDirs(projectDir string) ([]string, error) {
 	return mountDirs, nil
 }
 
-func buildVarsAndMountDirs(projectDir string, setProjectDir, setAirflowHome, setAirflowDagsFolder bool) (vars map[string]string, mountDirs []string, err error) {
-	vars = buildCommonVars()
+func buildflagsAndMountDirs(projectDir string, setProjectDir, setAirflowHome, setAirflowDagsFolder bool) (flags map[string]string, mountDirs []string, err error) {
+	flags = buildCommonFlags()
 	mountDirs, err = getBaseMountDirs(projectDir)
 	if err != nil {
 		return nil, nil, err
@@ -77,25 +77,34 @@ func buildVarsAndMountDirs(projectDir string, setProjectDir, setAirflowHome, set
 		if err != nil {
 			return nil, nil, err
 		}
-		vars["project-dir"] = projectDir
+		flags["project-dir"] = projectDir
 	}
 
 	if setAirflowHome && airflowHome != "" {
-		mountDirs = append(mountDirs, airflowHome)
-		vars["airflow-home"] = airflowHome
+		airflowHomeAbs, err := getAbsolutePath(airflowHome)
+		if err != nil {
+			return nil, nil, err
+		}
+		flags["airflow-home"] = airflowHomeAbs
+		mountDirs = append(mountDirs, airflowHomeAbs)
 	}
 
 	if setAirflowDagsFolder && airflowDagsFolder != "" {
-		mountDirs = append(mountDirs, airflowDagsFolder)
-		vars["airflow-dags-folder"] = airflowDagsFolder
+		airflowDagsFolderAbs, err := getAbsolutePath(airflowDagsFolder)
+		if err != nil {
+			return nil, nil, err
+		}
+		flags["airflow-dags-folder"] = airflowDagsFolderAbs
+		mountDirs = append(mountDirs, airflowDagsFolderAbs)
+
 	}
 
-	return vars, mountDirs, nil
+	return flags, mountDirs, nil
 }
 
-func executeCmd(cmd *cobra.Command, args []string, vars map[string]string, mountDirs []string) error {
+func executeCmd(cmd *cobra.Command, args []string, flags map[string]string, mountDirs []string) error {
 	cmdString := []string{cmd.Parent().Name(), cmd.Name()}
-	err := sql.CommonDockerUtil(cmdString, args, vars, mountDirs)
+	err := sql.CommonDockerUtil(cmdString, args, flags, mountDirs)
 	if err != nil {
 		return fmt.Errorf("error running %v: %w", cmdString, err)
 	}
@@ -104,25 +113,26 @@ func executeCmd(cmd *cobra.Command, args []string, vars map[string]string, mount
 }
 
 func executeBase(cmd *cobra.Command, args []string) error {
-	vars, mountDirs, err := buildVarsAndMountDirs(projectDir, false, false, false)
+	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, false, false, false)
 	if err != nil {
 		return err
 	}
-	return executeCmd(cmd, args, vars, mountDirs)
+	return executeCmd(cmd, args, flags, mountDirs)
 }
 
 func executeInit(cmd *cobra.Command, args []string) error {
-	projectDir = "."
 	if len(args) > 0 {
 		projectDir = args[0]
 	}
 
-	vars, mountDirs, err := buildVarsAndMountDirs(projectDir, false, true, true)
+	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, false, true, true)
 	if err != nil {
 		return err
 	}
 
-	return executeCmd(cmd, args, vars, mountDirs)
+	args = []string{mountDirs[0]}
+
+	return executeCmd(cmd, args, flags, mountDirs)
 }
 
 func executeValidate(cmd *cobra.Command, args []string) error {
@@ -130,14 +140,14 @@ func executeValidate(cmd *cobra.Command, args []string) error {
 		projectDir = args[0]
 	}
 
-	vars, mountDirs, err := buildVarsAndMountDirs(projectDir, false, false, false)
+	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, false, false, false)
 	if err != nil {
 		return err
 	}
 
-	args = mountDirs
+	args = []string{mountDirs[0]}
 
-	return executeCmd(cmd, args, vars, mountDirs)
+	return executeCmd(cmd, args, flags, mountDirs)
 }
 
 func executeGenerate(cmd *cobra.Command, args []string) error {
@@ -145,12 +155,12 @@ func executeGenerate(cmd *cobra.Command, args []string) error {
 		return sql.ArgNotSetError("workflow_name")
 	}
 
-	vars, mountDirs, err := buildVarsAndMountDirs(projectDir, true, false, false)
+	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, true, false, false)
 	if err != nil {
 		return err
 	}
 
-	return executeCmd(cmd, args, vars, mountDirs)
+	return executeCmd(cmd, args, flags, mountDirs)
 }
 
 func executeRun(cmd *cobra.Command, args []string) error {
@@ -158,7 +168,7 @@ func executeRun(cmd *cobra.Command, args []string) error {
 		return sql.ArgNotSetError("workflow_name")
 	}
 
-	vars, mountDirs, err := buildVarsAndMountDirs(projectDir, true, false, false)
+	flags, mountDirs, err := buildflagsAndMountDirs(projectDir, true, false, false)
 	if err != nil {
 		return err
 	}
@@ -167,7 +177,7 @@ func executeRun(cmd *cobra.Command, args []string) error {
 		args = append(args, "--verbose")
 	}
 
-	return executeCmd(cmd, args, vars, mountDirs)
+	return executeCmd(cmd, args, flags, mountDirs)
 }
 
 func executeHelp(cmd *cobra.Command, cmdString []string) {
@@ -220,7 +230,6 @@ func validateCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.SetHelpFunc(executeHelp)
-	cmd.Flags().StringVarP(&projectDir, "project_dir", "p", ".", "")
 	cmd.Flags().StringVarP(&connection, "connection", "c", "", "")
 	return cmd
 }
@@ -233,7 +242,7 @@ func generateCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.SetHelpFunc(executeHelp)
-	cmd.Flags().StringVarP(&projectDir, "project_dir", "p", ".", "")
+	cmd.Flags().StringVarP(&projectDir, "project-dir", "p", ".", "")
 	return cmd
 }
 
@@ -245,7 +254,7 @@ func runCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.SetHelpFunc(executeHelp)
-	cmd.Flags().StringVarP(&projectDir, "project_dir", "p", ".", "")
+	cmd.Flags().StringVarP(&projectDir, "project-dir", "p", ".", "")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "")
 	return cmd
 }

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,54 +30,61 @@ func TestFlowAboutCmd(t *testing.T) {
 }
 
 func TestFlowInitCmd(t *testing.T) {
-	tempDir := t.TempDir()
-	tempDirAirflowHome := t.TempDir()
-	tempDirAirflowDagsFolder := t.TempDir()
-	err := execFlowCmd([]string{"init", tempDir, "--airflow-home", tempDirAirflowHome, "--airflow-dags-folder", tempDirAirflowDagsFolder}...)
+	projectDir := t.TempDir()
+	os.Chdir(projectDir)
+	err := execFlowCmd([]string{"init"}...)
+	assert.NoError(t, err)
+}
+
+func TestFlowInitCmdWithFlags(t *testing.T) {
+	projectDir := t.TempDir()
+	AirflowHome := t.TempDir()
+	AirflowDagsFolder := t.TempDir()
+	err := execFlowCmd([]string{"init", projectDir, "--airflow-home", AirflowHome, "--airflow-dags-folder", AirflowDagsFolder}...)
 	assert.NoError(t, err)
 }
 
 func TestFlowValidateCmd(t *testing.T) {
-	tempDir := t.TempDir()
-	err := execFlowCmd([]string{"init", tempDir}...)
+	projectDir := t.TempDir()
+	err := execFlowCmd([]string{"init", projectDir}...)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"validate", tempDir, "--connection", "sqlite_conn"}...)
+	err = execFlowCmd([]string{"validate", projectDir, "--connection", "sqlite_conn"}...)
 	assert.NoError(t, err)
 }
 
 func TestFlowGenerateCmd(t *testing.T) {
-	tempDir := t.TempDir()
-	err := execFlowCmd([]string{"init", tempDir}...)
+	projectDir := t.TempDir()
+	err := execFlowCmd([]string{"init", projectDir}...)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"generate", "example_basic_transform", "--project-dir", tempDir}...)
+	err = execFlowCmd([]string{"generate", "example_basic_transform", "--project-dir", projectDir}...)
 	assert.NoError(t, err)
 }
 
 func TestFlowGenerateCmdWorkflowNameNotSet(t *testing.T) {
-	tempDir := t.TempDir()
-	err := execFlowCmd([]string{"init", tempDir}...)
+	projectDir := t.TempDir()
+	err := execFlowCmd([]string{"init", projectDir}...)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"generate"}...)
+	err = execFlowCmd([]string{"generate", "--project-dir", projectDir}...)
 	assert.EqualError(t, err, "argument not set:workflow_name")
 }
 
 func TestFlowRunCmd(t *testing.T) {
-	tempDir := t.TempDir()
-	err := execFlowCmd([]string{"init", tempDir}...)
+	projectDir := t.TempDir()
+	err := execFlowCmd([]string{"init", projectDir}...)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"run", "example_templating", "--env", "dev", "--project-dir", tempDir, "--verbose"}...)
+	err = execFlowCmd([]string{"run", "example_templating", "--env", "dev", "--project-dir", projectDir, "--verbose"}...)
 	assert.NoError(t, err)
 }
 
 func TestFlowRunCmdWorkflowNameNotSet(t *testing.T) {
-	tempDir := t.TempDir()
-	err := execFlowCmd([]string{"init", tempDir}...)
+	projectDir := t.TempDir()
+	err := execFlowCmd([]string{"init", projectDir}...)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"run"}...)
+	err = execFlowCmd([]string{"run", "--project-dir", projectDir}...)
 	assert.EqualError(t, err, "argument not set:workflow_name")
 }

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -32,7 +32,7 @@ func TestFlowInitCmd(t *testing.T) {
 	tempDir := t.TempDir()
 	tempDirAirflowHome := t.TempDir()
 	tempDirAirflowDagsFolder := t.TempDir()
-	err := execFlowCmd([]string{"init", tempDir, "--airflow_home", tempDirAirflowHome, "--airflow_dags_folder", tempDirAirflowDagsFolder}...)
+	err := execFlowCmd([]string{"init", tempDir, "--airflow-home", tempDirAirflowHome, "--airflow-dags-folder", tempDirAirflowDagsFolder}...)
 	assert.NoError(t, err)
 }
 

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -7,6 +7,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// chdir changes the current working directory to the named directory and
+// returns a function that, when called, restores the original working
+// directory.
+func chdir(t *testing.T, dir string) func() {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	return func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restoring working directory: %v", err)
+		}
+	}
+}
+
 func execFlowCmd(args ...string) error {
 	cmd := NewFlowCommand()
 	cmd.SetArgs(args)
@@ -31,7 +50,7 @@ func TestFlowAboutCmd(t *testing.T) {
 
 func TestFlowInitCmd(t *testing.T) {
 	projectDir := t.TempDir()
-	os.Chdir(projectDir)
+	defer chdir(t, projectDir)()
 	err := execFlowCmd([]string{"init"}...)
 	assert.NoError(t, err)
 }

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -50,7 +50,7 @@ func TestFlowGenerateCmd(t *testing.T) {
 	err := execFlowCmd([]string{"init", tempDir}...)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"generate", "example_basic_transform", "--project_dir", tempDir}...)
+	err = execFlowCmd([]string{"generate", "example_basic_transform", "--project-dir", tempDir}...)
 	assert.NoError(t, err)
 }
 
@@ -68,7 +68,7 @@ func TestFlowRunCmd(t *testing.T) {
 	err := execFlowCmd([]string{"init", tempDir}...)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"run", "example_templating", "--env", "dev", "--project_dir", tempDir, "--verbose"}...)
+	err = execFlowCmd([]string{"run", "example_templating", "--env", "dev", "--project-dir", tempDir, "--verbose"}...)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
## Description

The PR fixes the following issues for the flow commands:
1. For the init command, the airflow-home and airflow-dags-folder settings were out of sync with what we have defined in sql-cli with respect to underscore vs hyphen separator in their names. 
2. Argument & flag values for project-dir, airflow-home & airflow-dags-folder need to be absolute path for them to be mounted and referenced correctly in the docker container
3. Also renames the variable from vars to flags to make it readable and avoid confusion

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-sdk/issues/1150

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
