### PR TITLE
932 ke create from file

### DIFF
--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -324,9 +324,9 @@ type WorkerQueue struct {
 	ID                string `json:"id,omitempty"` // Empty when creating new WorkerQueues
 	Name              string `json:"name"`
 	IsDefault         bool   `json:"isDefault"`
-	MaxWorkerCount    int    `json:"maxWorkerCount"`
-	MinWorkerCount    int    `json:"minWorkerCount"`
-	WorkerConcurrency int    `json:"workerConcurrency"`
+	MaxWorkerCount    int    `json:"maxWorkerCount,omitempty"`
+	MinWorkerCount    int    `json:"minWorkerCount,omitempty"`
+	WorkerConcurrency int    `json:"workerConcurrency,omitempty"`
 	NodePoolID        string `json:"nodePoolId"`
 	PodCPU            string `json:"podCpu,omitempty"`
 	PodRAM            string `json:"podRam,omitempty"`

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/astronomer/astro-cli/astro-client"
 	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
+	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/spf13/afero"
@@ -134,6 +135,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -193,6 +195,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -253,6 +256,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -313,6 +317,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: cluster-name
@@ -394,6 +399,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -465,6 +471,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -540,6 +547,7 @@ deployment:
             "description": "description",
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
+            "executor": "CeleryExecutor",
             "scheduler_au": 5,
             "scheduler_count": 3,
             "cluster_name": "test-cluster",
@@ -670,6 +678,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -793,6 +802,7 @@ deployment:
             "description": "description",
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
+            "executor": "CeleryExecutor",
             "scheduler_au": 5,
             "scheduler_count": 3,
             "cluster_name": "test-cluster",
@@ -922,6 +932,7 @@ deployment:
             "description": "description",
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
+            "executor": "CeleryExecutor",
             "scheduler_au": 5,
             "scheduler_count": 3,
             "cluster_name": "test-cluster",
@@ -1049,6 +1060,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -1193,6 +1205,7 @@ deployment:
             "description": "description",
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
+            "executor": "CeleryExecutor",
             "scheduler_au": 5,
             "scheduler_count": 3,
             "cluster_name": "test-cluster",
@@ -1360,6 +1373,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -1437,6 +1451,7 @@ deployment:
             "description": "description",
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
+            "executor": "CeleryExecutor",
             "scheduler_au": 5,
             "scheduler_count": 3,
             "cluster_name": "test-cluster",
@@ -1564,6 +1579,7 @@ deployment:
             "description": "description",
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
+            "executor": "CeleryExecutor",
             "scheduler_au": 5,
             "scheduler_count": 3,
             "cluster_name": "test-cluster",
@@ -1690,6 +1706,7 @@ deployment:
     description: description 1
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -1841,6 +1858,7 @@ deployment:
             "description": "description",
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
+            "executor": "CeleryExecutor",
             "scheduler_au": 5,
             "scheduler_count": 3,
             "cluster_name": "test-cluster",
@@ -2005,6 +2023,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -2082,6 +2101,7 @@ deployment:
             "description": "description",
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
+            "executor": "CeleryExecutor",
             "scheduler_au": 5,
             "scheduler_count": 3,
             "cluster_name": "test-cluster",
@@ -2214,6 +2234,7 @@ deployment:
             "description": "description",
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
+            "executor": "CeleryExecutor",
             "scheduler_au": 5,
             "scheduler_count": 3,
             "cluster_name": "test-cluster",
@@ -2523,6 +2544,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
 			qList = []inspect.Workerq{
 				{
 					Name:       "default",
@@ -2590,7 +2612,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
 				DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
-					Executor: "CeleryExecutor",
+					Executor: deployment.CeleryExecutor,
 					Scheduler: astro.Scheduler{
 						AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
 						Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,
@@ -2616,6 +2638,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
 
 			expectedDeploymentInput = astro.CreateDeploymentInput{
 				WorkspaceID:           workspaceID,
@@ -2625,7 +2648,40 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
 				DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
-					Executor: "CeleryExecutor",
+					Executor: deployment.CeleryExecutor,
+					Scheduler: astro.Scheduler{
+						AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
+						Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,
+					},
+				},
+				WorkerQueues: nil,
+			}
+			mockClient := new(astro_mocks.Client)
+			actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, nil, mockClient)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedDeploymentInput, actualCreateInput)
+			mockClient.AssertExpectations(t)
+		})
+		t.Run("transforms formattedDeployment to CreateDeploymentInput if Kubernetes executor was requested", func(t *testing.T) {
+			deploymentFromFile = inspect.FormattedDeployment{}
+			expectedDeploymentInput = astro.CreateDeploymentInput{}
+			deploymentFromFile.Deployment.Configuration.ClusterName = "test-cluster"
+			deploymentFromFile.Deployment.Configuration.Name = "test-deployment"
+			deploymentFromFile.Deployment.Configuration.Description = "test-description"
+			deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
+			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
+			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+
+			expectedDeploymentInput = astro.CreateDeploymentInput{
+				WorkspaceID:           workspaceID,
+				ClusterID:             clusterID,
+				Label:                 deploymentFromFile.Deployment.Configuration.Name,
+				Description:           deploymentFromFile.Deployment.Configuration.Description,
+				RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
+				DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+				DeploymentSpec: astro.DeploymentCreateSpec{
+					Executor: deployment.KubeExecutor,
 					Scheduler: astro.Scheduler{
 						AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
 						Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,
@@ -2648,6 +2704,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
 			qList = []inspect.Workerq{
 				{
 					Name:              "default",
@@ -2721,7 +2778,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
 				DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
-					Executor: "CeleryExecutor",
+					Executor: deployment.CeleryExecutor,
 					Scheduler: astro.Scheduler{
 						AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
 						Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,
@@ -2902,9 +2959,25 @@ func TestCheckRequiredFields(t *testing.T) {
 		assert.ErrorIs(t, err, errRequiredField)
 		assert.ErrorContains(t, err, "missing required field: deployment.configuration.cluster_name")
 	})
+	t.Run("returns an error if executor is missing", func(t *testing.T) {
+		input.Deployment.Configuration.Name = "test-deployment"
+		input.Deployment.Configuration.ClusterName = "test-cluster"
+		err = checkRequiredFields(&input, "")
+		assert.ErrorIs(t, err, errRequiredField)
+		assert.ErrorContains(t, err, "missing required field: deployment.configuration.executor")
+	})
+	t.Run("returns an error if executor value is invalid", func(t *testing.T) {
+		input.Deployment.Configuration.Name = "test-deployment"
+		input.Deployment.Configuration.ClusterName = "test-cluster"
+		input.Deployment.Configuration.Executor = "test-executor"
+		err = checkRequiredFields(&input, "")
+		assert.ErrorIs(t, err, errInvalidValue)
+		assert.ErrorContains(t, err, "is not valid. It can either be CeleryExecutor or KubernetesExecutor")
+	})
 	t.Run("returns an error if alert email is invalid", func(t *testing.T) {
 		input.Deployment.Configuration.Name = "test-deployment"
-		input.Deployment.Configuration.ClusterName = "test-cluster-id"
+		input.Deployment.Configuration.ClusterName = "test-cluster"
+		input.Deployment.Configuration.Executor = deployment.CeleryExecutor
 		list := []string{"test@test.com", "testing@testing.com", "not-an-email"}
 		input.Deployment.AlertEmails = list
 		err = checkRequiredFields(&input, "")
@@ -2914,7 +2987,8 @@ func TestCheckRequiredFields(t *testing.T) {
 	t.Run("returns an error if env var keys are missing on create", func(t *testing.T) {
 		input = inspect.FormattedDeployment{}
 		input.Deployment.Configuration.Name = "test-deployment"
-		input.Deployment.Configuration.ClusterName = "test-cluster-id"
+		input.Deployment.Configuration.ClusterName = "test-cluster"
+		input.Deployment.Configuration.Executor = deployment.CeleryExecutor
 		list := []inspect.EnvironmentVariable{
 			{
 				IsSecret:  false,
@@ -2937,7 +3011,8 @@ func TestCheckRequiredFields(t *testing.T) {
 	t.Run("if queues were requested, it returns an error if queue name is missing", func(t *testing.T) {
 		input = inspect.FormattedDeployment{}
 		input.Deployment.Configuration.Name = "test-deployment"
-		input.Deployment.Configuration.ClusterName = "test-cluster-id"
+		input.Deployment.Configuration.ClusterName = "test-cluster"
+		input.Deployment.Configuration.Executor = deployment.CeleryExecutor
 		qList := []inspect.Workerq{
 			{
 				Name:       "",
@@ -2953,9 +3028,10 @@ func TestCheckRequiredFields(t *testing.T) {
 		assert.ErrorIs(t, err, errRequiredField)
 		assert.ErrorContains(t, err, "missing required field: deployment.worker_queues[0].name")
 	})
-	t.Run("if queues were requested, it returns an error if no queue is not default", func(t *testing.T) {
+	t.Run("if queues were requested, it returns an error if default queue is missing", func(t *testing.T) {
 		input.Deployment.Configuration.Name = "test-deployment"
-		input.Deployment.Configuration.ClusterName = "test-cluster-id"
+		input.Deployment.Configuration.ClusterName = "test-cluster"
+		input.Deployment.Configuration.Executor = deployment.CeleryExecutor
 		qList := []inspect.Workerq{
 			{
 				Name:       "test-q-1",
@@ -2973,7 +3049,8 @@ func TestCheckRequiredFields(t *testing.T) {
 	})
 	t.Run("if queues were requested, it returns an error if worker type is missing", func(t *testing.T) {
 		input.Deployment.Configuration.Name = "test-deployment"
-		input.Deployment.Configuration.ClusterName = "test-cluster-id"
+		input.Deployment.Configuration.ClusterName = "test-cluster"
+		input.Deployment.Configuration.Executor = deployment.CeleryExecutor
 		qList := []inspect.Workerq{
 			{
 				Name: "default",
@@ -2990,7 +3067,8 @@ func TestCheckRequiredFields(t *testing.T) {
 	})
 	t.Run("returns nil if there are no missing fields", func(t *testing.T) {
 		input.Deployment.Configuration.Name = "test-deployment"
-		input.Deployment.Configuration.ClusterName = "test-cluster-id"
+		input.Deployment.Configuration.ClusterName = "test-cluster"
+		input.Deployment.Configuration.Executor = deployment.CeleryExecutor
 		qList := []inspect.Workerq{
 			{
 				Name:       "default",
@@ -3847,5 +3925,20 @@ func TestCheckEnvVars(t *testing.T) {
 		input.Deployment.EnvVars = list
 		err = checkEnvVars(&input, "update")
 		assert.NoError(t, err)
+	})
+}
+
+func TestIsValidExecutor(t *testing.T) {
+	t.Run("returns true if executor is Celery", func(t *testing.T) {
+		actual := isValidExecutor(deployment.CeleryExecutor)
+		assert.True(t, actual)
+	})
+	t.Run("returns true if executor is Kubernetes", func(t *testing.T) {
+		actual := isValidExecutor(deployment.KubeExecutor)
+		assert.True(t, actual)
+	})
+	t.Run("returns false if executor is neither Celery nor Kubernetes", func(t *testing.T) {
+		actual := isValidExecutor("test-executor")
+		assert.False(t, actual)
 	})
 }

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -21,6 +21,7 @@ type deploymentMetadata struct {
 	ClusterID      *string    `mapstructure:"cluster_id" yaml:"cluster_id" json:"cluster_id"`
 	ReleaseName    *string    `mapstructure:"release_name" yaml:"release_name" json:"release_name"`
 	AirflowVersion *string    `mapstructure:"airflow_version" yaml:"airflow_version" json:"airflow_version"`
+	CurrentTag     *string    `mapstructure:"current_tag" yaml:"current_tag" json:"current_tag"`
 	Status         *string    `mapstructure:"status" yaml:"status" json:"status"`
 	CreatedAt      *time.Time `mapstructure:"created_at" yaml:"created_at" json:"created_at"`
 	UpdatedAt      *time.Time `mapstructure:"updated_at" yaml:"updated_at" json:"updated_at"`
@@ -137,6 +138,7 @@ func getDeploymentInfo(sourceDeployment *astro.Deployment) (map[string]interface
 		"workspace_id":    sourceDeployment.Workspace.ID,
 		"cluster_id":      sourceDeployment.Cluster.ID,
 		"airflow_version": sourceDeployment.RuntimeRelease.AirflowVersion,
+		"current_tag":     sourceDeployment.DeploymentSpec.Image.Tag,
 		"release_name":    sourceDeployment.ReleaseName,
 		"deployment_url":  deploymentURL,
 		"webserver_url":   sourceDeployment.DeploymentSpec.Webserver.URL,

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -271,6 +271,9 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 				Replicas: 3,
 			},
 			Webserver: astro.Webserver{URL: "some-url"},
+			Image: astro.Image{
+				Tag: "some-tag",
+			},
 		},
 		WorkerQueues: []astro.WorkerQueue{
 			{
@@ -307,6 +310,7 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 			WorkspaceID:    &sourceDeployment.Workspace.ID,
 			ClusterID:      &sourceDeployment.Cluster.ID,
 			AirflowVersion: &sourceDeployment.RuntimeRelease.AirflowVersion,
+			CurrentTag:     &sourceDeployment.DeploymentSpec.Image.Tag,
 			ReleaseName:    &sourceDeployment.ReleaseName,
 			DeploymentURL:  &expectedCloudDomainURL,
 			WebserverURL:   &sourceDeployment.DeploymentSpec.Webserver.URL,
@@ -331,6 +335,7 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 			ClusterID:      &sourceDeployment.Cluster.ID,
 			ReleaseName:    &sourceDeployment.ReleaseName,
 			AirflowVersion: &sourceDeployment.RuntimeRelease.AirflowVersion,
+			CurrentTag:     &sourceDeployment.DeploymentSpec.Image.Tag,
 			Status:         &sourceDeployment.Status,
 			CreatedAt:      &sourceDeployment.CreatedAt,
 			UpdatedAt:      &sourceDeployment.UpdatedAt,

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	createAction = "create"
-	updateAction = "update"
+	createAction     = "create"
+	updateAction     = "update"
+	defaultQueueName = "default"
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 	errQueueDoesNotExist         = errors.New("worker queue does not exist")
 	errInvalidQueue              = errors.New("worker queue selection failed")
 	errCannotDeleteDefaultQueue  = errors.New("default queue can not be deleted")
+	ErrNotSupported              = errors.New("KubernetesExecutor does not support")
 )
 
 func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType string, wQueueMin, wQueueMax, wQueueConcurrency int, force bool, client astro.Client, out io.Writer) error {
@@ -65,7 +67,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	}
 	queueToCreateOrUpdate = SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency, queueToCreateOrUpdate, defaultOptions)
 
-	err = IsWorkerQueueInputValid(queueToCreateOrUpdate, defaultOptions)
+	err = IsCeleryWorkerQueueInputValid(queueToCreateOrUpdate, defaultOptions)
 	if err != nil {
 		return err
 	}
@@ -165,10 +167,10 @@ func GetWorkerQueueDefaultOptions(client astro.Client) (astro.WorkerQueueDefault
 	return workerQueueDefaultOptions, nil
 }
 
-// IsWorkerQueueInputValid checks if the requestedWorkerQueue adheres to the floor and ceiling set in the defaultOptions
-// if it adheres to them, it returns nil
-// errInvalidWorkerQueueOption is returned if min, max or concurrency are out of range
-func IsWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue, defaultOptions astro.WorkerQueueDefaultOptions) error {
+// IsCeleryWorkerQueueInputValid checks if the requestedWorkerQueue adheres to the floor and ceiling set in the defaultOptions
+// if it adheres to them, it returns nil.
+// errInvalidWorkerQueueOption is returned if min, max or concurrency are out of range.
+func IsCeleryWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue, defaultOptions astro.WorkerQueueDefaultOptions) error {
 	var errorMessage string
 	if !(requestedWorkerQueue.MinWorkerCount >= defaultOptions.MinWorkerCount.Floor) ||
 		!(requestedWorkerQueue.MinWorkerCount <= defaultOptions.MinWorkerCount.Ceiling) {
@@ -185,6 +187,39 @@ func IsWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue, defaultOpt
 		errorMessage = fmt.Sprintf("worker concurrency must be between %d and %d", defaultOptions.WorkerConcurrency.Floor, defaultOptions.WorkerConcurrency.Ceiling)
 		return fmt.Errorf("%w: %s", errInvalidWorkerQueueOption, errorMessage)
 	}
+	return nil
+}
+
+// IsKubernetesWorkerQueueInputValid checks if the requestedQueue has all the necessary properties
+// required to create a worker queue for the KubernetesExecutor.
+// errNotSupported is returned for any invalid properties.
+func IsKubernetesWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue) error {
+	var errorMessage string
+	if requestedWorkerQueue.Name != defaultQueueName {
+		errorMessage = "a non default worker queue in the request. Rename the queue to default"
+		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+	}
+	if requestedWorkerQueue.PodCPU != "" {
+		errorMessage = "pod_cpu in the request. It will be calculated based on the requested worker_type"
+		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+	}
+	if requestedWorkerQueue.PodRAM != "" {
+		errorMessage = "pod_ram in the request. It will be calculated based on the requested worker_type"
+		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+	}
+	if requestedWorkerQueue.MinWorkerCount != 0 {
+		errorMessage = "min_worker_count in the request. It can only be used with CeleryExecutor"
+		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+	}
+	if requestedWorkerQueue.MaxWorkerCount != 0 {
+		errorMessage = "max_worker_count in the request. It can only be used with CeleryExecutor"
+		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+	}
+	if requestedWorkerQueue.WorkerConcurrency != 0 {
+		errorMessage = "worker_concurrency in the request. It can only be used with CeleryExecutor"
+		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+	}
+
 	return nil
 }
 
@@ -289,7 +324,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, client as
 		}
 	}
 	// check if default queue is being deleted
-	if name == "default" {
+	if name == defaultQueueName {
 		return errCannotDeleteDefaultQueue
 	}
 	queueToDelete = &astro.WorkerQueue{

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -190,6 +190,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster
@@ -349,6 +350,7 @@ deployment:
     description: description
     runtime_version: 6.0.0
     dag_deploy_enabled: true
+    executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
     cluster_name: test-cluster


### PR DESCRIPTION
## Description

This PR enables users to create KE deployments and KE specific worker queues from valid yaml or json files. It validates all the required fields for KE worker queues and returns an error if any are missing. It also returns an error if worker queue requested has `pod_ram` or `pod_cpu` in the request as those are calculated based on the requested worker type. If creating KE worker queues, it also returns an error if > 1 queues are requested. 


## 🎟 Issue(s)

Related #934 & #932

## 🧪 Functional Testing

#### create KE deployment
```bash
$ cat deployment-KE.yaml
deployment:
    environment_variables:
        - key: foo
          value: bar
        - key: bar
          value: awesome
          is_secret: true
    configuration:
        name: jp-KE-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        executor: KubernetesExecutor
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: gtadi
        workspace_name: CLI Test Workspace
    worker_queues:
        - name: default
          worker_type: m5.xlarge
    alert_emails:
        - test1@tester.com
        - test2@tester.com

$ astro deployment create --deployment-file deployment-KE.yaml
deployment:
    environment_variables:
        - is_secret: false
          key: foo
          updated_at: "2023-01-10T20:32:06.130Z"
          value: bar
        - is_secret: true
          key: bar
          updated_at: "2023-01-10T20:32:06.449Z"
          value: ""
    configuration:
        name: jp-KE-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        executor: KubernetesExecutor
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: gtadi
        workspace_name: CLI Test Workspace
    worker_queues:
        - name: default
          worker_type: m5.xlarge
          pod_cpu: "0.1"
          pod_ram: 0.25Gi
    metadata:
        deployment_id: clcqov8q8145632c0y3gbrqj09
        workspace_id: cl0v1p6lc728255byzyfs7lw21
        cluster_id: clbzeum5y000v0tyn8hbv5vsa
        release_name: blazing-terrestrial-6332
        airflow_version: 2.5.0
        status: UNKNOWN
        created_at: 2023-01-10T20:32:03.056Z
        updated_at: 2023-01-10T20:32:08.236Z
        deployment_url: cloud.astronomer-dev.io/cl0v1p6lc728255byzyfs7lw21/deployments/clcqov8q8145632c0y3gbrqj09/analytics
        webserver_url: astronomer.astronomer-dev.run/dgbrqj09?orgId=org_dlgevirUCwI9vX10
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```

#### KE Specific Errors
```bash
$ astro deployment create --deployment-file deployment-KE.yaml
Error: KubernetesExecutor does not support pod_ram or pod_cpu in the request. These will be calculated based on the requested worker_type
```

```bash
$ astro deployment create --deployment-file deployment-fail-KE.yaml
Error: KubernetesExecutor does not support more than one worker queue. (2) were requested
```

```bash
# if we request a KE deployment with Celery Queue Fields
$ astro deployment create --deployment-file deployment-fail-KE.yaml
Error: KubernetesExecutor does not support min_worker_count in the request. It can only be used with CeleryExecutor
```

```bash
$ astro deployment create --deployment-file deployment-fail-KE.yaml
Error: executor awesome-executor is not valid. It can either be CeleryExecutor or KubernetesExecutor
```


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
