### PR TITLE
wq update command works with KE

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -198,8 +198,8 @@ func getCreateOrUpdateInput(deploymentFromFile *inspect.FormattedDeployment, clu
 			// check if more than one queue is requested
 			if len(listQueues) > 1 {
 				return astro.CreateDeploymentInput{}, astro.UpdateDeploymentInput{},
-					fmt.Errorf("%w more than one worker queue. (%d) were requested",
-						workerqueue.ErrNotSupported, len(listQueues))
+					fmt.Errorf("%s %w more than one worker queue. (%d) were requested",
+						deployment.KubeExecutor, workerqueue.ErrNotSupported, len(listQueues))
 			}
 			for i := range listQueues {
 				err = workerqueue.IsKubernetesWorkerQueueInputValid(&listQueues[i])

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -30,16 +30,17 @@ var (
 	errQueueDoesNotExist         = errors.New("worker queue does not exist")
 	errInvalidQueue              = errors.New("worker queue selection failed")
 	errCannotDeleteDefaultQueue  = errors.New("default queue can not be deleted")
-	ErrNotSupported              = errors.New("KubernetesExecutor does not support")
+	ErrNotSupported              = errors.New("does not support")
 )
 
+// CreateOrUpdate creates a new worker queue or updates an existing worker queue for a deployment.
 func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType string, wQueueMin, wQueueMax, wQueueConcurrency int, force bool, client astro.Client, out io.Writer) error {
 	var (
 		requestedDeployment                  astro.Deployment
 		err                                  error
 		errHelp, succeededAction, nodePoolID string
 		queueToCreateOrUpdate                *astro.WorkerQueue
-		listToCreate                         []astro.WorkerQueue
+		listToCreate, existingQueues         []astro.WorkerQueue
 		defaultOptions                       astro.WorkerQueueDefaultOptions
 	)
 	// get or select the deployment
@@ -87,9 +88,11 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 		}
 	}
 
