### PR TITLE
Fix flow docker build

### DIFF
--- a/sql/flow.go
+++ b/sql/flow.go
@@ -50,6 +50,9 @@ func displayMessages(r io.Reader) error {
 		if jsonMessage.Stream == "\n" {
 			continue
 		}
+		if jsonMessage.Error != nil {
+			return jsonMessage.Error
+		}
 		// We only print steps which are actually running, e.g.
 		// Step 2/4 : ENV ASTRO_CLI Yes
 		//  ---> Running in 0afb2e0c5ad7

--- a/sql/flow_config.go
+++ b/sql/flow_config.go
@@ -62,7 +62,7 @@ func GetBaseDockerImageURI(configURL string) (string, error) {
 	var resp configResponse
 	err = json.NewDecoder(res.Body).Decode(&resp)
 	if err != nil {
-		return defaultDockerImageURI, fmt.Errorf("error parsing the base docker image from the configuration file: %w", err)
+		return defaultDockerImageURI, fmt.Errorf("error parsing the base docker image from the configuration file: %w. Using the default", err)
 	}
 
 	return resp.BaseDockerImage, nil

--- a/sql/include/dockerfile_content.go
+++ b/sql/include/dockerfile_content.go
@@ -7,6 +7,10 @@ import "strings"
 var Dockerfile = strings.TrimSpace(`
 FROM %s
 
+# build-essential is necessary to be able to build wheels for snowflake-connector-python
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+        build-essential
+
 ENV ASTRO_CLI Yes
 
 RUN pip install astro-sql-cli==%s


### PR DESCRIPTION
## Description

Currently, the flow docker build does not forward build errors from inside the container to the user hence it silently failed building. We noticed that it was re-installing every-time we run a command.

- add build-essential to system deps; note that this is required for snowflake-connector-python
- forward build errors to user

## 🎟 Issue(s)

Related #882, #860

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
