### PR TITLE
log into pr preview environments

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -205,8 +205,10 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 		return nil
 	}
 
-	deploymentURL := "cloud." + domain + "/" + deployInfo.workspaceID + "/deployments/" + deployInfo.deploymentID + "/analytics"
-
+	deploymentURL, err := deployment.GetDeploymentURL(deployInfo.deploymentID, deployInfo.workspaceID)
+	if err != nil {
+		return err
+	}
 	if deployInput.Dags {
 		if deployInput.Pytest != "" {
 			version, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.dagDeployEnabled, client)

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -912,9 +912,16 @@ func TestGetDeploymentURL(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)
 	})
+	t.Run("returns deploymentURL for pr preview environment", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPrPreview)
+		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id/analytics"
+		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedURL, actualURL)
+	})
 	t.Run("returns deploymentURL for local environment", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		expectedURL := "cloud.localhost/workspace-id/deployments/deployment-id/analytics"
+		expectedURL := "localhost:5000/workspace-id/deployments/deployment-id/analytics"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -323,7 +323,7 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 	t.Run("returns deployment Info for the requested local deployment", func(t *testing.T) {
 		var actualDeploymentInfo deploymentInfo
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		expectedCloudDomainURL := "cloud.localhost/" + sourceDeployment.Workspace.ID +
+		expectedCloudDomainURL := "localhost:5000/" + sourceDeployment.Workspace.ID +
 			"/deployments/" + sourceDeployment.ID + "/analytics"
 		expectedDeploymentInfo := deploymentInfo{
 			DeploymentID:   sourceDeployment.ID,

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -13,6 +13,7 @@ import (
 	astro "github.com/astronomer/astro-cli/astro-client"
 	"github.com/astronomer/astro-cli/cloud/auth"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/domainutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
@@ -47,11 +48,10 @@ func newTableOut() *printutil.Table {
 // TODO use astro.go wrapper around REST client
 func listOrganizations(c *config.Context) ([]OrgRes, error) {
 	var orgDomain string
-	if c.Domain == "localhost" {
-		orgDomain = config.CFG.LocalCore.GetString() + "/organizations"
-	} else {
-		orgDomain = "https://api." + c.Domain + "/v1alpha1/organizations"
-	}
+	withOutCloud := domainutil.FormatDomain(c.Domain)
+	// we use core api for this
+	orgDomain = domainutil.GetURLToEndpoint("https", withOutCloud, "v1alpha1/organizations")
+	orgDomain = domainutil.TransformToCoreAPIEndpoint(orgDomain)
 	authToken := c.Token
 	ctx := context.Background()
 	doOptions := &httputil.DoOptions{

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"io"
 
+	"github.com/astronomer/astro-cli/pkg/domainutil"
+
 	astro "github.com/astronomer/astro-cli/astro-client"
 	cloudAuth "github.com/astronomer/astro-cli/cloud/auth"
 	"github.com/astronomer/astro-cli/context"
@@ -66,7 +68,7 @@ func login(cmd *cobra.Command, args []string, astroClient astro.Client, out io.W
 	ctx, err := context.GetCurrentContext()
 	if err != nil || ctx.Domain == "" {
 		// Default case when no domain is passed, and error getting current context
-		return cloudLogin(cloudAuth.Domain, "", token, astroClient, out, shouldDisplayLoginLink)
+		return cloudLogin(domainutil.DefaultDomain, "", token, astroClient, out, shouldDisplayLoginLink)
 	} else if context.IsCloudDomain(ctx.Domain) {
 		return cloudLogin(ctx.Domain, "", token, astroClient, out, shouldDisplayLoginLink)
 	}

--- a/config/cloud_test.go
+++ b/config/cloud_test.go
@@ -31,42 +31,7 @@ contexts:
 	InitConfig(fs)
 }
 
-func TestContextGetCloudAPIURL(t *testing.T) {
-	initTestConfig()
-	CFG.LocalAstro.SetHomeString("http://localhost/v1")
-	CFG.CloudAPIProtocol.SetHomeString("https")
-	type fields struct {
-		Domain string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{
-			name:   "basic localhost case",
-			fields: fields{Domain: "localhost"},
-			want:   "http://localhost/v1",
-		},
-		{
-			name:   "basic cloud case",
-			fields: fields{Domain: "cloud.astro.io"},
-			want:   "https://api.astro.io/hub/v1",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &Context{
-				Domain: tt.fields.Domain,
-			}
-			if got := c.GetCloudAPIURL(); got != tt.want {
-				t.Errorf("Context.GetCloudAPIURL() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestContextGetPublicAPIURL(t *testing.T) {
+func TestContextGetPublicGraphQLAPIURL(t *testing.T) {
 	initTestConfig()
 	CFG.CloudAPIProtocol.SetHomeString("https")
 	type fields struct {
@@ -94,7 +59,7 @@ func TestContextGetPublicAPIURL(t *testing.T) {
 				Domain: tt.fields.Domain,
 			}
 			if got := c.GetPublicGraphQLAPIURL(); got != tt.want {
-				t.Errorf("Context.GetPublicAPIURL() = %v, want %v", got, tt.want)
+				t.Errorf("Context.GetPublicGraphQLAPIURL() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 const (
 	CloudPlatform    = "cloud"
 	SoftwarePlatform = "software"
+	PrPreview        = "prprievew"
 
 	localhostDomain = "localhost"
 	astrohubDomain  = "astrohub"

--- a/config/context.go
+++ b/config/context.go
@@ -17,8 +17,6 @@ var (
 	errNotConnected  = errors.New("not connected, have you authenticated to Astro? Run astro login and try again")
 )
 
-var splitNum = 2
-
 const (
 	contextsKey = "contexts"
 )

--- a/context/context.go
+++ b/context/context.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/domainutil"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
 	"github.com/spf13/cobra"
@@ -16,8 +17,7 @@ var (
 	// CloudDomainRegex is used to differentiate cloud domain from software domain
 	// See https://github.com/astronomer/astrohub-cli/issues/7 for regexp rationale
 	// This will need to be handled as part of the permanent solution to issue #432
-	CloudDomainRegex = regexp.MustCompile(`(cloud\.|^)astronomer(?:(-dev|-stage|-perf))?\.io`)
-
+	CloudDomainRegex     = regexp.MustCompile(`(?:(pr\d{4,6})\.|^)(?:cloud\.|)astronomer(?:-(dev|stage|perf))?\.io$`)
 	contextDeleteWarnMsg = "Are you sure you want to delete currently used context: %s"
 	cancelCtxDeleteMsg   = "Canceling context delete..."
 	failCtxDeleteMsg     = "Error deleting context %s: "
@@ -29,12 +29,6 @@ var tab = printutil.Table{
 	Header:       []string{"NAME"},
 	ColorRowCode: [2]string{"\033[1;32m", "\033[0m"},
 }
-
-const (
-	DevCloudDomain   = "astronomer-dev.io"
-	StageCloudDomain = "astronomer-stage.io"
-	PerfCloudDomain  = "astronomer-perf.io"
-)
 
 // ContextExists checks to see if context exist in config
 func Exists(domain string) bool {
@@ -166,10 +160,10 @@ func IsCloudContext() bool {
 
 // IsCloudDomain returns whether the given domain is related to cloud platform or not
 func IsCloudDomain(domain string) bool {
-	if domain == DevCloudDomain ||
-		domain == StageCloudDomain ||
-		domain == PerfCloudDomain ||
-		CloudDomainRegex.MatchString(domain) {
+	if CloudDomainRegex.MatchString(domain) {
+		return true
+	}
+	if domainutil.PRPreviewDomainRegex.MatchString(domain) {
 		return true
 	}
 

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -60,6 +60,7 @@ func TestIsCloudContext(t *testing.T) {
 		{"software-domain", "dev.astrodev.com", config.SoftwarePlatform, false},
 		{"software-domain", "software.astronomer-test.io", config.SoftwarePlatform, false},
 		{"local-software", "localhost", config.SoftwarePlatform, false},
+		{"prpreview", "pr1234.cloud.astronomer-dev.io", config.PrPreview, true},
 	}
 
 	for _, tt := range tests {
@@ -111,4 +112,17 @@ func TestListContext(t *testing.T) {
 	err := ListContext(&cobra.Command{}, []string{}, buf)
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "localhost")
+}
+
+func TestIsCloudDomain(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPrPreview)
+	actual := IsCloudDomain("pr1234.cloud.astronomer.io")
+	assert.True(t, actual)
+
+	// TODO this makes the first find pass in viper.IsSet()
+	// SetContext("pr1234.cloud.astronomer.io")
+	// TODO this finds the context
+	Switch("pr1234.cloud.astronomer.io")
+	actual = IsCloudContext()
+	assert.True(t, actual)
 }

--- a/pkg/domainutil/domain.go
+++ b/pkg/domainutil/domain.go
@@ -1,0 +1,61 @@
+package domainutil
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	DefaultDomain = "astronomer.io"
+	LocalDomain   = "localhost"
+)
+
+var PRPreviewDomainRegex = regexp.MustCompile(`^(pr\d{4,6}).astronomer-dev\.io$`)
+
+func FormatDomain(domain string) string {
+	if strings.Contains(domain, "cloud") {
+		domain = strings.Replace(domain, "cloud.", "", 1)
+	} else if domain == "" {
+		domain = DefaultDomain
+	}
+
+	return domain
+}
+
+func isPrPreviewDomain(domain string) bool {
+	return PRPreviewDomainRegex.MatchString(domain)
+}
+
+func getPRSubDomain(domain string) (prSubDomain, restOfDomain string) {
+	if isPrPreviewDomain(domain) {
+		prSubDomain, domain, _ = strings.Cut(domain, ".")
+	}
+	return prSubDomain, domain
+}
+
+func GetURLToEndpoint(protocol, domain, endpoint string) string {
+	var addr, prSubDomain string
+
+	switch domain {
+	case LocalDomain:
+		addr = fmt.Sprintf("%s://%s:8871/%s", "http", domain, endpoint)
+		return addr
+	default:
+		if isPrPreviewDomain(domain) {
+			prSubDomain, domain = getPRSubDomain(domain)
+			addr = fmt.Sprintf("%s://%s.api.%s/hub/%s", protocol, prSubDomain, domain, endpoint)
+			return addr
+		}
+		addr = fmt.Sprintf("%s://api.%s/hub/%s", protocol, domain, endpoint)
+	}
+	return addr
+}
+
+func TransformToCoreAPIEndpoint(addr string) string {
+	if strings.Contains(addr, "v1alpha1") {
+		addr = strings.Replace(addr, "/hub", "", 1)
+		addr = strings.Replace(addr, "localhost:8871", "localhost:8888", 1)
+	}
+	return addr
+}

--- a/pkg/domainutil/domain.go
+++ b/pkg/domainutil/domain.go
@@ -27,7 +27,7 @@ func isPrPreviewDomain(domain string) bool {
 	return PRPreviewDomainRegex.MatchString(domain)
 }
 
-func getPRSubDomain(domain string) (prSubDomain, restOfDomain string) {
+func GetPRSubDomain(domain string) (prSubDomain, restOfDomain string) {
 	if isPrPreviewDomain(domain) {
 		prSubDomain, domain, _ = strings.Cut(domain, ".")
 	}
@@ -43,7 +43,7 @@ func GetURLToEndpoint(protocol, domain, endpoint string) string {
 		return addr
 	default:
 		if isPrPreviewDomain(domain) {
-			prSubDomain, domain = getPRSubDomain(domain)
+			prSubDomain, domain = GetPRSubDomain(domain)
 			addr = fmt.Sprintf("%s://%s.api.%s/hub/%s", protocol, prSubDomain, domain, endpoint)
 			return addr
 		}

--- a/pkg/domainutil/domain_test.go
+++ b/pkg/domainutil/domain_test.go
@@ -92,14 +92,14 @@ func TestIsPrPreviewDomain(t *testing.T) {
 func TestGetPRSubDomain(t *testing.T) {
 	t.Run("returns pr subdomain for a valid PR preview domain", func(t *testing.T) {
 		for i, domainToCheck := range listOfPRURLs {
-			actualPR, actualDomain := getPRSubDomain(domainToCheck)
+			actualPR, actualDomain := GetPRSubDomain(domainToCheck)
 			assert.Equal(t, "astronomer-dev.io", actualDomain)
 			assert.Equal(t, listOfPRs[i], actualPR)
 		}
 	})
 	t.Run("returns empty pr subdomain for domains that are not a PR Preview domain", func(t *testing.T) {
 		for _, domainToCheck := range listOfURLs {
-			actualPRDomain, actualDomain := getPRSubDomain(domainToCheck)
+			actualPRDomain, actualDomain := GetPRSubDomain(domainToCheck)
 			assert.Equal(t, domainToCheck, actualDomain)
 			assert.Equal(t, "", actualPRDomain)
 		}

--- a/pkg/domainutil/domain_test.go
+++ b/pkg/domainutil/domain_test.go
@@ -1,0 +1,170 @@
+package domainutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	listOfURLs = []string{
+		"cloud.astronomer.io",
+		"cloud.astronomer-dev.io",
+		"cloud.astronomer-stage.io",
+		"cloud.astronomer-perf.io",
+		"pr1234.fail.astronomer-dev.io",
+		"pr1234.astronomer-dev.fail.io",
+		"pr1234.astronomer-devpr.io",
+		"pr1234.astroprnomer-dev.io",
+		"pr123.astroprnomer-dev.io",
+		"pr1234.astronomer-dev.io.fail",
+		"pr1234.cloud.astronomer-stage.io",
+		"pr1234.cloud.astronomer-perf.io",
+		"pr12345.cloud.astronomer-perf.io",
+		"pr1234.cloud1.astronomer-perf.io",
+		"pr1234.cloud.astronomer-stage.io",
+		"foo.pr1234.cloud.astronomer-perf.io",
+		"pr123.cloud.astronomer-stage.io",
+		"pr123.cloud.astronomer-perf.io",
+		"pr1234.cloud.astronomer.io",
+		"drum.cloud.astronomer-dev.io",
+		"drum.cloud.astronomer.io",
+	}
+	listOfPRURLs = []string{
+		"pr1234.astronomer-dev.io",
+		"pr12345.astronomer-dev.io",
+		"pr12346.astronomer-dev.io",
+	}
+	listOfPRs = []string{
+		"pr1234",
+		"pr12345",
+		"pr12346",
+	}
+)
+
+func TestFormatDomain(t *testing.T) {
+	t.Run("removes cloud from cloud.astronomer.io", func(t *testing.T) {
+		actual := FormatDomain("cloud.astronomer.io")
+		assert.Equal(t, "astronomer.io", actual)
+	})
+	t.Run("removes cloud from cloud.astronomer-dev.io", func(t *testing.T) {
+		actual := FormatDomain("cloud.astronomer-dev.io")
+		assert.Equal(t, "astronomer-dev.io", actual)
+	})
+	t.Run("removes cloud from cloud.astronomer-stage.io", func(t *testing.T) {
+		actual := FormatDomain("cloud.astronomer-stage.io")
+		assert.Equal(t, "astronomer-stage.io", actual)
+	})
+	t.Run("removes cloud from cloud.astronomer-perf.io", func(t *testing.T) {
+		actual := FormatDomain("cloud.astronomer-perf.io")
+		assert.Equal(t, "astronomer-perf.io", actual)
+	})
+	t.Run("removes cloud from pr1234.cloud.astronomer-dev.io", func(t *testing.T) {
+		actual := FormatDomain("pr1234.cloud.astronomer-dev.io")
+		assert.Equal(t, "pr1234.astronomer-dev.io", actual)
+	})
+	t.Run("sets default domain if one was not provided", func(t *testing.T) {
+		actual := FormatDomain("")
+		assert.Equal(t, "astronomer.io", actual)
+	})
+	t.Run("does not mutate domain if cloud is not found in input", func(t *testing.T) {
+		actual := FormatDomain("fail.astronomer-dev.io")
+		assert.Equal(t, "fail.astronomer-dev.io", actual)
+	})
+}
+
+func TestIsPrPreviewDomain(t *testing.T) {
+	t.Run("returns true if its pr preview domain", func(t *testing.T) {
+		for _, urlToCheck := range listOfPRURLs {
+			actual := isPrPreviewDomain(urlToCheck)
+			assert.True(t, actual, urlToCheck+" should be true")
+		}
+	})
+	t.Run("returns false if its not pr preview domain", func(t *testing.T) {
+		for _, urlToCheck := range listOfURLs {
+			actual := isPrPreviewDomain(urlToCheck)
+			assert.False(t, actual, urlToCheck+" should be false")
+		}
+	})
+}
+
+func TestGetPRSubDomain(t *testing.T) {
+	t.Run("returns pr subdomain for a valid PR preview domain", func(t *testing.T) {
+		for i, domainToCheck := range listOfPRURLs {
+			actualPR, actualDomain := getPRSubDomain(domainToCheck)
+			assert.Equal(t, "astronomer-dev.io", actualDomain)
+			assert.Equal(t, listOfPRs[i], actualPR)
+		}
+	})
+	t.Run("returns empty pr subdomain for domains that are not a PR Preview domain", func(t *testing.T) {
+		for _, domainToCheck := range listOfURLs {
+			actualPRDomain, actualDomain := getPRSubDomain(domainToCheck)
+			assert.Equal(t, domainToCheck, actualDomain)
+			assert.Equal(t, "", actualPRDomain)
+		}
+	})
+}
+
+func TestGetURLToEndpoint(t *testing.T) {
+	var prSubDomain, domain, expectedURL, endpoint string
+	endpoint = "myendpoint"
+	t.Run("returns localhost endpoint", func(t *testing.T) {
+		domain = "localhost"
+		expectedURL = fmt.Sprintf("http://%s:8871/%s", domain, endpoint)
+		actualURL := GetURLToEndpoint("https", domain, endpoint)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns pr preview endpoint", func(t *testing.T) {
+		prSubDomain = "pr1234"
+		domain = "pr1234.astronomer-dev.io"
+		expectedURL = fmt.Sprintf("https://%s.api.%s/hub/%s", prSubDomain, "astronomer-dev.io", endpoint)
+		actualURL := GetURLToEndpoint("https", domain, endpoint)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns cloud endpoint for prod", func(t *testing.T) {
+		domain = "astronomer.io"
+		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		actualURL := GetURLToEndpoint("https", domain, endpoint)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns cloud endpoint for dev", func(t *testing.T) {
+		domain = "astronomer-dev.io"
+		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		actualURL := GetURLToEndpoint("https", domain, endpoint)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns cloud endpoint for stage", func(t *testing.T) {
+		domain = "astronomer-stage.io"
+		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		actualURL := GetURLToEndpoint("https", domain, endpoint)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns cloud endpoint for perf", func(t *testing.T) {
+		domain = "astronomer-perf.io"
+		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		actualURL := GetURLToEndpoint("https", domain, endpoint)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+	t.Run("returns cloud endpoint for everything else", func(t *testing.T) {
+		domain = "someotherdomain.io"
+		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		actualURL := GetURLToEndpoint("https", domain, endpoint)
+		assert.Equal(t, expectedURL, actualURL)
+	})
+}
+
+func TestTransformToCoreApiEndpoint(t *testing.T) {
+	t.Run("transforms non-local url to core api endpoint", func(t *testing.T) {
+		actual := TransformToCoreAPIEndpoint("https://somedomain.io/hub/v1alpha1/great-endpoint")
+		assert.Equal(t, "https://somedomain.io/v1alpha1/great-endpoint", actual)
+	})
+	t.Run("transforms local url to core api endpoint", func(t *testing.T) {
+		actual := TransformToCoreAPIEndpoint("http://localhost:8871/v1alpha1/great-endpoint")
+		assert.Equal(t, "http://localhost:8888/v1alpha1/great-endpoint", actual)
+	})
+	t.Run("returns without changes if url is not meant for core api", func(t *testing.T) {
+		actual := TransformToCoreAPIEndpoint("https://somedomain.io/hub/valpha1/great-enedpoint")
+		assert.Equal(t, "https://somedomain.io/hub/valpha1/great-enedpoint", actual)
+	})
+}

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -18,6 +18,7 @@ const (
 	CloudDevPlatform      = "dev"
 	CloudPerfPlatform     = "perf"
 	CloudStagePlatform    = "stage"
+	CloudPrPreview        = "prpreview"
 	SoftwarePlatform      = "software"
 	Initial               = "initial"
 	SQLCLI                = "sql_cli"
@@ -85,6 +86,8 @@ contexts:
 		testConfig = `beta:
   sql_cli: true
 `
+	case CloudPrPreview:
+		testConfig = fmt.Sprintf(testConfig, "pr1234.cloud.asrtronomer-dev.io", strings.Replace("pr1234.cloud.astronomer-dev.io", ".", "_", -1), "pr1234.cloud.asrtronomer-dev.io")
 	case ErrorReturningContext:
 		// this is an error returning case
 		testConfig = fmt.Sprintf(testConfig, "error", "error", "error")

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -87,7 +87,7 @@ contexts:
   sql_cli: true
 `
 	case CloudPrPreview:
-		testConfig = fmt.Sprintf(testConfig, "pr1234.cloud.asrtronomer-dev.io", strings.Replace("pr1234.cloud.astronomer-dev.io", ".", "_", -1), "pr1234.cloud.asrtronomer-dev.io")
+		testConfig = fmt.Sprintf(testConfig, "pr1234.astronomer-dev.io", strings.Replace("pr1234.astronomer-dev.io", ".", "_", -1), "pr1234.astronomer-dev.io")
 	case ErrorReturningContext:
 		// this is an error returning case
 		testConfig = fmt.Sprintf(testConfig, "error", "error", "error")


### PR DESCRIPTION
## Description

Users can now log into pr preview environments using astro cli

## 🎟 Issue(s)

Related #805 Related #808 

## 🧪 Functional Testing

```bash
astro login pr5993.cloud.astronomer-dev.io

Welcome to the Astro CLI 🚀

To learn more about Astro, go to https://docs.astronomer.io

Please enter your account email: preview@astronomer.io

Press Enter to open the browser to log in or ^C to quit…
done
 CONTEXT DOMAIN                      WORKSPACE
 pr5993.astronomer-dev.io            cla9y4l9q0176jggw9njp6ehx

 Switched context

"Sample Workspace 1" Workspace found. This is your default Workspace.

Successfully authenticated to Astronomer
```


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