+	// sanitize all the existing queues based on executor
+	existingQueues = sanitizeExistingQueues(requestedDeployment.WorkerQueues, requestedDeployment.DeploymentSpec.Executor)
 	switch action {
 	case createAction:
-		if QueueExists(requestedDeployment.WorkerQueues, queueToCreateOrUpdate) {
+		if QueueExists(existingQueues, queueToCreateOrUpdate) {
 			// create does not allow updating existing queues
 			errHelp = fmt.Sprintf("use worker queue update %s instead", queueToCreateOrUpdate.Name)
 			return fmt.Errorf("%w: %s", errCannotUpdateExistingQueue, errHelp)
@@ -98,7 +101,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 		// user requested create, so we add queueToCreateOrUpdate to the list
 		listToCreate = append(requestedDeployment.WorkerQueues, *queueToCreateOrUpdate) //nolint
 	case updateAction:
-		if QueueExists(requestedDeployment.WorkerQueues, queueToCreateOrUpdate) {
+		if QueueExists(existingQueues, queueToCreateOrUpdate) {
 			if !force {
 				i, _ := input.Confirm(
 					fmt.Sprintf("\nAre you sure you want to %s the %s worker queue? If there are any tasks in your DAGs assigned to this worker queue, the tasks might get stuck in a queued state and fail to execute", action, ansi.Bold(queueToCreateOrUpdate.Name)))
@@ -109,7 +112,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 				}
 			}
 			// user requested an update and queueToCreateOrUpdate exists
-			listToCreate = updateQueueList(requestedDeployment.WorkerQueues, queueToCreateOrUpdate, requestedDeployment.DeploymentSpec.Executor)
+			listToCreate = updateQueueList(existingQueues, queueToCreateOrUpdate, requestedDeployment.DeploymentSpec.Executor)
 		} else {
 			// update does not allow creating new queues
 			errHelp = fmt.Sprintf("use worker queue create %s instead", queueToCreateOrUpdate.Name)
@@ -171,9 +174,10 @@ func GetWorkerQueueDefaultOptions(client astro.Client) (astro.WorkerQueueDefault
 	return workerQueueDefaultOptions, nil
 }
 
-// IsCeleryWorkerQueueInputValid checks if the requestedWorkerQueue adheres to the floor and ceiling set in the defaultOptions
+// IsCeleryWorkerQueueInputValid checks if the requestedWorkerQueue adheres to the floor and ceiling set in the defaultOptions.
 // if it adheres to them, it returns nil.
 // errInvalidWorkerQueueOption is returned if min, max or concurrency are out of range.
+// ErrNotSupported is returned if PodCPU or PodRAM are requested.
 func IsCeleryWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue, defaultOptions astro.WorkerQueueDefaultOptions) error {
 	var errorMessage string
 	if !(requestedWorkerQueue.MinWorkerCount >= defaultOptions.MinWorkerCount.Floor) ||
@@ -191,6 +195,14 @@ func IsCeleryWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue, defa
 		errorMessage = fmt.Sprintf("worker concurrency must be between %d and %d", defaultOptions.WorkerConcurrency.Floor, defaultOptions.WorkerConcurrency.Ceiling)
 		return fmt.Errorf("%w: %s", errInvalidWorkerQueueOption, errorMessage)
 	}
+	if requestedWorkerQueue.PodCPU != "" {
+		errorMessage = "pod_cpu in the request. It can only be used with KubernetesExecutor"
+		return fmt.Errorf("%s %w %s", deployment.CeleryExecutor, ErrNotSupported, errorMessage)
+	}
+	if requestedWorkerQueue.PodRAM != "" {
+		errorMessage = "pod_ram in the request. It can only be used with KubernetesExecutor"
+		return fmt.Errorf("%s %w %s", deployment.CeleryExecutor, ErrNotSupported, errorMessage)
+	}
 	return nil
 }
 
@@ -201,27 +213,27 @@ func IsKubernetesWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue) 
 	var errorMessage string
 	if requestedWorkerQueue.Name != defaultQueueName {
 		errorMessage = "a non default worker queue in the request. Rename the queue to default"
-		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.PodCPU != "" {
 		errorMessage = "pod_cpu in the request. It will be calculated based on the requested worker_type"
-		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.PodRAM != "" {
 		errorMessage = "pod_ram in the request. It will be calculated based on the requested worker_type"
-		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.MinWorkerCount != 0 {
 		errorMessage = "min_worker_count in the request. It can only be used with CeleryExecutor"
-		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.MaxWorkerCount != 0 {
 		errorMessage = "max_worker_count in the request. It can only be used with CeleryExecutor"
-		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.WorkerConcurrency != 0 {
 		errorMessage = "worker_concurrency in the request. It can only be used with CeleryExecutor"
-		return fmt.Errorf("%w %s", ErrNotSupported, errorMessage)
+		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 
 	return nil
@@ -308,11 +320,11 @@ func selectNodePool(workerType string, nodePools []astro.NodePool, out io.Writer
 // An errCannotDeleteDefaultQueue is returned if a user chooses the default queue
 func Delete(ws, deploymentID, deploymentName, name string, force bool, client astro.Client, out io.Writer) error {
 	var (
-		requestedDeployment astro.Deployment
-		err                 error
-		queueToDelete       *astro.WorkerQueue
-		listToDelete        []astro.WorkerQueue
-		queue               astro.WorkerQueue
+		requestedDeployment          astro.Deployment
+		err                          error
+		queueToDelete                *astro.WorkerQueue
+		listToDelete, existingQueues []astro.WorkerQueue
+		queue                        astro.WorkerQueue
 	)
 	// get or select the deployment
 	requestedDeployment, err = deployment.GetDeployment(ws, deploymentID, deploymentName, client)
@@ -336,7 +348,10 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, client as
 		IsDefault: false, // cannot delete a default queue
 	}
 
-	if QueueExists(requestedDeployment.WorkerQueues, queueToDelete) {
+	// sanitize all the existing queues based on executor
+	existingQueues = sanitizeExistingQueues(requestedDeployment.WorkerQueues, requestedDeployment.DeploymentSpec.Executor)
+
+	if QueueExists(existingQueues, queueToDelete) {
 		if !force {
 			i, _ := input.Confirm(
 				fmt.Sprintf("\nAre you sure you want to delete the %s worker queue? If there are any tasks in your DAGs assigned to this worker queue, the tasks might get stuck in a queued state and fail to execute", ansi.Bold(queueToDelete.Name)))
@@ -348,7 +363,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, client as
 		}
 
 		// create a new listToDelete without queueToDelete in it
-		for _, queue = range requestedDeployment.WorkerQueues {
+		for _, queue = range existingQueues {
 			if queue.Name != queueToDelete.Name {
 				listToDelete = append(listToDelete, queue)
 			}
@@ -406,6 +421,9 @@ func selectQueue(queueList []astro.WorkerQueue, out io.Writer) (string, error) {
 	return queueToDelete.Name, nil
 }
 
+// updateQueueList is used to merge existingQueues with the queueToUpdate. Based on the executor for the deployment, it
+// sets the resources for CeleryExecutor and removes all resources for KubernetesExecutor as they get calculated based
+// on the worker type.
 func updateQueueList(existingQueues []astro.WorkerQueue, queueToUpdate *astro.WorkerQueue, executor string) []astro.WorkerQueue {
 	for i, queue := range existingQueues {
 		if queue.Name != queueToUpdate.Name {
@@ -455,4 +473,29 @@ func getQueueName(name, action string, requestedDeployment *astro.Deployment, ou
 		}
 	}
 	return queueName, nil
+}
+
+// sanitizeExistingQueues takes a list of existing worker queues and removes fields that are not needed for queues based
+// on the executor. For deployments with CeleryExecutor it returns a list of queues without PodCPU and PodRam.  For
+// deployments with KubernetesExecutor it returns a list of queues with no resources as they get calculated
+// based on the worker type.
+func sanitizeExistingQueues(existingQueues []astro.WorkerQueue, executor string) []astro.WorkerQueue {
+	// sort queues by name
+	sort.Slice(existingQueues, func(i, j int) bool {
+		return existingQueues[i].Name < existingQueues[j].Name
+	})
+	for i := range existingQueues {
+		if executor == deployment.CeleryExecutor {
+			existingQueues[i].PodRAM = ""
+			existingQueues[i].PodCPU = ""
+		} else if executor == deployment.KubeExecutor {
+			// KubernetesExecutor calculates resources automatically based on the worker type
+			existingQueues[i].WorkerConcurrency = 0
+			existingQueues[i].MinWorkerCount = 0
+			existingQueues[i].MaxWorkerCount = 0
+			existingQueues[i].PodRAM = ""
+			existingQueues[i].PodCPU = ""
+		}
+	}
+	return existingQueues
 }

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -457,7 +457,7 @@ func TestUpdate(t *testing.T) {
 			},
 			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
 			DeploymentSpec: astro.DeploymentSpec{
-				Executor: "CeleryExecutor",
+				Executor: deployment.CeleryExecutor,
 				Scheduler: astro.Scheduler{
 					AU:       5,
 					Replicas: 3,
@@ -481,6 +481,46 @@ func TestUpdate(t *testing.T) {
 					MinWorkerCount:    8,
 					WorkerConcurrency: 150,
 					NodePoolID:        "test-pool-id-1",
+				},
+			},
+		},
+	}
+	keDeployment := []astro.Deployment{
+		{
+			ID:    "test-deployment-id",
+			Label: "test-deployment-label",
+			Cluster: astro.Cluster{
+				NodePools: []astro.NodePool{
+					{
+						ID:               "test-pool-id",
+						IsDefault:        false,
+						NodeInstanceType: "test-instance-type",
+						CreatedAt:        time.Now(),
+					},
+					{
+						ID:               "test-pool-id-1",
+						IsDefault:        true,
+						NodeInstanceType: "test-instance-type-1",
+						CreatedAt:        time.Now(),
+					},
+				},
+			},
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Executor: deployment.KubeExecutor,
+				Scheduler: astro.Scheduler{
+					AU:       5,
+					Replicas: 3,
+				},
+			},
+			WorkerQueues: []astro.WorkerQueue{
+				{
+					ID:         "test-wq-id",
+					Name:       "default",
+					IsDefault:  true,
+					PodCPU:     "huge",
+					PodRAM:     "lots",
+					NodePoolID: "test-pool-id",
 				},
 			},
 		},
@@ -514,6 +554,22 @@ func TestUpdate(t *testing.T) {
 		},
 		WorkerQueues: listToUpdate,
 	}
+	updateKEDeploymentInput := astro.UpdateDeploymentInput{
+		ID:    keDeployment[0].ID,
+		Label: keDeployment[0].Label,
+		DeploymentSpec: astro.DeploymentCreateSpec{
+			Executor:  keDeployment[0].DeploymentSpec.Executor,
+			Scheduler: keDeployment[0].DeploymentSpec.Scheduler,
+		},
+		WorkerQueues: []astro.WorkerQueue{
+			{
+				ID:         "test-wq-id",
+				Name:       "default",
+				IsDefault:  true,
+				NodePoolID: "test-pool-id",
+			},
+		},
+	}
 	mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
 		MinWorkerCount: astro.WorkerQueueOption{
 			Floor:   1,
@@ -531,144 +587,185 @@ func TestUpdate(t *testing.T) {
 			Default: 180,
 		},
 	}
-	t.Run("happy path update existing worker queue for a deployment", func(t *testing.T) {
-		expectedOutMessage := "worker queue " + expectedWorkerQueue.Name + " for test-deployment-label in test-ws-id workspace updated\n"
-		out := new(bytes.Buffer)
-		mockClient := new(astro_mocks.Client)
-
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
-		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
-		err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "test-queue-1", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, out)
-		assert.NoError(t, err)
-		assert.Contains(t, out.String(), expectedOutMessage)
-		mockClient.AssertExpectations(t)
-	})
-	t.Run("prompts user for queue name if one was not provided", func(t *testing.T) {
-		expectedOutMessage := "worker queue " + expectedWorkerQueue.Name + " for test-deployment-label in test-ws-id workspace updated\n"
-		defer testUtil.MockUserInput(t, "2")()
-		out := new(bytes.Buffer)
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
-		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
-		err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, out)
-		assert.NoError(t, err)
-		assert.Contains(t, out.String(), expectedOutMessage)
-	})
-	t.Run("prompts user for confirmation if --force was not provided", func(t *testing.T) {
-		t.Run("updates the queue if user replies yes", func(t *testing.T) {
+	t.Run("common across CE and KE executors", func(t *testing.T) {
+		t.Run("prompts user for confirmation if --force was not provided", func(t *testing.T) {
+			t.Run("updates the queue if user replies yes", func(t *testing.T) {
+				expectedOutMessage := "worker queue " + expectedWorkerQueue.Name + " for test-deployment-label in test-ws-id workspace updated\n"
+				defer testUtil.MockUserInput(t, "y")()
+				out := new(bytes.Buffer)
+				mockClient := new(astro_mocks.Client)
+				mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
+				mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+				mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
+				err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "test-queue-1", updateAction, "test-instance-type-1", 0, 0, 0, false, mockClient, out)
+				assert.NoError(t, err)
+				assert.Equal(t, expectedOutMessage, out.String())
+				mockClient.AssertExpectations(t)
+			})
+			t.Run("cancels update if user does not confirm", func(t *testing.T) {
+				expectedOutMessage := "Canceling worker queue update\n"
+				out := new(bytes.Buffer)
+				mockClient := new(astro_mocks.Client)
+				mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Once()
+				mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+				err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "test-queue-1", updateAction, "test-instance-type-1", 0, 0, 0, false, mockClient, out)
+				assert.NoError(t, err)
+				assert.Equal(t, expectedOutMessage, out.String())
+				mockClient.AssertExpectations(t)
+			})
+		})
+		t.Run("prompts user for queue name if one was not provided", func(t *testing.T) {
 			expectedOutMessage := "worker queue " + expectedWorkerQueue.Name + " for test-deployment-label in test-ws-id workspace updated\n"
-			defer testUtil.MockUserInput(t, "y")()
+			defer testUtil.MockUserInput(t, "2")()
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
-			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "test-queue-1", updateAction, "test-instance-type-1", 0, 0, 0, false, mockClient, out)
+			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, out)
 			assert.NoError(t, err)
-			assert.Equal(t, expectedOutMessage, out.String())
+			assert.Contains(t, out.String(), expectedOutMessage)
+		})
+		t.Run("returns an error when selecting a deployment fails", func(t *testing.T) {
+			mockClient := new(astro_mocks.Client)
+			out := new(bytes.Buffer)
+			defer testUtil.MockUserInput(t, "test-invalid-deployment-id")()
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(nil, deployment.ErrInvalidDeploymentKey).Once()
+			err := CreateOrUpdate("test-ws-id", "", "", "", "", "", 0, 0, 0, true, mockClient, out)
+			assert.ErrorIs(t, err, deployment.ErrInvalidDeploymentKey)
 			mockClient.AssertExpectations(t)
 		})
-		t.Run("cancels update if user does not confirm", func(t *testing.T) {
-			expectedOutMessage := "Canceling worker queue update\n"
+		t.Run("returns an error when selecting a node pool fails", func(t *testing.T) {
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Once()
-			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "test-queue-1", updateAction, "test-instance-type-1", 0, 0, 0, false, mockClient, out)
+			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "non-existent", 0, 200, 0, true, mockClient, out)
+			assert.ErrorIs(t, err, errInvalidNodePool)
+			mockClient.AssertExpectations(t)
+		})
+		t.Run("returns an error if user makes incorrect choice when selecting a queue to update", func(t *testing.T) {
+			expectedOutMessage := "invalid worker queue: 4 selected"
+			// mock os.Stdin
+			expectedInput := []byte("4") // there is no queue with this index
+			r, w, err := os.Pipe()
 			assert.NoError(t, err)
-			assert.Equal(t, expectedOutMessage, out.String())
+			_, err = w.Write(expectedInput)
+			assert.NoError(t, err)
+			w.Close()
+			stdin := os.Stdin
+			// Restore stdin right after the test.
+			defer func() { os.Stdin = stdin }()
+			os.Stdin = r
+
+			out := new(bytes.Buffer)
+			mockClient := new(astro_mocks.Client)
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
+			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+			mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
+			err = CreateOrUpdate("test-ws-id", "", "test-deployment-label", "", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, out)
+			assert.ErrorIs(t, err, errInvalidQueue)
+			assert.Contains(t, err.Error(), expectedOutMessage)
+		})
+		t.Run("returns an error when listing deployments fails", func(t *testing.T) {
+			mockClient := new(astro_mocks.Client)
+			out := new(bytes.Buffer)
+
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(nil, errGetDeployment).Once()
+			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "", 0, 0, 0, true, mockClient, out)
+			assert.ErrorIs(t, err, errGetDeployment)
+			mockClient.AssertExpectations(t)
+		})
+		t.Run("returns an error when updating requested queue would create a new queue", func(t *testing.T) {
+			out := new(bytes.Buffer)
+			mockClient := new(astro_mocks.Client)
+			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Once()
+			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "test-queue-2", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, out)
+			assert.ErrorIs(t, err, errCannotCreateNewQueue)
+			assert.ErrorContains(t, err, "worker queue does not exist: use worker queue create test-queue-2 instead")
+			mockClient.AssertExpectations(t)
+		})
+		t.Run("returns an error when update deployment fails", func(t *testing.T) {
+			out := new(bytes.Buffer)
+			mockClient := new(astro_mocks.Client)
+			defer testUtil.MockUserInput(t, "y")()
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
+			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+			mockClient.On("UpdateDeployment", mock.Anything).Return(astro.Deployment{}, errUpdateDeployment).Once()
+			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "test-instance-type", 0, 0, 0, true, mockClient, out)
+			assert.ErrorIs(t, err, errUpdateDeployment)
 			mockClient.AssertExpectations(t)
 		})
 	})
-	t.Run("returns an error if user makes incorrect choice when selecting a queue to update", func(t *testing.T) {
-		expectedOutMessage := "invalid worker queue: 4 selected"
-		// mock os.Stdin
-		expectedInput := []byte("4") // there is no queue with this index
-		r, w, err := os.Pipe()
-		assert.NoError(t, err)
-		_, err = w.Write(expectedInput)
-		assert.NoError(t, err)
-		w.Close()
-		stdin := os.Stdin
-		// Restore stdin right after the test.
-		defer func() { os.Stdin = stdin }()
-		os.Stdin = r
+	t.Run("when executor is CE", func(t *testing.T) {
+		t.Run("happy path update existing worker queue for a deployment", func(t *testing.T) {
+			expectedOutMessage := "worker queue " + expectedWorkerQueue.Name + " for test-deployment-label in test-ws-id workspace updated\n"
+			out := new(bytes.Buffer)
+			mockClient := new(astro_mocks.Client)
 
-		out := new(bytes.Buffer)
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
-		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
-		err = CreateOrUpdate("test-ws-id", "", "test-deployment-label", "", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, out)
-		assert.ErrorIs(t, err, errInvalidQueue)
-		assert.Contains(t, err.Error(), expectedOutMessage)
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
+			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+			mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
+			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "test-queue-1", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, out)
+			assert.NoError(t, err)
+			assert.Contains(t, out.String(), expectedOutMessage)
+			mockClient.AssertExpectations(t)
+		})
+		t.Run("returns an error when getting worker queue default options fails", func(t *testing.T) {
+			out := new(bytes.Buffer)
+			mockClient := new(astro_mocks.Client)
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Once()
+			mockClient.On("GetWorkerQueueOptions").Return(astro.WorkerQueueDefaultOptions{}, errWorkerQueueDefaultOptions).Once()
+			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "test-instance-type-1", 0, 200, 0, true, mockClient, out)
+			assert.ErrorIs(t, err, errWorkerQueueDefaultOptions)
+			mockClient.AssertExpectations(t)
+		})
+		t.Run("returns an error when requested worker queue input is not valid", func(t *testing.T) {
+			out := new(bytes.Buffer)
+			mockClient := new(astro_mocks.Client)
+			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Once()
+			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "test-instance-type", 25, 0, 0, true, mockClient, out)
+			assert.ErrorIs(t, err, errInvalidWorkerQueueOption)
+			mockClient.AssertExpectations(t)
+		})
 	})
-	t.Run("returns an error when listing deployments fails", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		out := new(bytes.Buffer)
+	t.Run("when executor is KE", func(t *testing.T) {
+		t.Run("happy path update existing worker queue for a deployment", func(t *testing.T) {
+			expectedOutMessage := "worker queue default for test-deployment-label in test-ws-id workspace updated\n"
+			out := new(bytes.Buffer)
+			mockClient := new(astro_mocks.Client)
 
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(nil, errGetDeployment).Once()
-		err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "", 0, 0, 0, true, mockClient, out)
-		assert.ErrorIs(t, err, errGetDeployment)
-		mockClient.AssertExpectations(t)
-	})
-	t.Run("returns an error when getting worker queue default options fails", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Once()
-		mockClient.On("GetWorkerQueueOptions").Return(astro.WorkerQueueDefaultOptions{}, errWorkerQueueDefaultOptions).Once()
-		err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "test-instance-type-1", 0, 200, 0, true, mockClient, out)
-		assert.ErrorIs(t, err, errWorkerQueueDefaultOptions)
-		mockClient.AssertExpectations(t)
-	})
-	t.Run("returns an error when selecting a node pool fails", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Once()
-		err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "non-existent", 0, 200, 0, true, mockClient, out)
-		assert.ErrorIs(t, err, errInvalidNodePool)
-		mockClient.AssertExpectations(t)
-	})
-	t.Run("returns an error when selecting a deployment fails", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		out := new(bytes.Buffer)
-		defer testUtil.MockUserInput(t, "test-invalid-deployment-id")()
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(nil, deployment.ErrInvalidDeploymentKey).Once()
-		err := CreateOrUpdate("test-ws-id", "", "", "", "", "", 0, 0, 0, true, mockClient, out)
-		assert.ErrorIs(t, err, deployment.ErrInvalidDeploymentKey)
-		mockClient.AssertExpectations(t)
-	})
-	t.Run("returns an error when requested worker queue input is not valid", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Once()
-		err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "test-instance-type", 25, 0, 0, true, mockClient, out)
-		assert.ErrorIs(t, err, errInvalidWorkerQueueOption)
-		mockClient.AssertExpectations(t)
-	})
-	t.Run("returns an error when updating requested queue would create a new queue", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Once()
-		err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "test-queue-2", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, out)
-		assert.ErrorIs(t, err, errCannotCreateNewQueue)
-		assert.ErrorContains(t, err, "worker queue does not exist: use worker queue create test-queue-2 instead")
-		mockClient.AssertExpectations(t)
-	})
-	t.Run("returns an error when update deployment fails", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astro_mocks.Client)
-		defer testUtil.MockUserInput(t, "y")()
-		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
-		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-		mockClient.On("UpdateDeployment", mock.Anything).Return(astro.Deployment{}, errUpdateDeployment).Once()
-		err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "", "", "test-instance-type", 0, 0, 0, true, mockClient, out)
-		assert.ErrorIs(t, err, errUpdateDeployment)
-		mockClient.AssertExpectations(t)
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(keDeployment, nil).Twice()
+			mockClient.On("UpdateDeployment", &updateKEDeploymentInput).Return(keDeployment[0], nil).Once()
+			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "default", updateAction, "test-instance-type", 0, 0, 0, true, mockClient, out)
+			assert.NoError(t, err)
+			assert.Contains(t, out.String(), expectedOutMessage)
+			mockClient.AssertExpectations(t)
+		})
+		t.Run("update existing worker queue with a new worker type", func(t *testing.T) {
+			expectedOutMessage := "worker queue default for test-deployment-label in test-ws-id workspace updated\n"
+			out := new(bytes.Buffer)
+			mockClient := new(astro_mocks.Client)
+			origNodePoolID := updateKEDeploymentInput.WorkerQueues[0].NodePoolID
+			updateKEDeploymentInput.WorkerQueues[0].NodePoolID = "test-pool-id-1"
+			defer func() { updateKEDeploymentInput.WorkerQueues[0].NodePoolID = origNodePoolID }()
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(keDeployment, nil).Twice()
+			mockClient.On("UpdateDeployment", &updateKEDeploymentInput).Return(keDeployment[0], nil).Once()
+			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "default", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, out)
+			assert.NoError(t, err)
+			assert.Contains(t, out.String(), expectedOutMessage)
+			mockClient.AssertExpectations(t)
+		})
+		t.Run("returns an error when requested input is not valid", func(t *testing.T) {
+			out := new(bytes.Buffer)
+			mockClient := new(astro_mocks.Client)
+			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(keDeployment, nil).Once()
+			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "test-KE-q", updateAction, "test-instance-type-1", 0, 0, 0, false, mockClient, out)
+			assert.ErrorIs(t, err, ErrNotSupported)
+			assert.ErrorContains(t, err, "KubernetesExecutor does not support a non default worker queue in the request. Rename the queue to default")
+			mockClient.AssertExpectations(t)
+		})
 	})
 }
 
