### PR TITLE
fix to not check workspaceId for a VR

### DIFF
--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"fmt"
+	"strings"
 
 	cloud "github.com/astronomer/astro-cli/cloud/deploy"
 	"github.com/astronomer/astro-cli/cmd/utils"
@@ -92,7 +93,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		deploymentID = args[0]
 	}
 
-	if deploymentID == "" || forcePrompt || workspaceID == "" {
+	if (!strings.HasPrefix(deploymentID, "vr-")) && (deploymentID == "" || forcePrompt || workspaceID == "") {
 		var err error
 		workspaceID, err = coalesceWorkspace()
 		if err != nil {

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -57,4 +57,7 @@ func TestDeployImage(t *testing.T) {
 
 	err = execDeployCmd([]string{"-f", "test-deployment-id", "--dags", "--parse", "--pytest"}...)
 	assert.NoError(t, err)
+
+	err = execDeployCmd([]string{"vr-Id"}...)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

fix to not check workspaceId for a VR

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screen Shot 2022-11-03 at 10 18 58](https://user-images.githubusercontent.com/65428224/199790524-4432d85a-0864-4b00-865d-c2d15e7d3903.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
