### PR TITLE
create deployments from YAML or JSON file

### DIFF
--- a/astro-client/astro.go
+++ b/astro-client/astro.go
@@ -41,6 +41,8 @@ type Client interface {
 	// Organizations
 	GetOrganizations() ([]Organization, error)
 	GetOrganizationAuditLogs(orgName string, earliest int) (io.ReadCloser, error)
+	// Alert Emails
+	UpdateAlertEmails(input UpdateDeploymentAlertsInput) (DeploymentAlerts, error)
 }
 
 func (c *HTTPClient) GetUserInfo() (*Self, error) {
@@ -310,4 +312,18 @@ func (c *HTTPClient) GetOrganizationAuditLogs(orgName string, earliest int) (io.
 		return nil, err
 	}
 	return streamBuffer, nil
+}
+
+// UpdateAlertEmails updates alert emails for a deployment
+func (c *HTTPClient) UpdateAlertEmails(input UpdateDeploymentAlertsInput) (DeploymentAlerts, error) {
+	req := Request{
+		Query:     UpdateDeploymentAlerts,
+		Variables: map[string]interface{}{"input": input},
+	}
+
+	resp, err := req.DoWithPublicClient(c)
+	if err != nil {
+		return DeploymentAlerts{}, err
+	}
+	return resp.Data.DeploymentAlerts, nil
 }

--- a/astro-client/mocks/Client.go
+++ b/astro-client/mocks/Client.go
@@ -432,6 +432,27 @@ func (_m *Client) ReportDagDeploymentStatus(input *astro.ReportDagDeploymentStat
 	return r0, r1
 }
 
