### PR TITLE
disable automatic decompression for audit logs

### DIFF
--- a/astro-client/astro.go
+++ b/astro-client/astro.go
@@ -305,6 +305,8 @@ func (c *HTTPClient) GetOrganizationAuditLogs(orgName string, earliest int) (io.
 		Headers: make(map[string]string),
 		Path:    fmt.Sprintf("/organizations/%s/audit-logs?earliest=%d", orgShortName, earliest),
 	}
+	// For this command only disable decompression.
+	c.HTTPClient.HTTPClient.Transport = &http.Transport{DisableCompression: true}
 	streamBuffer, err := c.DoPublicRESTStreamQuery(doOpts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

In this Astro [PR](https://github.com/astronomer/astro/pull/6859) we are fixing a bug in the content type header that prevents clients from automatically uncompressing the results.

However in the CLI we don't want to decompress on behalf of users.

This PR disables automatic decompression for the CLI.

Should be released before the Astro PR, but not critical
- If it comes before, the response header will still prevent automatic decompression ✅ 
- If it comes after, the response header will allow the CLI to automatically decompress the logs, and tho the file will be name `xx.ndjson.gzip`, the data in the file will be ndjson.

## 🎟 Issue(s)

https://github.com/astronomer/astro/issues/6857

## 🧪 Functional Testing

Test locally with the Astro [PR](https://github.com/astronomer/astro/pull/6859)


## 📸 Screenshots

Without disabling decompression:
![without](https://user-images.githubusercontent.com/3437048/205479085-b674b7a6-1bb7-4a37-9cf5-09cd847626a0.png)

With decompression disabled:
![with](https://user-images.githubusercontent.com/3437048/205479083-16b66fa3-028e-4d24-9367-43c635b6f2b8.png)

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
