### PR TITLE
Fix flow command generate-tasks default

### DIFF
--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -280,7 +280,7 @@ func generateCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.SetHelpFunc(executeHelp)
-	cmd.Flags().BoolVar(&generateTasks, "generate-tasks", true, "")
+	cmd.Flags().BoolVar(&generateTasks, "generate-tasks", false, "")
 	cmd.Flags().BoolVar(&noGenerateTasks, "no-generate-tasks", false, "")
 	cmd.Flags().StringVar(&environment, "env", "default", "")
 	cmd.Flags().StringVar(&projectDir, "project-dir", ".", "")
@@ -298,7 +298,7 @@ func runCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.SetHelpFunc(executeHelp)
-	cmd.Flags().BoolVar(&generateTasks, "generate-tasks", true, "")
+	cmd.Flags().BoolVar(&generateTasks, "generate-tasks", false, "")
 	cmd.Flags().BoolVar(&noGenerateTasks, "no-generate-tasks", false, "")
 	cmd.Flags().StringVar(&environment, "env", "default", "")
 	cmd.Flags().StringVar(&projectDir, "project-dir", ".", "")


### PR DESCRIPTION
## Description

We should not set the default to true as this would set the option - not use the typer cli default. This is, especially, important when the option does not exist as in the current sql-cli version 0.1.1. It will become available when 0.2.0 is released.

FYI https://github.com/astronomer/astro-sdk/blob/main/sql-cli/sql_cli/__main__.py#L69 is where we define the default.

## 🎟 Issue(s)

Related #893 

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
