### PR TITLE
Supporting enabling dag deploy for deployment executor

### DIFF
--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -51,6 +51,7 @@ var (
 				airflowVersion
 			}
 			deploymentSpec {
+				executor
 				image {
 					tag
 				}
@@ -101,6 +102,7 @@ var (
 				airflowVersion
 			}
 			deploymentSpec {
+				executor
 				image {
 					tag
 				}

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -440,7 +440,7 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy stri
 
 	spec := astro.DeploymentCreateSpec{
 		Scheduler: scheduler,
-		Executor:  "CeleryExecutor",
+		Executor:  currentDeployment.DeploymentSpec.Executor,
 	}
 
 	deploymentUpdate := &astro.UpdateDeploymentInput{

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -533,7 +533,7 @@ func TestUpdate(t *testing.T) {
 	deploymentResp := astro.Deployment{
 		ID:             "test-id",
 		RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
-		DeploymentSpec: astro.DeploymentSpec{Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
+		DeploymentSpec: astro.DeploymentSpec{Executor: "CeleryExecutor", Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
 		Cluster: astro.Cluster{
 			NodePools: []astro.NodePool{
 				{
@@ -763,7 +763,7 @@ func TestUpdate(t *testing.T) {
 		deploymentResp = astro.Deployment{
 			ID:               "test-id",
 			RuntimeRelease:   astro.RuntimeRelease{Version: "4.2.5"},
-			DeploymentSpec:   astro.DeploymentSpec{Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
+			DeploymentSpec:   astro.DeploymentSpec{Executor: "CeleryExecutor", Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
 			DagDeployEnabled: true,
 			Cluster: astro.Cluster{
 				NodePools: []astro.NodePool{

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -288,7 +288,7 @@ func TestDeploymentUpdate(t *testing.T) {
 		ID:             "test-id",
 		Label:          "test-name",
 		RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
-		DeploymentSpec: astro.DeploymentSpec{Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
+		DeploymentSpec: astro.DeploymentSpec{Executor: "CeleryExecutor", Scheduler: astro.Scheduler{AU: 5, Replicas: 3}},
 	}
 	deploymentUpdateInput := astro.UpdateDeploymentInput{
 		ID:          "test-id",


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Supporting enabling dag deploy for deployment executor

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
