### PR TITLE
return error from api

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -499,7 +499,7 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy stri
 	// update deployment
 	d, err := client.UpdateDeployment(deploymentUpdate)
 	if err != nil {
-		return errors.Wrap(err, astro.AstronomerConnectionErrMsg)
+		return err
 	}
 
 	if d.ID == "" {

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -717,6 +717,7 @@ func TestUpdate(t *testing.T) {
 
 		err := Update("test-id", "", ws, "", "", "", 0, 0, []astro.WorkerQueue{}, true, mockClient)
 		assert.ErrorIs(t, err, errMock)
+		assert.NotContains(t, err.Error(), astro.AstronomerConnectionErrMsg)
 		mockClient.AssertExpectations(t)
 	})
 


### PR DESCRIPTION

## Description

We no longer  wrap error an error message on `deployment.Update()`with `AstronomerConnectionErrMsg` as it is misleading. Instead we return the error from the api server. 

## 🎟 Issue(s)

Related #967 

## 🧪 Functional Testing

### Before

```bash
$ astro deployment worker-queue update -n e2e-ci-tag-stage-wq-ei9lu  -d clbv4rbx3544607wyc1onwoccy -t m5.xlarge         --min-count 5 -f

Error: Cannot connect to Astronomer. Try to log in with astro login or check your internet connection and user permissions.
```

### With this change

```bash
$ astro deployment worker-queue update -n e2e-ci-tag-stage-wq-ei9lu  -d clbv4rbx3544607wyc1onwoccy -t m5.xlarge         --min-count 5 -f

Error: Unable to update min worker count for the m5.xlarge node pool on your cluster, which is over-provisioned by 4 worker(s)
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
