### PR TITLE
Add missing verbose flags for flow init command

### DIFF
--- a/cmd/sql/e2e/flow_test.go
+++ b/cmd/sql/e2e/flow_test.go
@@ -126,9 +126,9 @@ func TestE2EFlowGenerateCmd(t *testing.T) {
 		args []string
 	}{
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--generate-tasks"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--no-generate-tasks"}},
+		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--no-generate-tasks"}},
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--no-verbose"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--verbose"}},
+		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--verbose"}},
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--env", "default"}},
 		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--env", "dev"}},
 	}
@@ -149,9 +149,9 @@ func TestE2EFlowRunCmd(t *testing.T) {
 		args []string
 	}{
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--generate-tasks"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--no-generate-tasks"}},
+		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--no-generate-tasks"}},
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--no-verbose"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--verbose"}},
+		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--verbose"}},
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--env", "default"}},
 		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--env", "dev"}},
 	}

--- a/cmd/sql/e2e/flow_test.go
+++ b/cmd/sql/e2e/flow_test.go
@@ -87,6 +87,8 @@ func TestE2EFlowInitCmdWithArgs(t *testing.T) {
 		{[]string{cmd, t.TempDir(), "--airflow-home", t.TempDir()}},
 		{[]string{cmd, t.TempDir(), "--airflow-dags-folder", t.TempDir()}},
 		{[]string{cmd, t.TempDir(), "--data-dir", t.TempDir()}},
+		{[]string{cmd, t.TempDir(), "--verbose"}},
+		{[]string{cmd, t.TempDir(), "--no-verbose"}},
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
@@ -104,6 +106,8 @@ func TestE2EFlowValidateCmd(t *testing.T) {
 		{[]string{cmd, t.TempDir()}},
 		{[]string{cmd, t.TempDir(), "--connection", "sqlite_conn"}},
 		{[]string{cmd, t.TempDir(), "--env", "dev"}},
+		{[]string{cmd, t.TempDir(), "--verbose"}},
+		{[]string{cmd, t.TempDir(), "--no-verbose"}},
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
@@ -123,6 +127,8 @@ func TestE2EFlowGenerateCmd(t *testing.T) {
 	}{
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--generate-tasks"}},
 		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--no-generate-tasks"}},
+		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--no-verbose"}},
+		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--verbose"}},
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--env", "default"}},
 		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--env", "dev"}},
 	}
@@ -143,9 +149,9 @@ func TestE2EFlowRunCmd(t *testing.T) {
 		args []string
 	}{
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--generate-tasks"}},
-		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--no-generate-tasks"}},
+		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--no-generate-tasks"}},
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--no-verbose"}},
-		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--verbose"}},
+		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--verbose"}},
 		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--env", "default"}},
 		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--env", "dev"}},
 	}

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -162,6 +162,8 @@ func resolvePath(path string) (string, error) {
 }
 
 // Extends args with flags e.g. "--project-dir ." or "--verbose"
+//
+//nolint:gocognit
 func extendLocalCmdArgsWithFlags(cmd *cobra.Command, args []string) []string {
 	switch cmd.Name() {
 	case initCmdName:
@@ -173,6 +175,12 @@ func extendLocalCmdArgsWithFlags(cmd *cobra.Command, args []string) []string {
 		}
 		if dataDir != "" {
 			args = append(args, "--data-dir", dataDir)
+		}
+		if verbose {
+			args = append(args, "--verbose")
+		}
+		if noVerbose {
+			args = append(args, "--no-verbose")
 		}
 	case configCmdName:
 		args = append(args, "--project-dir", projectDir, "--env", env)
@@ -473,6 +481,8 @@ func initCommand() *cobra.Command {
 	cmd.Flags().StringVar(&airflowHome, "airflow-home", "", "")
 	cmd.Flags().StringVar(&airflowDagsFolder, "airflow-dags-folder", "", "")
 	cmd.Flags().StringVar(&dataDir, "data-dir", "", "")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "")
+	cmd.Flags().BoolVar(&noVerbose, "no-verbose", false, "")
 	return cmd
 }
 

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -194,6 +194,8 @@ func TestFlowInitCmdWithArgs(t *testing.T) {
 		{[]string{cmd, "--airflow-home", t.TempDir()}},
 		{[]string{cmd, "--airflow-dags-folder", t.TempDir()}},
 		{[]string{cmd, "--data-dir", t.TempDir()}},
+		{[]string{cmd, "--verbose"}},
+		{[]string{cmd, "--no-verbose"}},
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
@@ -210,17 +212,14 @@ func TestFlowValidateCmd(t *testing.T) {
 		args []string
 	}{
 		{[]string{cmd, t.TempDir()}},
-		{[]string{cmd, t.TempDir(), "--connection", "sqlite_conn"}},
-		{[]string{cmd, t.TempDir(), "--env", "dev"}},
-		{[]string{cmd, t.TempDir(), "--verbose"}},
-		{[]string{cmd, t.TempDir(), "--no-verbose"}},
+		{[]string{cmd, "--connection", "<connection>"}},
+		{[]string{cmd, "--env", "<env>"}},
+		{[]string{cmd, "--verbose"}},
+		{[]string{cmd, "--no-verbose"}},
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
-			err := execFlowCmd("init", tc.args[1])
-			assert.NoError(t, err)
-
-			err = execFlowCmd(tc.args...)
+			err := execFlowCmd(tc.args...)
 			assert.NoError(t, err)
 		})
 	}
@@ -232,20 +231,17 @@ func TestFlowGenerateCmd(t *testing.T) {
 	testCases := []struct {
 		args []string
 	}{
-		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--generate-tasks"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--no-generate-tasks"}},
-		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--no-verbose"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--verbose"}},
-		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--env", "default"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--env", "dev"}},
-		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--output-dir", t.TempDir()}},
+		{[]string{cmd, "--project-dir", t.TempDir()}},
+		{[]string{cmd, "--generate-tasks"}},
+		{[]string{cmd, "--no-generate-tasks"}},
+		{[]string{cmd, "--no-verbose"}},
+		{[]string{cmd, "--verbose"}},
+		{[]string{cmd, "--env", "<env>"}},
+		{[]string{cmd, "--output-dir", t.TempDir()}},
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
-			err := execFlowCmd("init", tc.args[3])
-			assert.NoError(t, err)
-
-			err = execFlowCmd(tc.args...)
+			err := execFlowCmd(tc.args...)
 			assert.NoError(t, err)
 		})
 	}
