### PR TITLE
add configuration option for the binary name used for running docker commands

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -471,7 +471,8 @@ func (d *DockerCompose) Bash(container string) error {
 		}
 	}
 	// exec into container
-	err = cmdExec(DockerCmd, os.Stdout, os.Stderr, "exec", "-it", containerName, "bash")
+	dockerCommand := config.CFG.DockerCommand.GetString()
+	err = cmdExec(dockerCommand, os.Stdout, os.Stderr, "exec", "-it", containerName, "bash")
 	if err != nil {
 		return err
 	}
@@ -802,8 +803,10 @@ func checkServiceState(serviceState, expectedState string) bool {
 }
 
 func startDocker() error {
+	dockerCommand := config.CFG.DockerCommand.GetString()
+
 	buf := new(bytes.Buffer)
-	err := cmdExec(DockerCmd, buf, buf, "ps")
+	err := cmdExec(dockerCommand, buf, buf, "ps")
 	if err != nil {
 		// open docker
 		fmt.Println("\nDocker is not running. Starting up the Docker engine…")
@@ -824,6 +827,8 @@ func startDocker() error {
 }
 
 func waitForDocker() error {
+	dockerCommand := config.CFG.DockerCommand.GetString()
+
 	buf := new(bytes.Buffer)
 	timeout := time.After(time.Duration(timeoutNum) * time.Second)
 	ticker := time.NewTicker(time.Duration(tickNum) * time.Millisecond)
@@ -835,7 +840,7 @@ func waitForDocker() error {
 		// Got a tick, we should check if docker is up & running
 		case <-ticker.C:
 			buf.Reset()
-			err := cmdExec(DockerCmd, buf, buf, "ps")
+			err := cmdExec(dockerCommand, buf, buf, "ps")
 			if err != nil {
 				continue
 			} else {

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -9,6 +9,7 @@ import (
 
 	airflowTypes "github.com/astronomer/astro-cli/airflow/types"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/spf13/afero"
@@ -18,6 +19,8 @@ import (
 var errMock = errors.New("build error")
 
 func TestDockerImageBuild(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
 	handler := DockerImage{
 		imageName: "testing",
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ var (
 		CloudAPIToken:        newCfg("cloud.api.token", ""),
 		Context:              newCfg("context", ""),
 		Contexts:             newCfg("contexts", ""),
+		DockerCommand:        newCfg("container.binary", "docker"),
 		LocalAstro:           newCfg("local.astrohub", "http://localhost:8871/v1"),
 		LocalCore:            newCfg("local.core", "http://localhost:8888/v1alpha1"),
 		LocalPublicAstro:     newCfg("local.public_astrohub", "http://localhost:8871/graphql"),

--- a/config/types.go
+++ b/config/types.go
@@ -14,6 +14,7 @@ type cfgs struct {
 	CloudAPIToken        cfg
 	Context              cfg
 	Contexts             cfg
+	DockerCommand        cfg
 	LocalEnabled         cfg
 	LocalAstro           cfg
 	LocalCore            cfg


### PR DESCRIPTION
## Description
Adds the ability to specify the name of the binary used to execute docker commands by setting container.binary in ~/.astro/config. Users of docker-alternatives frequently have both docker and their alternative runtime installed. This causes problems when the real docker binary runs and tries to attempt to the  alternative container runtime and throws an error when they intended to not use docker at all. This configuration option allows the user to explicitly state the binary they wish to use.

## 🧪 Functional Testing

Confirmed all the following worked as expected:

Ran ~/astro-cli/astro dev start and kill under Docker with stock config file
Ran ~/astro-cli/astro dev start and kill under Docker with container.binary set to docker
exported DOCKER_HOST=unix:///Users/rob/.local/share/containers/podman/machine/podman-machine-default/podman.sock
Ran ~/astro-cli/astro dev start and kill with container.binary intentionally misset to docker and watched it fail
Corrected value to podman and it succeeded.
## 📸 Screenshots

<img width="853" alt="image" src="https://user-images.githubusercontent.com/89029510/210856604-61ee57c0-8ce0-43dc-af5d-968181c29530.png">


## 📋 Checklist

- [ X] Rebased from the main (or release if patching) branch (before testing)
- [X ] Ran `make test` before taking out of draft
- [ x] Ran `make lint` before taking out of draft
- [x ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
