### PR TITLE
Expose configs on Webserver for local dev

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -64,6 +64,7 @@ x-common-env-vars: &common-env-vars
   AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
   AIRFLOW__WEBSERVER__SECRET_KEY: "test-project-name"
   AIRFLOW__WEBSERVER__RBAC: "True"
+  AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "True"
   ASTRONOMER_ENVIRONMENT: local
 
 networks:
@@ -173,6 +174,7 @@ x-common-env-vars: &common-env-vars
   AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
   AIRFLOW__WEBSERVER__SECRET_KEY: "test-project-name"
   AIRFLOW__WEBSERVER__RBAC: "True"
+  AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "True"
   ASTRONOMER_ENVIRONMENT: local
 
 networks:

--- a/airflow/include/composeyml.go
+++ b/airflow/include/composeyml.go
@@ -14,6 +14,7 @@ x-common-env-vars: &common-env-vars
   AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
   AIRFLOW__WEBSERVER__SECRET_KEY: "{{ .ProjectName }}"
   AIRFLOW__WEBSERVER__RBAC: "True"
+  AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "True"
   ASTRONOMER_ENVIRONMENT: local
 
 networks:


### PR DESCRIPTION
We should expose configs on the webserver to aid debugging, this comes in handy where trying to figure out if configs set via env var took effect or not. There is no reason to hide them for local dev.

**Before**:
<img width="854" alt="image" src="https://user-images.githubusercontent.com/8811558/207970700-cffc4ea7-e91b-4663-a433-e918d52fc30e.png">


**After**:

<img width="914" alt="image" src="https://user-images.githubusercontent.com/8811558/207970580-72310d58-ae14-40f9-b296-2063ec662747.png">

## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

closes https://github.com/astronomer/astro-cli/issues/959

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
