### PR TITLE
Add flow E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 ---
 version: 2.1
+setup: true
+orbs:
+  path-filtering: circleci/path-filtering@0.1.3
 jobs:
   lint:
     working_directory: /go/src/github.com/astronomer/astro-cli
@@ -33,6 +36,10 @@ workflows:
     jobs:
       - lint
       - test
+      - path-filtering/filter:
+          mapping: |
+            cmd/sql/.* cmd-sql-changed true
+            sql/.* sql-changed true
       - approve-release:
           type: approval
           filters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,0 +1,51 @@
+version: 2.1
+
+executors:
+  docker-executor:
+    environment:
+      GIT_ORG: astronomer
+    docker:
+      - image: circleci/python:3
+
+parameters:
+  cmd-sql-changed:
+    type: boolean
+    default: false
+  sql-changed:
+    type: boolean
+    default: false
+
+jobs:
+  run-e2e-tests:
+    working_directory: /go/src/github.com/astronomer/astro-cli
+    docker:
+      - image: quay.io/astronomer/ap-dind-golang:20.10.21
+    steps:
+      - run-e2e-tests
+
+commands:
+  run-e2e-tests:
+    description: "Run e2e tests"
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: install dockerize
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.6.1
+      - run:
+          name: Run e2e tests
+          environment:
+            HOUSTON_HOST: houston
+          command: |
+            make e2e_test
+
+workflows:
+  run-e2e-tests:
+    when:
+      or:
+        - << pipeline.parameters.cmd-sql-changed >>
+        - << pipeline.parameters.sql-changed >>
+    jobs:
+      - run-e2e-tests

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,11 @@ core_api_gen:
 	make mock_astro_core
 
 test:
-	go test -count=1 -cover ./...
-	go test -coverprofile=coverage.txt -covermode=atomic ./...
+	go test -count=1 -cover $(shell go list ./... | grep -v e2e)
+	go test -coverprofile=coverage.txt -covermode=atomic $(shell go list ./... | grep -v e2e)
+
+e2e_test:
+	go test -count=1 $(shell go list ./... | grep e2e)
 
 mock: mock_airflow mock_houston mock_astro mock_pkg mock_sql_cli mock_astro_core
 

