### PR TITLE
remove con_uri from object export

### DIFF
--- a/settings/settings.go
+++ b/settings/settings.go
@@ -455,7 +455,6 @@ func ExportConnections(id string) error {
 			ConnLogin:    connections[i].ConnLogin,
 			ConnPassword: connections[i].ConnPassword,
 			ConnPort:     port,
-			ConnURI:      connections[i].ConnURI,
 			ConnExtra:    connections[i].ConnExtra,
 		}
 


### PR DESCRIPTION
## Description

Remove con_uri from object export to make the command compatible with `astro run`

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/915

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
