### PR TITLE
Print flow installation commands

### DIFF
--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -57,6 +57,9 @@ func patchDockerClientInit() error {
 		mockDockerBinder.On("ContainerLogs", mock.Anything, mock.Anything, mock.Anything).Return(sampleLog, nil)
 		return mockDockerBinder, nil
 	}
+	sql.PrintBuildingSteps = func(r io.Reader) error {
+		return nil
+	}
 	return nil
 }
 

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -60,6 +60,9 @@ func patchDockerClientInit() error {
 	sql.PrintBuildingSteps = func(r io.Reader) error {
 		return nil
 	}
+	sql.IoCopy = func(dst io.Writer, src io.Reader) (written int64, err error) {
+		return 0, nil
+	}
 	return nil
 }
 
@@ -90,24 +93,24 @@ func execFlowCmd(args ...string) error {
 }
 
 func TestFlowCmd(t *testing.T) {
-	err := execFlowCmd([]string{}...)
+	err := execFlowCmd()
 	assert.NoError(t, err)
 }
 
 func TestFlowVersionCmd(t *testing.T) {
-	err := execFlowCmd([]string{"version"}...)
+	err := execFlowCmd("version")
 	assert.NoError(t, err)
 }
 
 func TestFlowAboutCmd(t *testing.T) {
-	err := execFlowCmd([]string{"about"}...)
+	err := execFlowCmd("about")
 	assert.NoError(t, err)
 }
 
 func TestFlowInitCmd(t *testing.T) {
 	projectDir := t.TempDir()
 	defer chdir(t, projectDir)()
-	err := execFlowCmd([]string{"init"}...)
+	err := execFlowCmd("init")
 	assert.NoError(t, err)
 }
 
@@ -115,51 +118,51 @@ func TestFlowInitCmdWithFlags(t *testing.T) {
 	projectDir := t.TempDir()
 	AirflowHome := t.TempDir()
 	AirflowDagsFolder := t.TempDir()
-	err := execFlowCmd([]string{"init", projectDir, "--airflow-home", AirflowHome, "--airflow-dags-folder", AirflowDagsFolder}...)
+	err := execFlowCmd("init", projectDir, "--airflow-home", AirflowHome, "--airflow-dags-folder", AirflowDagsFolder)
 	assert.NoError(t, err)
 }
 
 func TestFlowValidateCmd(t *testing.T) {
 	projectDir := t.TempDir()
-	err := execFlowCmd([]string{"init", projectDir}...)
+	err := execFlowCmd("init", projectDir)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"validate", projectDir, "--connection", "sqlite_conn"}...)
+	err = execFlowCmd("validate", projectDir, "--connection", "sqlite_conn")
 	assert.NoError(t, err)
 }
 
 func TestFlowGenerateCmd(t *testing.T) {
 	projectDir := t.TempDir()
-	err := execFlowCmd([]string{"init", projectDir}...)
+	err := execFlowCmd("init", projectDir)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"generate", "example_basic_transform", "--project-dir", projectDir}...)
+	err = execFlowCmd("generate", "example_basic_transform", "--project-dir", projectDir)
 	assert.NoError(t, err)
 }
 
 func TestFlowGenerateCmdWorkflowNameNotSet(t *testing.T) {
 	projectDir := t.TempDir()
-	err := execFlowCmd([]string{"init", projectDir}...)
+	err := execFlowCmd("init", projectDir)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"generate", "--project-dir", projectDir}...)
+	err = execFlowCmd("generate", "--project-dir", projectDir)
 	assert.EqualError(t, err, "argument not set:workflow_name")
 }
 
 func TestFlowRunCmd(t *testing.T) {
 	projectDir := t.TempDir()
-	err := execFlowCmd([]string{"init", projectDir}...)
+	err := execFlowCmd("init", projectDir)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"run", "example_templating", "--env", "dev", "--project-dir", projectDir, "--verbose"}...)
+	err = execFlowCmd("run", "example_templating", "--env", "dev", "--project-dir", projectDir, "--verbose")
 	assert.NoError(t, err)
 }
 
 func TestFlowRunCmdWorkflowNameNotSet(t *testing.T) {
 	projectDir := t.TempDir()
-	err := execFlowCmd([]string{"init", projectDir}...)
+	err := execFlowCmd("init", projectDir)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"run", "--project-dir", projectDir}...)
+	err = execFlowCmd("run", "--project-dir", projectDir)
 	assert.EqualError(t, err, "argument not set:workflow_name")
 }

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -57,7 +57,7 @@ func patchDockerClientInit() error {
 		mockDockerBinder.On("ContainerLogs", mock.Anything, mock.Anything, mock.Anything).Return(sampleLog, nil)
 		return mockDockerBinder, nil
 	}
