### PR TITLE
Add data dir flag to flow config command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/fatih/camelcase v1.0.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/hashicorp/go-version v1.3.0
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/whilp/git-urls v1.0.0
@@ -94,7 +95,6 @@ require (
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
-	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect

--- a/sql/flow_config.go
+++ b/sql/flow_config.go
@@ -48,11 +48,12 @@ func GetPypiVersion(projectURL string) (string, error) {
 	versions := make([]*version.Version, len(resp.Releases))
 	index := 0
 	for release := range resp.Releases {
-		versions[index], err = version.NewVersion(release)
-		if err != nil {
-			return "", fmt.Errorf("error parsing release version %w", err)
+		if v, err := version.NewVersion(release); err != nil {
+			fmt.Println(fmt.Errorf("error parsing release version %w", err))
+		} else {
+			versions[index] = v
+			index++
 		}
-		index++
 	}
 	sort.Sort(sort.Reverse(version.Collection(versions)))
 	return versions[0].Original(), nil


### PR DESCRIPTION
## Description

This PR exposes the sql-cli init flag `--data-dir` in the flow command.

* use latest release version from sql-cli pypi

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-sdk/pull/1407
Closes https://github.com/astronomer/astro-sdk/issues/1315

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
