### PR TITLE
Stop needing user/pass for same project locally

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -153,6 +153,7 @@ func generateConfig(projectName, airflowHome, envFile, buildImage, settingsFile 
 		SettingsFile:         settingsFile,
 		SettingsFileExist:    settingsFileExist,
 		TriggererEnabled:     triggererEnabled,
+		ProjectName:          projectName,
 	}
 
 	buff := new(bytes.Buffer)

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -96,6 +96,7 @@ type ComposeConfig struct {
 	SettingsFile         string
 	SettingsFileExist    bool
 	TriggererEnabled     bool
+	ProjectName          string
 }
 
 type DockerCompose struct {

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -62,6 +62,7 @@ x-common-env-vars: &common-env-vars
   AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql://postgres:postgres@postgres:5432
   AIRFLOW__CORE__LOAD_EXAMPLES: "False"
   AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+  AIRFLOW__WEBSERVER__SECRET_KEY: "test-project-name"
   AIRFLOW__WEBSERVER__RBAC: "True"
   ASTRONOMER_ENVIRONMENT: local
 
@@ -170,6 +171,7 @@ x-common-env-vars: &common-env-vars
   AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql://postgres:postgres@postgres:5432
   AIRFLOW__CORE__LOAD_EXAMPLES: "False"
   AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+  AIRFLOW__WEBSERVER__SECRET_KEY: "test-project-name"
   AIRFLOW__WEBSERVER__RBAC: "True"
   ASTRONOMER_ENVIRONMENT: local
 

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -12,6 +12,7 @@ x-common-env-vars: &common-env-vars
   AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@{{ .PostgresHost }}:5432
   AIRFLOW__CORE__LOAD_EXAMPLES: "False"
   AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+  AIRFLOW__WEBSERVER__SECRET_KEY: "{{ .ProjectName }}"
   AIRFLOW__WEBSERVER__RBAC: "True"
   ASTRONOMER_ENVIRONMENT: local
 


### PR DESCRIPTION
Currently, user needs to login everytime they run `astro dev stop` and start or restart again.

This PR adds a secret key environment variable `AIRFLOW__WEBSERVER__SECRET_KEY (that is the config setting of Airflow: https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#secret-key). The value is set to the project name so a different project will have a different key, hence users will have to login again.

This improves the dev experience for our users.

## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/957

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

- Run `astro dev start` and add username/pass in the Webserver. 
- Run `astro dev restart` and just visit the webserver again and you should still be able to access all the pages without having to re-enter username password

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
