### PR TITLE
Fix flow build executed via root

### DIFF
--- a/sql/flow.go
+++ b/sql/flow.go
@@ -106,7 +106,7 @@ var CommonDockerUtil = func(cmd, args []string, flags map[string]string, mountDi
 
 	currentUser, _ := user.Current()
 
-	dockerfileContent := []byte(fmt.Sprintf(include.Dockerfile, baseImage, astroSQLCliVersion, currentUser.Uid, currentUser.Username))
+	dockerfileContent := []byte(fmt.Sprintf(include.Dockerfile, baseImage, astroSQLCliVersion, currentUser.Username, currentUser.Uid, currentUser.Username))
 	if err := Os().WriteFile(SQLCliDockerfilePath, dockerfileContent, SQLCLIDockerfileWriteMode); err != nil {
 		return statusCode, cout, fmt.Errorf("error writing dockerfile %w", err)
 	}

--- a/sql/include/dockerfile_content.go
+++ b/sql/include/dockerfile_content.go
@@ -16,7 +16,7 @@ RUN apt-install-and-clean \
 
 RUN pip install astro-sql-cli==%s
 
-RUN useradd --uid %s --create-home %s
+RUN id -u %s &>/dev/null || useradd --uid %s --create-home %s
 # This is necessary to run the docker image in GNU Linux since Astro CLI 1.8
 # It is temporary, since some SQL commands still rely on the default airflow config
 # https://github.com/astronomer/astro-sdk/issues/1219


### PR DESCRIPTION
## Description

The proposed change fixes the flow docker build executed via a user which already exists in the container such as root.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