-	sql.PrintBuildingSteps = func(r io.Reader) error {
+	sql.DisplayMessages = func(r io.Reader) error {
 		return nil
 	}
 	sql.IoCopy = func(dst io.Writer, src io.Reader) (written int64, err error) {

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -26,7 +26,6 @@ var (
 	DockerClientInit   = NewDockerClient
 	IoCopy             = io.Copy
 	PrintBuildingSteps = printBuildingSteps
-	Println            = fmt.Println
 )
 
 func getContext(filePath string) io.Reader {
@@ -59,14 +58,10 @@ func printBuildingSteps(r io.Reader) error {
 		//  ---> Running in 0afb2e0c5ad7
 		if strings.HasPrefix(prevStream, "Step ") && strings.HasPrefix(currStream, " ---> Running in ") {
 			if firstMessage {
-				if _, err := Println("Installing flow.. This might take some time."); err != nil {
-					return err
-				}
+				fmt.Println("Installing flow.. This might take some time.")
 				firstMessage = false
 			}
-			if _, err := Println(prevStream); err != nil {
-				return err
-			}
+			fmt.Println(prevStream)
 		}
 		prevStream = currStream
 	}

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -54,6 +54,9 @@ func printBuildingSteps(r io.Reader) error {
 			continue
 		}
 		currStream = jsonMessage.Stream
+		// We only print steps which are actually running, e.g.
+		// Step 2/4 : ENV ASTRO_CLI Yes
+		//  ---> Running in 0afb2e0c5ad7
 		if strings.HasPrefix(prevStream, "Step ") && strings.HasPrefix(currStream, " ---> Running in ") {
 			if firstMessage {
 				if _, err := Println("Installing flow.. This might take some time."); err != nil {

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -28,8 +28,10 @@ const (
 )
 
 var (
-	DockerClientInit = NewDockerClient
-	ioCopy           = io.Copy
+	DockerClientInit   = NewDockerClient
+	ioCopy             = io.Copy
+	PrintBuildingSteps = printBuildingSteps
+	Println            = fmt.Println
 )
 
 func getContext(filePath string) io.Reader {
@@ -59,10 +61,14 @@ func printBuildingSteps(r io.Reader) error {
 		currStream = jsonMessage.Stream
 		if strings.HasPrefix(prevStream, "Step ") && strings.HasPrefix(currStream, " ---> Running in ") {
 			if firstMessage {
-				fmt.Println("Installing flow.. This might take some time.")
+				if _, err := Println("Installing flow.. This might take some time."); err != nil {
+					return err
+				}
 				firstMessage = false
 			}
-			fmt.Println(prevStream)
+			if _, err := Println(prevStream); err != nil {
+				return err
+			}
 		}
 		prevStream = currStream
 	}
@@ -101,7 +107,7 @@ func CommonDockerUtil(cmd, args []string, flags map[string]string, mountDirs []s
 	}
 
 	// We print the steps which are not cached
-	err = printBuildingSteps(body.Body)
+	err = PrintBuildingSteps(body.Body)
 	if err != nil {
 		err = fmt.Errorf("retrieving logs failed %w", err)
 		return err

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -41,7 +41,7 @@ func printBuildingSteps(r io.Reader) error {
 	decoder := json.NewDecoder(r)
 	var prevStream string
 	var currStream string
-	var firstMessage bool = true
+	firstMessage := true
 	for {
 		var jsonMessage jsonmessage.JSONMessage
 		if err := decoder.Decode(&jsonMessage); err != nil {

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -24,7 +24,7 @@ const (
 
 var (
 	DockerClientInit   = NewDockerClient
-	ioCopy             = io.Copy
+	IoCopy             = io.Copy
 	PrintBuildingSteps = printBuildingSteps
 	Println            = fmt.Println
 )
@@ -151,7 +151,7 @@ func CommonDockerUtil(cmd, args []string, flags map[string]string, mountDirs []s
 		return fmt.Errorf("docker container logs fetching failed %w", err)
 	}
 
-	if _, err := ioCopy(os.Stdout, cout); err != nil {
+	if _, err := IoCopy(os.Stdout, cout); err != nil {
 		return fmt.Errorf("docker logs forwarding failed %w", err)
 	}
 

--- a/sql/flow_test.go
+++ b/sql/flow_test.go
@@ -230,7 +230,7 @@ func TestCommonDockerUtilLogsCopyFailure(t *testing.T) {
 	PrintBuildingSteps = func(r io.Reader) error {
 		return nil
 	}
-	ioCopy = func(dst io.Writer, src io.Reader) (written int64, err error) {
+	IoCopy = func(dst io.Writer, src io.Reader) (written int64, err error) {
 		return 0, errMock
 	}
 	err := CommonDockerUtil(testCommand, nil, nil, nil)
@@ -238,5 +238,5 @@ func TestCommonDockerUtilLogsCopyFailure(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 	mockDockerBinder.AssertExpectations(t)
 	PrintBuildingSteps = printBuildingSteps
-	ioCopy = io.Copy
+	IoCopy = io.Copy
 }


### PR DESCRIPTION
## Description

Currently, `flow` users are not seeing any progress made during the very first installation. This PR is addressing this by showing the commands for installing it - but only when the layers are not cached yet.

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-sdk/issues/1143

## 📸 Screenshots

First time running `astro flow` command:

<img width="907" alt="Screenshot 2022-11-07 at 16 23 31" src="https://user-images.githubusercontent.com/23282078/200347688-4bda09e0-8413-4d85-8e08-211331f01039.png">

...

<img width="909" alt="Screenshot 2022-11-07 at 16 25 39" src="https://user-images.githubusercontent.com/23282078/200348213-63363aa6-4934-47e6-98e7-397aabd4c9b6.png">

When installed, it won't show the output as all of it is _cached_:

<img width="688" alt="Screenshot 2022-11-07 at 16 22 07" src="https://user-images.githubusercontent.com/23282078/200347342-4cddd4f9-e790-4a0c-bd43-e1ca2685dc1f.png">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
