### PR TITLE
skip tests when no dags available

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -268,9 +268,13 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 			return err
 		}
 
-		err = parseOrPytestDAG(deployInput.Pytest, version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
-		if err != nil {
-			return err
+		if len(dagFiles) > 0 {
+			err = parseOrPytestDAG(deployInput.Pytest, version, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace)
+			if err != nil {
+				return err
+			}
+		} else {
+			fmt.Println("No DAGs found. Skipping testing...")
 		}
 
 		// Create the image

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -589,6 +589,8 @@ func TestDeployFailure(t *testing.T) {
 	path := "./testfiles/dags/test.py"
 	fileutil.WriteStringToFile(path, "testing")
 
+	defer os.RemoveAll("./testfiles/dags/")
+
 	// no context set failure
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	err := config.ResetCurrentContext()
@@ -673,8 +675,6 @@ func TestDeployFailure(t *testing.T) {
 	deployInput.EnvFile = "invalid-path"
 	err = Deploy(deployInput, mockClient)
 	assert.ErrorIs(t, err, envFileMissing)
-
-	defer os.RemoveAll("./testfiles/dags/")
 
 	mockClient.AssertExpectations(t)
 	mockImageHandler.AssertExpectations(t)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -585,6 +585,10 @@ func TestNoDagsDeployVR(t *testing.T) {
 }
 
 func TestDeployFailure(t *testing.T) {
+	os.Mkdir("./testfiles/dags", os.ModePerm)
+	path := "./testfiles/dags/test.py"
+	fileutil.WriteStringToFile(path, "testing")
+
 	// no context set failure
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	err := config.ResetCurrentContext()
@@ -669,6 +673,8 @@ func TestDeployFailure(t *testing.T) {
 	deployInput.EnvFile = "invalid-path"
 	err = Deploy(deployInput, mockClient)
 	assert.ErrorIs(t, err, envFileMissing)
+
+	defer os.RemoveAll("./testfiles/dags/")
 
 	mockClient.AssertExpectations(t)
 	mockImageHandler.AssertExpectations(t)

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -464,8 +464,9 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy stri
 			fmt.Println("\nDAG-only deploys is already enabled for this deployment.")
 			return nil
 		}
-		fmt.Printf("\nYou enabled DAG-only deploys for this Deployment. Running tasks will not be interrupted and new tasks will continue to be scheduled." +
-			"\nRun `astro deploy --dags` after this command to push new changes. It may take a few minutes for the Airflow UI to update..\n\n")
+
+		fmt.Printf("\nYou enabled DAG-only deploys for this Deployment. Running tasks are not interrupted but new tasks will not be scheduled." +
+			"\nRun `astro deploy --dags` to complete enabling this feature and resume your DAGs. It may take a few minutes for the Airflow UI to update..\n\n")
 		deploymentUpdate.DagDeployEnabled = true
 	} else if dagDeploy == "disable" {
 		if !currentDeployment.DagDeployEnabled {


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Skip tests when no dags available

## 🎟 Issue(s)

Related #869 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screen Shot 2022-11-18 at 10 30 15](https://user-images.githubusercontent.com/65428224/202777274-d01a9065-c57a-4b4d-9fb9-cdd250dc0a5b.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
