### PR TITLE
Update deployment from YAML or JSON file 

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -279,24 +279,6 @@ func deploymentFromName(existingDeployments []astro.Deployment, deploymentName s
 	return astro.Deployment{}
 }
 
-// queuesFromDeployment takes existingDeployment as its argument.
-// It returns the existing worker queues from the existingDeployment.
-func queuesFromDeployment(existingDeployment *astro.Deployment) []astro.WorkerQueue {
-	return existingDeployment.WorkerQueues
-}
-
-// alertEmailsFromDeployment takes existingDeployment as its argument.
-// It returns the existing alert emails from the existingDeployment.
-func alertEmailsFromDeployment(existingDeployment *astro.Deployment) astro.DeploymentAlerts {
-	return astro.DeploymentAlerts{AlertEmails: existingDeployment.AlertEmails}
-}
-
-// envVarsFromDeployment takes existingDeployment as its argument.
-// It returns the existing environment variables from the existingDeployment.
-func envVarsFromDeployment(existingDeployment *astro.Deployment) []astro.EnvironmentVariablesObject {
-	return existingDeployment.DeploymentSpec.EnvironmentVariablesObjects
-}
-
 // getClusterInfoFromName takes clusterName and organizationID as its arguments.
 // It returns the clusterID and list of nodepools if the cluster is found in the organization.
 // It returns an errClusterNotFound if the cluster does not exist in the organization.
@@ -356,7 +338,7 @@ func getNodePoolIDFromWorkerType(workerType, clusterName string, nodePools []ast
 }
 
 // createEnvVars takes a deploymentFromFile, deploymentID and a client as its arguments.
