### PR TITLE
updates from file can toggle executor

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -240,7 +240,7 @@ func getCreateOrUpdateInput(deploymentFromFile *inspect.FormattedDeployment, clu
 			Description:      deploymentFromFile.Deployment.Configuration.Description,
 			DagDeployEnabled: deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 			DeploymentSpec: astro.DeploymentCreateSpec{
-				Executor: "CeleryExecutor",
+				Executor: deploymentFromFile.Deployment.Configuration.Executor,
 				Scheduler: astro.Scheduler{
 					AU:       deploymentFromFile.Deployment.Configuration.SchedulerAU,
 					Replicas: deploymentFromFile.Deployment.Configuration.SchedulerCount,


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related #933 #935

## 🧪 Functional Testing

> inspect an existing deployment
```bash
$ astro deployment inspect -n jp-CE-test
deployment:
    environment_variables:
        - is_secret: false
          key: foo
          updated_at: "2023-01-12T05:22:04.708Z"
          value: bar
        - is_secret: true
          key: bar
          updated_at: "2023-01-12T05:22:04.948Z"
          value: ""
    configuration:
        name: jp-CE-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        executor: CeleryExecutor
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: team-airflow-operator
        workspace_name: CLI Test Workspace
    worker_queues:
        - name: default
          max_worker_count: 10
          min_worker_count: 1
          worker_concurrency: 16
          worker_type: m5.xlarge
    metadata:
        deployment_id: clcsn8nhi4182331z5wlhhymbh
        workspace_id: cl0v1p6lc728255byzyfs7lw21
        cluster_id: cl9ftbunb006q0uzgfrdk0r6t
        release_name: scientific-battery-8949
        airflow_version: 2.5.0
        current_tag: 7.1.0
        status: UNKNOWN
        created_at: 2023-01-12T05:22:01.83Z
        updated_at: 2023-01-12T05:22:06.455Z
        deployment_url: cloud.astronomer-dev.io/cl0v1p6lc728255byzyfs7lw21/deployments/clcsn8nhi4182331z5wlhhymbh/analytics
        webserver_url: astronomer.astronomer-dev.run/dlhhymbh?orgId=org_dlgevirUCwI9vX10
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```

> update the executor from CE -> KE
```bash
$ cat deployment.yaml
deployment:
    environment_variables:
        - key: foo
          value: bar
        - key: bar
          value: awesome
          is_secret: true
    configuration:
        name: jp-CE-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        executor: KubernetesExecutor
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: team-airflow-operator
        workspace_name: CLI Test Workspace
    alert_emails:
        - test1@tester.com
        - test2@tester.com

$ astro deployment update --deployment-file deployment.yaml
deployment:
    environment_variables:
        - is_secret: false
          key: foo
          updated_at: "2023-01-12T05:25:32.108Z"
          value: bar
        - is_secret: true
          key: bar
          updated_at: "2023-01-12T05:25:34.316Z"
          value: ""
    configuration:
        name: jp-CE-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        executor: KubernetesExecutor
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: team-airflow-operator
        workspace_name: CLI Test Workspace
    worker_queues:
        - name: default
          worker_type: m5.xlarge
          pod_cpu: "0.1"
          pod_ram: 0.25Gi
    metadata:
        deployment_id: clcsn8nhi4182331z5wlhhymbh
        workspace_id: cl0v1p6lc728255byzyfs7lw21
        cluster_id: cl9ftbunb006q0uzgfrdk0r6t
        release_name: scientific-battery-8949
        airflow_version: 2.5.0
        current_tag: 7.1.0
        status: UNKNOWN
        created_at: 2023-01-12T05:22:01.83Z
        updated_at: 2023-01-12T05:25:35.885Z
        deployment_url: cloud.astronomer-dev.io/cl0v1p6lc728255byzyfs7lw21/deployments/clcsn8nhi4182331z5wlhhymbh/analytics
        webserver_url: astronomer.astronomer-dev.run/dlhhymbh?orgId=org_dlgevirUCwI9vX10
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```
> KE specific errors
```bash
$ astro deployment update --deployment-file deployment-fail-KE.yaml
Error: KubernetesExecutor does not support pod_ram in the request. It will be calculated based on the requested worker_type
```
```bash
$ astro deployment update --deployment-file deployment-fail-KE.yaml
Error: KubernetesExecutor does not support more than one worker queue. (2) were requested
```

```bash
$ astro deployment update --deployment-file deployment-fail-KE.yaml
Error: KubernetesExecutor does not support max_worker_count in the request. It can only be used with CeleryExecutor
```

```bash
$ astro deployment update --deployment-file deployment-fail-KE.yaml
Error: executor awesome-executor is not valid. It can either be CeleryExecutor or KubernetesExecutor
```

## 📸 Screenshots

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
