### PR TITLE
Disable astronomer update-check in flow env

### DIFF
--- a/sql/include/dockerfile_content.go
+++ b/sql/include/dockerfile_content.go
@@ -8,6 +8,7 @@ var Dockerfile = strings.TrimSpace(`
 FROM %s
 
 ENV ASTRO_CLI Yes
+ENV AIRFLOW__ASTRONOMER__UPDATE_CHECK_INTERVAL 0
 
 # build-essential is necessary to be able to build wheels for snowflake-connector-python
 RUN apt-install-and-clean \


### PR DESCRIPTION
## Description

Currently, when running flow in the astro-runtime image we continuously check for updates. This is not necessary for the flow environment.

Furthermore, the flow command will only be used locally hence when we deploy to astro (cloud) we will use a different image  for running this workflow anyway.

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-sdk/pull/1286

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
