### PR TITLE
explicitly specify the repository used for postgres as docker.io

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -79,7 +79,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:12.6
+    image: docker.io/postgres:12.6
     restart: unless-stopped
     networks:
       - airflow

--- a/airflow/include/composeyml.yml
+++ b/airflow/include/composeyml.yml
@@ -23,7 +23,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:12.6
+    image: docker.io/postgres:12.6
     restart: unless-stopped
     networks:
       - airflow


### PR DESCRIPTION
## Description

Explicitly state the repository we are pulling from is docker.io. This is the current default value, this is just explicitly adding it.

This is designed to be a low-risk incremental improvement towards supporting a wider variety of docker backends and configurations thereof - e.g. podman on CICD.

```
echo "
[registries.search]
registries = ['docker.io']" | sudo tee -a /etc/containers/registries.conf
```
## 🧪 Functional Testing

On Mac OS X  (with Docker Desktop) created a new astro directory, ran ~/astro-cli/astro dev init and ~/astro-cli/astro dev start and then made sure it came up as before in the web browser as before.

## 📸 Screenshots
Note that Docker re-simplifies this image name so I tweaked the version up a minor version just to demonstrate its pulling from the new location. This version bump is not reflected in this patch.
> Add screenshots to illustrate the validity of these changes.
<img width="343" alt="image" src="https://user-images.githubusercontent.com/89029510/210385516-d7efa65e-43d7-433b-b948-e1e1a4b9bb00.png">

## 📋 Checklist

NOTE: make test is failing on main for me, ignoring and assuming CICD pipeline will run relevant tests.

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
