### PR TITLE
Fix SQL flow run

### DIFF
--- a/sql/include/dockerfile_content.go
+++ b/sql/include/dockerfile_content.go
@@ -16,11 +16,15 @@ RUN apt-install-and-clean \
 
 RUN pip install astro-sql-cli==%s
 
+RUN useradd --uid %s --create-home %s
 # This is necessary to run the docker image in GNU Linux since Astro CLI 1.8
 # It is temporary, since some SQL commands still rely on the default airflow config
 # https://github.com/astronomer/astro-sdk/issues/1219
 RUN chmod -R 777 /usr/local/airflow
 
+
 # override Runtime ENTRYPOINT in a way it's cached (empty ENTRYPOINT [] isn't)
 ENTRYPOINT ["/usr/bin/env"]
+
+
 `)


### PR DESCRIPTION
## Description

As part of Astro CLI 1.8.2, although all the other SQL commands worked fine, the `astro flow run` did not:
<img width="739" alt="Screenshot 2022-11-24 at 10 01 30 AM" src="https://user-images.githubusercontent.com/272048/203762938-ccef1bcc-2c40-4ca6-b9fb-6bcf8a866b89.png">

## 🧪 Functional Testing


```
$ ./astro flow init ~/Projects/abc
Initialized an Astro SQL project at /home/tati/Projects/abc

$ ./astro flow validate /home/tati/Projects/abc
Validating connection(s) for environment 'default'
Validating connection sqlite_conn               PASSED


$./astro flow run example_basic_transform --project-dir /home/tati/Projects/abc
Running the workflow example_basic_transform for default environment
Processing top_animations... SUCCESS
Completed running the workflow example_basic_transform. Final state: SUCCESS 🚀


```


## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
