### PR TITLE
Update the dags folder access from read only to shared access

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -110,7 +110,7 @@ services:
       - postgres
     environment: *common-env-vars
     volumes:
-      - airflow_home/dags:/usr/local/airflow/dags:ro
+      - airflow_home/dags:/usr/local/airflow/dags:z
       - airflow_home/plugins:/usr/local/airflow/plugins:z
       - airflow_home/include:/usr/local/airflow/include:z
       - airflow_home/tests:/usr/local/airflow/tests:z
@@ -221,7 +221,7 @@ services:
       - postgres
     environment: *common-env-vars
     volumes:
-      - airflow_home/dags:/usr/local/airflow/dags:ro
+      - airflow_home/dags:/usr/local/airflow/dags:z
       - airflow_home/plugins:/usr/local/airflow/plugins:z
       - airflow_home/include:/usr/local/airflow/include:z
       - airflow_home/tests:/usr/local/airflow/tests:z

--- a/airflow/include/composeyml.yml
+++ b/airflow/include/composeyml.yml
@@ -54,7 +54,7 @@ services:
       - postgres
     environment: *common-env-vars
     volumes:
-      - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:ro
+      - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:{{ .MountLabel }}
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:{{ .MountLabel }}
       - {{ .AirflowHome }}/include:/usr/local/airflow/include:{{ .MountLabel }}
       - {{ .AirflowHome }}/tests:/usr/local/airflow/tests:{{ .MountLabel }}


### PR DESCRIPTION
## Description
Changes:
- Updated the dags folder access from read-only to shared volume access in the scheduler container

## 🎟 Issue(s)

Related #1004 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
