### PR TITLE
Add "--generate-tasks" option to flow run and flow generate commands.

### DIFF
--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -15,6 +15,7 @@ var (
 	airflowHome       string
 	airflowDagsFolder string
 	projectDir        string
+	generateTasks     bool
 	verbose           bool
 )
 
@@ -161,6 +162,10 @@ func executeGenerate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if generateTasks {
+		args = append(args, "--generate-tasks")
+	}
+
 	return executeCmd(cmd, args, flags, mountDirs)
 }
 
@@ -176,6 +181,10 @@ func executeRun(cmd *cobra.Command, args []string) error {
 
 	if verbose {
 		args = append(args, "--verbose")
+	}
+
+	if generateTasks {
+		args = append(args, "--generate-tasks")
 	}
 
 	return executeCmd(cmd, args, flags, mountDirs)
@@ -244,6 +253,7 @@ func generateCommand() *cobra.Command {
 	}
 	cmd.SetHelpFunc(executeHelp)
 	cmd.Flags().StringVarP(&projectDir, "project-dir", "p", ".", "")
+	cmd.Flags().BoolVarP(&generateTasks, "generate-tasks", "g", false, "")
 	return cmd
 }
 
@@ -256,6 +266,7 @@ func runCommand() *cobra.Command {
 	}
 	cmd.SetHelpFunc(executeHelp)
 	cmd.Flags().StringVarP(&projectDir, "project-dir", "p", ".", "")
+	cmd.Flags().BoolVarP(&generateTasks, "generate-tasks", "g", false, "")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "")
 	return cmd
 }

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -132,11 +132,23 @@ func TestFlowGenerateCmd(t *testing.T) {
 
 	err = execFlowCmd([]string{"generate", "example_basic_transform", "--project-dir", projectDir}...)
 	assert.NoError(t, err)
+}
 
-	err = execFlowCmd([]string{"generate", "example_basic_transform", "--generate-tasks", "--project-dir", projectDir}...)
+func TestFlowGenerateGenerateTasksCmd(t *testing.T) {
+	projectDir := t.TempDir()
+	err := execFlowCmd([]string{"init", projectDir}...)
 	assert.NoError(t, err)
 
-	err = execFlowCmd([]string{"run", "example_templating", "--env", "dev", "--generate-tasks", "--project-dir", projectDir, "--verbose"}...)
+	err = execFlowCmd([]string{"generate", "example_basic_transform", "--project-dir", projectDir, "--generate-tasks"}...)
+	assert.NoError(t, err)
+}
+
+func TestFlowRunGenerateTasksCmd(t *testing.T) {
+	projectDir := t.TempDir()
+	err := execFlowCmd([]string{"init", projectDir}...)
+	assert.NoError(t, err)
+
+	err = execFlowCmd([]string{"run", "example_basic_transform", "--project-dir", projectDir, "--generate-tasks"}...)
 	assert.NoError(t, err)
 }
 

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -132,6 +132,12 @@ func TestFlowGenerateCmd(t *testing.T) {
 
 	err = execFlowCmd([]string{"generate", "example_basic_transform", "--project-dir", projectDir}...)
 	assert.NoError(t, err)
+
+	err = execFlowCmd([]string{"generate", "example_basic_transform", "--generate-tasks", "--project-dir", projectDir}...)
+	assert.NoError(t, err)
+
+	err = execFlowCmd([]string{"run", "example_templating", "--env", "dev", "--generate-tasks", "--project-dir", projectDir, "--verbose"}...)
+	assert.NoError(t, err)
 }
 
 func TestFlowGenerateCmdWorkflowNameNotSet(t *testing.T) {


### PR DESCRIPTION
## Description

With https://github.com/astronomer/astro-sdk/pull/1140 we now have a "render mode" in our sql-cli generated DAGs. This propagates the option to the astro-cli for flow users.

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-sdk/issues/1221

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
