### PR TITLE
improve error messaging

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -131,7 +131,7 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, out io.Writer
 	if hasEnvVars(&formattedDeployment) {
 		_, err = createEnvVars(&formattedDeployment, createdOrUpdatedDeployment.ID, client)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w \n failed to %s alert emails", err, action)
 		}
 	}
 	// create alert emails

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -894,6 +894,7 @@ deployment:
 			mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, errTest)
 			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
 			assert.ErrorIs(t, err, errTest)
+			assert.ErrorContains(t, err, "\n failed to create alert emails")
 			mockClient.AssertExpectations(t)
 		})
 		t.Run("returns an error from the api if creating alert emails fails", func(t *testing.T) {


### PR DESCRIPTION

## Description

When env vars fail to create or update we also let users know that alert emails have not been created or updated as well. This is only when creating/updating deployments from file. 

## 🎟 Issue(s)

Related #977 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
