### PR TITLE
Add getAstroCloudConfig method

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -195,7 +195,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 		if label == "" {
 			return errors.New("you must give your Deployment a name")
 		}
-		deployments, err := getDeployments(workspaceID, client)
+		deployments, err := GetDeployments(workspaceID, client)
 		if err != nil {
 			return errors.Wrap(err, errInvalidDeployment.Error())
 		}
@@ -386,7 +386,7 @@ func healthPoll(deploymentID, ws string, client astro.Client) error {
 		// Got a tick, we should check if deployment is healthy
 		case <-ticker.C:
 			buf.Reset()
-			deployments, err := getDeployments(ws, client)
+			deployments, err := GetDeployments(ws, client)
 			if err != nil {
 				return err
 			}
@@ -559,7 +559,7 @@ func Delete(deploymentID, ws, deploymentName string, forceDelete bool, client as
 	return nil
 }
 
-func getDeployments(ws string, client astro.Client) ([]astro.Deployment, error) {
+func GetDeployments(ws string, client astro.Client) ([]astro.Deployment, error) {
 	c, err := config.GetCurrentContext()
 	if err != nil {
 		return []astro.Deployment{}, err
@@ -573,7 +573,7 @@ func getDeployments(ws string, client astro.Client) ([]astro.Deployment, error) 
 	return deployments, nil
 }
 
-func selectDeployment(deployments []astro.Deployment, message string) (astro.Deployment, error) {
+func SelectDeployment(deployments []astro.Deployment, message string) (astro.Deployment, error) {
 	// select deployment
 	if len(deployments) == 0 {
 		i, _ := input.Confirm(noDeployments)
@@ -622,7 +622,7 @@ func selectDeployment(deployments []astro.Deployment, message string) (astro.Dep
 }
 
 func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client) (astro.Deployment, error) {
-	deployments, err := getDeployments(ws, client)
+	deployments, err := GetDeployments(ws, client)
 	if err != nil {
 		return astro.Deployment{}, errors.Wrap(err, errInvalidDeployment.Error())
 	}
@@ -668,7 +668,7 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 }
 
 func deploymentSelectionProcess(ws string, deployments []astro.Deployment, client astro.Client) (astro.Deployment, error) {
-	currentDeployment, err := selectDeployment(deployments, "Select a Deployment")
+	currentDeployment, err := SelectDeployment(deployments, "Select a Deployment")
 	if err != nil {
 		return astro.Deployment{}, err
 	}
@@ -687,11 +687,11 @@ func deploymentSelectionProcess(ws string, deployments []astro.Deployment, clien
 		}
 
 		// get a new deployment list
-		deployments, err = getDeployments(ws, client)
+		deployments, err = GetDeployments(ws, client)
 		if err != nil {
 			return astro.Deployment{}, err
 		}
-		currentDeployment, err = selectDeployment(deployments, "Select which Deployment you want to update")
+		currentDeployment, err = SelectDeployment(deployments, "Select which Deployment you want to update")
 		if err != nil {
 			return astro.Deployment{}, err
 		}

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -559,7 +559,7 @@ func Delete(deploymentID, ws, deploymentName string, forceDelete bool, client as
 	return nil
 }
 
-func GetDeployments(ws string, client astro.Client) ([]astro.Deployment, error) {
+var GetDeployments = func(ws string, client astro.Client) ([]astro.Deployment, error) {
 	c, err := config.GetCurrentContext()
 	if err != nil {
 		return []astro.Deployment{}, err
@@ -573,7 +573,7 @@ func GetDeployments(ws string, client astro.Client) ([]astro.Deployment, error) 
 	return deployments, nil
 }
 
-func SelectDeployment(deployments []astro.Deployment, message string) (astro.Deployment, error) {
+var SelectDeployment = func(deployments []astro.Deployment, message string) (astro.Deployment, error) {
 	// select deployment
 	if len(deployments) == 0 {
 		i, _ := input.Confirm(noDeployments)

--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -70,7 +70,7 @@ func List(client astro.Client, out io.Writer) error {
 	return nil
 }
 
-func GetWorkspaceSelection(client astro.Client, out io.Writer) (string, error) {
+var GetWorkspaceSelection = func(client astro.Client, out io.Writer) (string, error) {
 	tab := printutil.Table{
 		Padding:        []int{5, 44, 50},
 		DynamicPadding: true,

--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -70,7 +70,7 @@ func List(client astro.Client, out io.Writer) error {
 	return nil
 }
 
-func getWorkspaceSelection(client astro.Client, out io.Writer) (string, error) {
+func GetWorkspaceSelection(client astro.Client, out io.Writer) (string, error) {
 	tab := printutil.Table{
 		Padding:        []int{5, 44, 50},
 		DynamicPadding: true,
@@ -111,7 +111,7 @@ func getWorkspaceSelection(client astro.Client, out io.Writer) (string, error) {
 // Switch switches workspaces
 func Switch(id string, client astro.Client, out io.Writer) error {
 	if id == "" {
-		_id, err := getWorkspaceSelection(client, out)
+		_id, err := GetWorkspaceSelection(client, out)
 		if err != nil {
 			return err
 		}

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -143,7 +143,7 @@ func TestGetWorkspaceSelection(t *testing.T) {
 		os.Stdin = r
 
 		buf := new(bytes.Buffer)
-		resp, err := getWorkspaceSelection(mockClient, buf)
+		resp, err := GetWorkspaceSelection(mockClient, buf)
 		assert.NoError(t, err)
 		assert.Equal(t, mockResponse[0].ID, resp)
 		mockClient.AssertExpectations(t)
@@ -153,7 +153,7 @@ func TestGetWorkspaceSelection(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{}, errMock).Once()
 		buf := new(bytes.Buffer)
-		_, err := getWorkspaceSelection(mockClient, buf)
+		_, err := GetWorkspaceSelection(mockClient, buf)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -179,7 +179,7 @@ func TestGetWorkspaceSelection(t *testing.T) {
 		os.Stdin = r
 
 		buf := new(bytes.Buffer)
-		_, err = getWorkspaceSelection(mockClient, buf)
+		_, err = GetWorkspaceSelection(mockClient, buf)
 		assert.ErrorIs(t, err, errInvalidWorkspaceKey)
 		mockClient.AssertExpectations(t)
 	})
@@ -190,7 +190,7 @@ func TestGetWorkspaceSelection(t *testing.T) {
 		assert.NoError(t, err)
 
 		buf := new(bytes.Buffer)
-		_, err = getWorkspaceSelection(mockClient, buf)
+		_, err = GetWorkspaceSelection(mockClient, buf)
 		assert.EqualError(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 		mockClient.AssertExpectations(t)
 	})

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/astronomer/astro-cli/astro-client"
 	cloudDeploy "github.com/astronomer/astro-cli/cloud/deploy"
+	astroDeployment "github.com/astronomer/astro-cli/cloud/deployment"
+	astroWorkspace "github.com/astronomer/astro-cli/cloud/workspace"
 	cloudCmd "github.com/astronomer/astro-cli/cmd/cloud"
 	"github.com/astronomer/astro-cli/cmd/utils"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -29,8 +31,29 @@ var (
 	imageBuildResponse = types.ImageBuildResponse{
 		Body: io.NopCloser(strings.NewReader("Image built")),
 	}
-	containerCreateCreatedBody = container.ContainerCreateCreatedBody{ID: "123"}
-	sampleLog                  = io.NopCloser(strings.NewReader("Sample log"))
+	containerCreateCreatedBody    = container.ContainerCreateCreatedBody{ID: "123"}
+	sampleLog                     = io.NopCloser(strings.NewReader("Sample log"))
+	originalGetWorkspaceSelection = astroWorkspace.GetWorkspaceSelection
+	originalGetDeployments        = astroDeployment.GetDeployments
+	originalSelectDeployment      = astroDeployment.SelectDeployment
+	mockGetWorkspaceSelection     = func(client astro.Client, out io.Writer) (string, error) {
+		return "W1", nil
+	}
+	mockGetWorkspaceSelectionErr = func(client astro.Client, out io.Writer) (string, error) {
+		return "", errMock
+	}
+	mockGetDeployments = func(ws string, client astro.Client) ([]astro.Deployment, error) {
+		return nil, nil
+	}
+	mockGetDeploymentsErr = func(ws string, client astro.Client) ([]astro.Deployment, error) {
+		return nil, errMock
+	}
+	mockSelectDeployment = func(deployments []astro.Deployment, message string) (astro.Deployment, error) {
+		return astro.Deployment{ID: "D1", Workspace: astro.Workspace{ID: "W1"}}, nil
+	}
+	mockSelectDeploymentErr = func(deployments []astro.Deployment, message string) (astro.Deployment, error) {
+		return astro.Deployment{}, errMock
+	}
 )
 
 func getContainerWaitResponse(raiseError bool, statusCode int64) (bodyCh <-chan container.ContainerWaitOKBody, errCh <-chan error) {
@@ -368,4 +391,87 @@ func TestFlowDeployWorkflowsCmd(t *testing.T) {
 	assert.NoError(t, err)
 
 	Os = sql.NewOsBind
+}
+
+func TestPromptAstroCloudConfigDeploymentAndWorkspaceUnsetGetWorkspaceSelectionFailure(t *testing.T) {
+	astroWorkspace.GetWorkspaceSelection = mockGetWorkspaceSelectionErr
+	_, _, err := promptAstroCloudConfig("", "")
+	assert.ErrorIs(t, err, errMock)
+	astroWorkspace.GetWorkspaceSelection = originalGetWorkspaceSelection
+}
+
+func TestPromptAstroCloudConfigDeploymentAndWorkspaceUnsetGetDeploymentsFailure(t *testing.T) {
+	astroWorkspace.GetWorkspaceSelection = mockGetWorkspaceSelection
+	astroDeployment.GetDeployments = mockGetDeploymentsErr
+	_, _, err := promptAstroCloudConfig("", "")
+	assert.ErrorIs(t, err, errMock)
+	astroWorkspace.GetWorkspaceSelection = originalGetWorkspaceSelection
+	astroDeployment.GetDeployments = originalGetDeployments
+}
+
+func TestPromptAstroCloudConfigDeploymentAndWorkspaceUnsetSelectDeploymentFailure(t *testing.T) {
+	astroWorkspace.GetWorkspaceSelection = mockGetWorkspaceSelection
+	astroDeployment.GetDeployments = mockGetDeployments
+	astroDeployment.SelectDeployment = mockSelectDeploymentErr
+	_, _, err := promptAstroCloudConfig("", "")
+	assert.ErrorIs(t, err, errMock)
+	astroWorkspace.GetWorkspaceSelection = originalGetWorkspaceSelection
+	astroDeployment.GetDeployments = originalGetDeployments
+	astroDeployment.SelectDeployment = originalSelectDeployment
+}
+
+func TestPromptAstroCloudConfigDeploymentAndWorkspaceUnsetSuccess(t *testing.T) {
+	astroWorkspace.GetWorkspaceSelection = mockGetWorkspaceSelection
+	astroDeployment.GetDeployments = mockGetDeployments
+	astroDeployment.SelectDeployment = mockSelectDeployment
+	selectedAstroDeploymentID, selectedAstroWorkspaceID, err := promptAstroCloudConfig("", "")
+	assert.NoError(t, err)
+	assert.EqualValues(t, "D1", selectedAstroDeploymentID)
+	assert.EqualValues(t, "W1", selectedAstroWorkspaceID)
+	astroWorkspace.GetWorkspaceSelection = originalGetWorkspaceSelection
+	astroDeployment.GetDeployments = originalGetDeployments
+	astroDeployment.SelectDeployment = originalSelectDeployment
+}
+
+func TestPromptAstroCloudConfigDeploymentUnsetGetDeploymentsFailure(t *testing.T) {
+	astroDeployment.GetDeployments = mockGetDeploymentsErr
+	_, _, err := promptAstroCloudConfig("", "W2")
+	assert.ErrorIs(t, err, errMock)
+	astroDeployment.GetDeployments = originalGetDeployments
+}
+
+func TestPromptAstroCloudConfigDeploymentUnsetSelectDeploymentFailure(t *testing.T) {
+	astroDeployment.GetDeployments = mockGetDeployments
+	astroDeployment.SelectDeployment = mockSelectDeploymentErr
+	_, _, err := promptAstroCloudConfig("", "W2")
+	assert.ErrorIs(t, err, errMock)
+	astroDeployment.GetDeployments = originalGetDeployments
+	astroDeployment.SelectDeployment = originalSelectDeployment
+}
+
+func TestPromptAstroCloudConfigDeploymentUnsetSuccess(t *testing.T) {
+	astroDeployment.GetDeployments = mockGetDeployments
+	astroDeployment.SelectDeployment = mockSelectDeployment
+	selectedAstroDeploymentID, selectedAstroWorkspaceID, err := promptAstroCloudConfig("", "W2")
+	assert.NoError(t, err)
+	assert.EqualValues(t, "D1", selectedAstroDeploymentID)
+	assert.EqualValues(t, "W2", selectedAstroWorkspaceID)
+	astroDeployment.GetDeployments = originalGetDeployments
+	astroDeployment.SelectDeployment = originalSelectDeployment
+}
+
+func TestPromptAstroCloudConfigWorkspaceUnsetGetWorkspaceSelectionFailure(t *testing.T) {
+	astroWorkspace.GetWorkspaceSelection = mockGetWorkspaceSelectionErr
+	_, _, err := promptAstroCloudConfig("D2", "")
+	assert.ErrorIs(t, err, errMock)
+	astroWorkspace.GetWorkspaceSelection = originalGetWorkspaceSelection
+}
+
+func TestPromptAstroCloudConfigWorkspaceUnsetSuccess(t *testing.T) {
+	astroWorkspace.GetWorkspaceSelection = mockGetWorkspaceSelection
+	selectedAstroDeploymentID, selectedAstroWorkspaceID, err := promptAstroCloudConfig("D2", "")
+	assert.NoError(t, err)
+	assert.EqualValues(t, "D2", selectedAstroDeploymentID)
+	assert.EqualValues(t, "W1", selectedAstroWorkspaceID)
+	astroWorkspace.GetWorkspaceSelection = originalGetWorkspaceSelection
 }


### PR DESCRIPTION
## Description

We add a function to map the Astro Cloud config (deployment id and workspace id) to a SQL CLI environment.

## 🎟 Issue(s)

Related #1007 
Closes https://github.com/astronomer/astro-sdk/issues/1517

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
