### PR TITLE
update timeout copy

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -65,7 +65,7 @@ var (
 	errNoFile                = errors.New("file specified does not exist")
 	errSettingsPath          = "error looking for settings.yaml"
 	errComposeProjectRunning = errors.New("project is up and running")
-	errWebServerUnHealthy    = errors.New("webserver failed to start")
+	errWebServerUnHealthy    = errors.New("webserver has not become healthy yet")
 
 	initSettings      = settings.ConfigSettings
 	exportSettings    = settings.Export
@@ -763,8 +763,8 @@ var checkWebserverHealth = func(settingsFile string, project *types.Project, com
 	})
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			fmt.Println("\nProject is not running. Run 'astro dev logs --webserver | --scheduler' for details.")
-			return fmt.Errorf("%w: timed out after %s", errWebServerUnHealthy, timeout)
+			fmt.Println("\nProject is not yet running. The project is still attempting to start up. Run 'astro dev logs --webserver | --scheduler' for details.")
+			return fmt.Errorf("%w: the health check timed out after %s. Use the --wait flag to increase the time out", errWebServerUnHealthy, timeout)
 		}
 		if !errors.Is(err, errComposeProjectRunning) {
 			return err

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1425,7 +1425,7 @@ func TestCheckWebserverHealth(t *testing.T) {
 
 		err := checkWebserverHealth(settingsFile, &types.Project{Name: "test"}, composeMock, 2, false, 1*time.Second)
 		assert.ErrorIs(t, err, errWebServerUnHealthy)
-		assert.ErrorContains(t, err, "webserver failed to start: timed out after 1s")
+		assert.ErrorContains(t, err, "webserver has not become healthy yet: the health check timed out after 1s")
 	})
 	t.Run("timeout waiting for webserver to get to healthy with long timeout", func(t *testing.T) {
 		settingsFile := "./testfiles/test_dag_inegrity_file.py" // any file which exists
@@ -1454,7 +1454,7 @@ func TestCheckWebserverHealth(t *testing.T) {
 
 		err := checkWebserverHealth(settingsFile, &types.Project{Name: "test"}, composeMock, 2, false, 1*time.Second)
 		assert.ErrorIs(t, err, errWebServerUnHealthy)
-		assert.ErrorContains(t, err, "webserver failed to start: timed out after 1s")
+		assert.ErrorContains(t, err, "webserver has not become healthy yet: the health check timed out after 1s")
 	})
 }
 


### PR DESCRIPTION
## Description

update timeout copy to

```
Project is not yet running. The project is still attempting to start up. Run 'astro dev logs --webserver | --scheduler' for details.
Error: webserver has not become healthy yet: the health check timed out after 0s. Use the --wait flag to increase the time out
```

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/950

## 🧪 Functional Testing

manual test

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