@@ -1262,7 +1359,7 @@ func TestUpdateQueueList(t *testing.T) {
 			WorkerConcurrency: 20,
 			NodePoolID:        "test-worker-1",
 		}
-		updatedQueueList := updateQueueList(existingQs, &updatedQ)
+		updatedQueueList := updateQueueList(existingQs, &updatedQ, deployment.CeleryExecutor)
 		assert.Equal(t, updatedQ, updatedQueueList[1])
 	})
 	t.Run("does not update id or isDefault when queue exists", func(t *testing.T) {
@@ -1284,7 +1381,7 @@ func TestUpdateQueueList(t *testing.T) {
 			WorkerConcurrency: 20,
 			NodePoolID:        "test-worker-1",
 		}
-		updatedQueueList := updateQueueList(existingQs, &updatedQRequest)
+		updatedQueueList := updateQueueList(existingQs, &updatedQRequest, "")
 		assert.Equal(t, updatedQ, updatedQueueList[1])
 	})
 	t.Run("does not change any queues if queue to update does not exist", func(t *testing.T) {
@@ -1297,8 +1394,76 @@ func TestUpdateQueueList(t *testing.T) {
 			WorkerConcurrency: 20,
 			NodePoolID:        "test-worker-1",
 		}
-		updatedQueueList := updateQueueList(existingQs, &updatedQRequest)
+		updatedQueueList := updateQueueList(existingQs, &updatedQRequest, "")
 		assert.Equal(t, existingQs, updatedQueueList)
+	})
+	t.Run("zeroes out podRam and podCPU for KE queue updates", func(t *testing.T) {
+		existingKEQ := []astro.WorkerQueue{
+			{
+				ID:                "q-1",
+				Name:              "default",
+				IsDefault:         true,
+				MaxWorkerCount:    10,
+				MinWorkerCount:    1,
+				WorkerConcurrency: 16,
+				PodRAM:            "lots",
+				PodCPU:            "huge",
+				NodePoolID:        "test-worker-1",
+			},
+		}
+		updatedQRequest := astro.WorkerQueue{
+			ID:         "q-1",
+			Name:       "default",
+			IsDefault:  true,
+			PodRAM:     "lots",
+			PodCPU:     "huge",
+			NodePoolID: "test-worker-1",
+		}
+		expectedQList := []astro.WorkerQueue{
+			{
+				ID:         "q-1",
+				Name:       "default",
+				IsDefault:  true,
+				NodePoolID: "test-worker-1",
+			},
+		}
+
+		updatedQueueList := updateQueueList(existingKEQ, &updatedQRequest, deployment.KubeExecutor)
+		assert.Equal(t, expectedQList, updatedQueueList)
+	})
+	t.Run("updates nodepoolID for KE queue updates", func(t *testing.T) {
+		existingKEQ := []astro.WorkerQueue{
+			{
+				ID:                "q-1",
+				Name:              "default",
+				IsDefault:         true,
+				MaxWorkerCount:    10,
+				MinWorkerCount:    1,
+				WorkerConcurrency: 16,
+				PodRAM:            "lots",
+				PodCPU:            "huge",
+				NodePoolID:        "test-worker-1",
+			},
+		}
+		updatedQRequest := astro.WorkerQueue{
+			ID:         "q-1",
+			Name:       "default",
+			IsDefault:  true,
+			PodRAM:     "lots",
+			PodCPU:     "huge",
+			NodePoolID: "test-worker-2",
+		}
+		expectedQList := []astro.WorkerQueue{
+			{
+				ID:         "q-1",
+				Name:       "default",
+				IsDefault:  true,
+				NodePoolID: "test-worker-2",
+			},
+		}
+
+		updatedQueueList := updateQueueList(existingKEQ, &updatedQRequest, deployment.KubeExecutor)
+		assert.Equal(t, expectedQList, updatedQueueList)
 	})
 }
 