-// It updates the deployment identified by deploymentID with environment variables.
+// It updates the deployment identified by deploymentID with requested environment variables.
 // It returns an error if it fails to modify the environment variables for a deployment.
 func createEnvVars(deploymentFromFile *inspect.FormattedDeployment, deploymentID string, client astro.Client) ([]astro.EnvironmentVariablesObject, error) {
 	var (
@@ -450,7 +432,7 @@ func hasAlertEmails(deploymentFromFile *inspect.FormattedDeployment) bool {
 }
 
 // createAlertEmails takes a deploymentFromFile and deploymentID and a client as its arguments.
-// It creates alert emails for the deplyment identified by deploymentID.
+// It creates or updates alert emails for the deployment identified by deploymentID.
 // It returns an error if it fails to update the alert emails for a deployment.
 func createAlertEmails(deploymentFromFile *inspect.FormattedDeployment, deploymentID string, client astro.Client) (astro.DeploymentAlerts, error) {
 	var (

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 
 	"github.com/astronomer/astro-cli/astro-client"
 	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
@@ -17,29 +18,33 @@ import (
 var (
 	errEmptyFile                      = errors.New("has no content")
 	errCreateFailed                   = errors.New("failed to create deployment with input")
+	errUpdateFailed                   = errors.New("failed to update deployment with input")
 	errRequiredField                  = errors.New("missing required field")
 	errCannotUpdateExistingDeployment = errors.New("already exists")
 	errNotFound                       = errors.New("does not exist")
 )
 
 const (
-	jsonFormat = "json"
+	jsonFormat   = "json"
+	createAction = "create"
+	updateAction = "update"
 )
 
-// Create takes a file and creates a deployment with the confiuration specified in the file.
+// CreateOrUpdate takes a file and creates a deployment with the confiuration specified in the file.
 // inputFile can be in yaml or json format
 // It returns an error if any required information is missing or incorrectly specified.
-func Create(inputFile string, client astro.Client, out io.Writer) error {
+func CreateOrUpdate(inputFile, action string, client astro.Client, out io.Writer) error {
 	var (
-		err                                           error
-		errHelp, clusterID, workspaceID, outputFormat string
-		dataBytes                                     []byte
-		formattedDeployment                           inspect.FormattedDeployment
-		createInput                                   astro.CreateDeploymentInput
-		existingDeployments                           []astro.Deployment
-		createdDeployment                             astro.Deployment
-		nodePools                                     []astro.NodePool
-		jsonOutput                                    bool
+		err                                            error
+		errHelp, clusterID, workspaceID, outputFormat  string
+		dataBytes                                      []byte
+		formattedDeployment                            inspect.FormattedDeployment
+		createInput                                    astro.CreateDeploymentInput
+		updateInput                                    astro.UpdateDeploymentInput
+		existingDeployment, createdOrUpdatedDeployment astro.Deployment
+		existingDeployments                            []astro.Deployment
+		nodePools                                      []astro.NodePool
+		jsonOutput                                     bool
 	)
 
 	// get file contents as []byte
@@ -81,35 +86,57 @@ func Create(inputFile string, client astro.Client, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	// check if deployment exists
-	if deploymentExists(existingDeployments, formattedDeployment.Deployment.Configuration.Name) {
-		// create does not allow updating existing deployments
-		errHelp = fmt.Sprintf("use deployment update --from-file %s instead", inputFile)
-		return fmt.Errorf("deployment: %s %w: %s", formattedDeployment.Deployment.Configuration.Name,
-			errCannotUpdateExistingDeployment, errHelp)
-	}
-	// this deployment does not exist so create it
-
-	// transform formattedDeployment to DeploymentCreateInput
-	createInput, err = getCreateInput(&formattedDeployment, clusterID, workspaceID, nodePools, client)
-	if err != nil {
-		return err
-	}
-	// create the deployment
-	createdDeployment, err = client.CreateDeployment(&createInput)
-	if err != nil {
-		return fmt.Errorf("%s: %w %+v", err.Error(), errCreateFailed, createInput)
+	switch action {
+	case createAction:
+		// check if deployment exists
+		if deploymentExists(existingDeployments, formattedDeployment.Deployment.Configuration.Name) {
+			// create does not allow updating existing deployments
+			errHelp = fmt.Sprintf("use deployment update --from-file %s instead", inputFile)
+			return fmt.Errorf("deployment: %s %w: %s", formattedDeployment.Deployment.Configuration.Name,
+				errCannotUpdateExistingDeployment, errHelp)
+		}
+		// this deployment does not exist so create it
+		// transform formattedDeployment to DeploymentCreateInput
+		createInput, _, err = getCreateOrUpdateInput(&formattedDeployment, clusterID, workspaceID, createAction, &astro.Deployment{}, nodePools, client)
+		if err != nil {
+			return err
+		}
+		// create the deployment
+		createdOrUpdatedDeployment, err = client.CreateDeployment(&createInput)
+		if err != nil {
+			return fmt.Errorf("%s: %w %+v", err.Error(), errCreateFailed, createInput)
+		}
+	case updateAction:
+		// check if deployment does not exist
+		if !deploymentExists(existingDeployments, formattedDeployment.Deployment.Configuration.Name) {
+			// update does not allow creating new deployments
+			errHelp = fmt.Sprintf("use deployment create --from-file %s instead", inputFile)
+			return fmt.Errorf("deployment: %s %w: %s", formattedDeployment.Deployment.Configuration.Name,
+				errNotFound, errHelp)
+		}
+		// this deployment exists so update it
+		existingDeployment = deploymentFromName(existingDeployments, formattedDeployment.Deployment.Configuration.Name)
+		// transform formattedDeployment to DeploymentUpdateInput
+		_, updateInput, err = getCreateOrUpdateInput(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, client)
+		if err != nil {
+			return err
+		}
+		// update the deployment
+		createdOrUpdatedDeployment, err = client.UpdateDeployment(&updateInput)
+		if err != nil {
+			return fmt.Errorf("%s: %w %+v", err.Error(), errUpdateFailed, updateInput)
+		}
 	}
 	// create environment variables
 	if hasEnvVars(&formattedDeployment) {
-		_, err = createEnvVars(&formattedDeployment, createdDeployment.ID, client)
+		_, err = createEnvVars(&formattedDeployment, createdOrUpdatedDeployment.ID, client)
 		if err != nil {
 			return err
 		}
 	}
 	// create alert emails
 	if hasAlertEmails(&formattedDeployment) {
-		_, err = createAlertEmails(&formattedDeployment, createdDeployment.ID, client)
+		_, err = createAlertEmails(&formattedDeployment, createdOrUpdatedDeployment.ID, client)
 		if err != nil {
 			return err
 		}
@@ -117,19 +144,22 @@ func Create(inputFile string, client astro.Client, out io.Writer) error {
 	if jsonOutput {
 		outputFormat = jsonFormat
 	}
-	return inspect.Inspect(workspaceID, "", createdDeployment.ID, outputFormat, client, out, "")
+	return inspect.Inspect(workspaceID, "", createdOrUpdatedDeployment.ID, outputFormat, client, out, "")
 }
 
-// getCreateInput transforms an inspect.FormattedDeployment into astro.CreateDeploymentInput.
-// If worker-queues were requested, it gets node pool id from the worker type and validates queue options.
+// getCreateOrUpdateInput transforms an inspect.FormattedDeployment into astro.CreateDeploymentInput or
+// astro.UpdateDeploymentInput based on the action requested.
+// If worker-queues were requested, it gets node pool id work the workers and validates queue options.
 // If no queue options were specified, it sets default values.
 // It returns an error if getting default options fail.
 // It returns an error if worker-queue options are not valid.
 // It returns an error if node pool id could not be found for the worker type.
-func getCreateInput(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID string, nodePools []astro.NodePool, client astro.Client) (astro.CreateDeploymentInput, error) {
+func getCreateOrUpdateInput(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astro.Deployment, nodePools []astro.NodePool, client astro.Client) (astro.CreateDeploymentInput, astro.UpdateDeploymentInput, error) {
 	var (
 		defaultOptions astro.WorkerQueueDefaultOptions
 		listQueues     []astro.WorkerQueue
+		createInput    astro.CreateDeploymentInput
+		updateInput    astro.UpdateDeploymentInput
 		err            error
 	)
 
@@ -138,12 +168,12 @@ func getCreateInput(deploymentFromFile *inspect.FormattedDeployment, clusterID, 
 		// get defaults for min-count, max-count and concurrency from API
 		defaultOptions, err = workerqueue.GetWorkerQueueDefaultOptions(client)
 		if err != nil {
-			return astro.CreateDeploymentInput{}, err
+			return astro.CreateDeploymentInput{}, astro.UpdateDeploymentInput{}, err
 		}
 		// transform inspect.WorkerQ to []astro.WorkerQueue
-		listQueues, err = getQueues(deploymentFromFile, nodePools)
+		listQueues, err = getQueues(deploymentFromFile, nodePools, existingDeployment.WorkerQueues)
 		if err != nil {
-			return astro.CreateDeploymentInput{}, err
+			return astro.CreateDeploymentInput{}, astro.UpdateDeploymentInput{}, err
 		}
 		for i := range listQueues {
 			// set default values if none were specified
@@ -151,29 +181,48 @@ func getCreateInput(deploymentFromFile *inspect.FormattedDeployment, clusterID, 
 			// check if queue is valid
 			err = workerqueue.IsWorkerQueueInputValid(a, defaultOptions)
 			if err != nil {
-				return astro.CreateDeploymentInput{}, err
+				return astro.CreateDeploymentInput{}, astro.UpdateDeploymentInput{}, err
 			}
 			// add it to the list of queues to be created
 			listQueues[i] = *a
 		}
 	}
-	createInput := astro.CreateDeploymentInput{
-		WorkspaceID:           workspaceID,
-		ClusterID:             clusterID,
-		Label:                 deploymentFromFile.Deployment.Configuration.Name,
-		Description:           deploymentFromFile.Deployment.Configuration.Description,
-		RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
-		DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
-		DeploymentSpec: astro.DeploymentCreateSpec{
-			Executor: "CeleryExecutor",
-			Scheduler: astro.Scheduler{
-				AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
-				Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,
+	switch action {
+	case createAction:
+		createInput = astro.CreateDeploymentInput{
+			WorkspaceID:           workspaceID,
+			ClusterID:             clusterID,
+			Label:                 deploymentFromFile.Deployment.Configuration.Name,
+			Description:           deploymentFromFile.Deployment.Configuration.Description,
+			RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
+			DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+			DeploymentSpec: astro.DeploymentCreateSpec{
+				Executor: "CeleryExecutor",
+				Scheduler: astro.Scheduler{
+					AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
+					Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,
+				},
 			},
-		},
-		WorkerQueues: listQueues,
+			WorkerQueues: listQueues,
+		}
+	case updateAction:
+		updateInput = astro.UpdateDeploymentInput{
+			ID:               existingDeployment.ID,
+			ClusterID:        clusterID,
+			Label:            deploymentFromFile.Deployment.Configuration.Name,
+			Description:      deploymentFromFile.Deployment.Configuration.Description,
+			DagDeployEnabled: deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+			DeploymentSpec: astro.DeploymentCreateSpec{
+				Executor: "CeleryExecutor",
+				Scheduler: astro.Scheduler{
+					AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
+					Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,
+				},
+			},
+			WorkerQueues: listQueues,
+		}
 	}
-	return createInput, nil
+	return createInput, updateInput, nil
 }
 
 // checkRequiredFields ensures all required fields are present in inspect.FormattedDeployment.
@@ -205,7 +254,7 @@ func checkRequiredFields(deploymentFromFile *inspect.FormattedDeployment) error 
 	return nil
 }
 
-// DeploymentExists deploymentToCreate as its argument.
+// deploymentExists deploymentToCreate as its argument.
 // It returns true if deploymentToCreate exists.
 // It returns false if deploymentToCreate does not exist.
 func deploymentExists(existingDeployments []astro.Deployment, deploymentNameToCreate string) bool {
@@ -216,6 +265,36 @@ func deploymentExists(existingDeployments []astro.Deployment, deploymentNameToCr
 		}
 	}
 	return false
+}
+
+// deploymentFromName takes existingDeployments and deploymentName as its arguments.
+// It returns the existing deployment that matches deploymentName.
+func deploymentFromName(existingDeployments []astro.Deployment, deploymentName string) astro.Deployment {
+	for i := range existingDeployments {
+		if existingDeployments[i].Label == deploymentName {
+			// deployment that matched name
+			return existingDeployments[i]
+		}
+	}
+	return astro.Deployment{}
+}
+
+// queuesFromDeployment takes existingDeployment as its argument.
+// It returns the existing worker queues from the existingDeployment.
+func queuesFromDeployment(existingDeployment *astro.Deployment) []astro.WorkerQueue {
+	return existingDeployment.WorkerQueues
+}
+
+// alertEmailsFromDeployment takes existingDeployment as its argument.
+// It returns the existing alert emails from the existingDeployment.
+func alertEmailsFromDeployment(existingDeployment *astro.Deployment) astro.DeploymentAlerts {
+	return astro.DeploymentAlerts{AlertEmails: existingDeployment.AlertEmails}
+}
+
+// envVarsFromDeployment takes existingDeployment as its argument.
+// It returns the existing environment variables from the existingDeployment.
+func envVarsFromDeployment(existingDeployment *astro.Deployment) []astro.EnvironmentVariablesObject {
+	return existingDeployment.DeploymentSpec.EnvironmentVariablesObjects
 }
 
 // getClusterInfoFromName takes clusterName and organizationID as its arguments.
@@ -305,23 +384,45 @@ func createEnvVars(deploymentFromFile *inspect.FormattedDeployment, deploymentID
 }
 
 // getQueues takes a deploymentFromFile as its arguments.
-// It returns a list of worker queues to be created.
-func getQueues(deploymentFromFile *inspect.FormattedDeployment, nodePools []astro.NodePool) ([]astro.WorkerQueue, error) {
+// It returns a list of worker queues to be created or updated.
+func getQueues(deploymentFromFile *inspect.FormattedDeployment, nodePools []astro.NodePool, existingQueues []astro.WorkerQueue) ([]astro.WorkerQueue, error) {
 	var (
 		qList      []astro.WorkerQueue
 		nodePoolID string
 		err        error
 	)
 	requestedQueues := deploymentFromFile.Deployment.WorkerQs
+	// sort existing queues by name
+	if len(existingQueues) > 1 {
+		sort.Slice(existingQueues, func(i, j int) bool {
+			return existingQueues[i].Name < existingQueues[j].Name
+		})
+	}
+	// sort requested queues by name
+	if len(requestedQueues) > 1 {
+		sort.Slice(requestedQueues, func(i, j int) bool {
+			return requestedQueues[i].Name < requestedQueues[j].Name
+		})
+	}
 	qList = make([]astro.WorkerQueue, len(requestedQueues))
-	for i, queue := range requestedQueues {
-		qList[i].Name = queue.Name
-		qList[i].IsDefault = queue.IsDefault
-		qList[i].MinWorkerCount = queue.MinWorkerCount
-		qList[i].MaxWorkerCount = queue.MaxWorkerCount
-		qList[i].WorkerConcurrency = queue.WorkerConcurrency
+	for i := range requestedQueues {
+		// check if requested queue exists
+		if i < len(existingQueues) {
+			// add existing queue to list of queues to return
+			if requestedQueues[i].Name == existingQueues[i].Name {
+				// update existing queue
+				qList[i].Name = existingQueues[i].Name
+				qList[i].ID = existingQueues[i].ID
+			}
+		}
+		// add new queue or update existing queue properties to list of queues to return
+		qList[i].Name = requestedQueues[i].Name
+		qList[i].IsDefault = requestedQueues[i].IsDefault
+		qList[i].MinWorkerCount = requestedQueues[i].MinWorkerCount
+		qList[i].MaxWorkerCount = requestedQueues[i].MaxWorkerCount
+		qList[i].WorkerConcurrency = requestedQueues[i].WorkerConcurrency
 		// map worker type to node pool id
-		nodePoolID, err = getNodePoolIDFromWorkerType(queue.WorkerType, deploymentFromFile.Deployment.Configuration.ClusterName, nodePools)
+		nodePoolID, err = getNodePoolIDFromWorkerType(requestedQueues[i].WorkerType, deploymentFromFile.Deployment.Configuration.ClusterName, nodePools)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -304,7 +304,7 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error {
 			return errFlag
 		}
 
-		return fromfile.Create(inputFile, astroClient, out)
+		return fromfile.CreateOrUpdate(inputFile, "create", astroClient, out)
 	}
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {
 		return errors.New("Invalid --dag-deploy value)")

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -315,6 +315,127 @@ func TestDeploymentUpdate(t *testing.T) {
 	_, err = execDeploymentCmd(cmdArgs...)
 	assert.Error(t, err)
 
+	t.Run("updates a deployment from file", func(t *testing.T) {
+		orgID := "test-org-id"
+		filePath := "./test-deployment.yaml"
+		data := `
+deployment:
+  environment_variables:
+    - is_secret: false
+      key: foo
+      updated_at: NOW
+      value: bar
+    - is_secret: true
+      key: bar
+      updated_at: NOW+1
+      value: baz
+  configuration:
+    name: test-deployment-label
+    description: description
+    runtime_version: 6.0.0
+    dag_deploy_enabled: true
+    scheduler_au: 5
+    scheduler_count: 3
+    cluster_name: test-cluster
+    workspace_name: test-workspace
+  worker_queues:
+    - name: default
+      is_default: true
+      max_worker_count: 130
+      min_worker_count: 12
+      worker_concurrency: 180
+      worker_type: test-worker-1
+    - name: test-queue-1
+      is_default: false
+      max_worker_count: 175
+      min_worker_count: 8
+      worker_concurrency: 176
+      worker_type: test-worker-2
+  metadata:
+    deployment_id: test-deployment-id
+    workspace_id: test-ws-id
+    cluster_id: cluster-id
+    release_name: great-release-name
+    airflow_version: 2.4.0
+    status: UNHEALTHY
+    created_at: 2022-11-17T13:25:55.275697-08:00
+    updated_at: 2022-11-17T13:25:55.275697-08:00
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    webserver_url: some-url
+  alert_emails:
+    - test1@test.com
+    - test2@test.com
+`
+		clusters := []astro.Cluster{
+			{
+				ID:   "test-cluster-id",
+				Name: "test-cluster",
+				NodePools: []astro.NodePool{
+					{
+						ID:               "test-pool-id",
+						IsDefault:        false,
+						NodeInstanceType: "test-worker-1",
+					},
+					{
+						ID:               "test-pool-id-2",
+						IsDefault:        false,
+						NodeInstanceType: "test-worker-2",
+					},
+				},
+			},
+		}
+		updatedDeployment := astro.Deployment{
+			ID:    "test-deployment-id",
+			Label: "test-deployment-label",
+		}
+		mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
+			MinWorkerCount: astro.WorkerQueueOption{
+				Floor:   1,
+				Ceiling: 20,
+				Default: 5,
+			},
+			MaxWorkerCount: astro.WorkerQueueOption{
+				Floor:   16,
+				Ceiling: 200,
+				Default: 125,
+			},
+			WorkerConcurrency: astro.WorkerQueueOption{
+				Floor:   175,
+				Ceiling: 275,
+				Default: 180,
+			},
+		}
+		mockClient = new(astro_mocks.Client)
+		mockClient.On("ListWorkspaces", orgID).Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id", Label: "test-workspace"}}, nil)
+		mockClient.On("ListClusters", orgID).Return(clusters, nil)
+		mockClient.On("ListDeployments", orgID, ws).Return([]astro.Deployment{updatedDeployment}, nil).Once()
+		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+		mockClient.On("UpdateDeployment", mock.Anything).Return(updatedDeployment, nil)
+		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, nil)
+		mockClient.On("UpdateAlertEmails", mock.Anything).Return(astro.DeploymentAlerts{}, nil)
+		mockClient.On("ListDeployments", orgID, ws).Return([]astro.Deployment{updatedDeployment}, nil)
+		origClient := astroClient
+		astroClient = mockClient
+		fileutil.WriteStringToFile(filePath, data)
+		defer func() {
+			astroClient = origClient
+			afero.NewOsFs().Remove(filePath)
+		}()
+		cmdArgs := []string{"update", "--deployment-file", "test-deployment.yaml"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		mockClient.AssertExpectations(t)
+	})
+	t.Run("returns an error if updating a deployment from file fails", func(t *testing.T) {
+		cmdArgs := []string{"update", "--deployment-file", "test-file-name.json"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.ErrorContains(t, err, "open test-file-name.json: no such file or directory")
+	})
+	t.Run("returns an error if from-file is specified with any other flags", func(t *testing.T) {
+		cmdArgs := []string{"update", "--deployment-file", "test-deployment.yaml", "--description", "fail"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.ErrorIs(t, err, errFlag)
+	})
 	mockClient.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Description

This PR enables users to update existing deployments from file. It builds update capability on on top of PR #942.

It validates required fields for a deployment. If worker queues are specified, it validates required fields for worker queues.
It maps between names and ids so for e.g. users can specify a deployment.configuration.cluster_name in the file and we look up the cluster's id when we use it. If all checks pass, it updates the worker queues to the list specified in the input file. If the user does not specify any existing worker queues, they will be deleted. If new queues were in the input file, they will be created and if existing queues are specified with different options, they will be updated. 

Post deployment creation, if the file had environment variables or alert emails; those get updated as well. It uses the list specified in the input file verbatim so if any existing alert emails or environment variables are excluded, they will be deleted from the existing deployment. If the user does not want to change any existing alert emails or environment variables, empty lists can be passed via the input file and no existing environment variables or alert emails will get modified.

Successful output comes from the inspect command so if users used a JSON file as input, the output is in json format. Else the output is in yaml format.

## 🎟 Issue(s)

Related #734 

## 🧪 Functional Testing

### happy path
```bash
astro deployment update --deployment-file deployment.yaml
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
