### PR TITLE
Check env file path on astro deploy

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -66,7 +66,7 @@ var (
 
 var (
 	errDagsParseFailed = errors.New("your local DAGs did not parse. Fix the listed errors or use `astro deploy [deployment-id] -f` to force deploy") //nolint:revive
-	envFileMissing     = errors.New("Env file path is incorrect")                                                                                    //nolint:revive
+	envFileMissing     = errors.New("Env file path is incorrect: ")                                                                                  //nolint:revive
 )
 
 type deploymentInfo struct {
@@ -253,7 +253,7 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 	} else {
 		envFileExists, _ := fileutil.Exists(deployInput.EnvFile, nil)
 		if !envFileExists {
-			return envFileMissing
+			return fmt.Errorf("%w %s", envFileMissing, deployInput.EnvFile)
 		}
 
 		if deployInfo.dagDeployEnabled && len(dagFiles) == 0 {

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -64,7 +64,10 @@ var (
 	azureUploader        = azure.Upload
 )
 
-var errDagsParseFailed = errors.New("your local DAGs did not parse. Fix the listed errors or use `astro deploy [deployment-id] -f` to force deploy") //nolint:revive
+var (
+	errDagsParseFailed = errors.New("your local DAGs did not parse. Fix the listed errors or use `astro deploy [deployment-id] -f` to force deploy") //nolint:revive
+	envFileMissing     = errors.New("Env file path is incorrect")                                                                                    //nolint:revive
+)
 
 type deploymentInfo struct {
 	deploymentID     string
@@ -248,6 +251,11 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 			fmt.Sprintf("\n Deployment View: %s", ansi.Bold(deploymentURL)) +
 			fmt.Sprintf("\n Airflow UI: %s", ansi.Bold(deployInfo.webserverURL)))
 	} else {
+		envFileExists, _ := fileutil.Exists(deployInput.EnvFile, nil)
+		if !envFileExists {
+			return envFileMissing
+		}
+
 		if deployInfo.dagDeployEnabled && len(dagFiles) == 0 {
 			fmt.Println("No DAGs found. Skipping DAG deploy.")
 		}

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -462,10 +462,18 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy stri
 	}
 
 	if dagDeploy == "enable" {
+		if currentDeployment.DagDeployEnabled {
+			fmt.Println("\nDAG-only deploys is already enabled for this deployment.")
+			return nil
+		}
 		fmt.Printf("\nYou enabled DAG-only deploys for this Deployment. Running tasks will not be interrupted and new tasks will continue to be scheduled." +
 			"\nRun `astro deploy --dags` after this command to push new changes. It may take a few minutes for the Airflow UI to update..\n\n")
 		deploymentUpdate.DagDeployEnabled = true
 	} else if dagDeploy == "disable" {
+		if !currentDeployment.DagDeployEnabled {
+			fmt.Println("\nDAG-only deploys is already disabled for this deployment.")
+			return nil
+		}
 		if config.CFG.ShowWarnings.GetBool() {
 			i, _ := input.Confirm("\nWarning: This command will disable DAG-only deploys for this Deployment. Running tasks will not be interrupted, but new tasks will not be scheduled" +
 				"\nRun `astro deploy` after this command to restart your DAGs. It may take a few minutes for the Airflow UI to update." +

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	astro "github.com/astronomer/astro-cli/astro-client"
@@ -73,4 +74,16 @@ func TestOrganizationExportAuditLogs(t *testing.T) {
 		_, err := execOrganizationCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})
+
+	// Delete audit logs exports
+	currentDir, _ := os.Getwd()
+	files, _ := os.ReadDir(currentDir)
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "audit-logs-") {
+			func() {
+				defer os.Remove(file.Name())
+			}
+		}
+	}
+	defer os.Remove("test.json")
 }

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -80,10 +80,8 @@ func TestOrganizationExportAuditLogs(t *testing.T) {
 	files, _ := os.ReadDir(currentDir)
 	for _, file := range files {
 		if strings.HasPrefix(file.Name(), "audit-logs-") {
-			func() {
-				defer os.Remove(file.Name())
-			}
+			os.Remove(file.Name())
 		}
 	}
-	defer os.Remove("test.json")
+	os.Remove("test.json")
 }


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Check env file path on astro deploy

## 🎟 Issue(s)

Related #874 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screen Shot 2022-11-16 at 17 32 46](https://user-images.githubusercontent.com/65428224/202332052-8f31fdee-8383-49f9-bb2f-804391ecb7a6.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