--- a/cmd/cloud/deployment_workerqueue.go
+++ b/cmd/cloud/deployment_workerqueue.go
@@ -100,7 +100,7 @@ func deploymentWorkerQueueCreateOrUpdate(cmd *cobra.Command, _ []string, out io.
 		return err
 	}
 
-	return workerqueue.CreateOrUpdate(ws, deploymentID, deploymentName, name, cmd.Name(), workerType, minWorkerCount, maxWorkerCount, concurrency, true, astroClient, out)
+	return workerqueue.CreateOrUpdate(ws, deploymentID, deploymentName, name, cmd.Name(), workerType, minWorkerCount, maxWorkerCount, concurrency, force, astroClient, out)
 }
 
 func deploymentWorkerQueueDelete(cmd *cobra.Command, _ []string, out io.Writer) error {

--- a/cmd/cloud/deployment_workerqueue_test.go
+++ b/cmd/cloud/deployment_workerqueue_test.go
@@ -467,7 +467,7 @@ func TestNewDeploymentWorkerQueueUpdateCmd(t *testing.T) {
 		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
 
 		// updating min, max and concurrency to defaults along with worker type
-		cmdArgs := []string{"worker-queue", "update", "-n", "test-queue-1", "-t", "test-instance-type"}
+		cmdArgs := []string{"worker-queue", "update", "-n", "test-queue-1", "-t", "test-instance-type", "-f"}
 		resp, err := execDeploymentCmd(cmdArgs...)
 		assert.NoError(t, err)
 		assert.Contains(t, resp, expectedOutMessage)


### PR DESCRIPTION
## Description

> This PR enables the `astro deployment worker-queue update` command to create correct queues based on the executor for the existing deployment being requested to update. `KubernetesExecutor` only supports one default queue and so if a user changes their worker type, we request the existing deployment to be updated with a new default queue and the resources be re-calculated based on the new worker-type.

## 🎟 Issue(s)

Related #931

## 🧪 Functional Testing

> update a default queue for a KE deployment
```bash
$ astro deployment worker-queue update --deployment-name jp-KE-test -t m5.xlarge -f

 #     WORKER QUEUE     ISDEFAULT     ID
 1     default          true          clcthey1d08452zvz1xop6bd3

> 1
worker queue default for jp-KE-test in cl0v1p6lc728255byzyfs7lw21 workspace updated
```
> update can be canceled
```bash
$ astro deployment worker-queue update --deployment-name jp-KE-test -n default -t m5.xlarge

Are you sure you want to update the default worker queue? If there are any tasks in your DAGs assigned to this worker queue, the tasks might get stuck in a queued state and fail to execute (y/n) n
Canceling worker queue update
```
> error when input is not valid 
```bash
jpatel@jemishs-mbp astro-cli % ./astro deployment worker-queue update --deployment-name jp-KE-test -n another-queue -t m5.xlarge
Error: KubernetesExecutor does not support a non default worker queue in the request. Rename the queue to default
```
## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
