### PR TITLE
Add missing EOF line for docker compose tests

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -154,6 +154,7 @@ services:
       start_period: 5s
       timeout: 60s
     
+
 `
 		mockM1Checker := func(myOS, myArch string) bool {
 			return false
@@ -286,6 +287,7 @@ services:
       - airflow_home/include:/usr/local/airflow/include:z
       - airflow_logs:/usr/local/airflow/logs
     
+
 `
 		mockM1Checker := func(myOS, myArch string) bool {
 			return false


### PR DESCRIPTION
## Description

Changes:
- Fix broken tests with moving to YAML file for docker-compose, tests needed an EOF line break to pass

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
