### PR TITLE
add the correct .ndjson extention to audit log filename

### DIFF
--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -134,7 +134,7 @@ func organizationExportAuditLogs(cmd *cobra.Command) error {
 	if auditLogsOutputFilePath != "" {
 		outputFileName = auditLogsOutputFilePath
 	} else {
-		outputFileName = fmt.Sprintf("audit-logs-%s.gz", time.Now().Format("2006-01-02-150405"))
+		outputFileName = fmt.Sprintf("audit-logs-%s.ndjson.gz", time.Now().Format("2006-01-02-150405"))
 	}
 
 	var filePerms fs.FileMode = 0o755


### PR DESCRIPTION
## Description

We were just producing a `.gz` file. The correct format is [ndjson](http://ndjson.org/).

## 🎟 Issue(s)

[Related #6739](https://app.zenhub.com/workspaces/managed-airflow---admin-625732835c23b0001411e270/issues/astronomer/astro/6739)

## 🧪 Functional Testing

![Screenshot 2022-12-01 at 3 00 37 PM](https://user-images.githubusercontent.com/3437048/205177131-2fa54753-476b-45ec-af5b-40eb2a8e2ff7.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
