### PR TITLE
Fix flow command flags

### DIFF
--- a/sql/flow.go
+++ b/sql/flow.go
@@ -104,7 +104,7 @@ func CommonDockerUtil(cmd, args []string, flags map[string]string, mountDirs []s
 
 	cmd = append(cmd, args...)
 	for key, value := range flags {
-		cmd = append(cmd, fmt.Sprintf("--%s %s", key, value))
+		cmd = append(cmd, fmt.Sprintf("--%s", key), value)
 	}
 
 	binds := []string{}


### PR DESCRIPTION
## Description

The related PR (see below) broke the flags creation. This PR fixes it.

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-cli/pull/860

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
