### PR TITLE
create KE or CE deployments

### DIFF
--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -328,6 +328,8 @@ type WorkerQueue struct {
 	MinWorkerCount    int    `json:"minWorkerCount"`
 	WorkerConcurrency int    `json:"workerConcurrency"`
 	NodePoolID        string `json:"nodePoolId"`
+	PodCPU            string `json:"podCpu,omitempty"`
+	PodRAM            string `json:"podRam,omitempty"`
 }
 
 type WorkerQueueDefaultOptions struct {

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -32,6 +32,8 @@ var (
 
 const (
 	noWorkspaceMsg = "no workspaces with id (%s) found"
+	KubeExecutor   = "KubernetesExecutor"
+	CeleryExecutor = "CeleryExecutor"
 )
 
 // TODO: get these values from the Astrohub API
@@ -143,7 +145,7 @@ func Logs(deploymentID, ws, deploymentName string, warnLogs, errorLogs, infoLogs
 	return nil
 }
 
-func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeploy string, schedulerAU, schedulerReplicas int, client astro.Client, waitForStatus bool) error {
+func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeploy, executor string, schedulerAU, schedulerReplicas int, client astro.Client, waitForStatus bool) error {
 	var organizationID string
 	var currentWorkspace astro.Workspace
 	var dagDeployEnabled bool
@@ -171,7 +173,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 	// validate workspace
 	ws, err := client.ListWorkspaces(c.Organization)
 	if err != nil {
-		return errors.Wrap(err, astro.AstronomerConnectionErrMsg)
+		return err
 	}
 
 	for i := range ws {
@@ -217,7 +219,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 	}
 
 	spec := astro.DeploymentCreateSpec{
-		Executor:  "CeleryExecutor",
+		Executor:  executor,
 		Scheduler: scheduler,
 	}
 
@@ -240,7 +242,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 	// Create request
 	d, err := client.CreateDeployment(createInput)
 	if err != nil {
-		return errors.Wrap(err, astro.AstronomerConnectionErrMsg)
+		return err
 	}
 
 	if waitForStatus {
@@ -679,7 +681,7 @@ func deploymentSelectionProcess(ws string, deployments []astro.Deployment, clien
 		}
 
 		// walk user through creating a deployment
-		err = createDeployment("", ws, "", "", runtimeVersion, "disable", SchedulerAuMin, SchedulerReplicasMin, client, false)
+		err = createDeployment("", ws, "", "", runtimeVersion, "disable", CeleryExecutor, SchedulerAuMin, SchedulerReplicasMin, client, false)
 		if err != nil {
 			return astro.Deployment{}, err
 		}


### PR DESCRIPTION
## Description

This PR enables users to create deployments with either `KubernetesExecutor` or `CeleryExecutor`. It validates that users pass in correct value for the `-e` or `--executor` flag when creating deployments. It uses `CeleryExecutor` by default if none was specified by the user.

## 🎟 Issue(s)

Related #928 

## 🧪 Functional Testing

#### Kubernetes Executor
```bash
$ astro deployment create -n jp-ke-test --executor KubernetesExecutor
Current Workspace: Production Readiness E2E

 NAME           NAMESPACE                   CLUSTER                                                                     DEPLOYMENT ID                  RUNTIME VERSION                    DAG DEPLOY ENABLED
 jp-ke-test     combusting-fission-1439     aws_workerQ_testing_2023-01-04 09:53:15.893940_create_with_old_template     clcieq2e2187761iybzhw9ko2z     7.1.0 (based on Airflow 2.5.0)     false

 Successfully created Deployment: jp-ke-test
 Deployment can be accessed at the following URLs

 Deployment Dashboard: cloud.astronomer-dev.io/cl6wg2zra144002dyw8px6t6ip/deployments/clcieq2e2187761iybzhw9ko2z/analytics
 Airflow Dashboard: astronomer.astronomer-dev.run/dhw9ko2z?orgId=org_dlgevirUCwI9vX10

```

#### validate via CLI
```bash
$ astro deployment inspect clcieq2e2187761iybzhw9ko2z -k configuration.executor
KubernetesExecutor
```

#### validate via UI
![Screenshot 2023-01-04 at 5 34 21 PM](https://user-images.githubusercontent.com/37133965/210681652-2db8c4c2-fc07-4d7c-9e3c-5464f9b32b81.png)

#### CeleryExecutor
```bash
$ astro deployment create -n jp-test
Current Workspace: Production Readiness E2E

 jp-test     burning-atmosphere-0921     cl6wg2zra144002dyw8px6t6ip     clbzeum5y000v0tyn8hbv5vsa     clcb2a1yb2832022ztlukalw0vr     7.1.0                  7.1.0 (based on Airflow 2.5.0)     false

 Successfully created Deployment: jp-test
 Deployment can be accessed at the following URLs

 Deployment Dashboard: cloud.astronomer-dev.io/cl6wg2zra144002dyw8px6t6ip/deployments/clcb2a1yb2832022ztlukalw0vr/analytics
 Airflow Dashboard: astronomer.astronomer-dev.run/dkalw0vr?orgId=org_dlgevirUCwI9vX10
```
#### validate via CLI

```bash
$ astro deployment inspect clcies2yr191641iyb7nggefqw -k configuration.executor
CeleryExecutor
```

#### validate via UI
![Screenshot 2023-01-04 at 5 35 46 PM](https://user-images.githubusercontent.com/37133965/210681776-ff441cbb-3675-4a4f-b02b-68bc1dd6660b.png)


#### Invalid Executor

```bash
jpatel@jemishs-mbp astro-cli % ./astro deployment create -n jp-test -e KubeExecutor
Error: KubeExecutor is not a valid executor
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
