### PR TITLE
Check if dockerignore file exists if not create it

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -439,12 +439,9 @@ func buildImageWithoutDags(path string, imageHandler airflow.ImageHandler) error
 	dockerIgnoreCreate := false
 	fullpath := filepath.Join(path, ".dockerignore")
 
-	fileExist, err := fileutil.Exists(fullpath, nil)
-	if err != nil {
-		return err
-	}
+	fileExist, _ := fileutil.Exists(fullpath, nil)
 	if !fileExist {
-		// Create monitoring dag file
+		// Create a dockerignore file and add the dags folder entry
 		err := fileutil.WriteStringToFile(fullpath, "dags/")
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.
Check if dockerignore file exists if not create it during astro deploy with dag deploy enabled

## 🎟 Issue(s)

Related #850 
## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screen Shot 2022-11-01 at 11 50 01](https://user-images.githubusercontent.com/65428224/199321380-309ac2d8-d988-4022-a606-b1ec78945e2b.png)

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
