### PR TITLE
infer `isdefault` from queue name

### DIFF
--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2352,7 +2352,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			qList = []inspect.Workerq{
 				{
 					Name:              "default",
-					IsDefault:         true,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    3,
 					WorkerConcurrency: 200,
@@ -2360,7 +2359,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				},
 				{
 					Name:              "test-q-2",
-					IsDefault:         false,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    3,
 					WorkerConcurrency: 200,
@@ -2418,7 +2416,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			qList = []inspect.Workerq{
 				{
 					Name:              "default",
-					IsDefault:         true,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    30,
 					WorkerConcurrency: 200,
@@ -2426,7 +2423,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				},
 				{
 					Name:              "test-q-2",
-					IsDefault:         false,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    3,
 					WorkerConcurrency: 200,
@@ -2484,7 +2480,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			qList = []inspect.Workerq{
 				{
 					Name:              "default",
-					IsDefault:         true,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    30,
 					WorkerConcurrency: 200,
@@ -2492,7 +2487,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				},
 				{
 					Name:              "test-q-2",
-					IsDefault:         false,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    3,
 					WorkerConcurrency: 200,
@@ -2532,12 +2526,10 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			qList = []inspect.Workerq{
 				{
 					Name:       "default",
-					IsDefault:  true,
 					WorkerType: "test-worker-1",
 				},
 				{
 					Name:       "test-q-2",
-					IsDefault:  false,
 					WorkerType: "test-worker-2",
 				},
 			}
@@ -2659,7 +2651,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			qList = []inspect.Workerq{
 				{
 					Name:              "default",
-					IsDefault:         true,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    3,
 					WorkerConcurrency: 200,
@@ -2667,7 +2658,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				},
 				{
 					Name:              "test-q-2",
-					IsDefault:         false,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    3,
 					WorkerConcurrency: 200,
@@ -2800,7 +2790,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			qList = []inspect.Workerq{
 				{
 					Name:              "default",
-					IsDefault:         true,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    3,
 					WorkerConcurrency: 200,
@@ -2808,7 +2797,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				},
 				{
 					Name:              "test-q-2",
-					IsDefault:         false,
 					MaxWorkerCount:    16,
 					MinWorkerCount:    3,
 					WorkerConcurrency: 200,
@@ -2953,12 +2941,10 @@ func TestCheckRequiredFields(t *testing.T) {
 		qList := []inspect.Workerq{
 			{
 				Name:       "",
-				IsDefault:  true,
 				WorkerType: "test-worker-1",
 			},
 			{
 				Name:       "test-q-2",
-				IsDefault:  false,
 				WorkerType: "test-worker-2",
 			},
 		}
@@ -2967,37 +2953,33 @@ func TestCheckRequiredFields(t *testing.T) {
 		assert.ErrorIs(t, err, errRequiredField)
 		assert.ErrorContains(t, err, "missing required field: deployment.worker_queues[0].name")
 	})
-	t.Run("if queues were requested, it returns an error if default queue is not named default", func(t *testing.T) {
+	t.Run("if queues were requested, it returns an error if no queue is not default", func(t *testing.T) {
 		input.Deployment.Configuration.Name = "test-deployment"
 		input.Deployment.Configuration.ClusterName = "test-cluster-id"
 		qList := []inspect.Workerq{
 			{
 				Name:       "test-q-1",
-				IsDefault:  false,
 				WorkerType: "test-worker-1",
 			},
 			{
 				Name:       "test-q-2",
-				IsDefault:  true,
 				WorkerType: "test-worker-2",
 			},
 		}
 		input.Deployment.WorkerQs = qList
 		err = checkRequiredFields(&input, "create")
 		assert.ErrorIs(t, err, errRequiredField)
-		assert.ErrorContains(t, err, "missing required field: deployment.worker_queues[1].name = default")
+		assert.ErrorContains(t, err, "missing required field: deployment.worker_queues[0].name = default")
 	})
 	t.Run("if queues were requested, it returns an error if worker type is missing", func(t *testing.T) {
 		input.Deployment.Configuration.Name = "test-deployment"
 		input.Deployment.Configuration.ClusterName = "test-cluster-id"
 		qList := []inspect.Workerq{
 			{
-				Name:      "test-q-1",
-				IsDefault: false,
+				Name: "default",
 			},
 			{
 				Name:       "default",
-				IsDefault:  true,
 				WorkerType: "test-worker-2",
 			},
 		}
@@ -3012,12 +2994,10 @@ func TestCheckRequiredFields(t *testing.T) {
 		qList := []inspect.Workerq{
 			{
 				Name:       "default",
-				IsDefault:  true,
 				WorkerType: "test-worker-1",
 			},
 			{
 				Name:       "test-q-2",
-				IsDefault:  false,
 				WorkerType: "test-worker-2",
 			},
 		}
@@ -3340,7 +3320,6 @@ func TestHasQueues(t *testing.T) {
 		qList := []inspect.Workerq{
 			{
 				Name:              "default",
-				IsDefault:         true,
 				MaxWorkerCount:    16,
 				MinWorkerCount:    3,
 				WorkerConcurrency: 20,
@@ -3348,7 +3327,6 @@ func TestHasQueues(t *testing.T) {
 			},
 			{
 				Name:              "test-q-2",
-				IsDefault:         false,
 				MaxWorkerCount:    16,
 				MinWorkerCount:    3,
 				WorkerConcurrency: 20,
@@ -3395,7 +3373,6 @@ func TestGetQueues(t *testing.T) {
 		qList := []inspect.Workerq{
 			{
 				Name:              "default",
-				IsDefault:         true,
 				MaxWorkerCount:    16,
 				MinWorkerCount:    3,
 				WorkerConcurrency: 20,
@@ -3403,7 +3380,6 @@ func TestGetQueues(t *testing.T) {
 			},
 			{
 				Name:              "test-q-2",
-				IsDefault:         false,
 				MaxWorkerCount:    16,
 				MinWorkerCount:    3,
 				WorkerConcurrency: 20,
@@ -3462,7 +3438,6 @@ func TestGetQueues(t *testing.T) {
 		qList := []inspect.Workerq{
 			{
 				Name:              "default",
-				IsDefault:         true,
 				MaxWorkerCount:    18,
 				MinWorkerCount:    4,
 				WorkerConcurrency: 25,
@@ -3470,7 +3445,6 @@ func TestGetQueues(t *testing.T) {
 			},
 			{
 				Name:              "test-q-2",
-				IsDefault:         false,
 				MaxWorkerCount:    16,
 				MinWorkerCount:    3,
 				WorkerConcurrency: 20,
@@ -3538,7 +3512,6 @@ func TestGetQueues(t *testing.T) {
 		qList := []inspect.Workerq{
 			{
 				Name:              "default",
-				IsDefault:         true,
 				MaxWorkerCount:    18,
 				MinWorkerCount:    4,
 				WorkerConcurrency: 25,
@@ -3546,7 +3519,6 @@ func TestGetQueues(t *testing.T) {
 			},
 			{
 				Name:              "test-q-2", // this queue is being added
-				IsDefault:         false,
 				MaxWorkerCount:    16,
 				MinWorkerCount:    3,
 				WorkerConcurrency: 20,
@@ -3575,7 +3547,6 @@ func TestGetQueues(t *testing.T) {
 		qList := []inspect.Workerq{
 			{
 				Name:              "default",
-				IsDefault:         true,
 				MaxWorkerCount:    16,
 				MinWorkerCount:    3,
 				WorkerConcurrency: 20,
@@ -3583,7 +3554,6 @@ func TestGetQueues(t *testing.T) {
 			},
 			{
 				Name:              "test-q-2",
-				IsDefault:         false,
 				MaxWorkerCount:    16,
 				MinWorkerCount:    3,
 				WorkerConcurrency: 20,

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -41,7 +41,6 @@ type deploymentConfig struct {
 
 type Workerq struct {
 	Name              string `mapstructure:"name" yaml:"name" json:"name"`
-	IsDefault         bool   `mapstructure:"is_default" yaml:"is_default" json:"is_default"`
 	MaxWorkerCount    int    `mapstructure:"max_worker_count" yaml:"max_worker_count" json:"max_worker_count"`
 	MinWorkerCount    int    `mapstructure:"min_worker_count" yaml:"min_worker_count" json:"min_worker_count"`
 	WorkerConcurrency int    `mapstructure:"worker_concurrency" yaml:"worker_concurrency" json:"worker_concurrency"`
@@ -171,7 +170,6 @@ func getQMap(sourceDeploymentQs []astro.WorkerQueue, sourceNodePools []astro.Nod
 	for _, queue := range sourceDeploymentQs {
 		newQ := map[string]interface{}{
 			"name":               queue.Name,
-			"is_default":         queue.IsDefault,
 			"max_worker_count":   queue.MaxWorkerCount,
 			"min_worker_count":   queue.MinWorkerCount,
 			"worker_concurrency": queue.WorkerConcurrency,

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -822,13 +822,11 @@ func TestFormatPrintableDeployment(t *testing.T) {
         workspace_name: test-ws
     worker_queues:
         - name: default
-          is_default: true
           max_worker_count: 130
           min_worker_count: 12
           worker_concurrency: 110
           worker_type: test-instance-type
         - name: test-queue-1
-          is_default: false
           max_worker_count: 175
           min_worker_count: 8
           worker_concurrency: 150
@@ -979,7 +977,6 @@ func TestFormatPrintableDeployment(t *testing.T) {
         "worker_queues": [
             {
                 "name": "default",
-                "is_default": true,
                 "max_worker_count": 130,
                 "min_worker_count": 12,
                 "worker_concurrency": 110,
@@ -987,7 +984,6 @@ func TestFormatPrintableDeployment(t *testing.T) {
             },
             {
                 "name": "test-queue-1",
-                "is_default": false,
                 "max_worker_count": 175,
                 "min_worker_count": 8,
                 "worker_concurrency": 150,


### PR DESCRIPTION
- create or update input does not need to have `isDefault` for any worker queues

## Description

This PR enables users to no longer have to specify `isDefault` for any worker queues when creating or updating deployments from file. Inspecting a deployment no longer prints`isDefault` for any worker queues as the default queue is named `default`. 

## 🎟 Issue(s)

Related #1000

## 🧪 Functional Testing

#### create a deployment from file
```bash
$cat deployment.yaml

deployment:
    environment_variables:
        - key: foo
          value: bar
        - key: bar
          value: awesome
          is_secret: true
    configuration:
        name: jp-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: Production Readiness - DX - LTS
        workspace_name: Production Readiness E2E
    worker_queues:
        - name: default
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```

```bash
$ astro deployment create --deployment-file deployment.yaml
deployment:
    environment_variables:
        - is_secret: false
          key: foo
          updated_at: "2023-01-04T07:07:07.898Z"
          value: bar
        - is_secret: true
          key: bar
          updated_at: "2023-01-04T07:07:09.374Z"
          value: ""
    configuration:
        name: jp-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: Production Readiness - DX - LTS
        workspace_name: Production Readiness E2E
    worker_queues:
        - name: default
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
    metadata:
        deployment_id: clchbguxy370481jwf3vy2ocdk
        workspace_id: cl6wg2zra144002dyw8px6t6ip
        cluster_id: cl6zcnlc600ht0vuibivf53jh
        release_name: heliocentric-planet-3309
        airflow_version: 2.5.0
        status: UNKNOWN
        created_at: 2023-01-04T07:07:01.414Z
        updated_at: 2023-01-04T07:07:23.925Z
        deployment_url: cloud.astronomer-dev.io/cl6wg2zra144002dyw8px6t6ip/deployments/clchbguxy370481jwf3vy2ocdk/analytics
        webserver_url: astronomer.astronomer-dev.run/dvy2ocdk?orgId=org_dlgevirUCwI9vX10
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```

#### update a deployment from file
```bash
$ cat deployment.yaml
deployment:
    environment_variables:
        - key: foo
          value: bar
        - key: bar
          value: awesome
          is_secret: true
    configuration:
        name: jp-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: Production Readiness - DX - LTS
        workspace_name: Production Readiness E2E
    worker_queues:
        - name: default
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
        - name: q-1
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```

```bash
$ astro deployment update --deployment-file deployment.yaml
deployment:
    environment_variables:
        - is_secret: false
          key: foo
          updated_at: "2023-01-04T07:12:29.066Z"
          value: bar
        - is_secret: true
          key: bar
          updated_at: "2023-01-04T07:12:33.596Z"
          value: ""
    configuration:
        name: jp-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: Production Readiness - DX - LTS
        workspace_name: Production Readiness E2E
    worker_queues:
        - name: default
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
        - name: q-1
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
    metadata:
        deployment_id: clchbguxy370481jwf3vy2ocdk
        workspace_id: cl6wg2zra144002dyw8px6t6ip
        cluster_id: cl6zcnlc600ht0vuibivf53jh
        release_name: heliocentric-planet-3309
        airflow_version: 2.5.0
        status: UNKNOWN
        created_at: 2023-01-04T07:07:01.414Z
        updated_at: 2023-01-04T07:12:36.642Z
        deployment_url: cloud.astronomer-dev.io/cl6wg2zra144002dyw8px6t6ip/deployments/clchbguxy370481jwf3vy2ocdk/analytics
        webserver_url: astronomer.astronomer-dev.run/dvy2ocdk?orgId=org_dlgevirUCwI9vX10
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```
#### inspect a deployment

```bash
$ astro deployment inspect clchbguxy370481jwf3vy2ocdk
deployment:
    environment_variables:
        - is_secret: false
          key: foo
          updated_at: "2023-01-04T07:12:29.066Z"
          value: bar
        - is_secret: true
          key: bar
          updated_at: "2023-01-04T07:12:33.596Z"
          value: ""
    configuration:
        name: jp-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: Production Readiness - DX - LTS
        workspace_name: Production Readiness E2E
    worker_queues:
        - name: default
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
        - name: q-1
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
    metadata:
        deployment_id: clchbguxy370481jwf3vy2ocdk
        workspace_id: cl6wg2zra144002dyw8px6t6ip
        cluster_id: cl6zcnlc600ht0vuibivf53jh
        release_name: heliocentric-planet-3309
        airflow_version: 2.5.0
        status: UNKNOWN
        created_at: 2023-01-04T07:07:01.414Z
        updated_at: 2023-01-04T07:12:36.642Z
        deployment_url: cloud.astronomer-dev.io/cl6wg2zra144002dyw8px6t6ip/deployments/clchbguxy370481jwf3vy2ocdk/analytics
        webserver_url: astronomer.astronomer-dev.run/dvy2ocdk?orgId=org_dlgevirUCwI9vX10
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
