### PR TITLE
Invalid workspaceId check on astro deploy

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -49,7 +49,7 @@ const (
 	parseAndPytest     = "parse-and-all-tests"
 	enableDagDeployMsg = "DAG-only deploys are not enabled for this Deployment. Run 'astro deployment update %s --dag-deploy enable' to enable DAG-only deploys."
 	dagDeployDisabled  = "dag deploy is not enabled for deployment"
-	invalidWorkspaceID = "Invalid --workspace-id %s was provided"
+	invalidWorkspaceID = "Invalid workspace id %s was provided through the --workspace-id flag\n"
 )
 
 var (

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -49,6 +49,7 @@ const (
 	parseAndPytest     = "parse-and-all-tests"
 	enableDagDeployMsg = "DAG-only deploys are not enabled for this Deployment. Run 'astro deployment update %s --dag-deploy enable' to enable DAG-only deploys."
 	dagDeployDisabled  = "dag deploy is not enabled for deployment"
+	invalidWorkspaceID = "Invalid --workspace-id %s was provided"
 )
 
 var (
@@ -197,6 +198,11 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 	deployInfo, err := getDeploymentInfo(deployInput.RuntimeID, deployInput.WsID, deployInput.DeploymentName, deployInput.Prompt, domain, client)
 	if err != nil {
 		return err
+	}
+
+	if deployInput.WsID != deployInfo.workspaceID {
+		fmt.Printf(invalidWorkspaceID, deployInput.WsID)
+		return nil
 	}
 
 	deploymentURL := "cloud." + domain + "/" + deployInfo.workspaceID + "/deployments/" + deployInfo.deploymentID + "/analytics"

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -36,6 +36,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 		ID:             "test-id",
 		ReleaseName:    "test-name",
 		RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+		Workspace:      astro.Workspace{ID: ws},
 		DeploymentSpec: astro.DeploymentSpec{
 			Webserver: astro.Webserver{URL: "test-url"},
 		},
@@ -45,7 +46,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 	deployInput := InputDeploy{
 		Path:           "./testfiles/",
 		RuntimeID:      "",
-		WsID:           "test-ws-id",
+		WsID:           ws,
 		Pytest:         "parse",
 		EnvFile:        "",
 		ImageName:      "",
@@ -58,7 +59,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 	mockClient := new(astro_mocks.Client)
 
 	mockClient.On("GetDeployment", mock.Anything).Return(mockDeplyResp, nil).Times(3)
-	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
+	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", Workspace: astro.Workspace{ID: ws}}}, nil).Once()
 	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(4)
 	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(4)
 	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(4)
@@ -134,6 +135,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	mockDeplyResp := astro.Deployment{
 		ID:             "test-id",
 		ReleaseName:    "test-name",
+		Workspace:      astro.Workspace{ID: ws},
 		RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 		DeploymentSpec: astro.DeploymentSpec{
 			Webserver: astro.Webserver{URL: "test-url"},
@@ -144,7 +146,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	deployInput := InputDeploy{
 		Path:           "./testfiles/",
 		RuntimeID:      "",
-		WsID:           "test-ws-id",
+		WsID:           ws,
 		Pytest:         "parse",
 		EnvFile:        "",
 		ImageName:      "",
@@ -157,7 +159,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	mockClient := new(astro_mocks.Client)
 
 	mockClient.On("GetDeployment", mock.Anything).Return(mockDeplyResp, nil).Times(5)
-	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", DagDeployEnabled: true}}, nil).Times(2)
+	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", Workspace: astro.Workspace{ID: ws}, DagDeployEnabled: true}}, nil).Times(2)
 	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(7)
 	mockClient.On("CreateImage", mock.Anything).Return(&astro.Image{}, nil).Times(7)
 	mockClient.On("DeployImage", mock.Anything).Return(&astro.Image{}, nil).Times(7)
@@ -254,7 +256,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	deployInput = InputDeploy{
 		Path:           "./testfiles1/",
 		RuntimeID:      "",
-		WsID:           "test-ws-id",
+		WsID:           ws,
 		Pytest:         "parse",
 		EnvFile:        "",
 		ImageName:      "",
@@ -279,6 +281,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 		{
 			ID:             "test-id",
 			ReleaseName:    "test-name",
+			Workspace:      astro.Workspace{ID: ws},
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
 				Webserver: astro.Webserver{URL: "test-url"},
@@ -289,6 +292,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 		{
 			ID:             "test-id-2",
 			ReleaseName:    "test-name-2",
+			Workspace:      astro.Workspace{ID: ws},
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
 				Webserver: astro.Webserver{URL: "test-url"},
@@ -301,7 +305,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 	deployInput := InputDeploy{
 		Path:           "./testfiles/",
 		RuntimeID:      "test-id",
-		WsID:           "test-ws-id",
+		WsID:           ws,
 		Pytest:         "",
 		EnvFile:        "",
 		ImageName:      "",
@@ -381,6 +385,7 @@ func TestDagsDeployFailed(t *testing.T) {
 		{
 			ID:             "test-id",
 			ReleaseName:    "test-name",
+			Workspace:      astro.Workspace{ID: ws},
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
 				Webserver: astro.Webserver{URL: "test-url"},
@@ -391,6 +396,7 @@ func TestDagsDeployFailed(t *testing.T) {
 		{
 			ID:             "test-id-2",
 			ReleaseName:    "test-name-2",
+			Workspace:      astro.Workspace{ID: ws},
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
 				Webserver: astro.Webserver{URL: "test-url"},
@@ -403,7 +409,7 @@ func TestDagsDeployFailed(t *testing.T) {
 	deployInput := InputDeploy{
 		Path:           "./testfiles/",
 		RuntimeID:      "test-id",
-		WsID:           "test-ws-id",
+		WsID:           ws,
 		Pytest:         "",
 		EnvFile:        "",
 		ImageName:      "",
@@ -454,7 +460,7 @@ func TestDagsDeployVR(t *testing.T) {
 	deployInput := InputDeploy{
 		Path:           "./testfiles/",
 		RuntimeID:      runtimeID,
-		WsID:           "test-ws-id",
+		WsID:           ws,
 		Pytest:         "",
 		EnvFile:        "",
 		ImageName:      "",
@@ -503,7 +509,7 @@ func TestNoDagsDeploy(t *testing.T) {
 	deployInput := InputDeploy{
 		Path:           "./testfiles/",
 		RuntimeID:      "test-id",
-		WsID:           "test-ws-id",
+		WsID:           ws,
 		Pytest:         "",
 		EnvFile:        "",
 		ImageName:      "",
@@ -526,7 +532,7 @@ func TestDeployFailure(t *testing.T) {
 	deployInput := InputDeploy{
 		Path:           "./testfiles/",
 		RuntimeID:      "test-id",
-		WsID:           "test-ws-id",
+		WsID:           ws,
 		Pytest:         "parse",
 		EnvFile:        "",
 		ImageName:      "",
@@ -544,6 +550,7 @@ func TestDeployFailure(t *testing.T) {
 		{
 			ID:             "test-id",
 			ReleaseName:    "test-name",
+			Workspace:      astro.Workspace{ID: ws},
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
 				Webserver: astro.Webserver{URL: "test-url"},
@@ -588,6 +595,13 @@ func TestDeployFailure(t *testing.T) {
 	deployInput.RuntimeID = ""
 	err = Deploy(deployInput, mockClient)
 	assert.ErrorIs(t, err, errDagsParseFailed)
+
+	mockClient.On("ListDeployments", org, "invalid-workspace").Return(mockDeplyResp, nil).Once()
+	defer testUtil.MockUserInput(t, "y")()
+	deployInput.RuntimeID = "test-id"
+	deployInput.WsID = "invalid-workspace"
+	err = Deploy(deployInput, mockClient)
+	assert.NoError(t, err)
 
 	mockClient.AssertExpectations(t)
 	mockImageHandler.AssertExpectations(t)

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -87,7 +87,7 @@ func deployTests(parse, pytest, forceDeploy bool, pytestFile string) string {
 func deploy(cmd *cobra.Command, args []string) error {
 	deploymentID := ""
 
-	// Get release name from args, if passed
+	// Get deploymentId from args, if passed
 	if len(args) > 0 {
 		deploymentID = args[0]
 	}
@@ -100,7 +100,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Save release name in config if specified
+	// Save deploymentId in config if specified
 	if len(deploymentID) > 0 && saveDeployConfig {
 		err := config.CFG.ProjectDeployment.SetProjectString(deploymentID)
 		if err != nil {

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -86,16 +86,15 @@ func deployTests(parse, pytest, forceDeploy bool, pytestFile string) string {
 
 func deploy(cmd *cobra.Command, args []string) error {
 	deploymentID := ""
-	ws := ""
 
 	// Get release name from args, if passed
 	if len(args) > 0 {
 		deploymentID = args[0]
 	}
 
-	if deploymentID == "" || forcePrompt {
+	if deploymentID == "" || forcePrompt || workspaceID == "" {
 		var err error
-		ws, err = coalesceWorkspace()
+		workspaceID, err = coalesceWorkspace()
 		if err != nil {
 			return errors.Wrap(err, "failed to find a valid workspace")
 		}
@@ -127,7 +126,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 	deployInput := cloud.InputDeploy{
 		Path:           config.WorkingPath,
 		RuntimeID:      deploymentID,
-		WsID:           ws,
+		WsID:           workspaceID,
 		Pytest:         pytestFile,
 		EnvFile:        envFile,
 		ImageName:      imageName,


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Invalid workspaceId check on astro deploy

## 🎟 Issue(s)

Related #761 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

<img width="648" alt="Screen Shot 2022-11-02 at 02 40 23" src="https://user-images.githubusercontent.com/65428224/199456377-24545b46-2903-46fb-b70a-f09f5d5cc257.png">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
