### PR TITLE
Add config command and call config command to mount airflow dirs

### DIFF
--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -152,6 +152,20 @@ func TestFlowInitCmdWithFlags(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestFlowConfigCmd(t *testing.T) {
+	projectDir := t.TempDir()
+	AirflowHome := t.TempDir()
+	AirflowDagsFolder := t.TempDir()
+	err := execFlowCmd("init", projectDir, "--airflow-home", AirflowHome, "--airflow-dags-folder", AirflowDagsFolder)
+	assert.NoError(t, err)
+
+	err = execFlowCmd("config", "--project-dir", projectDir, "--key", "airflow_home")
+	assert.NoError(t, err)
+
+	err = execFlowCmd("config", "--project-dir", projectDir)
+	assert.EqualError(t, err, "required flag(s) \"key\" not set")
+}
+
 func TestFlowValidateCmd(t *testing.T) {
 	patchDockerClientInit(t, 0, nil)
 	projectDir := t.TempDir()

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -159,11 +159,11 @@ func TestFlowConfigCmd(t *testing.T) {
 	err := execFlowCmd("init", projectDir, "--airflow-home", AirflowHome, "--airflow-dags-folder", AirflowDagsFolder)
 	assert.NoError(t, err)
 
-	err = execFlowCmd("config", "--project-dir", projectDir, "--key", "airflow_home")
+	err = execFlowCmd("config", "--project-dir", projectDir, "airflow_home")
 	assert.NoError(t, err)
 
 	err = execFlowCmd("config", "--project-dir", projectDir)
-	assert.EqualError(t, err, "required flag(s) \"key\" not set")
+	assert.EqualError(t, err, "argument not set:key")
 }
 
 func TestFlowValidateCmd(t *testing.T) {

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -74,7 +74,7 @@ func displayMessages(r io.Reader) error {
 	return nil
 }
 
-func ConvertReadCloserToString(readCloser io.ReadCloser) (string, error) {
+var ConvertReadCloserToString = func(readCloser io.ReadCloser) (string, error) {
 	buf := new(strings.Builder)
 	_, err := Io().Copy(buf, readCloser)
 	if err != nil {
@@ -83,7 +83,7 @@ func ConvertReadCloserToString(readCloser io.ReadCloser) (string, error) {
 	return buf.String(), nil
 }
 
-func CommonDockerUtil(cmd, args []string, flags map[string]string, mountDirs []string, returnOutput bool) (exitCode int64, output io.ReadCloser, err error) {
+var CommonDockerUtil = func(cmd, args []string, flags map[string]string, mountDirs []string, returnOutput bool) (exitCode int64, output io.ReadCloser, err error) {
 	var statusCode int64
 	var cout io.ReadCloser
 
@@ -94,7 +94,7 @@ func CommonDockerUtil(cmd, args []string, flags map[string]string, mountDirs []s
 		return statusCode, cout, fmt.Errorf("docker client initialization failed %w", err)
 	}
 
-	astroSQLCliVersion, err := getPypiVersion(astroSQLCLIProjectURL)
+	astroSQLCliVersion, err := "0.2.2a3", nil
 	if err != nil {
 		return statusCode, cout, err
 	}

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -93,7 +93,7 @@ func captureStdout(sourceOutput io.ReadCloser) (string, error) {
 	return outputLogs, nil
 }
 
-func CommonDockerUtil(cmd, args []string, flags map[string]string, mountDirs []string, returnStdout bool) (int64, string, error) {
+func CommonDockerUtil(cmd, args []string, flags map[string]string, mountDirs []string, returnStdout bool) (exitCode int64, output string, err error) {
 	var statusCode int64
 	ctx := context.Background()
 
@@ -181,7 +181,6 @@ func CommonDockerUtil(cmd, args []string, flags map[string]string, mountDirs []s
 
 	cout, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
 	if err != nil {
-
 		return statusCode, "", fmt.Errorf("docker container logs fetching failed %w", err)
 	}
 

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -76,7 +76,7 @@ func displayMessages(r io.Reader) error {
 
 func ConvertReadCloserToString(readCloser io.ReadCloser) (string, error) {
 	buf := new(strings.Builder)
-	_, err := io.Copy(buf, readCloser)
+	_, err := Io().Copy(buf, readCloser)
 	if err != nil {
 		return "", fmt.Errorf("converting readcloser output to string failed %w", err)
 	}

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -94,7 +94,7 @@ var CommonDockerUtil = func(cmd, args []string, flags map[string]string, mountDi
 		return statusCode, cout, fmt.Errorf("docker client initialization failed %w", err)
 	}
 
-	astroSQLCliVersion, err := "0.2.2a3", nil
+	astroSQLCliVersion, err := getPypiVersion(astroSQLCLIProjectURL)
 	if err != nil {
 		return statusCode, cout, err
 	}

--- a/sql/flow_test.go
+++ b/sql/flow_test.go
@@ -74,7 +74,11 @@ func TestCommonDockerUtilWithReturnValue(t *testing.T) {
 	DisplayMessages = mockDisplayMessagesNil
 	_, output, err := CommonDockerUtil(testCommand, nil, map[string]string{"flag": "value"}, []string{"mountDirectory"}, true)
 	assert.NoError(t, err)
-	assert.Equal(t, "Sample log", output)
+
+	outputString, err := ConvertReadCloserToString(output)
+	assert.NoError(t, err)
+	assert.Equal(t, "Sample log", outputString)
+
 	mockDockerBinder.AssertExpectations(t)
 	DisplayMessages = displayMessages
 }

--- a/sql/flow_test.go
+++ b/sql/flow_test.go
@@ -312,3 +312,15 @@ func TestContainerRemoveFailure(t *testing.T) {
 	DisplayMessages = displayMessages
 	Io = NewIoBind
 }
+
+func TestConvertReadCloserToStringFailure(t *testing.T) {
+	mockIo := mocks.NewIoBind(t)
+	Io = func() IoBind {
+		mockIo.On("Copy", mock.Anything, mock.Anything).Return(int64(0), errMock)
+		return mockIo
+	}
+	_, err := ConvertReadCloserToString(io.NopCloser(strings.NewReader("Hello, world!")))
+	expectedErr := fmt.Errorf("converting readcloser output to string failed %w", errMock)
+	assert.Equal(t, expectedErr, err)
+	Io = NewIoBind
+}

--- a/sql/flow_test.go
+++ b/sql/flow_test.go
@@ -60,6 +60,25 @@ func getContainerWaitResponse(raiseError bool) (bodyCh <-chan container.Containe
 	return readOnlyStatusCh, readOnlyErrCh
 }
 
+func TestCommonDockerUtilWithReturnValue(t *testing.T) {
+	mockDockerBinder := new(mocks.DockerBind)
+	Docker = func() (DockerBind, error) {
+		mockDockerBinder.On("ImageBuild", mock.Anything, mock.Anything, mock.Anything).Return(imageBuildResponse, nil)
+		mockDockerBinder.On("ContainerCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(containerCreateCreatedBody, nil)
+		mockDockerBinder.On("ContainerStart", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockDockerBinder.On("ContainerWait", mock.Anything, mock.Anything, mock.Anything).Return(getContainerWaitResponse(false))
+		mockDockerBinder.On("ContainerLogs", mock.Anything, mock.Anything, mock.Anything).Return(sampleLog, nil)
+		mockDockerBinder.On("ContainerRemove", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		return mockDockerBinder, nil
+	}
+	DisplayMessages = mockDisplayMessagesNil
+	_, output, err := CommonDockerUtil(testCommand, nil, map[string]string{"flag": "value"}, []string{"mountDirectory"}, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "Sample log", output)
+	mockDockerBinder.AssertExpectations(t)
+	DisplayMessages = displayMessages
+}
+
 func TestCommonDockerUtilSuccess(t *testing.T) {
 	mockDocker := mocks.NewDockerBind(t)
 	Docker = func() (DockerBind, error) {
@@ -77,7 +96,7 @@ func TestCommonDockerUtilSuccess(t *testing.T) {
 		return mockOs
 	}
 	DisplayMessages = mockDisplayMessagesNil
-	_, err := CommonDockerUtil(testCommand, nil, map[string]string{"flag": "value"}, []string{"mountDirectory"})
+	_, _, err := CommonDockerUtil(testCommand, nil, map[string]string{"flag": "value"}, []string{"mountDirectory"}, false)
 	assert.NoError(t, err)
 	DisplayMessages = displayMessages
 	Os = NewOsBind
@@ -127,21 +146,21 @@ func TestDockerClientInitFailure(t *testing.T) {
 	Docker = func() (DockerBind, error) {
 		return nil, errMock
 	}
-	_, err := CommonDockerUtil(testCommand, nil, map[string]string{"flag": "value"}, []string{"mountDirectory"})
+	_, _, err := CommonDockerUtil(testCommand, nil, map[string]string{"flag": "value"}, []string{"mountDirectory"}, false)
 	expectedErr := fmt.Errorf("docker client initialization failed %w", errMock)
 	assert.Equal(t, expectedErr, err)
 }
 
 func TestGetPypiVersionFailure(t *testing.T) {
 	getPypiVersion = mockGetPypiVersionErr
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	assert.ErrorIs(t, err, errMock)
 	getPypiVersion = GetPypiVersion
 }
 
 func TestGetBaseDockerImageURI(t *testing.T) {
 	getBaseDockerImageURI = mockBaseDockerImageURIErr
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	assert.ErrorIs(t, err, errMock)
 	getBaseDockerImageURI = GetBaseDockerImageURI
 }
@@ -152,7 +171,7 @@ func TestOsWriteFileErr(t *testing.T) {
 		mockOs.On("WriteFile", mock.Anything, mock.Anything, mock.Anything).Return(errMock)
 		return mockOs
 	}
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	assert.ErrorIs(t, err, errMock)
 	Os = NewOsBind
 }
@@ -163,7 +182,7 @@ func TestImageBuildFailure(t *testing.T) {
 		mockDocker.On("ImageBuild", mock.Anything, mock.Anything, mock.Anything).Return(imageBuildResponse, errMock)
 		return mockDocker, nil
 	}
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	expectedErr := fmt.Errorf("image building failed %w", errMock)
 	assert.Equal(t, expectedErr, err)
 }
@@ -175,7 +194,7 @@ func TestImageBuildResponseDisplayMessagesFailure(t *testing.T) {
 		return mockDocker, nil
 	}
 	DisplayMessages = mockDisplayMessagesErr
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	expectedErr := fmt.Errorf("image build response read failed %w", errMock)
 	assert.Equal(t, expectedErr, err)
 	DisplayMessages = displayMessages
@@ -189,7 +208,7 @@ func TestContainerCreateFailure(t *testing.T) {
 		return mockDocker, nil
 	}
 	DisplayMessages = mockDisplayMessagesNil
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	expectedErr := fmt.Errorf("docker container creation failed %w", errMock)
 	assert.Equal(t, expectedErr, err)
 	DisplayMessages = displayMessages
@@ -204,7 +223,7 @@ func TestContainerStartFailure(t *testing.T) {
 		return mockDocker, nil
 	}
 	DisplayMessages = mockDisplayMessagesNil
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	expectedErr := fmt.Errorf("docker container start failed %w", errMock)
 	assert.Equal(t, expectedErr, err)
 	DisplayMessages = displayMessages
@@ -220,7 +239,7 @@ func TestContainerWaitFailure(t *testing.T) {
 		return mockDocker, nil
 	}
 	DisplayMessages = mockDisplayMessagesNil
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	expectedErr := fmt.Errorf("docker container wait failed %w", errMock)
 	assert.Equal(t, expectedErr, err)
 	DisplayMessages = displayMessages
@@ -237,7 +256,7 @@ func TestContainerLogsFailure(t *testing.T) {
 		return mockDocker, nil
 	}
 	DisplayMessages = mockDisplayMessagesNil
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	expectedErr := fmt.Errorf("docker container logs fetching failed %w", errMock)
 	assert.Equal(t, expectedErr, err)
 	DisplayMessages = displayMessages
@@ -259,7 +278,7 @@ func TestCommonDockerUtilLogsCopyFailure(t *testing.T) {
 		mockIo.On("Copy", mock.Anything, mock.Anything).Return(int64(0), errMock)
 		return mockIo
 	}
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	expectedErr := fmt.Errorf("docker logs forwarding failed %w", errMock)
 	assert.Equal(t, expectedErr, err)
 	DisplayMessages = displayMessages
@@ -283,7 +302,7 @@ func TestContainerRemoveFailure(t *testing.T) {
 		mockIo.On("Copy", mock.Anything, mock.Anything).Return(int64(0), nil)
 		return mockIo
 	}
-	_, err := CommonDockerUtil(testCommand, nil, nil, nil)
+	_, _, err := CommonDockerUtil(testCommand, nil, nil, nil, false)
 	expectedErr := fmt.Errorf("docker remove failed %w", errMock)
 	assert.Equal(t, expectedErr, err)
 	DisplayMessages = displayMessages


### PR DESCRIPTION
## Description

Currently, if Airflow home and DAGs directory are set other than the default, those
directories are needed for the execution of commands like generate and run, but those
do not get mounted in the Docker container. SQL CLI now exposes a new command - config; 
to get those values. We now use that config command from SQL CLI internally while running 
generate & run command to get values of the global directories to be mounted.
Additional, we also are adding a cobra command to expose the SQL CLI config command.

## 🎟 Issue(s)

related: https://github.com/astronomer/astro-sdk/issues/1230

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