@@ -257,39 +253,45 @@ func TestFlowRunCmd(t *testing.T) {
 	testCases := []struct {
 		args []string
 	}{
-		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--generate-tasks"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--no-generate-tasks"}},
-		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--no-verbose"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--verbose"}},
-		{[]string{cmd, "example_basic_transform", "--project-dir", t.TempDir(), "--env", "default"}},
-		{[]string{cmd, "example_templating", "--project-dir", t.TempDir(), "--env", "dev"}},
+		{[]string{cmd, "--project-dir", t.TempDir()}},
+		{[]string{cmd, "--generate-tasks"}},
+		{[]string{cmd, "--no-generate-tasks"}},
+		{[]string{cmd, "--no-verbose"}},
+		{[]string{cmd, "--verbose"}},
+		{[]string{cmd, "--env", "<env>"}},
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
-			err := execFlowCmd("init", tc.args[3])
-			assert.NoError(t, err)
-
-			err = execFlowCmd(tc.args...)
+			err := execFlowCmd(tc.args...)
 			assert.NoError(t, err)
 		})
 	}
 }
 
-func TestDebugFlowFlagInitCmd(t *testing.T) {
+func TestDebugFlowFlagCmd(t *testing.T) {
 	defer patchExecuteCmdInDocker(t, 0, nil)()
-	projectDir := t.TempDir()
-	err := execFlowCmd("--debug", "init", projectDir)
-	assert.NoError(t, err)
-}
-
-func TestDebugFlowFlagRunCmd(t *testing.T) {
-	defer patchExecuteCmdInDocker(t, 0, nil)()
-	projectDir := t.TempDir()
-	err := execFlowCmd("--no-debug", "init", projectDir)
-	assert.NoError(t, err)
-
-	err = execFlowCmd("--debug", "run", "example_basic_transform", "--project-dir", projectDir)
-	assert.NoError(t, err)
+	testCases := []struct {
+		args []string
+	}{
+		{[]string{"--debug", "version"}},
+		{[]string{"--no-debug", "version"}},
+		{[]string{"--debug", "about"}},
+		{[]string{"--no-debug", "about"}},
+		{[]string{"--debug", "init"}},
+		{[]string{"--no-debug", "init"}},
+		{[]string{"--debug", "validate"}},
+		{[]string{"--no-debug", "validate"}},
+		{[]string{"--debug", "generate"}},
+		{[]string{"--no-debug", "generate"}},
+		{[]string{"--debug", "run"}},
+		{[]string{"--no-debug", "run"}},
+	}
+	for _, tc := range testCases {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			err := execFlowCmd(tc.args...)
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestFlowDeployWithWorkflowCmd(t *testing.T) {


### PR DESCRIPTION
## Description

We add missing verbose flags for flow init command.

- add more e2e tests
- refactor unit tests

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
