### PR TITLE
improve login flow

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
-
-	"github.com/astronomer/astro-cli/pkg/domainutil"
 
 	astro "github.com/astronomer/astro-cli/astro-client"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	cloudAuth "github.com/astronomer/astro-cli/cloud/auth"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/domainutil"
+	"github.com/astronomer/astro-cli/pkg/input"
 	softwareAuth "github.com/astronomer/astro-cli/software/auth"
 
 	"github.com/spf13/cobra"
@@ -60,7 +61,20 @@ func login(cmd *cobra.Command, args []string, astroClient astro.Client, coreClie
 	cmd.SilenceUsage = true
 
 	if len(args) == 1 {
+		// check if user provided a valid cloud domain
 		if !context.IsCloudDomain(args[0]) {
+			// get the domain from context as an extra check
+			ctx, _ := context.GetCurrentContext()
+			if context.IsCloudDomain(ctx.Domain) {
+				// print an error if context domain is a valid cloud domain
+				fmt.Fprintf(out, "Error: %s is an invalid domain to login into Astro.\n", args[0])
+				// give the user an option to login to software
+				y, _ := input.Confirm("Are you trying to authenticate to Astronomer Software?")
+				if !y {
+					fmt.Println("Canceling login...")
+					return nil
+				}
+			}
 			return softwareLogin(args[0], oAuth, "", "", houstonVersion, houstonClient, out)
 		}
 		return cloudLogin(args[0], "", token, astroClient, coreClient, out, shouldDisplayLoginLink)

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -41,6 +41,7 @@ func TestLogin(t *testing.T) {
 	login(&cobra.Command{}, []string{cloudDomain}, nil, nil, buf)
 
 	// software login success
+	testUtil.InitTestConfig(testUtil.Initial)
 	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, buf)
 
 	// no domain, cloud login
@@ -54,6 +55,18 @@ func TestLogin(t *testing.T) {
 	// no domain, no current context set
 	config.ResetCurrentContext()
 	login(&cobra.Command{}, []string{}, nil, nil, buf)
+
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	defer testUtil.MockUserInput(t, "n")()
+	login(&cobra.Command{}, []string{"fail.astronomer.io"}, nil, nil, buf)
+	assert.Contains(t, buf.String(), "fail.astronomer.io is an invalid domain to login into Astro.\n")
+
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	softwareDomain = "software.astronomer.io"
+	buf = new(bytes.Buffer)
+	defer testUtil.MockUserInput(t, "y")()
+	login(&cobra.Command{}, []string{"software.astronomer.io"}, nil, nil, buf)
+	assert.Contains(t, buf.String(), "software.astronomer.io is an invalid domain to login into Astro.\n")
 }
 
 func TestLogout(t *testing.T) {


### PR DESCRIPTION
## Description

This PR improves UX when a user provides an incorrect cloud domain when logging in. Before this, the invalid domain would incorrectly try and login into a software context as shown below:

```bash
$ astro login fail.astronomer.io
 CLUSTER                             WORKSPACE
 fail.astronomer.io                  N/A
Error: HTTP DO Failed: Post "https://houston.fail.astronomer.io:443/v1": dial tcp: lookup houston.fail.astronomer.io on 192.168.86.1:53: no such host
```
With this PR we do an extra check on the user's context and print an error if their context was previously set to log into a valid cloud domain. Additionally we give the user an option to login to astronomer software if they want.

## 🎟 Issue(s)

Related #747 

## 🧪 Functional Testing

```bash
$ astro login fail.astronomer.io
Error: fail.astronomer.io is an invalid domain to login into Astro.
Are you trying to authenticate to Astronomer Software? (y/n) n
Canceling login...
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
