### PR TITLE
Cleanup files after tests

### DIFF
--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -22,6 +22,7 @@ var (
 	auditLogsOutputFilePath            string
 	auditLogsEarliestParam             int
 	auditLogsEarliestParamDefaultValue = 90
+	auditLogsDefaultFileNamePrefix     = "audit-logs"
 	shouldDisplayLoginLink             bool
 )
 
@@ -131,7 +132,7 @@ func organizationExportAuditLogs(cmd *cobra.Command) error {
 	if auditLogsOutputFilePath != "" {
 		outputFileName = auditLogsOutputFilePath
 	} else {
-		outputFileName = fmt.Sprintf("audit-logs-%s.gz", time.Now().Format("2006-01-02-150405"))
+		outputFileName = fmt.Sprintf("%s-%s.gz", auditLogsDefaultFileNamePrefix, time.Now().Format("2006-01-02-150405"))
 	}
 
 	var filePerms fs.FileMode = 0o755

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -67,7 +68,7 @@ func TestOrganizationExportAuditLogs(t *testing.T) {
 		cmdArgs := []string{"audit-logs", "export", "--organization-name", "Astronomer"}
 		_, err := execOrganizationCmd(cmdArgs...)
 		assert.NoError(t, err)
-		files, err := filepath.Glob("audit-logs-*")
+		files, err := filepath.Glob(fmt.Sprintf("%s-*", auditLogsDefaultFileNamePrefix))
 		assert.NoError(t, err)
 		for _, f := range files {
 			err = os.Remove(f)

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	astro "github.com/astronomer/astro-cli/astro-client"
@@ -66,11 +67,19 @@ func TestOrganizationExportAuditLogs(t *testing.T) {
 		cmdArgs := []string{"audit-logs", "export", "--organization-name", "Astronomer"}
 		_, err := execOrganizationCmd(cmdArgs...)
 		assert.NoError(t, err)
+		files, err := filepath.Glob("audit-logs-*")
+		assert.NoError(t, err)
+		for _, f := range files {
+			err = os.Remove(f)
+			assert.NoError(t, err)
+		}
 	})
 
 	t.Run("with auditLogsOutputFilePath param", func(t *testing.T) {
 		cmdArgs := []string{"audit-logs", "export", "--organization-name", "Astronomer", "--output-file", "test.json"}
 		_, err := execOrganizationCmd(cmdArgs...)
+		assert.NoError(t, err)
+		err = os.Remove("test.json")
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Description

Fixes a bug in unit tests where some generated files are not cleaned up


## 🧪 Functional Testing

- test locally

## 📸 Screenshots

![Screen Shot 2022-11-17 at 3 21 01 PM](https://user-images.githubusercontent.com/3437048/202580805-ad1e2cb6-2ded-437d-b299-5a52d2fb03c4.png)
![before](https://user-images.githubusercontent.com/3437048/202580809-71e8fbce-f32a-450c-8c25-d2691d3c5ed6.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
