### PR TITLE
Fix flow config cmd args

### DIFF
--- a/cmd/sql/e2e/flow_test.go
+++ b/cmd/sql/e2e/flow_test.go
@@ -111,7 +111,7 @@ func TestE2EFlowConfigCmd(t *testing.T) {
 			err := execFlowCmd("init", projectDir, tc.initFlag, t.TempDir())
 			assert.NoError(t, err)
 
-			err = execFlowCmd("config", "--project-dir", projectDir, tc.configKey)
+			err = execFlowCmd("config", "get", tc.configKey, "--project-dir", projectDir)
 			assert.NoError(t, err)
 		})
 	}

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -128,7 +128,7 @@ func getProjectDirFromArgs(args []string) string {
 
 // Read config cmd output for retrieving config settings such as airflow_home
 func readConfigCmdOutput(key string) (string, error) {
-	args := []string{key}
+	args := []string{"get", key}
 	output, err := readCmdOutput(configCmd, args)
 	if err != nil {
 		return "", err

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -193,7 +193,7 @@ func TestFlowConfigCmd(t *testing.T) {
 			err := execFlowCmd("init", projectDir, tc.initFlag, t.TempDir())
 			assert.NoError(t, err)
 
-			err = execFlowCmd("config", "--project-dir", projectDir, tc.configKey)
+			err = execFlowCmd("config", "get", tc.configKey, "--project-dir", projectDir)
 			assert.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
## Description

Starting from sql-cli 0.3.0, the sql-cli `config` cmd requires a `get` arg to get information about the config.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
