### PR TITLE
Adds .airflowignore

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -109,6 +109,7 @@ func Init(path, airflowImageName, airflowImageTag string) error {
 		"airflow_settings.yaml":                Settingsyml,
 		"dags/example_dag_basic.py":            ExampleDagBasic,
 		"dags/example_dag_advanced.py":         ExampleDagAdvanced,
+		"dags/.airflowignore":                  "",
 		"README.md":                            Readme,
 		"tests/dags/test_dag_integrity.py":     DagIntegrityTest,
 		".astro/test_dag_integrity_default.py": DagIntegrityTestDefault,

--- a/airflow/airflow_test.go
+++ b/airflow/airflow_test.go
@@ -78,6 +78,7 @@ func TestInit(t *testing.T) {
 		"airflow_settings.yaml",
 		"dags/example_dag_basic.py",
 		"dags/example_dag_advanced.py",
+		"dags/.airflowignore",
 		"README.md",
 	}
 	for _, file := range expectedFiles {


### PR DESCRIPTION
## Description

Adds `.airflowignore` inside of the `dags` directory when running `astro dev init`

To read more about the `.airflowignore` functionality <https://airflow.apache.org/docs/apache-airflow/stable/concepts/dags.html#airflowignore>

## 🎟 Issue(s)

#975 

## 🧪 Functional Testing

```
go main dev init

ls -la dags
```


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
