### PR TITLE
Fix SQL CLI on Linux (1.8 release)

### DIFF
--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -41,6 +41,7 @@ func createProjectDir(projectDir string) (mountDir string, err error) {
 	}
 
 	err = os.MkdirAll(projectDir, os.ModePerm)
+
 	if err != nil {
 		err = fmt.Errorf("error creating project directory %s: %w", projectDir, err)
 		return "", err

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
 	"strings"
 
 	"github.com/astronomer/astro-cli/sql/include"
@@ -58,7 +59,7 @@ func displayMessages(r io.Reader) error {
 		//  ---> Running in 0afb2e0c5ad7
 		if strings.HasPrefix(prevMessage.Stream, "Step ") && strings.HasPrefix(jsonMessage.Stream, " ---> Running in ") {
 			if isFirstMessage {
-				fmt.Println("Installing flow.. This might take some time.")
+				fmt.Println("Installing flow... This might take some time.")
 				isFirstMessage = false
 			}
 			err := prevMessage.Display(os.Stdout, true)
@@ -122,12 +123,14 @@ func CommonDockerUtil(cmd, args []string, flags map[string]string, mountDirs []s
 		binds = append(binds, fmt.Sprintf("%s:%s", mountDir, mountDir))
 	}
 
+	currentUser, _ := user.Current()
 	resp, err := cli.ContainerCreate(
 		ctx,
 		&container.Config{
 			Image: SQLCliDockerImageName,
 			Cmd:   cmd,
 			Tty:   true,
+			User:  currentUser.Uid,
 		},
 		&container.HostConfig{
 			Binds: binds,

--- a/sql/flow_test.go
+++ b/sql/flow_test.go
@@ -108,7 +108,7 @@ func TestDisplayMessages(t *testing.T) {
 
 	w.Close()
 	out, _ := io.ReadAll(r)
-	expectedOutput := `Installing flow.. This might take some time.
+	expectedOutput := `Installing flow... This might take some time.
 Step 2/4 : ENV ASTRO_CLI Yes
 `
 	assert.Equal(t, expectedOutput, string(out))

--- a/sql/include/dockerfile_content.go
+++ b/sql/include/dockerfile_content.go
@@ -15,4 +15,12 @@ RUN apt-install-and-clean \
         build-essential
 
 RUN pip install astro-sql-cli==%s
+
+# This is necessary to run the docker image in GNU Linux since Astro CLI 1.8
+# It is temporary, since some SQL commands still rely on the default airflow config
+# https://github.com/astronomer/astro-sdk/issues/1219
+RUN chmod -R 777 /usr/local/airflow
+
+# override Runtime ENTRYPOINT in a way it's cached (empty ENTRYPOINT [] isn't)
+ENTRYPOINT ["/usr/bin/env"]
 `)


### PR DESCRIPTION
## Description
Since we changed the based docker image to run the SQL CLI (1.8 RC, #882 ), the SQL features stopped working on Linux.

In short, the issue happened after we changed the base image to run SQL CLI commands to use the Astro Runtime. SInce it uses a different user (`astro`), that user did not have permission to write in the mounted volumes. This PR makes a couple of tweaks so things work as expected.

## 🧪 Functional Testing

Under GNU LInux (e.g Ubuntu), run:
```
$ make build
$ ./astro flow init some-proj
```

As of 1.8, the `flow init` command was raising the following exception in Linux (not in MacOs):
```
Error: [('/usr/local/lib/python3.9/site-packages/include/base/data', 
'/home/tati/Projects/proj18-r/data', "[Errno 13] Permission denied: 
'/home/tati/Projects/proj18-r/data'"), 
('/usr/local/lib/python3.9/site-packages/include/base/workflows', 
'/home/tati/Projects/proj18-r/workflows', "[Errno 13] Permission denied: 
'/home/tati/Projects/proj18-r/workflows'"), 
('/usr/local/lib/python3.9/site-packages/include/base/.airflow', 
'/home/tati/Projects/proj18-r/.airflow', "[Errno 13] Permission denied: 
'/home/tati/Projects/proj18-r/.airflow'"), 
('/usr/local/lib/python3.9/site-packages/include/base/config', 
'/home/tati/Projects/proj18-r/config', "[Errno 13] Permission denied: 
'/home/tati/Projects/proj18-r/config'"), 
(PosixPath('/usr/local/lib/python3.9/site-packages/include/base'), 
PosixPath('/home/tati/Projects/proj18-r'), '[Errno 1] Operation not permitted')]

```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
