### PR TITLE
add current org id in header

### DIFF
--- a/astro-client/client.go
+++ b/astro-client/client.go
@@ -99,6 +99,11 @@ func (c *HTTPClient) doPublicGraphQLQuery(doOpts *httputil.DoOptions) (*Response
 	if cl.Token != "" {
 		doOpts.Headers["authorization"] = cl.Token
 	}
+
+	if cl.Organization != "" {
+		doOpts.Headers["astro-current-org-id"] = cl.Organization
+	}
+
 	doOpts.Headers["apollographql-client-name"] = "cli" //nolint: goconst
 	doOpts.Headers["apollographql-client-version"] = version.CurrVersion
 	doOpts.Method = http.MethodPost


### PR DESCRIPTION
## Description

pass current org id in http header for GQL to support audit log as gql request url does not include org context.
## 🎟 Issue(s)

https://github.com/astronomer/astro/issues/6994

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
