### PR TITLE
Fix timeout copy again

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -762,7 +762,7 @@ var checkWebserverHealth = func(settingsFile string, project *types.Project, com
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			fmt.Printf("\n")
-			return fmt.Errorf("there might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out", timeout) // nolint:goerr113
+			return fmt.Errorf("there might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out", timeout) //nolint:goerr113
 		}
 		if !errors.Is(err, errComposeProjectRunning) {
 			return err

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -762,7 +762,7 @@ var checkWebserverHealth = func(settingsFile string, project *types.Project, com
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			fmt.Printf("\n")
-			return fmt.Errorf("there might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out", timeout)
+			return fmt.Errorf("there might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out", timeout) // nolint:goerr113
 		}
 		if !errors.Is(err, errComposeProjectRunning) {
 			return err

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -64,7 +64,7 @@ var (
 	errNoFile                = errors.New("file specified does not exist")
 	errSettingsPath          = "error looking for settings.yaml"
 	errComposeProjectRunning = errors.New("project is up and running")
-	errWebServerUnHealthy    = errors.New("webserver has not become healthy yet")
+	// errWebServerUnHealthy    = errors.New("webserver has not become healthy yet")
 
 	initSettings      = settings.ConfigSettings
 	exportSettings    = settings.Export
@@ -762,8 +762,10 @@ var checkWebserverHealth = func(settingsFile string, project *types.Project, com
 	})
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			fmt.Println("\nProject is not yet running. The project is still attempting to start up. Run 'astro dev logs --webserver | --scheduler' for details.")
-			return fmt.Errorf("%w: the health check timed out after %s. Use the --wait flag to increase the time out", errWebServerUnHealthy, timeout)
+			// fmt.Println("\nProject is not yet running. The project is still attempting to start up. Run 'astro dev logs --webserver | --scheduler' for details.")
+			// return fmt.Errorf("%w: the health check timed out after %s. Use the --wait flag to increase the time out", errWebServerUnHealthy, timeout)
+			fmt.Printf("\n")
+			return fmt.Errorf("There might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out.", timeout)
 		}
 		if !errors.Is(err, errComposeProjectRunning) {
 			return err

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -762,7 +762,7 @@ var checkWebserverHealth = func(settingsFile string, project *types.Project, com
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			fmt.Printf("\n")
-			return fmt.Errorf("There might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out.", timeout)
+			return fmt.Errorf("there might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out", timeout)
 		}
 		if !errors.Is(err, errComposeProjectRunning) {
 			return err

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -64,7 +64,6 @@ var (
 	errNoFile                = errors.New("file specified does not exist")
 	errSettingsPath          = "error looking for settings.yaml"
 	errComposeProjectRunning = errors.New("project is up and running")
-	// errWebServerUnHealthy    = errors.New("webserver has not become healthy yet")
 
 	initSettings      = settings.ConfigSettings
 	exportSettings    = settings.Export
@@ -762,8 +761,6 @@ var checkWebserverHealth = func(settingsFile string, project *types.Project, com
 	})
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			// fmt.Println("\nProject is not yet running. The project is still attempting to start up. Run 'astro dev logs --webserver | --scheduler' for details.")
-			// return fmt.Errorf("%w: the health check timed out after %s. Use the --wait flag to increase the time out", errWebServerUnHealthy, timeout)
 			fmt.Printf("\n")
 			return fmt.Errorf("There might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out.", timeout)
 		}

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1426,8 +1426,7 @@ func TestCheckWebserverHealth(t *testing.T) {
 		isM1 = mockIsM1
 
 		err := checkWebserverHealth(settingsFile, &types.Project{Name: "test"}, composeMock, 2, false, 1*time.Second)
-		assert.ErrorIs(t, err, errWebServerUnHealthy)
-		assert.ErrorContains(t, err, "webserver has not become healthy yet: the health check timed out after 1s")
+		assert.ErrorContains(t, err, "The webserver health check timed out after 1s")
 	})
 	t.Run("timeout waiting for webserver to get to healthy with long timeout", func(t *testing.T) {
 		settingsFile := "./testfiles/test_dag_inegrity_file.py" // any file which exists
@@ -1455,8 +1454,7 @@ func TestCheckWebserverHealth(t *testing.T) {
 		isM1 = mockIsM1
 
 		err := checkWebserverHealth(settingsFile, &types.Project{Name: "test"}, composeMock, 2, false, 1*time.Second)
-		assert.ErrorIs(t, err, errWebServerUnHealthy)
-		assert.ErrorContains(t, err, "webserver has not become healthy yet: the health check timed out after 1s")
+		assert.ErrorContains(t, err, "The webserver health check timed out after 1s")
 	})
 }
 


### PR DESCRIPTION
## Description

fix timeout copy again

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

tested manually 

## 📸 Screenshots
<img width="841" alt="Screenshot 2022-12-20 at 11 40 02 AM" src="https://user-images.githubusercontent.com/63181127/208731892-efa88c6c-ea0d-425b-b0bd-95ba0f640780.png">

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
