### PR TITLE
allow astro deploy push image when dags are empty

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -173,18 +173,19 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 		return errors.New("no domain set, re-authenticate")
 	}
 
-	dagFiles := fileutil.GetFilesWithSpecificExtension(deployInput.Path+"/dags", ".py")
-	if len(dagFiles) == 0 && config.CFG.ShowWarnings.GetBool() {
-		i, _ := input.Confirm("Warning: No DAGs found. This will delete any existing DAGs. Are you sure you want to deploy?")
-
-		if !i {
-			fmt.Println("Canceling deploy...")
-			return nil
-		}
-	}
+	dagsPath := filepath.Join(deployInput.Path, "dags")
+	dagFiles := fileutil.GetFilesWithSpecificExtension(dagsPath, ".py")
 
 	// Deploy dags if deployInput runtimeId is virtual runtime
 	if strings.HasPrefix(deployInput.RuntimeID, "vr-") {
+		if len(dagFiles) == 0 && config.CFG.ShowWarnings.GetBool() {
+			i, _ := input.Confirm("Warning: No DAGs found. This will delete any existing DAGs. Are you sure you want to deploy?")
+
+			if !i {
+				fmt.Println("Canceling deploy...")
+				return nil
+			}
+		}
 		fmt.Println("Initiating DAG deploy for: " + deployInput.RuntimeID)
 		err = deployDags(deployInput.Path, deployInput.RuntimeID, client)
 		if err != nil {
@@ -208,6 +209,14 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 	deploymentURL := "cloud." + domain + "/" + deployInfo.workspaceID + "/deployments/" + deployInfo.deploymentID + "/analytics"
 
 	if deployInput.Dags {
+		if len(dagFiles) == 0 && config.CFG.ShowWarnings.GetBool() {
+			i, _ := input.Confirm("Warning: No DAGs found. This will delete any existing DAGs. Are you sure you want to deploy?")
+
+			if !i {
+				fmt.Println("Canceling deploy...")
+				return nil
+			}
+		}
 		if deployInput.Pytest != "" {
 			version, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.dagDeployEnabled, client)
 			if err != nil {
@@ -239,6 +248,10 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 			fmt.Sprintf("\n Deployment View: %s", ansi.Bold(deploymentURL)) +
 			fmt.Sprintf("\n Airflow UI: %s", ansi.Bold(deployInfo.webserverURL)))
 	} else {
+		if deployInfo.dagDeployEnabled && len(dagFiles) == 0 {
+			fmt.Println("No DAGs found. Skipping DAG deploy.")
+		}
+
 		// Build our image
 		version, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.dagDeployEnabled, client)
 		if err != nil {
@@ -282,7 +295,7 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 			return err
 		}
 
-		if deployInfo.dagDeployEnabled {
+		if deployInfo.dagDeployEnabled && len(dagFiles) > 0 {
 			err = deployDags(deployInput.Path, deployInfo.deploymentID, client)
 			if err != nil {
 				return err

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -504,8 +504,29 @@ func TestDagsDeployVR(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestNoDagsDeployVR(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	config.CFG.ShowWarnings.SetHomeString("true")
+	mockClient := new(astro_mocks.Client)
+	runtimeID := "vr-test-id"
+
+	deployInput := InputDeploy{
+		Path:           "./testfiles/",
+		RuntimeID:      runtimeID,
+		WsID:           ws,
+		Pytest:         "",
+		EnvFile:        "",
+		ImageName:      "",
+		DeploymentName: "",
+		Prompt:         false,
+		Dags:           false,
+	}
+
+	err := Deploy(deployInput, mockClient)
+	assert.NoError(t, err)
+}
+
 func TestNoDagsDeploy(t *testing.T) {
-	defer testUtil.MockUserInput(t, "n")()
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("true")
 	mockClient := new(astro_mocks.Client)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -380,6 +380,61 @@ func TestDagsDeploySuccess(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestNoDagsDeploy(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	config.CFG.ShowWarnings.SetHomeString("true")
+	mockClient := new(astro_mocks.Client)
+
+	ctx, err := config.GetCurrentContext()
+	assert.NoError(t, err)
+	ctx.Token = "test testing"
+	err = ctx.SetContext()
+	assert.NoError(t, err)
+
+	mockDeplyResp := []astro.Deployment{
+		{
+			ID:             "test-id",
+			ReleaseName:    "test-name",
+			Workspace:      astro.Workspace{ID: ws},
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Webserver: astro.Webserver{URL: "test-url"},
+			},
+			CreatedAt:        time.Now(),
+			DagDeployEnabled: true,
+		},
+		{
+			ID:             "test-id-2",
+			ReleaseName:    "test-name-2",
+			Workspace:      astro.Workspace{ID: ws},
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Webserver: astro.Webserver{URL: "test-url"},
+			},
+			CreatedAt:        time.Now(),
+			DagDeployEnabled: true,
+		},
+	}
+
+	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(1)
+
+	deployInput := InputDeploy{
+		Path:           "./testfiles/",
+		RuntimeID:      "test-id",
+		WsID:           ws,
+		Pytest:         "",
+		EnvFile:        "",
+		ImageName:      "",
+		DeploymentName: "",
+		Prompt:         true,
+		Dags:           true,
+	}
+	err = Deploy(deployInput, mockClient)
+	assert.NoError(t, err)
+
+	mockClient.AssertExpectations(t)
+}
+
 func TestDagsDeployFailed(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -523,57 +578,6 @@ func TestNoDagsDeployVR(t *testing.T) {
 	}
 
 	err := Deploy(deployInput, mockClient)
-	assert.NoError(t, err)
-}
-
-func TestNoDagsDeploy(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	config.CFG.ShowWarnings.SetHomeString("true")
-	mockClient := new(astro_mocks.Client)
-
-	ctx, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	ctx.Token = "test testing"
-	err = ctx.SetContext()
-	assert.NoError(t, err)
-
-	mockDeplyResp := []astro.Deployment{
-		{
-			ID:             "test-id",
-			ReleaseName:    "test-name",
-			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
-			DeploymentSpec: astro.DeploymentSpec{
-				Webserver: astro.Webserver{URL: "test-url"},
-			},
-			CreatedAt:        time.Now(),
-			DagDeployEnabled: true,
-		},
-		{
-			ID:             "test-id-2",
-			ReleaseName:    "test-name-2",
-			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
-			DeploymentSpec: astro.DeploymentSpec{
-				Webserver: astro.Webserver{URL: "test-url"},
-			},
-			CreatedAt:        time.Now(),
-			DagDeployEnabled: true,
-		},
-	}
-
-	mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(mockDeplyResp, nil).Times(1)
-
-	deployInput := InputDeploy{
-		Path:           "./testfiles/",
-		RuntimeID:      "test-id",
-		WsID:           ws,
-		Pytest:         "",
-		EnvFile:        "",
-		ImageName:      "",
-		DeploymentName: "",
-		Prompt:         true,
-		Dags:           true,
-	}
-	err = Deploy(deployInput, mockClient)
 	assert.NoError(t, err)
 
 	mockClient.AssertExpectations(t)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

allow astro deploy push image when dags are empty

## 🎟 Issue(s)

Related #869 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
