### PR TITLE
Fix command in flow dockerfile

### DIFF
--- a/sql/include/dockerfile_content.go
+++ b/sql/include/dockerfile_content.go
@@ -16,7 +16,7 @@ RUN apt-install-and-clean \
 
 RUN pip install astro-sql-cli==%s
 
-RUN id -u %s &>/dev/null || useradd --uid %s --create-home %s
+RUN id -u %s 2>/dev/null || useradd --uid %s --create-home %s
 # This is necessary to run the docker image in GNU Linux since Astro CLI 1.8
 # It is temporary, since some SQL commands still rely on the default airflow config
 # https://github.com/astronomer/astro-sdk/issues/1219


### PR DESCRIPTION
## Description

The operator `&>` we are using does not work in all shells and apparently not in the docker "shell".

## Screenshot

<img width="1738" alt="Screenshot 2022-12-20 at 18 59 15" src="https://user-images.githubusercontent.com/23282078/208734591-aa4ffe60-ed8a-4152-8f53-fb1d44e9d1c5.png">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