+// UpdateAlertEmails provides a mock function with given fields: input
+func (_m *Client) UpdateAlertEmails(input astro.UpdateDeploymentAlertsInput) (astro.DeploymentAlerts, error) {
+	ret := _m.Called(input)
+
+	var r0 astro.DeploymentAlerts
+	if rf, ok := ret.Get(0).(func(astro.UpdateDeploymentAlertsInput) astro.DeploymentAlerts); ok {
+		r0 = rf(input)
+	} else {
+		r0 = ret.Get(0).(astro.DeploymentAlerts)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(astro.UpdateDeploymentAlertsInput) error); ok {
+		r1 = rf(input)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpdateDeployment provides a mock function with given fields: input
 func (_m *Client) UpdateDeployment(input *astro.UpdateDeploymentInput) (astro.Deployment, error) {
 	ret := _m.Called(input)

--- a/astro-client/mutations.go
+++ b/astro-client/mutations.go
@@ -147,4 +147,11 @@ var (
 		}
 	}
   `
+	UpdateDeploymentAlerts = `
+	mutation updateDeploymentAlerts($input: UpdateDeploymentAlertsInput!) {
+		updateDeploymentAlerts(input: $input) {
+			alertEmails
+		}
+	}
+  `
 )

--- a/astro-client/mutations.go
+++ b/astro-client/mutations.go
@@ -51,6 +51,17 @@ var (
 				version
 				airflowVersion
 			}
+			workerQueues {
+				id
+				name
+				isDefault
+				workerConcurrency
+				minWorkerCount
+				maxWorkerCount
+				nodePoolId
+				podCpu
+				podRam
+			}
 			deploymentSpec {
 				image {
 					tag

--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -22,9 +22,6 @@ var (
 			dagDeployEnabled
 			cluster {
 				id
-			}
-			cluster {
-				id
 				name
 				cloudProvider
 				nodePools {
@@ -74,6 +71,7 @@ var (
 			workspace {
 				id
 				organizationId
+				label
 			}
 		}
 	}
@@ -87,6 +85,13 @@ var (
 			releaseName
 			cluster {
 				id
+				name
+				nodePools {
+					id
+					isDefault
+					nodeInstanceType
+					maxNodeCount
+				}
 			}
 			createdAt
 			status
@@ -115,7 +120,17 @@ var (
 			}
 			workspace {
 				id
+				label
 				organizationId
+			}
+			workerQueues {
+				id
+				name
+				isDefault
+				nodePoolId
+				workerConcurrency
+				minWorkerCount
+				maxWorkerCount
 			}
 		}
 	}`
@@ -161,6 +176,12 @@ var (
 			id
 			name
 			cloudProvider
+			nodePools {
+				id
+				isDefault
+				maxNodeCount
+				nodeInstanceType
+			}
 		}
 	}
 	`

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -271,6 +271,7 @@ type CreateDeploymentInput struct {
 	RuntimeReleaseVersion string               `json:"runtimeReleaseVersion"`
 	DagDeployEnabled      bool                 `json:"dagDeployEnabled"`
 	DeploymentSpec        DeploymentCreateSpec `json:"deploymentSpec"`
+	WorkerQueues          []WorkerQueue        `json:"workerQueues"`
 }
 
 type DeploymentCreateSpec struct {

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -29,6 +29,7 @@ type ResponseData struct {
 	ReportDagDeploymentStatus DagDeploymentStatus          `json:"reportDagDeploymentStatus,omitempty"`
 	GetWorkerQueueOptions     WorkerQueueDefaultOptions    `json:"workerQueueOptions,omitempty"`
 	GetOrganizations          []Organization               `json:"organizations,omitempty"`
+	DeploymentAlerts          DeploymentAlerts             `json:"alertEmails,omitempty"`
 }
 
 type Self struct {
@@ -346,4 +347,13 @@ type NodePool struct {
 	IsDefault        bool      `json:"isDefault"`
 	NodeInstanceType string    `json:"nodeInstanceType"`
 	CreatedAt        time.Time `json:"createdAt"`
+}
+
+type UpdateDeploymentAlertsInput struct {
+	DeploymentID string   `json:"deploymentId"`
+	AlertEmails  []string `json:"alertEmails"`
+}
+
+type DeploymentAlerts struct {
+	AlertEmails []string `json:"alertEmails"`
 }

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -1,0 +1,75 @@
+package fromfile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/astronomer/astro-cli/astro-client"
+	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
+	"github.com/ghodss/yaml"
+)
+
+var (
+	errEmptyFile    = errors.New("has no content")
+	errCreateFailed = errors.New("failed to create deployment with input")
+)
+
+// TODO we need an io.Writer to create happy path output
+func Create(inputFile string, client astro.Client) error {
+	var (
+		err                 error
+		dataBytes           []byte
+		formattedDeployment inspect.FormattedDeployment
+		createInput         astro.CreateDeploymentInput
+	)
+
+	// get file contents as []byte
+	dataBytes, err = os.ReadFile(inputFile)
+	if err != nil {
+		return err
+	}
+	// return errEmptyFile if we have no dataBytes
+	if len(dataBytes) == 0 {
+		return fmt.Errorf("%s %w", inputFile, errEmptyFile)
+	}
+	// unmarshal to a formattedDeployment
+	err = yaml.Unmarshal(dataBytes, &formattedDeployment)
+	if err != nil {
+		return err
+	}
+	// transform formattedDeployment to DeploymentCreateInput
+	createInput = getCreateInput(&formattedDeployment)
+
+	// TODO validate required fields
+	// TODO should we check if deployment exists before creating it?
+
+	// create the deployment
+	_, err = client.CreateDeployment(&createInput)
+	if err != nil {
+		return fmt.Errorf("%s: %w %+v", err.Error(), errCreateFailed, createInput)
+	}
+	// TODO add happy path output **should we call inspect?
+	return nil
+}
+
+// getCreateInput transforms an inspect.FormattedDeployment into a astro.CreateDeploymentInput
+func getCreateInput(deploymentFromFile *inspect.FormattedDeployment) astro.CreateDeploymentInput {
+	// TODO add env Vars and **Alert Emails
+	createInput := astro.CreateDeploymentInput{
+		WorkspaceID:           "",
+		ClusterID:             deploymentFromFile.Deployment.Configuration.ClusterID,
+		Label:                 deploymentFromFile.Deployment.Configuration.Name,
+		Description:           deploymentFromFile.Deployment.Configuration.Description,
+		RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
+		DagDeployEnabled:      false, // TODO should come from configuration
+		DeploymentSpec: astro.DeploymentCreateSpec{
+			Executor: "CeleryExecutor",
+			Scheduler: astro.Scheduler{
+				AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
+				Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,
+			},
+		},
+	}
+	return createInput
+}

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -17,17 +17,18 @@ var (
 	errCreateFailed                   = errors.New("failed to create deployment with input")
 	errRequiredField                  = errors.New("missing required field")
 	errCannotUpdateExistingDeployment = errors.New("already exists")
+	errNotFound                       = errors.New("does not exist")
 )
 
 // TODO we need an io.Writer to create happy path output
 func Create(inputFile string, client astro.Client) error {
 	var (
-		err                 error
-		errHelp             string
-		dataBytes           []byte
-		formattedDeployment inspect.FormattedDeployment
-		createInput         astro.CreateDeploymentInput
-		existingDeployments []astro.Deployment
+		err                             error
+		errHelp, clusterID, workspaceID string
+		dataBytes                       []byte
+		formattedDeployment             inspect.FormattedDeployment
+		createInput                     astro.CreateDeploymentInput
+		existingDeployments             []astro.Deployment
 	)
 
 	// get file contents as []byte
@@ -49,25 +50,33 @@ func Create(inputFile string, client astro.Client) error {
 	if err != nil {
 		return err
 	}
-	// transform formattedDeployment to DeploymentCreateInput
-	createInput = getCreateInput(&formattedDeployment)
-	// TODO should we check if deployment exists before creating it?
-	// map names to id
-	// yes we should check for existence
 	c, err := config.GetCurrentContext()
 	if err != nil {
 		return err
 	}
-	existingDeployments, err = client.ListDeployments(c.Organization, c.Workspace)
+	// map workspace name to id
+	workspaceID, err = getWorkspaceIDFromName(formattedDeployment.Deployment.Configuration.WorkspaceName, c.Organization, client)
+	if err != nil {
+		return err
+	}
+	// map cluster name to id
+	clusterID, err = getClusterIDFromName(formattedDeployment.Deployment.Configuration.ClusterName, c.Organization, client)
+	if err != nil {
+		return err
+	}
+	existingDeployments, err = client.ListDeployments(c.Organization, workspaceID)
 	if err != nil {
 		return err
 	}
 	// check if deployment exists
-	if deploymentExists(existingDeployments, &createInput) {
+	if deploymentExists(existingDeployments, formattedDeployment.Deployment.Configuration.Name) {
 		// create does not allow updating existing deployments
 		errHelp = fmt.Sprintf("use deployment update --from-file %s instead", inputFile)
-		return fmt.Errorf("deployment: %s %w: %s", createInput.Label, errCannotUpdateExistingDeployment, errHelp)
+		return fmt.Errorf("deployment: %s %w: %s", formattedDeployment.Deployment.Configuration.Name,
+			errCannotUpdateExistingDeployment, errHelp)
 	}
+	// transform formattedDeployment to DeploymentCreateInput
+	createInput = getCreateInput(&formattedDeployment, clusterID, workspaceID)
 	// create the deployment
 	_, err = client.CreateDeployment(&createInput)
 	if err != nil {
@@ -77,16 +86,16 @@ func Create(inputFile string, client astro.Client) error {
 	return nil
 }
 
-// getCreateInput transforms an inspect.FormattedDeployment into a astro.CreateDeploymentInput
-func getCreateInput(deploymentFromFile *inspect.FormattedDeployment) astro.CreateDeploymentInput {
+// getCreateInput transforms an inspect.FormattedDeployment into astro.CreateDeploymentInput
+func getCreateInput(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID string) astro.CreateDeploymentInput {
 	// TODO add env Vars and **Alert Emails
 	createInput := astro.CreateDeploymentInput{
-		WorkspaceID:           "",
-		ClusterID:             deploymentFromFile.Deployment.Configuration.ClusterID,
+		WorkspaceID:           workspaceID,
+		ClusterID:             clusterID,
 		Label:                 deploymentFromFile.Deployment.Configuration.Name,
 		Description:           deploymentFromFile.Deployment.Configuration.Description,
 		RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
-		DagDeployEnabled:      false, // TODO should come from configuration
+		DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 		DeploymentSpec: astro.DeploymentCreateSpec{
 			Executor: "CeleryExecutor",
 			Scheduler: astro.Scheduler{
@@ -104,8 +113,8 @@ func checkRequiredFields(deploymentFromFile *inspect.FormattedDeployment) error 
 	if deploymentFromFile.Deployment.Configuration.Name == "" {
 		return fmt.Errorf("%w: %s", errRequiredField, "deployment.configuration.name")
 	}
-	if deploymentFromFile.Deployment.Configuration.ClusterID == "" {
-		return fmt.Errorf("%w: %s", errRequiredField, "deployment.configuration.cluster_id")
+	if deploymentFromFile.Deployment.Configuration.ClusterName == "" {
+		return fmt.Errorf("%w: %s", errRequiredField, "deployment.configuration.cluster_name")
 	}
 	return nil
 }
@@ -113,13 +122,55 @@ func checkRequiredFields(deploymentFromFile *inspect.FormattedDeployment) error 
 // DeploymentExists deploymentToCreate as its argument.
 // It returns true if deploymentToCreate exists.
 // It returns false if deploymentToCreate does not exist.
-func deploymentExists(existingDeployments []astro.Deployment, deploymentToCreate *astro.CreateDeploymentInput) bool {
+func deploymentExists(existingDeployments []astro.Deployment, deploymentNameToCreate string) bool {
 	// TODO use pointers to make it more efficient
 	for _, deployment := range existingDeployments {
-		if deployment.Label == deploymentToCreate.Label {
+		if deployment.Label == deploymentNameToCreate {
 			// deployment exists
 			return true
 		}
 	}
 	return false
+}
+
+// getClusterIDFromName takes clusterName and organizationID as its arguments.
+// It returns the clusterID if the cluster is found in the organization.
+// It returns an errClusterNotFound if the cluster does not exist in the organization.
+func getClusterIDFromName(clusterName, organizationID string, client astro.Client) (string, error) {
+	var (
+		existingClusters []astro.Cluster
+		err              error
+	)
+	existingClusters, err = client.ListClusters(organizationID)
+	if err != nil {
+		return "", err
+	}
+	for _, cluster := range existingClusters {
+		if cluster.Name == clusterName {
+			return cluster.ID, nil
+		}
+	}
+	err = fmt.Errorf("cluster_name: %s %w in organization: %s", clusterName, errNotFound, organizationID)
+	return "", err
+}
+
+// getWorkspaceIDFromName takes workspaceName and organizationID as its arguments.
+// It returns the workspaceID if the workspace is found in the organization.
+// It returns an errWorkspaceNotFound if the workspace does not exist in the organization.
+func getWorkspaceIDFromName(workspaceName, organizationID string, client astro.Client) (string, error) {
+	var (
+		existingWorkspaces []astro.Workspace
+		err                error
+	)
+	existingWorkspaces, err = client.ListWorkspaces(organizationID)
+	if err != nil {
+		return "", err
+	}
+	for _, workspace := range existingWorkspaces {
+		if workspace.Label == workspaceName {
+			return workspace.ID, nil
+		}
+	}
+	err = fmt.Errorf("workspace_name: %s %w in organization: %s", workspaceName, errNotFound, organizationID)
+	return "", err
 }

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -261,8 +261,8 @@ func getWorkspaceIDFromName(workspaceName, organizationID string, client astro.C
 	return "", err
 }
 
-// getNodePoolIDFromWorkerType takes maps the workerType to a node pool id in nodePools.
-// It returns an error if the worker type does not exist in any node pool in nodePools.
+// getNodePoolIDFromWorkerType maps the node pool id in nodePools to a worker type.
+// It returns an error if the node pool id does not exist in any node pool in nodePools.
 func getNodePoolIDFromWorkerType(workerType, clusterName string, nodePools []astro.NodePool) (string, error) {
 	var (
 		pool astro.NodePool

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -114,7 +114,6 @@ func Create(inputFile string, client astro.Client, out io.Writer) error {
 			return err
 		}
 	}
-	// TODO add happy path output by calling inspect
 	if jsonOutput {
 		outputFormat = jsonFormat
 	}
@@ -122,7 +121,7 @@ func Create(inputFile string, client astro.Client, out io.Writer) error {
 }
 
 // getCreateInput transforms an inspect.FormattedDeployment into astro.CreateDeploymentInput.
-// If worker-queues were requested, it gets node pool id work the workers and validates queue options.
+// If worker-queues were requested, it gets node pool id from the worker type and validates queue options.
 // If no queue options were specified, it sets default values.
 // It returns an error if getting default options fail.
 // It returns an error if worker-queue options are not valid.

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -1,0 +1,307 @@
+package fromfile
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	"github.com/astronomer/astro-cli/astro-client"
+	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
+	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/astro-cli/pkg/fileutil"
+)
+
+var errTest = errors.New("test error")
+
+func TestCreate(t *testing.T) {
+	var (
+		err            error
+		filePath, data string
+	)
+
+	t.Run("reads the yaml file and creates a deployment", func(t *testing.T) {
+		mockClient := new(astro_mocks.Client)
+		filePath = "./deployment.yaml"
+		data = `
+deployment:
+  environment_variables:
+    - is_secret: false
+      key: foo
+      updated_at: NOW
+      value: bar
+    - is_secret: true
+      key: bar
+      updated_at: NOW+1
+      value: baz
+  configuration:
+    name: test-deployment-label
+    description: description
+    runtime_version: 6.0.0
+    scheduler_au: 5
+    scheduler_count: 3
+    cluster_id: cluster-id
+  worker_queues:
+    - name: default
+      id: test-wq-id
+      is_default: true
+      max_worker_count: 130
+      min_worker_count: 12
+      worker_concurrency: 110
+      node_pool_id: test-pool-id
+    - name: test-queue-1
+      id: test-wq-id-1
+      is_default: false
+      max_worker_count: 175
+      min_worker_count: 8
+      worker_concurrency: 150
+      node_pool_id: test-pool-id-1
+  metadata:
+    deployment_id: test-deployment-id
+    workspace_id: test-ws-id
+    cluster_id: cluster-id
+    release_name: great-release-name
+    airflow_version: 2.4.0
+    dag_deploy_enabled: true
+    status: UNHEALTHY
+    created_at: 2022-11-17T13:25:55.275697-08:00
+    updated_at: 2022-11-17T13:25:55.275697-08:00
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    webserver_url: some-url
+`
+
+		fileutil.WriteStringToFile(filePath, data)
+		defer afero.NewOsFs().Remove(filePath)
+		mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{}, nil)
+		err = Create("deployment.yaml", mockClient)
+		assert.NoError(t, err)
+		mockClient.AssertExpectations(t)
+	})
+	t.Run("reads the json file and creates a deployment", func(t *testing.T) {
+		mockClient := new(astro_mocks.Client)
+		filePath = "./deployment.yaml"
+		data = `{
+    "deployment": {
+        "environment_variables": [
+            {
+                "is_secret": false,
+                "key": "foo",
+                "updated_at": "NOW",
+                "value": "bar"
+            },
+            {
+                "is_secret": true,
+                "key": "bar",
+                "updated_at": "NOW+1",
+                "value": "baz"
+            }
+        ],
+        "configuration": {
+            "name": "test-deployment-label",
+            "description": "description",
+            "runtime_version": "6.0.0",
+            "scheduler_au": 5,
+            "scheduler_count": 3,
+            "cluster_id": "cluster-id"
+        },
+        "worker_queues": [
+            {
+                "name": "default",
+                "id": "test-wq-id",
+                "is_default": true,
+                "max_worker_count": 130,
+                "min_worker_count": 12,
+                "worker_concurrency": 110,
+                "node_pool_id": "test-pool-id"
+            },
+            {
+                "name": "test-queue-1",
+                "id": "test-wq-id-1",
+                "is_default": false,
+                "max_worker_count": 175,
+                "min_worker_count": 8,
+                "worker_concurrency": 150,
+                "node_pool_id": "test-pool-id-1"
+            }
+        ],
+        "metadata": {
+            "deployment_id": "test-deployment-id",
+            "workspace_id": "test-ws-id",
+            "cluster_id": "cluster-id",
+            "release_name": "great-release-name",
+            "airflow_version": "2.4.0",
+            "dag_deploy_enabled": true,
+            "status": "UNHEALTHY",
+            "created_at": "2022-11-17T12:26:45.362983-08:00",
+            "updated_at": "2022-11-17T12:26:45.362983-08:00",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "webserver_url": "some-url"
+        },
+        "alert_emails": [
+            "email1",
+            "email2"
+        ]
+    }
+}`
+
+		fileutil.WriteStringToFile(filePath, data)
+		defer afero.NewOsFs().Remove(filePath)
+		mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{}, nil)
+		err = Create("deployment.yaml", mockClient)
+		assert.NoError(t, err)
+		mockClient.AssertExpectations(t)
+	})
+	t.Run("returns an error if file does not exist", func(t *testing.T) {
+		err = Create("deployment.yaml", nil)
+		assert.ErrorContains(t, err, "open deployment.yaml: no such file or directory")
+	})
+	t.Run("returns an error if file exists but no perms to read it", func(t *testing.T) {
+		filePath = "deployment.yaml"
+		data = "test"
+		err = fileutil.WriteStringToFile(filePath, data)
+		assert.NoError(t, err)
+		mode := fs.FileMode(0o000)
+		afero.NewOsFs().Chmod(filePath, mode)
+		defer afero.NewOsFs().Remove(filePath)
+		err = Create("deployment.yaml", nil)
+		assert.ErrorContains(t, err, "permission denied")
+	})
+	t.Run("returns an error if file exists but user provides incorrect path", func(t *testing.T) {
+		filePath = "./2/deployment.yaml"
+		data = "test"
+		err = fileutil.WriteStringToFile(filePath, data)
+		assert.NoError(t, err)
+		defer afero.NewOsFs().RemoveAll("./2")
+		err = Create("1/deployment.yaml", nil)
+		assert.ErrorContains(t, err, "open 1/deployment.yaml: no such file or directory")
+	})
+	t.Run("returns an error if file is empty", func(t *testing.T) {
+		filePath = "./deployment.yaml"
+		data = ""
+		fileutil.WriteStringToFile(filePath, data)
+		defer afero.NewOsFs().Remove(filePath)
+		err = Create("deployment.yaml", nil)
+		assert.ErrorIs(t, err, errEmptyFile)
+		assert.ErrorContains(t, err, "deployment.yaml has no content")
+	})
+	t.Run("returns an error if unmarshalling fails", func(t *testing.T) {
+		filePath = "./deployment.yaml"
+		data = "test"
+		fileutil.WriteStringToFile(filePath, data)
+		defer afero.NewOsFs().Remove(filePath)
+		err = Create("deployment.yaml", nil)
+		assert.ErrorContains(t, err, "error unmarshaling JSON:")
+	})
+	t.Run("returns an error from the api if create deployment fails", func(t *testing.T) {
+		mockClient := new(astro_mocks.Client)
+		filePath = "./deployment.yaml"
+		data = `{
+    "deployment": {
+        "environment_variables": [
+            {
+                "is_secret": false,
+                "key": "foo",
+                "updated_at": "NOW",
+                "value": "bar"
+            },
+            {
+                "is_secret": true,
+                "key": "bar",
+                "updated_at": "NOW+1",
+                "value": "baz"
+            }
+        ],
+        "configuration": {
+            "name": "test-deployment-label",
+            "description": "description",
+            "runtime_version": "6.0.0",
+            "scheduler_au": 5,
+            "scheduler_count": 3,
+            "cluster_id": "cluster-id"
+        },
+        "worker_queues": [
+            {
+                "name": "default",
+                "id": "test-wq-id",
+                "is_default": true,
+                "max_worker_count": 130,
+                "min_worker_count": 12,
+                "worker_concurrency": 110,
+                "node_pool_id": "test-pool-id"
+            },
+            {
+                "name": "test-queue-1",
+                "id": "test-wq-id-1",
+                "is_default": false,
+                "max_worker_count": 175,
+                "min_worker_count": 8,
+                "worker_concurrency": 150,
+                "node_pool_id": "test-pool-id-1"
+            }
+        ],
+        "metadata": {
+            "deployment_id": "test-deployment-id",
+            "workspace_id": "test-ws-id",
+            "cluster_id": "cluster-id",
+            "release_name": "great-release-name",
+            "airflow_version": "2.4.0",
+            "dag_deploy_enabled": true,
+            "status": "UNHEALTHY",
+            "created_at": "2022-11-17T12:26:45.362983-08:00",
+            "updated_at": "2022-11-17T12:26:45.362983-08:00",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "webserver_url": "some-url"
+        },
+        "alert_emails": [
+            "email1",
+            "email2"
+        ]
+    }
+}`
+
+		fileutil.WriteStringToFile(filePath, data)
+		defer afero.NewOsFs().Remove(filePath)
+		mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{}, errTest)
+		err = Create("deployment.yaml", mockClient)
+		assert.ErrorIs(t, err, errCreateFailed)
+		assert.ErrorContains(t, err, "test error: failed to create deployment with input")
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestGetCreateInput(t *testing.T) {
+	t.Run("transforms formattedDeployment to CreateDeploymentInput", func(t *testing.T) {
+		var (
+			expectedDeploymentInput, actual astro.CreateDeploymentInput
+			deploymentFromFile              inspect.FormattedDeployment
+		)
+		deploymentFromFile.Deployment.Configuration.ClusterID = "test-cluster-id"
+		deploymentFromFile.Deployment.Configuration.Name = "test-deployment"
+		deploymentFromFile.Deployment.Configuration.Description = "test-description"
+		deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
+		deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
+		deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+
+		expectedDeploymentInput = astro.CreateDeploymentInput{
+			WorkspaceID:           "",
+			ClusterID:             deploymentFromFile.Deployment.Configuration.ClusterID,
+			Label:                 deploymentFromFile.Deployment.Configuration.Name,
+			Description:           deploymentFromFile.Deployment.Configuration.Description,
+			RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
+			DagDeployEnabled:      false, // should come from configuration
+			DeploymentSpec: astro.DeploymentCreateSpec{
+				Executor: "CeleryExecutor",
+				Scheduler: astro.Scheduler{
+					AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
+					Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,
+				},
+			},
+		}
+		actual = getCreateInput(&deploymentFromFile)
+		assert.Equal(t, expectedDeploymentInput, actual)
+	})
+}

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -39,14 +39,14 @@ type deploymentConfig struct {
 	WorkspaceName    string `mapstructure:"workspace_name" yaml:"workspace_name" json:"workspace_name"`
 }
 
-type workerq struct {
+type Workerq struct {
 	Name              string `mapstructure:"name" yaml:"name" json:"name"`
 	ID                string `mapstructure:"id" yaml:"id" json:"id"`
 	IsDefault         bool   `mapstructure:"is_default" yaml:"is_default" json:"is_default"`
 	MaxWorkerCount    int    `mapstructure:"max_worker_count" yaml:"max_worker_count" json:"max_worker_count"`
 	MinWorkerCount    int    `mapstructure:"min_worker_count" yaml:"min_worker_count" json:"min_worker_count"`
 	WorkerConcurrency int    `mapstructure:"worker_concurrency" yaml:"worker_concurrency" json:"worker_concurrency"`
-	NodePoolID        string `mapstructure:"node_pool_id" yaml:"node_pool_id" json:"node_pool_id"`
+	WorkerType        string `mapstructure:"worker_type" yaml:"worker_type" json:"worker_type"`
 }
 
 type EnvironmentVariable struct {
@@ -59,7 +59,7 @@ type EnvironmentVariable struct {
 type orderedPieces struct {
 	EnvVars       []EnvironmentVariable `mapstructure:"environment_variables" yaml:"environment_variables" json:"environment_variables"`
 	Configuration deploymentConfig      `mapstructure:"configuration" yaml:"configuration" json:"configuration"`
-	WorkerQs      []workerq             `mapstructure:"worker_queues" yaml:"worker_queues" json:"worker_queues"`
+	WorkerQs      []Workerq             `mapstructure:"worker_queues" yaml:"worker_queues" json:"worker_queues"`
 	Metadata      deploymentMetadata    `mapstructure:"metadata" yaml:"metadata" json:"metadata"`
 	AlertEmails   []string              `mapstructure:"alert_emails" yaml:"alert_emails" json:"alert_emails"`
 }

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -49,7 +49,7 @@ type workerq struct {
 	NodePoolID        string `mapstructure:"node_pool_id" yaml:"node_pool_id" json:"node_pool_id"`
 }
 
-type environmentVariable struct {
+type EnvironmentVariable struct {
 	IsSecret  bool   `mapstructure:"is_secret" yaml:"is_secret" json:"is_secret"`
 	Key       string `mapstructure:"key" yaml:"key" json:"key"`
 	UpdatedAt string `mapstructure:"updated_at" yaml:"updated_at" json:"updated_at"`
@@ -57,7 +57,7 @@ type environmentVariable struct {
 }
 
 type orderedPieces struct {
-	EnvVars       []environmentVariable `mapstructure:"environment_variables" yaml:"environment_variables" json:"environment_variables"`
+	EnvVars       []EnvironmentVariable `mapstructure:"environment_variables" yaml:"environment_variables" json:"environment_variables"`
 	Configuration deploymentConfig      `mapstructure:"configuration" yaml:"configuration" json:"configuration"`
 	WorkerQs      []workerq             `mapstructure:"worker_queues" yaml:"worker_queues" json:"worker_queues"`
 	Metadata      deploymentMetadata    `mapstructure:"metadata" yaml:"metadata" json:"metadata"`

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -41,7 +41,6 @@ type deploymentConfig struct {
 
 type Workerq struct {
 	Name              string `mapstructure:"name" yaml:"name" json:"name"`
-	ID                string `mapstructure:"id" yaml:"id" json:"id"`
 	IsDefault         bool   `mapstructure:"is_default" yaml:"is_default" json:"is_default"`
 	MaxWorkerCount    int    `mapstructure:"max_worker_count" yaml:"max_worker_count" json:"max_worker_count"`
 	MinWorkerCount    int    `mapstructure:"min_worker_count" yaml:"min_worker_count" json:"min_worker_count"`
@@ -171,7 +170,6 @@ func getQMap(sourceDeploymentQs []astro.WorkerQueue, sourceNodePools []astro.Nod
 	queueMap := make([]map[string]interface{}, 0, len(sourceDeploymentQs))
 	for _, queue := range sourceDeploymentQs {
 		newQ := map[string]interface{}{
-			"id":                 queue.ID,
 			"name":               queue.Name,
 			"is_default":         queue.IsDefault,
 			"max_worker_count":   queue.MaxWorkerCount,

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -16,26 +16,27 @@ import (
 )
 
 type deploymentMetadata struct {
-	DeploymentID     string    `mapstructure:"deployment_id" yaml:"deployment_id" json:"deployment_id"`
-	WorkspaceID      string    `mapstructure:"workspace_id" yaml:"workspace_id" json:"workspace_id"`
-	ClusterID        string    `mapstructure:"cluster_id" yaml:"cluster_id" json:"cluster_id"`
-	ReleaseName      string    `mapstructure:"release_name" yaml:"release_name" json:"release_name"`
-	AirflowVersion   string    `mapstructure:"airflow_version" yaml:"airflow_version" json:"airflow_version"`
-	DagDeployEnabled bool      `mapstructure:"dag_deploy_enabled" yaml:"dag_deploy_enabled" json:"dag_deploy_enabled"`
-	Status           string    `mapstructure:"status" yaml:"status" json:"status"`
-	CreatedAt        time.Time `mapstructure:"created_at" yaml:"created_at" json:"created_at"`
-	UpdatedAt        time.Time `mapstructure:"updated_at" yaml:"updated_at" json:"updated_at"`
-	DeploymentURL    string    `mapstructure:"deployment_url" yaml:"deployment_url" json:"deployment_url"`
-	WebserverURL     string    `mapstructure:"webserver_url" yaml:"webserver_url" json:"webserver_url"`
+	DeploymentID   string    `mapstructure:"deployment_id" yaml:"deployment_id" json:"deployment_id"`
+	WorkspaceID    string    `mapstructure:"workspace_id" yaml:"workspace_id" json:"workspace_id"`
+	ClusterID      string    `mapstructure:"cluster_id" yaml:"cluster_id" json:"cluster_id"`
+	ReleaseName    string    `mapstructure:"release_name" yaml:"release_name" json:"release_name"`
+	AirflowVersion string    `mapstructure:"airflow_version" yaml:"airflow_version" json:"airflow_version"`
+	Status         string    `mapstructure:"status" yaml:"status" json:"status"`
+	CreatedAt      time.Time `mapstructure:"created_at" yaml:"created_at" json:"created_at"`
+	UpdatedAt      time.Time `mapstructure:"updated_at" yaml:"updated_at" json:"updated_at"`
+	DeploymentURL  string    `mapstructure:"deployment_url" yaml:"deployment_url" json:"deployment_url"`
+	WebserverURL   string    `mapstructure:"webserver_url" yaml:"webserver_url" json:"webserver_url"`
 }
 
 type deploymentConfig struct {
-	Name           string `mapstructure:"name" yaml:"name" json:"name"`
-	Description    string `mapstructure:"description" yaml:"description" json:"description"`
-	RunTimeVersion string `mapstructure:"runtime_version" yaml:"runtime_version" json:"runtime_version"`
-	SchedulerAU    int    `mapstructure:"scheduler_au" yaml:"scheduler_au" json:"scheduler_au"`
-	SchedulerCount int    `mapstructure:"scheduler_count" yaml:"scheduler_count" json:"scheduler_count"`
-	ClusterID      string `mapstructure:"cluster_id" yaml:"cluster_id" json:"cluster_id"` // this is also in deploymentMetadata
+	Name             string `mapstructure:"name" yaml:"name" json:"name"`
+	Description      string `mapstructure:"description" yaml:"description" json:"description"`
+	RunTimeVersion   string `mapstructure:"runtime_version" yaml:"runtime_version" json:"runtime_version"`
+	DagDeployEnabled bool   `mapstructure:"dag_deploy_enabled" yaml:"dag_deploy_enabled" json:"dag_deploy_enabled"`
+	SchedulerAU      int    `mapstructure:"scheduler_au" yaml:"scheduler_au" json:"scheduler_au"`
+	SchedulerCount   int    `mapstructure:"scheduler_count" yaml:"scheduler_count" json:"scheduler_count"`
+	ClusterName      string `mapstructure:"cluster_name" yaml:"cluster_name" json:"cluster_name"`
+	WorkspaceName    string `mapstructure:"workspace_name" yaml:"workspace_name" json:"workspace_name"`
 }
 
 type workerq struct {
@@ -131,28 +132,29 @@ func getDeploymentInfo(sourceDeployment *astro.Deployment) (map[string]interface
 		return nil, err
 	}
 	return map[string]interface{}{
-		"deployment_id":      sourceDeployment.ID,
-		"workspace_id":       sourceDeployment.Workspace.ID,
-		"cluster_id":         sourceDeployment.Cluster.ID,
-		"airflow_version":    sourceDeployment.RuntimeRelease.AirflowVersion,
-		"release_name":       sourceDeployment.ReleaseName,
-		"deployment_url":     deploymentURL,
-		"webserver_url":      sourceDeployment.DeploymentSpec.Webserver.URL,
-		"created_at":         sourceDeployment.CreatedAt,
-		"updated_at":         sourceDeployment.UpdatedAt,
-		"status":             sourceDeployment.Status,
-		"dag_deploy_enabled": sourceDeployment.DagDeployEnabled,
+		"deployment_id":   sourceDeployment.ID,
+		"workspace_id":    sourceDeployment.Workspace.ID,
+		"cluster_id":      sourceDeployment.Cluster.ID,
+		"airflow_version": sourceDeployment.RuntimeRelease.AirflowVersion,
+		"release_name":    sourceDeployment.ReleaseName,
+		"deployment_url":  deploymentURL,
+		"webserver_url":   sourceDeployment.DeploymentSpec.Webserver.URL,
+		"created_at":      sourceDeployment.CreatedAt,
+		"updated_at":      sourceDeployment.UpdatedAt,
+		"status":          sourceDeployment.Status,
 	}, nil
 }
 
 func getDeploymentConfig(sourceDeployment *astro.Deployment) map[string]interface{} {
 	return map[string]interface{}{
-		"name":            sourceDeployment.Label,
-		"description":     sourceDeployment.Description,
-		"cluster_id":      sourceDeployment.Cluster.ID,
-		"runtime_version": sourceDeployment.RuntimeRelease.Version,
-		"scheduler_au":    sourceDeployment.DeploymentSpec.Scheduler.AU,
-		"scheduler_count": sourceDeployment.DeploymentSpec.Scheduler.Replicas,
+		"name":               sourceDeployment.Label,
+		"description":        sourceDeployment.Description,
+		"workspace_name":     sourceDeployment.Workspace.Label,
+		"cluster_name":       sourceDeployment.Cluster.Name,
+		"runtime_version":    sourceDeployment.RuntimeRelease.Version,
+		"dag_deploy_enabled": sourceDeployment.DagDeployEnabled,
+		"scheduler_au":       sourceDeployment.DeploymentSpec.Scheduler.AU,
+		"scheduler_count":    sourceDeployment.DeploymentSpec.Scheduler.Replicas,
 	}
 }
 

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -63,7 +63,7 @@ type orderedPieces struct {
 	AlertEmails   []string              `mapstructure:"alert_emails" yaml:"alert_emails" json:"alert_emails"`
 }
 
-type formattedDeployment struct {
+type FormattedDeployment struct {
 	Deployment orderedPieces `mapstructure:"deployment" yaml:"deployment" json:"deployment"`
 }
 
@@ -199,7 +199,7 @@ func formatPrintableDeployment(outputFormat string, printableDeployment map[stri
 	var (
 		infoToPrint     []byte
 		err             error
-		formatWithOrder formattedDeployment
+		formatWithOrder FormattedDeployment
 	)
 
 	// use mapstructure to decode to a struct

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -752,7 +752,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
         - email1
         - email2
 `
-		var orderedAndTaggedDeployment, unorderedDeployment formattedDeployment
+		var orderedAndTaggedDeployment, unorderedDeployment FormattedDeployment
 		actualPrintableDeployment, err := formatPrintableDeployment("", printableDeployment)
 		assert.NoError(t, err)
 		// testing we get valid yaml
@@ -846,7 +846,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
         ]
     }
 }`
-		var orderedAndTaggedDeployment, unorderedDeployment formattedDeployment
+		var orderedAndTaggedDeployment, unorderedDeployment FormattedDeployment
 		actualPrintableDeployment, err := formatPrintableDeployment("json", printableDeployment)
 		assert.NoError(t, err)
 		// testing we get valid json

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -49,7 +49,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	// get defaults for min-count, max-count and concurrency from API
 	defaultOptions, err = GetWorkerQueueDefaultOptions(client)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errWorkerQueueDefaultOptions, err.Error())
+		return err
 	}
 
 	// get the node poolID to use
@@ -63,7 +63,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 		IsDefault:  false, // cannot create a default queue
 		NodePoolID: nodePoolID,
 	}
-	queueToCreateOrUpdate = setWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency, queueToCreateOrUpdate, defaultOptions)
+	queueToCreateOrUpdate = SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency, queueToCreateOrUpdate, defaultOptions)
 
 	err = IsWorkerQueueInputValid(queueToCreateOrUpdate, defaultOptions)
 	if err != nil {
@@ -123,9 +123,9 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	return nil
 }
 
-// setWorkerQueueValues sets values for MinWorkerCount, MaxWorkerCount and WorkerConcurrency
+// SetWorkerQueueValues sets values for MinWorkerCount, MaxWorkerCount and WorkerConcurrency
 // Default values are used if the user did not request any
-func setWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency int, workerQueueToCreate *astro.WorkerQueue, workerQueueDefaultOptions astro.WorkerQueueDefaultOptions) *astro.WorkerQueue {
+func SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency int, workerQueueToCreate *astro.WorkerQueue, workerQueueDefaultOptions astro.WorkerQueueDefaultOptions) *astro.WorkerQueue {
 	if wQueueMin != 0 {
 		// use the value from the user input
 		workerQueueToCreate.MinWorkerCount = wQueueMin
@@ -160,7 +160,7 @@ func GetWorkerQueueDefaultOptions(client astro.Client) (astro.WorkerQueueDefault
 	)
 	workerQueueDefaultOptions, err = client.GetWorkerQueueOptions()
 	if err != nil {
-		return astro.WorkerQueueDefaultOptions{}, err
+		return astro.WorkerQueueDefaultOptions{}, fmt.Errorf("%w: %s", errWorkerQueueDefaultOptions, err.Error())
 	}
 	return workerQueueDefaultOptions, nil
 }

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -782,27 +782,27 @@ func TestSetWorkerQueueValues(t *testing.T) {
 		NodePoolID:        "",
 	}
 	t.Run("sets user provided min worker count for queue", func(t *testing.T) {
-		actualQueue := setWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
 		assert.Equal(t, mockWorkerQueue.MinWorkerCount, actualQueue.MinWorkerCount)
 	})
 	t.Run("sets user provided max worker count for queue", func(t *testing.T) {
-		actualQueue := setWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
 		assert.Equal(t, mockWorkerQueue.MaxWorkerCount, actualQueue.MaxWorkerCount)
 	})
 	t.Run("sets user provided worker concurrency for queue", func(t *testing.T) {
-		actualQueue := setWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
 		assert.Equal(t, mockWorkerQueue.WorkerConcurrency, actualQueue.WorkerConcurrency)
 	})
 	t.Run("sets default min worker count for queue if user did not provide it", func(t *testing.T) {
-		actualQueue := setWorkerQueueValues(0, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(0, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
 		assert.Equal(t, mockWorkerQueueDefaultOptions.MinWorkerCount.Default, actualQueue.MinWorkerCount)
 	})
 	t.Run("sets default max worker count for queue if user did not provide it", func(t *testing.T) {
-		actualQueue := setWorkerQueueValues(10, 0, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(10, 0, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
 		assert.Equal(t, mockWorkerQueueDefaultOptions.MaxWorkerCount.Default, actualQueue.MaxWorkerCount)
 	})
 	t.Run("sets default worker concurrency for queue if user did not provide it", func(t *testing.T) {
-		actualQueue := setWorkerQueueValues(10, 150, 0, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(10, 150, 0, mockWorkerQueue, mockWorkerQueueDefaultOptions)
 		assert.Equal(t, mockWorkerQueueDefaultOptions.WorkerConcurrency.Default, actualQueue.WorkerConcurrency)
 	})
 }

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -126,6 +126,7 @@ func newDeploymentCreateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&clusterID, "cluster-id", "c", "", "Cluster to create the Deployment in")
 	cmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "v", "", "Runtime version for the Deployment")
 	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "disable", "Enables DAG-only deploys for the deployment")
+	// cmd.Flags().StringVarP(&depFile, "deployment-file", "", "deployment.yaml", "Location of file containing the deployment to create")
 	cmd.Flags().IntVarP(&schedulerAU, "scheduler-au", "s", deployment.SchedulerAuMin, "The Deployment's Scheduler resources in AUs")
 	cmd.Flags().IntVarP(&schedulerReplicas, "scheduler-replicas", "r", deployment.SchedulerReplicasMin, "The number of Scheduler replicas for the Deployment")
 	cmd.Flags().BoolVarP(&waitForStatus, "wait", "i", false, "Wait for the Deployment to become healthy before ending the command")

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -61,6 +61,7 @@ var (
 		$ astro deployment variable update --deployment-id <deployment-id> --load --env .env.my-deployment
 		`
 	httpClient = httputil.NewHTTPClient()
