### PR TITLE
fix missing fields in Create and Update deployment output

### DIFF
--- a/astro-client/mutations.go
+++ b/astro-client/mutations.go
@@ -46,6 +46,7 @@ var (
 			dagDeployEnabled
 			cluster {
 				id
+				name
 			}
 			runtimeRelease {
 				version
@@ -87,6 +88,7 @@ var (
 			dagDeployEnabled
 			cluster {
 				id
+				name
 			}
 			runtimeRelease {
 				version

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -265,13 +265,9 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 func createOutput(workspaceID string, d *astro.Deployment) error {
 	tab := newTableOut()
 
-	currentTag := d.DeploymentSpec.Image.Tag
-	if currentTag == "" {
-		currentTag = "?"
-	}
 	runtimeVersionText := d.RuntimeRelease.Version + " (based on Airflow " + d.RuntimeRelease.AirflowVersion + ")"
 
-	tab.AddRow([]string{d.Label, d.ReleaseName, workspaceID, d.Cluster.ID, d.ID, currentTag, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
+	tab.AddRow([]string{d.Label, d.ReleaseName, d.Cluster.Name, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
 
 	deploymentURL, err := GetDeploymentURL(d.ID, workspaceID)
 	if err != nil {
@@ -516,14 +512,9 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy stri
 	if !queueCreateUpdate {
 		tabDeployment := newTableOut()
 
-		currentTag := d.DeploymentSpec.Image.Tag
-		if currentTag == "" {
-			currentTag = "?"
-		}
-
 		runtimeVersionText := d.RuntimeRelease.Version + " (based on Airflow " + d.RuntimeRelease.AirflowVersion + ")"
 
-		tabDeployment.AddRow([]string{d.Label, d.ReleaseName, ws, d.Cluster.ID, d.ID, currentTag, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
+		tabDeployment.AddRow([]string{d.Label, d.ReleaseName, d.Cluster.Name, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
 		tabDeployment.SuccessMsg = "\n Successfully updated Deployment"
 		tabDeployment.Print(os.Stdout)
 	}


### PR DESCRIPTION

## Description

This PR fills in correct fields to be printed when creating and updating deployments via CLI. Prior to this change, both the commands had `workspaceID` and `currentTag` being printed as missing fields. This PR also adds `cluster.name` to be correctly printed after creating or updating a deployment.
 
## 🎟 Issue(s)

Related #998

## 🧪 Functional Testing

#### create deployment

```bash
$ astro deployment create -n jp-test
Current Workspace: Production Readiness E2E


Please select a Cluster for your Deployment:
...

> 2
 NAME        NAMESPACE                      CLUSTER     DEPLOYMENT ID                  RUNTIME VERSION                    DAG DEPLOY ENABLED
 jp-test     transparent-astronaut-9723     gtadi       clcgzmomv436362cwik0ibpi7y     7.1.0 (based on Airflow 2.5.0)     false

 Successfully created Deployment: jp-test
 Deployment can be accessed at the following URLs

 Deployment Dashboard: cloud.astronomer-dev.io/cl6wg2zra144002dyw8px6t6ip/deployments/clcgzmomv436362cwik0ibpi7y/analytics
 Airflow Dashboard: astronomer.astronomer-dev.run/d0ibpi7y?orgId=org_dlgevirUCwI9vX10
```

#### update deployment

```bash
$ astro deployment update clcgzmomv436362cwik0ibpi7y -n jp-test-1

Are you sure you want to update the jp-test Deployment? (y/n) y
 NAME          NAMESPACE                      CLUSTER     DEPLOYMENT ID                  RUNTIME VERSION                    DAG DEPLOY ENABLED
 jp-test-1     transparent-astronaut-9723     gtadi       clcgzmomv436362cwik0ibpi7y     7.1.0 (based on Airflow 2.5.0)     false

 Successfully updated Deployment
```


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
