### PR TITLE
cli keeps calling non paginated endpoint even when interactive flag is on

### DIFF
--- a/cmd/software/workspace_test.go
+++ b/cmd/software/workspace_test.go
@@ -133,7 +133,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 		houstonClient = houstonMock
 		defer func() { houstonClient = currentClient }()
 
-		houstonMock.On("ValidateWorkspaceId", wsID).Return(&houston.Workspace{}, nil).Once()
+		houstonMock.On("ValidateWorkspaceID", wsID).Return(&houston.Workspace{}, nil).Once()
 
 		err := workspaceSwitch(&cobra.Command{}, buf, []string{wsID})
 		assert.NoError(t, err)
@@ -152,7 +152,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 		houstonClient = houstonMock
 		defer func() { houstonClient = currentClient }()
 
-		houstonMock.On("ValidateWorkspaceId", wsID).Return(&houston.Workspace{}, nil).Once()
+		houstonMock.On("ValidateWorkspaceID", wsID).Return(&houston.Workspace{}, nil).Once()
 
 		err := workspaceSwitch(&cobra.Command{}, buf, []string{wsID})
 		assert.NoError(t, err)
@@ -172,7 +172,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 		houstonClient = houstonMock
 		defer func() { houstonClient = currentClient }()
 
-		houstonMock.On("ValidateWorkspaceId", wsID).Return(&houston.Workspace{}, nil).Once()
+		houstonMock.On("ValidateWorkspaceID", wsID).Return(&houston.Workspace{}, nil).Once()
 
 		err := workspaceSwitch(&cobra.Command{}, buf, []string{wsID})
 		assert.NoError(t, err)

--- a/cmd/software/workspace_test.go
+++ b/cmd/software/workspace_test.go
@@ -133,7 +133,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 		houstonClient = houstonMock
 		defer func() { houstonClient = currentClient }()
 
-		houstonMock.On("GetWorkspace", wsID).Return(&houston.Workspace{}, nil).Once()
+		houstonMock.On("ValidateWorkspaceId", wsID).Return(&houston.Workspace{}, nil).Once()
 
 		err := workspaceSwitch(&cobra.Command{}, buf, []string{wsID})
 		assert.NoError(t, err)
@@ -152,7 +152,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 		houstonClient = houstonMock
 		defer func() { houstonClient = currentClient }()
 
-		houstonMock.On("GetWorkspace", wsID).Return(&houston.Workspace{}, nil).Once()
+		houstonMock.On("ValidateWorkspaceId", wsID).Return(&houston.Workspace{}, nil).Once()
 
 		err := workspaceSwitch(&cobra.Command{}, buf, []string{wsID})
 		assert.NoError(t, err)
@@ -172,7 +172,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 		houstonClient = houstonMock
 		defer func() { houstonClient = currentClient }()
 