+	errFlag    = errors.New("--deployment-file can not be used with other arguments")
 )
 
 func newDeploymentRootCmd(out io.Writer) *cobra.Command {
@@ -297,6 +298,12 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error {
 
 	// request is to create from a file
 	if inputFile != "" {
+		requestedFlags := cmd.Flags().NFlag()
+		if requestedFlags > 1 {
+			// other flags were requested
+			return errFlag
+		}
+
 		return fromfile.Create(inputFile, astroClient, out)
 	}
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {

--- a/cmd/cloud/deployment_inspect_test.go
+++ b/cmd/cloud/deployment_inspect_test.go
@@ -133,7 +133,7 @@ func TestNewDeploymentInspectCmd(t *testing.T) {
 	})
 	t.Run("returns a deployment's specific field", func(t *testing.T) {
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Once()
-		cmdArgs := []string{"inspect", "-n", "test-deployment-label", "-k", "configuration.cluster_id"}
+		cmdArgs := []string{"inspect", "-n", "test-deployment-label", "-k", "metadata.cluster_id"}
 		resp, err := execDeploymentCmd(cmdArgs...)
 		assert.NoError(t, err)
 		assert.Contains(t, resp, deploymentResponse[0].Cluster.ID)

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -272,6 +272,11 @@ deployment:
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "open test-file-name.json: no such file or directory")
 	})
+	t.Run("returns an error if from-file is specified with any other flags", func(t *testing.T) {
+		cmdArgs := []string{"create", "--deployment-file", "test-deployment.yaml", "--description", "fail"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.ErrorIs(t, err, errFlag)
+	})
 	mockClient.AssertExpectations(t)
 }
 

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -136,17 +136,23 @@ func TestDeploymentCreate(t *testing.T) {
 		}
 	})
 
