### PR TITLE
Fix deployment delete hard delete functionality

### DIFF
--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -27,7 +27,7 @@ type UpdateDeploymentImageRequest struct {
 // DeleteDeploymentRequest - properties to delete a deployment
 type DeleteDeploymentRequest struct {
 	DeploymentID string `json:"deploymentId"`
-	HardDelete   bool   `json:"delpoymentHardDelete"`
+	HardDelete   bool   `json:"deploymentHardDelete"`
 }
 
 var (


### PR DESCRIPTION
## Description
Changes:
- Fixed typo related to hard delete field name in delete deployment mutation

## 🎟 Issue(s)

Related #913 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
