### PR TITLE
minor changes  to astro deployment inspect

### DIFF
--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -91,20 +91,20 @@ func getDeploymentInspectInfo(sourceDeployment *astro.Deployment) (map[string]in
 
 func getDeploymentConfig(sourceDeployment *astro.Deployment) map[string]interface{} {
 	return map[string]interface{}{
-		"name":               sourceDeployment.Label,
-		"description":        sourceDeployment.Description,
-		"cluster_id":         sourceDeployment.Cluster.ID,
-		"runtime_version":    sourceDeployment.RuntimeRelease.Version,
-		"scheduler_au":       sourceDeployment.DeploymentSpec.Scheduler.AU,
-		"scheduler_replicas": sourceDeployment.DeploymentSpec.Scheduler.Replicas,
+		"name":            sourceDeployment.Label,
+		"description":     sourceDeployment.Description,
+		"cluster_id":      sourceDeployment.Cluster.ID,
+		"runtime_version": sourceDeployment.RuntimeRelease.Version,
+		"scheduler_au":    sourceDeployment.DeploymentSpec.Scheduler.AU,
+		"scheduler_count": sourceDeployment.DeploymentSpec.Scheduler.Replicas,
 	}
 }
 
 func getAdditional(sourceDeployment *astro.Deployment) map[string]interface{} {
 	return map[string]interface{}{
-		"alert_emails":         sourceDeployment.AlertEmails,
-		"worker_queues":        getQMap(sourceDeployment.WorkerQueues),
-		"astronomer_variables": getVariablesMap(sourceDeployment.DeploymentSpec.EnvironmentVariablesObjects), // API only returns values when !EnvironmentVariablesObject.isSecret
+		"alert_emails":          sourceDeployment.AlertEmails,
+		"worker_queues":         getQMap(sourceDeployment.WorkerQueues),
+		"environment_variables": getVariablesMap(sourceDeployment.DeploymentSpec.EnvironmentVariablesObjects), // API only returns values when !EnvironmentVariablesObject.isSecret
 	}
 }
 
@@ -188,11 +188,11 @@ func getSpecificField(deploymentMap map[string]interface{}, requestedField strin
 func getPrintableDeployment(infoMap, configMap, additionalMap map[string]interface{}) map[string]interface{} {
 	printableDeployment := map[string]interface{}{
 		"deployment": map[string]interface{}{
-			"information":          infoMap,
-			"configuration":        configMap,
-			"alert_emails":         additionalMap["alert_emails"],
-			"worker_queues":        additionalMap["worker_queues"],
-			"astronomer_variables": additionalMap["astronomer_variables"],
+			"metadata":              infoMap,
+			"configuration":         configMap,
+			"alert_emails":          additionalMap["alert_emails"],
+			"worker_queues":         additionalMap["worker_queues"],
+			"environment_variables": additionalMap["environment_variables"],
 		},
 	}
 	return printableDeployment

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -16,16 +16,17 @@ import (
 )
 
 type deploymentMetadata struct {
-	DeploymentID   string    `mapstructure:"deployment_id" yaml:"deployment_id" json:"deployment_id"`
-	WorkspaceID    string    `mapstructure:"workspace_id" yaml:"workspace_id" json:"workspace_id"`
-	ClusterID      string    `mapstructure:"cluster_id" yaml:"cluster_id" json:"cluster_id"`
-	ReleaseName    string    `mapstructure:"release_name" yaml:"release_name" json:"release_name"`
-	AirflowVersion string    `mapstructure:"airflow_version" yaml:"airflow_version" json:"airflow_version"`
-	Status         string    `mapstructure:"status" yaml:"status" json:"status"`
-	CreatedAt      time.Time `mapstructure:"created_at" yaml:"created_at" json:"created_at"`
-	UpdatedAt      time.Time `mapstructure:"updated_at" yaml:"updated_at" json:"updated_at"`
-	DeploymentURL  string    `mapstructure:"deployment_url" yaml:"deployment_url" json:"deployment_url"`
-	WebserverURL   string    `mapstructure:"webserver_url" yaml:"webserver_url" json:"webserver_url"`
+	DeploymentID     string    `mapstructure:"deployment_id" yaml:"deployment_id" json:"deployment_id"`
+	WorkspaceID      string    `mapstructure:"workspace_id" yaml:"workspace_id" json:"workspace_id"`
+	ClusterID        string    `mapstructure:"cluster_id" yaml:"cluster_id" json:"cluster_id"`
+	ReleaseName      string    `mapstructure:"release_name" yaml:"release_name" json:"release_name"`
+	AirflowVersion   string    `mapstructure:"airflow_version" yaml:"airflow_version" json:"airflow_version"`
+	DagDeployEnabled bool      `mapstructure:"dag_deploy_enabled" yaml:"dag_deploy_enabled" json:"dag_deploy_enabled"`
+	Status           string    `mapstructure:"status" yaml:"status" json:"status"`
+	CreatedAt        time.Time `mapstructure:"created_at" yaml:"created_at" json:"created_at"`
+	UpdatedAt        time.Time `mapstructure:"updated_at" yaml:"updated_at" json:"updated_at"`
+	DeploymentURL    string    `mapstructure:"deployment_url" yaml:"deployment_url" json:"deployment_url"`
+	WebserverURL     string    `mapstructure:"webserver_url" yaml:"webserver_url" json:"webserver_url"`
 }
 
 type deploymentConfig struct {
@@ -91,7 +92,7 @@ func Inspect(wsID, deploymentName, deploymentID, outputFormat string, client ast
 	}
 
 	// create a map for deployment.information
-	deploymentInfoMap, err = getDeploymentInspectInfo(&requestedDeployment)
+	deploymentInfoMap, err = getDeploymentInfo(&requestedDeployment)
 	if err != nil {
 		return err
 	}
@@ -119,7 +120,7 @@ func Inspect(wsID, deploymentName, deploymentID, outputFormat string, client ast
 	return nil
 }
 
-func getDeploymentInspectInfo(sourceDeployment *astro.Deployment) (map[string]interface{}, error) {
+func getDeploymentInfo(sourceDeployment *astro.Deployment) (map[string]interface{}, error) {
 	var (
 		deploymentURL string
 		err           error
@@ -130,16 +131,17 @@ func getDeploymentInspectInfo(sourceDeployment *astro.Deployment) (map[string]in
 		return nil, err
 	}
 	return map[string]interface{}{
-		"deployment_id":   sourceDeployment.ID,
-		"workspace_id":    sourceDeployment.Workspace.ID,
-		"cluster_id":      sourceDeployment.Cluster.ID,
-		"airflow_version": sourceDeployment.RuntimeRelease.AirflowVersion,
-		"release_name":    sourceDeployment.ReleaseName,
-		"deployment_url":  deploymentURL,
-		"webserver_url":   sourceDeployment.DeploymentSpec.Webserver.URL,
-		"created_at":      sourceDeployment.CreatedAt,
-		"updated_at":      sourceDeployment.UpdatedAt,
-		"status":          sourceDeployment.Status,
+		"deployment_id":      sourceDeployment.ID,
+		"workspace_id":       sourceDeployment.Workspace.ID,
+		"cluster_id":         sourceDeployment.Cluster.ID,
+		"airflow_version":    sourceDeployment.RuntimeRelease.AirflowVersion,
+		"release_name":       sourceDeployment.ReleaseName,
+		"deployment_url":     deploymentURL,
+		"webserver_url":      sourceDeployment.DeploymentSpec.Webserver.URL,
+		"created_at":         sourceDeployment.CreatedAt,
+		"updated_at":         sourceDeployment.UpdatedAt,
+		"status":             sourceDeployment.Status,
+		"dag_deploy_enabled": sourceDeployment.DagDeployEnabled,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

This pr adds ordered output when printing deployments. Also renamed a few keys based on user feedback.

## 🎟 Issue(s)

Related #876 

## 🧪 Functional Testing

### yaml output
```bash
$ astro deployment inspect claaesqk6329512z1h8f62bn12
deployment:
    environment_variables:
        - is_secret: true
          key: FOO
          updated_at: "2022-11-10T01:48:09.961Z"
          value: ""
    configuration:
        name: andytest
        description: ""
        runtime_version: 6.0.3
        scheduler_au: 5
        scheduler_count: 1
        cluster_id: cl6zcnlc600ht0vuibivf53jh
    worker_queues:
        - name: default
          id: claaesqk7329542z1h9u8isby3
          is_default: true
          max_worker_count: 10
          min_worker_count: 0
          worker_concurrency: 16
          node_pool_id: cl6zcnlc8395442eui99mvlqhv
    metadata:
        deployment_id: claaesqk6329512z1h8f62bn12
        workspace_id: cl6wg2zra144002dyw8px6t6ip
        cluster_id: cl6zcnlc600ht0vuibivf53jh
        release_name: combusting-velocity-9074
        airflow_version: 2.4.2
        dag_deploy_enabled: false
        status: HEALTHY
        created_at: 2022-11-10T01:46:26.55Z
        updated_at: 2022-11-11T18:05:22.567Z
        deployment_url: cloud.astronomer-dev.io/cl6wg2zra144002dyw8px6t6ip/deployments/claaesqk6329512z1h8f62bn12/analytics
        webserver_url: astronomer.astronomer-dev.run/df62bn12?orgId=org_dlgevirUCwI9vX10
    alert_emails: []
```
### json output
```bash
$ astro deployment inspect claaesqk6329512z1h8f62bn12 -o json

{
    "deployment": {
        "environment_variables": [
            {
                "is_secret": true,
                "key": "FOO",
                "updated_at": "2022-11-10T01:48:09.961Z",
                "value": ""
            }
        ],
        "configuration": {
            "name": "andytest",
            "description": "",
            "runtime_version": "6.0.3",
            "scheduler_au": 5,
            "scheduler_count": 1,
            "cluster_id": "cl6zcnlc600ht0vuibivf53jh"
        },
        "worker_queues": [
            {
                "name": "default",
                "id": "claaesqk7329542z1h9u8isby3",
                "is_default": true,
                "max_worker_count": 10,
                "min_worker_count": 0,
                "worker_concurrency": 16,
                "node_pool_id": "cl6zcnlc8395442eui99mvlqhv"
            }
        ],
        "metadata": {
            "deployment_id": "claaesqk6329512z1h8f62bn12",
            "workspace_id": "cl6wg2zra144002dyw8px6t6ip",
            "cluster_id": "cl6zcnlc600ht0vuibivf53jh",
            "release_name": "combusting-velocity-9074",
            "airflow_version": "2.4.2",
            "dag_deploy_enabled": false,
            "status": "HEALTHY",
            "created_at": "2022-11-10T01:46:26.55Z",
            "updated_at": "2022-11-11T18:05:22.567Z",
            "deployment_url": "cloud.astronomer-dev.io/cl6wg2zra144002dyw8px6t6ip/deployments/claaesqk6329512z1h8f62bn12/analytics",
            "webserver_url": "astronomer.astronomer-dev.run/df62bn12?orgId=org_dlgevirUCwI9vX10"
        },
        "alert_emails": []
    }
}
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