-		houstonMock.On("GetWorkspace", wsID).Return(&houston.Workspace{}, nil).Once()
+		houstonMock.On("ValidateWorkspaceId", wsID).Return(&houston.Workspace{}, nil).Once()
 
 		err := workspaceSwitch(&cobra.Command{}, buf, []string{wsID})
 		assert.NoError(t, err)

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -30,6 +30,7 @@ type ClientInterface interface {
 	PaginatedListWorkspaces(pageSize int, pageNumber int) ([]Workspace, error)
 	DeleteWorkspace(workspaceID string) (*Workspace, error)
 	GetWorkspace(workspaceID string) (*Workspace, error)
+	ValidateWorkspaceId(workspaceID string) (*Workspace, error)
 	UpdateWorkspace(workspaceID string, args map[string]string) (*Workspace, error)
 	// workspace users and roles
 	AddWorkspaceUser(workspaceID, email, role string) (*Workspace, error)

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -30,7 +30,7 @@ type ClientInterface interface {
 	PaginatedListWorkspaces(pageSize int, pageNumber int) ([]Workspace, error)
 	DeleteWorkspace(workspaceID string) (*Workspace, error)
 	GetWorkspace(workspaceID string) (*Workspace, error)
-	ValidateWorkspaceId(workspaceID string) (*Workspace, error)
+	ValidateWorkspaceID(workspaceID string) (*Workspace, error)
 	UpdateWorkspace(workspaceID string, args map[string]string) (*Workspace, error)
 	// workspace users and roles
 	AddWorkspaceUser(workspaceID, email, role string) (*Workspace, error)

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -675,6 +675,29 @@ func (_m *ClientInterface) GetWorkspace(workspaceID string) (*houston.Workspace,
 	return r0, r1
 }
 
+// ValidateWorkspaceId provides a mock function with given fields: workspaceID
+func (_m *ClientInterface) ValidateWorkspaceId(workspaceID string) (*houston.Workspace, error) {
+	ret := _m.Called(workspaceID)
+
+	var r0 *houston.Workspace
+	if rf, ok := ret.Get(0).(func(string) *houston.Workspace); ok {
+		r0 = rf(workspaceID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Workspace)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(workspaceID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetWorkspaceTeamRole provides a mock function with given fields: workspaceID, teamID
 func (_m *ClientInterface) GetWorkspaceTeamRole(workspaceID string, teamID string) (*houston.Team, error) {
 	ret := _m.Called(workspaceID, teamID)

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -675,8 +675,8 @@ func (_m *ClientInterface) GetWorkspace(workspaceID string) (*houston.Workspace,
 	return r0, r1
 }
 
-// ValidateWorkspaceId provides a mock function with given fields: workspaceID
-func (_m *ClientInterface) ValidateWorkspaceId(workspaceID string) (*houston.Workspace, error) {
+// ValidateWorkspaceID provides a mock function with given fields: workspaceID
+func (_m *ClientInterface) ValidateWorkspaceID(workspaceID string) (*houston.Workspace, error) {
 	ret := _m.Called(workspaceID)
 
 	var r0 *houston.Workspace

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -457,6 +457,22 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 	}
     `
 
+	ValidateWorkspaceIdGetRequest = `
+	query GetWorkspace(
+		$workspaceUuid: Uuid!
+	){
+		workspace(
+			workspaceUuid: $workspaceUuid
+		){
+			id
+			label
+			description
+			createdAt
+			updatedAt
+		}
+	}
+    `
+
 	WorkspacesGetRequest = `
 	query GetWorkspaces {
 		workspaces {

--- a/houston/queries.go
+++ b/houston/queries.go
@@ -457,7 +457,7 @@ mutation UpdateDeployment($deploymentId: Uuid!, $payload: JSON!, $executor: Exec
 	}
     `
 
-	ValidateWorkspaceIdGetRequest = `
+	ValidateWorkspaceIDGetRequest = `
 	query GetWorkspace(
 		$workspaceUuid: Uuid!
 	){

--- a/houston/workspace.go
+++ b/houston/workspace.go
@@ -79,6 +79,26 @@ func (h ClientImplementation) GetWorkspace(workspaceID string) (*Workspace, erro
 	return workspace, nil
 }
 
+// ValidateWorkspaceId - get a workspace
+func (h ClientImplementation) ValidateWorkspaceId(workspaceID string) (*Workspace, error) {
+	req := Request{
+		Query:     ValidateWorkspaceIdGetRequest,
+		Variables: map[string]interface{}{"workspaceUuid": workspaceID},
+	}
+
+	res, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	workspace := res.Data.GetWorkspace
+	if workspace == nil {
+		return nil, ErrWorkspaceNotFound{workspaceID: workspaceID}
+	}
+
+	return workspace, nil
+}
+
 // UpdateWorkspace - update a workspace
 func (h ClientImplementation) UpdateWorkspace(workspaceID string, args map[string]string) (*Workspace, error) {
 	req := Request{

--- a/houston/workspace.go
+++ b/houston/workspace.go
@@ -79,10 +79,10 @@ func (h ClientImplementation) GetWorkspace(workspaceID string) (*Workspace, erro
 	return workspace, nil
 }
 
-// ValidateWorkspaceId - get a workspace
-func (h ClientImplementation) ValidateWorkspaceId(workspaceID string) (*Workspace, error) {
+// ValidateWorkspaceID - get a workspace
+func (h ClientImplementation) ValidateWorkspaceID(workspaceID string) (*Workspace, error) {
 	req := Request{
-		Query:     ValidateWorkspaceIdGetRequest,
+		Query:     ValidateWorkspaceIDGetRequest,
 		Variables: map[string]interface{}{"workspaceUuid": workspaceID},
 	}
 

--- a/houston/workspace_test.go
+++ b/houston/workspace_test.go
@@ -334,6 +334,53 @@ func TestGetWorkspace(t *testing.T) {
 	})
 }
 
+func TestValidateWorkspaceID(t *testing.T) {
+	testUtil.InitTestConfig("software")
+
+	mockResponse := &Response{
+		Data: ResponseData{
+			GetWorkspace: &Workspace{
+				ID:          "workspace-id",
+				Label:       "label",
+				Description: "test description",
+				CreatedAt:   "2020-06-25T22:10:42.385Z",
+				UpdatedAt:   "2020-06-25T22:10:42.385Z",
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockResponse)
+	assert.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		response, err := api.ValidateWorkspaceID("workspace-id")
+		assert.NoError(t, err)
+		assert.Equal(t, response, mockResponse.Data.GetWorkspace)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.ValidateWorkspaceID("workspace-id")
+		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+}
+
 func TestUpdateWorkspace(t *testing.T) {
 	testUtil.InitTestConfig("software")
 

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -131,6 +131,8 @@ func registryAuth(client houston.ClientInterface, out io.Writer) error {
 func Login(domain string, oAuthOnly bool, username, password string, client houston.ClientInterface, out io.Writer) error {
 	var token string
 	var err error
+	var workspaces []houston.Workspace
+
 	interactive := config.CFG.Interactive.GetBool()
 	pageSize := config.CFG.PageSize.GetInt()
 	if !(pageSize > 0 && pageSize < defaultPageSize) {
@@ -173,7 +175,12 @@ func Login(domain string, oAuthOnly bool, username, password string, client hous
 		return err
 	}
 
-	workspaces, err := client.ListWorkspaces()
+	if interactive {
+		workspaces, err = client.PaginatedListWorkspaces(2, 0)
+	} else {
+		workspaces, err = client.ListWorkspaces()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -136,6 +136,7 @@ func getWorkspaces(client houston.ClientInterface, interactive bool) ([]houston.
 	var err error
 
 	if interactive {
+		// To identify if the user has access to more than one workspace by setting workspace page size to 2, if so, take the user to the workspace switch flow.
 		workspacePageSize := 2
 		workspaces, err = client.PaginatedListWorkspaces(workspacePageSize, 0)
 	} else {

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -127,12 +127,24 @@ func registryAuth(client houston.ClientInterface, out io.Writer) error {
 	return nil
 }
 
+func getWorkspaces(client houston.ClientInterface, interactive bool) ([]houston.Workspace, error) {
+	var workspaces []houston.Workspace
+	var err error
+
+	if interactive {
+		workspacePageSize := 2
+		workspaces, err = client.PaginatedListWorkspaces(workspacePageSize, 0)
+	} else {
+		workspaces, err = client.ListWorkspaces()
+	}
+
+	return workspaces, err
+}
+
 // Login handles authentication to houston and registry
 func Login(domain string, oAuthOnly bool, username, password string, client houston.ClientInterface, out io.Writer) error {
 	var token string
 	var err error
-	var workspaces []houston.Workspace
-
 	interactive := config.CFG.Interactive.GetBool()
 	pageSize := config.CFG.PageSize.GetInt()
 	if !(pageSize > 0 && pageSize < defaultPageSize) {
@@ -175,12 +187,7 @@ func Login(domain string, oAuthOnly bool, username, password string, client hous
 		return err
 	}
 
-	if interactive {
-		workspaces, err = client.PaginatedListWorkspaces(2, 0)
-	} else {
-		workspaces, err = client.ListWorkspaces()
-	}
-
+	workspaces, err := getWorkspaces(client, interactive)
 	if err != nil {
 		return err
 	}

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -60,7 +60,7 @@ var switchToLastUsedWorkspace = func(client houston.ClientInterface, c *config.C
 	}
 
 	// validate workspace
-	workspace, err := client.ValidateWorkspaceId(c.LastUsedWorkspace)
+	workspace, err := client.ValidateWorkspaceID(c.LastUsedWorkspace)
 	if err != nil || workspace != nil && workspace.ID != c.LastUsedWorkspace {
 		log.Debugf("last used workspace id is not valid: %s", err.Error())
 		return false

--- a/software/auth/auth_test.go
+++ b/software/auth/auth_test.go
@@ -104,6 +104,11 @@ func TestSwitchToLastUsedWorkspace(t *testing.T) {
 			args: args{c: &config.Context{LastUsedWorkspace: "test-workspace-id", Domain: "test-domain"}, workspace: &houston.Workspace{ID: "test-workspace-id"}, err: nil},
 			want: true,
 		},
+		{
+			name: "workspace present, unable to set workspace context ",
+			args: args{c: &config.Context{LastUsedWorkspace: "test-workspace-id"}, workspace: &houston.Workspace{ID: "test-workspace-id"}, err: nil},
+			want: false,
+		},
 	}
 
 	houstonMock := new(houstonMocks.ClientInterface)

--- a/software/workspace/workspace.go
+++ b/software/workspace/workspace.go
@@ -237,7 +237,7 @@ func Switch(id string, pageSize int, client houston.ClientInterface, out io.Writ
 		id = workspaceSelection.id
 	}
 	// validate workspace
-	_, err := client.GetWorkspace(id)
+	_, err := client.ValidateWorkspaceId(id)
 	if err != nil {
 		return fmt.Errorf("workspace id is not valid: %w", err)
 	}

--- a/software/workspace/workspace.go
+++ b/software/workspace/workspace.go
@@ -237,7 +237,7 @@ func Switch(id string, pageSize int, client houston.ClientInterface, out io.Writ
 		id = workspaceSelection.id
 	}
 	// validate workspace
-	_, err := client.ValidateWorkspaceId(id)
+	_, err := client.ValidateWorkspaceID(id)
 	if err != nil {
 		return fmt.Errorf("workspace id is not valid: %w", err)
 	}

--- a/software/workspace/workspace_test.go
+++ b/software/workspace/workspace_test.go
@@ -240,7 +240,7 @@ contexts:
 	config.InitConfig(fs)
 
 	api := new(mocks.ClientInterface)
-	api.On("ValidateWorkspaceId", mockWorkspace.ID).Return(mockWorkspace, nil)
+	api.On("ValidateWorkspaceID", mockWorkspace.ID).Return(mockWorkspace, nil)
 	api.On("ListWorkspaces").Return(mockWorkspaceList, nil)
 
 	defer testUtil.MockUserInput(t, "3")()
@@ -335,7 +335,7 @@ contexts:
 	wsID := "ckbv7zvb100pe0760xp98qnh9"
 
 	api := new(mocks.ClientInterface)
-	api.On("ValidateWorkspaceId", wsID).Return(nil, errMock)
+	api.On("ValidateWorkspaceID", wsID).Return(nil, errMock)
 
 	buf := new(bytes.Buffer)
 	err := Switch(wsID, 0, api, buf)

--- a/software/workspace/workspace_test.go
+++ b/software/workspace/workspace_test.go
@@ -240,7 +240,7 @@ contexts:
 	config.InitConfig(fs)
 
 	api := new(mocks.ClientInterface)
-	api.On("GetWorkspace", mockWorkspace.ID).Return(mockWorkspace, nil)
+	api.On("ValidateWorkspaceId", mockWorkspace.ID).Return(mockWorkspace, nil)
 	api.On("ListWorkspaces").Return(mockWorkspaceList, nil)
 
 	defer testUtil.MockUserInput(t, "3")()
@@ -335,7 +335,7 @@ contexts:
 	wsID := "ckbv7zvb100pe0760xp98qnh9"
 
 	api := new(mocks.ClientInterface)
-	api.On("GetWorkspace", wsID).Return(nil, errMock)
+	api.On("ValidateWorkspaceId", wsID).Return(nil, errMock)
 
 	buf := new(bytes.Buffer)
 	err := Switch(wsID, 0, api, buf)


### PR DESCRIPTION
## Description

_**Issue**_: CLI makes a workspace list query to identify if there is 1 or more workspace

_**Fix**_: If the interactive flag is set to true, CLI will call the paginated workspace query with page size 2 to make the same decision to auto-select the first workspace if it returns 1 record if it returns more than 1. The user will be prompted to select a workspace 

_**Enhancement**_: Added new query to validate `workspaceId`, which does not pull `roleBindings` since it's not required to validate `workspaceId`.


## 🎟 Issue(s)

Related https://github.com/astronomer/issues/issues/5166

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots
> with-interactive-flag-set-to-true
![with-interactive-flag-set-to-true](https://user-images.githubusercontent.com/5626812/199082463-748d6349-95e2-4086-a83f-a4e9896f5208.png)

> with-interactive-flag-set-to-false
![with-interactive-flag-set-to-false](https://user-images.githubusercontent.com/5626812/199082467-51a68d5c-d5cb-4917-b8aa-c9045286669a.png)

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
