### PR TITLE
do not enable/disable dag deploy if already enabled/disabled

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -462,10 +462,18 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy stri
 	}
 
 	if dagDeploy == "enable" {
+		if currentDeployment.DagDeployEnabled {
+			fmt.Println("\nDAG-only deploys is already enabled for this deployment.")
+			return nil
+		}
 		fmt.Printf("\nYou enabled DAG-only deploys for this Deployment. Running tasks will not be interrupted and new tasks will continue to be scheduled." +
 			"\nRun `astro deploy --dags` after this command to push new changes. It may take a few minutes for the Airflow UI to update..\n\n")
 		deploymentUpdate.DagDeployEnabled = true
 	} else if dagDeploy == "disable" {
+		if !currentDeployment.DagDeployEnabled {
+			fmt.Println("\nDAG-only deploys is already disabled for this deployment.")
+			return nil
+		}
 		if config.CFG.ShowWarnings.GetBool() {
 			i, _ := input.Confirm("\nWarning: This command will disable DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled" +
 				"\nRun `astro deploy` after this command to restart your DAGs. It may take a few minutes for the Airflow UI to update." +


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

do not enable/disable dag deploy if already enabled/disabled

## 🎟 Issue(s)

Related #879 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screen Shot 2022-11-16 at 15 03 27](https://user-images.githubusercontent.com/65428224/202313490-875149ff-5adc-478d-9056-cf32ec5dfaee.png)

![Screen Shot 2022-11-16 at 15 03 54](https://user-images.githubusercontent.com/65428224/202313539-30021367-5c3e-4712-9929-61f74a4b1c08.png)

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