--- a/cmd/sql/e2e/flow_test.go
+++ b/cmd/sql/e2e/flow_test.go
@@ -1,0 +1,180 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	sql "github.com/astronomer/astro-cli/cmd/sql"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// chdir changes the current working directory to the named directory and
+// returns a function that, when called, restores the original working
+// directory.
+func chdir(t *testing.T, dir string) func() {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	return func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restoring working directory: %v", err)
+		}
+	}
+}
+
+func execFlowCmd(args ...string) error {
+	cmd := sql.NewFlowCommand()
+	cmd.SetArgs(args)
+	_, err := cmd.ExecuteC()
+	return err
+}
+
+func TestE2EFlowCmd(t *testing.T) {
+	err := execFlowCmd()
+	assert.NoError(t, err)
+}
+
+func TestE2EFlowVersionCmd(t *testing.T) {
+	err := execFlowCmd("version")
+	assert.NoError(t, err)
+}
+
+func TestE2EFlowAboutCmd(t *testing.T) {
+	err := execFlowCmd("about")
+	assert.NoError(t, err)
+}
+
+func TestE2EFlowInitCmd(t *testing.T) {
+	projectDir := t.TempDir()
+	defer chdir(t, projectDir)()
+	err := execFlowCmd("init")
+	assert.NoError(t, err)
+}
+
+func TestE2EFlowInitCmdWithFlags(t *testing.T) {
+	projectDir := t.TempDir()
+	airflowHome := t.TempDir()
+	airflowDagsFolder := t.TempDir()
+	err := execFlowCmd("init", projectDir, "--airflow-home", airflowHome, "--airflow-dags-folder", airflowDagsFolder)
+	assert.NoError(t, err)
+}
+
+func TestE2EFlowConfigCmd(t *testing.T) {
+	projectDir := t.TempDir()
+	airflowHome := t.TempDir()
+	airflowDagsFolder := t.TempDir()
+	err := execFlowCmd("init", projectDir, "--airflow-home", airflowHome, "--airflow-dags-folder", airflowDagsFolder)
+	assert.NoError(t, err)
+
+	err = execFlowCmd("config", "--project-dir", projectDir, "airflow_home")
+	assert.NoError(t, err)
+}
+
+func TestE2EFlowConfigCmdArgumentNotSetError(t *testing.T) {
+	projectDir := t.TempDir()
+	airflowHome := t.TempDir()
+	airflowDagsFolder := t.TempDir()
+	err := execFlowCmd("init", projectDir, "--airflow-home", airflowHome, "--airflow-dags-folder", airflowDagsFolder)
+	assert.NoError(t, err)
+
+	err = execFlowCmd("config", "--project-dir", projectDir)
+	assert.EqualError(t, err, "argument not set:key")
+}
+
+func TestE2EFlowValidateCmd(t *testing.T) {
+	projectDir := t.TempDir()
+	err := execFlowCmd("init", projectDir)
+	assert.NoError(t, err)
+
+	err = execFlowCmd("validate", projectDir, "--connection", "sqlite_conn")
+	assert.NoError(t, err)
+}
+
+func TestE2EFlowValidateAllCmd(t *testing.T) {
+	projectDir := t.TempDir()
+	err := execFlowCmd("init", projectDir)
+	assert.NoError(t, err)
+
+	err = execFlowCmd("validate", projectDir)
+	assert.NoError(t, err)
+}
+
+func TestE2EFlowGenerateCmd(t *testing.T) {
+	testCases := []struct {
+		workflowName  string
+		env           string
+		generateTasks string
+	}{
+		{"example_basic_transform", "default", "--generate-tasks"},
+		{"example_basic_transform", "default", "--no-generate-tasks"},
+		{"example_templating", "dev", "--generate-tasks"},
+		{"example_templating", "dev", "--no-generate-tasks"},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s in %s with %s", tc.workflowName, tc.env, tc.generateTasks), func(t *testing.T) {
+			projectDir := t.TempDir()
+			err := execFlowCmd("init", projectDir)
+			assert.NoError(t, err)
+
+			err = execFlowCmd("generate", tc.workflowName, "--project-dir", projectDir, "--env", tc.env, tc.generateTasks)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestE2EFlowGenerateCmdWorkflowNameNotSetError(t *testing.T) {
+	projectDir := t.TempDir()
+	err := execFlowCmd("init", projectDir)
+	assert.NoError(t, err)
+
+	err = execFlowCmd("generate", "--project-dir", projectDir)
+	assert.EqualError(t, err, "argument not set:workflow_name")
+}
+
+func TestE2EFlowRunCmd(t *testing.T) {
+	testCases := []struct {
+		workflowName  string
+		env           string
+		generateTasks string
+	}{
+		{"example_basic_transform", "default", "--generate-tasks"},
+		{"example_basic_transform", "default", "--no-generate-tasks"},
+		{"example_templating", "dev", "--generate-tasks"},
+		{"example_templating", "dev", "--no-generate-tasks"},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s in %s with %s", tc.workflowName, tc.env, tc.generateTasks), func(t *testing.T) {
+			projectDir := t.TempDir()
+			err := execFlowCmd("init", projectDir)
+			assert.NoError(t, err)
+
+			err = execFlowCmd("run", tc.workflowName, "--project-dir", projectDir, "--env", tc.env, tc.generateTasks)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestE2EFlowRunVerboseCmd(t *testing.T) {
+	projectDir := t.TempDir()
+	err := execFlowCmd("init", projectDir)
+	assert.NoError(t, err)
+
+	err = execFlowCmd("run", "example_basic_transform", "--project-dir", projectDir, "--verbose")
+	assert.NoError(t, err)
+}
+
+func TestE2EFlowRunCmdWorkflowNameNotSetError(t *testing.T) {
+	projectDir := t.TempDir()
+	err := execFlowCmd("init", projectDir)
+	assert.NoError(t, err)
+
+	err = execFlowCmd("run", "--project-dir", projectDir)
+	assert.EqualError(t, err, "argument not set:workflow_name")
+}


### PR DESCRIPTION
## Description

This PR adds e2e tests for the flow command and also adds a circleci config to run them in CI when related files change.

- trigger e2e tests on flow changes
- add continue_config for running e2e tests
- add make command for e2e test
- move e2e test file to separate package

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
