### PR TITLE
update deployment from file blocks changing cluster

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -26,6 +26,7 @@ var (
 	errCannotUpdateExistingDeployment = errors.New("already exists")
 	errNotFound                       = errors.New("does not exist")
 	errInvalidValue                   = errors.New("is not valid")
+	errNotPermitted                   = errors.New("is not permitted")
 )
 
 const (
@@ -227,6 +228,11 @@ func getCreateOrUpdateInput(deploymentFromFile *inspect.FormattedDeployment, clu
 			WorkerQueues: listQueues,
 		}
 	case updateAction:
+		// check if cluster is being changed
+		if clusterID != existingDeployment.Cluster.ID {
+			return astro.CreateDeploymentInput{}, astro.UpdateDeploymentInput{},
+				fmt.Errorf("changing an existing deployment's cluster %w", errNotPermitted)
+		}
 		updateInput = astro.UpdateDeploymentInput{
 			ID:               existingDeployment.ID,
 			ClusterID:        clusterID,

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -1809,6 +1809,22 @@ deployment:
 				ID:          "test-deployment-id",
 				Label:       "test-deployment-label",
 				Description: "description",
+				Cluster: astro.Cluster{
+					ID:   "test-cluster-id",
+					Name: "test-cluster",
+					NodePools: []astro.NodePool{
+						{
+							ID:               "test-pool-id",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-1",
+						},
+						{
+							ID:               "test-pool-id-2",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-2",
+						},
+					},
+				},
 			}
 			updatedDeployment := astro.Deployment{
 				ID:          "test-deployment-id",
@@ -1970,6 +1986,22 @@ deployment:
 				ID:          "test-deployment-id",
 				Label:       "test-deployment-label",
 				Description: "description",
+				Cluster: astro.Cluster{
+					ID:   "test-cluster-id",
+					Name: "test-cluster",
+					NodePools: []astro.NodePool{
+						{
+							ID:               "test-pool-id",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-1",
+						},
+						{
+							ID:               "test-pool-id-2",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-2",
+						},
+					},
+				},
 			}
 			updatedDeployment := astro.Deployment{
 				ID:          "test-deployment-id",
@@ -2312,6 +2344,22 @@ deployment:
 				ID:          "test-deployment-id",
 				Label:       "test-deployment-label",
 				Description: "description",
+				Cluster: astro.Cluster{
+					ID:   "test-cluster-id",
+					Name: "test-cluster",
+					NodePools: []astro.NodePool{
+						{
+							ID:               "test-pool-id",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-1",
+						},
+						{
+							ID:               "test-pool-id-2",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-2",
+						},
+					},
+				},
 			}
 			orgID = "test-org-id"
 			mockWorkerQueueDefaultOptions = astro.WorkerQueueDefaultOptions{
@@ -3051,6 +3099,33 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			mockClient := new(astro_mocks.Client)
 			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, nil, mockClient)
 			assert.NoError(t, err)
+			assert.Equal(t, expectedUpdateDeploymentInput, actualUpdateInput)
+			mockClient.AssertExpectations(t)
+		})
+		t.Run("returns an error if the cluster is being changed", func(t *testing.T) {
+			deploymentID = "test-deployment-id"
+			deploymentFromFile = inspect.FormattedDeployment{}
+			expectedUpdateDeploymentInput = astro.UpdateDeploymentInput{}
+			deploymentFromFile.Deployment.Configuration.ClusterName = "test-cluster-1"
+			deploymentFromFile.Deployment.Configuration.Name = "test-deployment-modified"
+			deploymentFromFile.Deployment.Configuration.Description = "test-description"
+			deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
+			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
+			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+			existingDeployment := astro.Deployment{
+				ID:    deploymentID,
+				Label: "test-deployment",
+				Cluster: astro.Cluster{
+					ID: "test-cluster-id",
+				},
+			}
+
+			expectedUpdateDeploymentInput = astro.UpdateDeploymentInput{}
+			mockClient := new(astro_mocks.Client)
+			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, "diff-cluster", workspaceID, "update", &existingDeployment, nil, mockClient)
+			assert.ErrorIs(t, err, errNotPermitted)
+			assert.ErrorContains(t, err, "changing an existing deployment's cluster is not permitted")
 			assert.Equal(t, expectedUpdateDeploymentInput, actualUpdateInput)
 			mockClient.AssertExpectations(t)
 		})

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -340,6 +340,9 @@ func deploymentUpdate(cmd *cobra.Command, args []string, out io.Writer) error {
 		return errors.Wrap(err, "failed to find a valid workspace")
 	}
 
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+
 	// request is to update from a file
 	if inputFile != "" {
 		requestedFlags := cmd.Flags().NFlag()
@@ -352,9 +355,6 @@ func deploymentUpdate(cmd *cobra.Command, args []string, out io.Writer) error {
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {
 		return errors.New("Invalid --dag-deploy value)")
 	}
-
-	// Silence Usage as we have now validated command input
-	cmd.SilenceUsage = true
 
 	// Get release name from args, if passed
 	if len(args) > 0 {

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -12,6 +12,7 @@ import (
 	astro "github.com/astronomer/astro-cli/astro-client"
 	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
 	"github.com/astronomer/astro-cli/cloud/deployment"
+	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 
@@ -331,6 +332,20 @@ func TestDeploymentUpdate(t *testing.T) {
 	_, err = execDeploymentCmd(cmdArgs...)
 	assert.Error(t, err)
 
+	t.Run("returns an error when getting workspace fails", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		ctx, err := config.GetCurrentContext()
+		assert.NoError(t, err)
+		ctx.Workspace = ""
+		err = ctx.SetContext()
+		assert.NoError(t, err)
+		defer testUtil.InitTestConfig(testUtil.CloudPlatform)
+		expectedOut := "Usage:\n"
+		cmdArgs := []string{"update", "-n", "doesnotexist"}
+		resp, err := execDeploymentCmd(cmdArgs...)
+		assert.Error(t, err)
+		assert.Contains(t, resp, expectedOut)
+	})
 	t.Run("updates a deployment from file", func(t *testing.T) {
 		orgID := "test-org-id"
 		filePath := "./test-deployment.yaml"
@@ -402,8 +417,9 @@ deployment:
 			},
 		}
 		updatedDeployment := astro.Deployment{
-			ID:    "test-deployment-id",
-			Label: "test-deployment-label",
+			ID:      "test-deployment-id",
+			Label:   "test-deployment-label",
+			Cluster: astro.Cluster{ID: "test-cluster-id", Name: "test-cluster"},
 		}
 		mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
 			MinWorkerCount: astro.WorkerQueueOption{

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -343,7 +343,7 @@ func TestDeploymentUpdate(t *testing.T) {
 		expectedOut := "Usage:\n"
 		cmdArgs := []string{"update", "-n", "doesnotexist"}
 		resp, err := execDeploymentCmd(cmdArgs...)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed to find a valid workspace")
 		assert.Contains(t, resp, expectedOut)
 	})
 	t.Run("updates a deployment from file", func(t *testing.T) {


### PR DESCRIPTION

## Description

> This PR detects when an update request using `--deployment-file` would change the existing deployment's cluster and does not allow that update. Instead  it returns an `errNotPermitted`.


## 🎟 Issue(s)

Related #1012

## 🧪 Functional Testing

> inspect an existing deployment's cluster
```bash
$ astro deployment inspect -n jp-test -k metadata.cluster_id
clbzeum5y000v0tyn8hbv5vsa
$ astro deployment inspect -n jp-test -k configuration.cluster_name
gtadi
```
> request an update to change the cluster fails with an error
```bash
jpatel@jemishs-mbp astro-cli % cat deployment.yaml
deployment:
    environment_variables:
        - key: foo
          value: bar
        - key: bar
          value: awesome
          is_secret: true
    configuration:
        name: jp-test
        description: ""
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        executor: KubernetesExecutor
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: team-airflow-operator 
        workspace_name: CLI Test Workspace
    alert_emails:
        - test1@tester.com
        - test2@tester.com
$ astro deployment update --deployment-file deployment.yaml
Error: changing an existing deployment's cluster is not permitted
```
## 📸 Screenshots


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