-	cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable"}
-	_, err = execDeploymentCmd(cmdArgs...)
-	assert.NoError(t, err)
+	t.Run("creates a deployment when dag-deploy is disabled", func(t *testing.T) {
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+	})
 
-	cmdArgs = []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "enable"}
-	_, err = execDeploymentCmd(cmdArgs...)
-	assert.NoError(t, err)
+	t.Run("creates a deployment when dag deploy is enabled", func(t *testing.T) {
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "enable"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+	})
 
-	cmdArgs = []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "some-value"}
-	_, err = execDeploymentCmd(cmdArgs...)
-	assert.Error(t, err)
+	t.Run("returns an error if dag-deploy flag has an incorrect value", func(t *testing.T) {
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "some-value"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.Error(t, err)
+	})
 
 	mockClient.AssertExpectations(t)
 }

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -11,8 +11,10 @@ import (
 	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	astro "github.com/astronomer/astro-cli/astro-client"
 	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
+	"github.com/astronomer/astro-cli/pkg/fileutil"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -154,6 +156,122 @@ func TestDeploymentCreate(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("creates a deployment from file", func(t *testing.T) {
+		orgID := "test-org-id"
+		filePath := "./test-deployment.yaml"
+		data := `
+deployment:
+  environment_variables:
+    - is_secret: false
+      key: foo
+      updated_at: NOW
+      value: bar
+    - is_secret: true
+      key: bar
+      updated_at: NOW+1
+      value: baz
+  configuration:
+    name: test-deployment-label
+    description: description
+    runtime_version: 6.0.0
+    dag_deploy_enabled: true
+    scheduler_au: 5
+    scheduler_count: 3
+    cluster_name: test-cluster
+    workspace_name: test-workspace
+  worker_queues:
+    - name: default
+      is_default: true
+      max_worker_count: 130
+      min_worker_count: 12
+      worker_concurrency: 180
+      worker_type: test-worker-1
+    - name: test-queue-1
+      is_default: false
+      max_worker_count: 175
+      min_worker_count: 8
+      worker_concurrency: 176
+      worker_type: test-worker-2
+  metadata:
+    deployment_id: test-deployment-id
+    workspace_id: test-ws-id
+    cluster_id: cluster-id
+    release_name: great-release-name
+    airflow_version: 2.4.0
+    status: UNHEALTHY
+    created_at: 2022-11-17T13:25:55.275697-08:00
+    updated_at: 2022-11-17T13:25:55.275697-08:00
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    webserver_url: some-url
+  alert_emails:
+    - test1@test.com
+    - test2@test.com
+`
+		clusters := []astro.Cluster{
+			{
+				ID:   "test-cluster-id",
+				Name: "test-cluster",
+				NodePools: []astro.NodePool{
+					{
+						ID:               "test-pool-id",
+						IsDefault:        false,
+						NodeInstanceType: "test-worker-1",
+					},
+					{
+						ID:               "test-pool-id-2",
+						IsDefault:        false,
+						NodeInstanceType: "test-worker-2",
+					},
+				},
+			},
+		}
+		createdDeployment := astro.Deployment{
+			ID:    "test-deployment-id",
+			Label: "test-deployment-label",
+		}
+		mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
+			MinWorkerCount: astro.WorkerQueueOption{
+				Floor:   1,
+				Ceiling: 20,
+				Default: 5,
+			},
+			MaxWorkerCount: astro.WorkerQueueOption{
+				Floor:   16,
+				Ceiling: 200,
+				Default: 125,
+			},
+			WorkerConcurrency: astro.WorkerQueueOption{
+				Floor:   175,
+				Ceiling: 275,
+				Default: 180,
+			},
+		}
+		mockClient = new(astro_mocks.Client)
+		mockClient.On("ListWorkspaces", orgID).Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id", Label: "test-workspace"}}, nil)
+		mockClient.On("ListClusters", orgID).Return(clusters, nil)
+		mockClient.On("ListDeployments", orgID, ws).Return([]astro.Deployment{}, nil).Once()
+		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+		mockClient.On("CreateDeployment", mock.Anything).Return(createdDeployment, nil)
+		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, nil)
+		mockClient.On("UpdateAlertEmails", mock.Anything).Return(astro.DeploymentAlerts{}, nil)
+		mockClient.On("ListDeployments", orgID, ws).Return([]astro.Deployment{createdDeployment}, nil)
+		origClient := astroClient
+		astroClient = mockClient
+		fileutil.WriteStringToFile(filePath, data)
+		defer func() {
+			astroClient = origClient
+			afero.NewOsFs().Remove(filePath)
+		}()
+		cmdArgs := []string{"create", "--deployment-file", "test-deployment.yaml"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		mockClient.AssertExpectations(t)
+	})
+	t.Run("returns an error if creating a deployment from file fails", func(t *testing.T) {
+		cmdArgs := []string{"create", "--deployment-file", "test-file-name.json"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.ErrorContains(t, err, "open test-file-name.json: no such file or directory")
+	})
 	mockClient.AssertExpectations(t)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/deepmap/oapi-codegen v1.12.2
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/fatih/camelcase v1.0.0
+	github.com/ghodss/yaml v1.0.0
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/whilp/git-urls v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -421,6 +421,7 @@ github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui72
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/getsentry/raven-go v0.0.0-20180121060056-563b81fc02b7/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -468,7 +469,6 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -554,7 +554,6 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -665,7 +664,6 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -723,7 +721,6 @@ github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHef
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -732,7 +729,6 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
-github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -790,7 +786,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
@@ -988,7 +983,6 @@ github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
@@ -1001,7 +995,6 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
@@ -1371,7 +1364,6 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiTs/Igowgfkj25AcZrtiE=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220411224347-583f2d630306 h1:+gHMid33q6pen7kv9xvT+JRinntgeXO2AeZVd0AWD3w=
 golang.org/x/time v0.0.0-20220411224347-583f2d630306/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -1440,7 +1432,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f h1:GGU+dLjvlC3qDwqYgL6UgRmHXhOOgns0bZu2Ty5mm6U=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
@@ -1581,8 +1572,6 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=


### PR DESCRIPTION
## Description

This PR enables creating a deployment from a yaml or json file. Files can either be valid YAML or JSON format and users do not have to indicate the format. This way of creating deployments allows users to specify `deployment.configuration` such as `deployment.configuration.name` for setting the deployment's name. 

It does not use `deployment.metadata` for configuring anything so users can use the inspect command and save an existing deployment to a file; make changes and then use it as input to `astro deployment create --deployment-file`.

It validates required fields for a deployment. If worker queues are specified, it validates required fields for worker queues. 
It maps between names and ids so for e.g. users can specify a `deployment.configuration.cluster_name` in the file and we look up the cluster's id when we use it. 

Post deployment creation, if the file had environment variables or alert emails; those get created as well.  

Successful output comes from the inspect command so if users used a JSON file as input, the output is in json format. Else the output is in yaml format. 

## 🎟 Issue(s)

Related #733 

## 🧪 Functional Testing

#### happy path 
```bash
# input file
$ cat deployment.yaml
deployment:
    environment_variables:
        - key: foo
          value: bar
        - key: beer
          value: awesome
          is_secret: true
    configuration:
        name: jp-test
        description: test deployment create from file
        runtime_version: 7.0.0
        dag_deploy_enabled: false
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: Frank Test Cluster CA Central - LTS
        workspace_name: CLI Test Workspace
    worker_queues:
        - name: default
          id: clbh33gt6265752zt638qyrglc
          is_default: true
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```
```bash
# command run
$ astro deployment create --deployment-file deployment.yaml
deployment:
    environment_variables:
        - is_secret: false
          key: foo
          updated_at: "2022-12-09T23:53:01.885Z"
          value: bar
        - is_secret: true
          key: beer
          updated_at: "2022-12-09T23:53:02.248Z"
          value: ""
    configuration:
        name: jp-test
        description: ""
        runtime_version: 7.0.0
        dag_deploy_enabled: false
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: Frank Test Cluster CA Central - LTS
        workspace_name: CLI Test Workspace
    worker_queues:
        - name: default
          id: clbh5ybk0110772503stp2xh2v
          is_default: true
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
    metadata:
        deployment_id: clbh5ybjz110732503e94m13z7
        workspace_id: cl0v1p6lc728255byzyfs7lw21
        cluster_id: cl8woz99j003j0t37fpux1nbd
        release_name: geodetic-spectroscope-9368
        airflow_version: 2.5.0
        status: UNKNOWN
        created_at: 2022-12-09T23:52:56.063Z
        updated_at: 2022-12-09T23:53:04.596Z
        deployment_url: cloud.astronomer-dev.io/cl0v1p6lc728255byzyfs7lw21/deployments/clbh5ybjz110732503e94m13z7/analytics
        webserver_url: astronomer.astronomer-dev.run/d94m13z7?orgId=org_dlgevirUCwI9vX10
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```

#### some sample errors
```bash
$ astro deployment create --deployment-file deployment.yaml
Error: deployment.yaml has no content

$ astro deployment create --deployment-file deployment.yaml
Error: error converting YAML to JSON: yaml: line 7: could not find expected ':'

$ astro deployment create --deployment-file deployment.yaml
Error: missing required field: deployment.worker_queues[0].worker_type

$ astro deployment create --deployment-file deployment1.yaml
Error: open deployment1.yaml: no such file or directory

$ astro deployment create --deployment-file deployment.yaml
Error: worker_type: m5.xlarge does not exist in cluster: Production Readiness - DX - LTS
```
## Screenshots
![Queues](https://user-images.githubusercontent.com/37133965/206814880-81fb785d-b8af-424c-ae6f-c4c010b06c39.png)
![vars](https://user-images.githubusercontent.com/37133965/206814882-63437929-4519-4f1f-bfc9-4c6ba7fd996b.png)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
