### PR TITLE
Fix patch in flow tests not returning to original values

### DIFF
--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -67,7 +67,7 @@ func getBaseMountDirs(projectDir string) ([]string, error) {
 
 var appendConfigKeyMountDir = func(configKey string, configFlags map[string]string, mountDirs []string) ([]string, error) {
 	args := []string{configKey}
-	exitCode, output, err := sql.CommonDockerUtil(configCommandString, args, configFlags, mountDirs, true)
+	exitCode, output, err := sql.ExecuteCmdInDocker(configCommandString, args, configFlags, mountDirs, true)
 	if err != nil {
 		return mountDirs, fmt.Errorf("error running %v: %w", configCommandString, err)
 	}
@@ -79,7 +79,7 @@ var appendConfigKeyMountDir = func(configKey string, configFlags map[string]stri
 		return mountDirs, err
 	}
 	mountDirs = append(mountDirs, strings.TrimSpace(configKeyDir))
-	return mountDirs, err
+	return mountDirs, nil
 }
 
 func buildFlagsAndMountDirs(projectDir string, setProjectDir, setAirflowHome, setAirflowDagsFolder, mountGlobalDirs bool) (flags map[string]string, mountDirs []string, err error) {
@@ -134,7 +134,7 @@ func executeCmd(cmd *cobra.Command, args []string, flags map[string]string, moun
 	if debug {
 		cmdString = slices.Insert(cmdString, 1, "--debug")
 	}
-	exitCode, _, err := sql.CommonDockerUtil(cmdString, args, flags, mountDirs, false)
+	exitCode, _, err := sql.ExecuteCmdInDocker(cmdString, args, flags, mountDirs, false)
 	if err != nil {
 		return fmt.Errorf("error running %v: %w", cmdString, err)
 	}
@@ -271,7 +271,7 @@ func executeRun(cmd *cobra.Command, args []string) error {
 }
 
 func executeHelp(cmd *cobra.Command, cmdString []string) {
-	exitCode, _, err := sql.CommonDockerUtil(cmdString, nil, nil, nil, false)
+	exitCode, _, err := sql.ExecuteCmdInDocker(cmdString, nil, nil, nil, false)
 	if err != nil {
 		panic(fmt.Errorf("error running %v: %w", cmdString, err))
 	}

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -28,7 +28,7 @@ const (
 var (
 	Docker          = NewDockerBind
 	Io              = NewIoBind
-	DisplayMessages = displayMessages
+	DisplayMessages = OriginalDisplayMessages
 	Os              = NewOsBind
 )
 
@@ -37,7 +37,7 @@ func getContext(filePath string) io.Reader {
 	return ctx
 }
 
-func displayMessages(r io.Reader) error {
+func OriginalDisplayMessages(r io.Reader) error {
 	decoder := json.NewDecoder(r)
 	var prevMessage jsonmessage.JSONMessage
 	isFirstMessage := true
@@ -83,7 +83,7 @@ var ConvertReadCloserToString = func(readCloser io.ReadCloser) (string, error) {
 	return buf.String(), nil
 }
 
-var CommonDockerUtil = func(cmd, args []string, flags map[string]string, mountDirs []string, returnOutput bool) (exitCode int64, output io.ReadCloser, err error) {
+var ExecuteCmdInDocker = func(cmd, args []string, flags map[string]string, mountDirs []string, returnOutput bool) (exitCode int64, output io.ReadCloser, err error) {
 	var statusCode int64
 	var cout io.ReadCloser
 


### PR DESCRIPTION
## Description

This PR primarily fixes patchDockerClientInit, now called patchExecuteCmdInDocker, to reset the original values at then of each test case if used like this, for example: `defer patchExecuteCmdInDocker(t, 0, errMock)()`.

Moreover the PR also includes some refactoring:

- rename CommonDockerUtil to ExecuteCmdInDocker
- make displayMessages public
- more refactoring

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
