### PR TITLE
Replace `gopkg.in/yaml.v2` with `gopkg.in/yaml.v3`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,10 +24,8 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.8.1
-	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.1.0
 	golang.org/x/sys v0.1.0
-	golang.org/x/text v0.4.0 // indirect
 )
 
 require (
@@ -43,7 +41,6 @@ require (
 	github.com/whilp/git-urls v1.0.0
 	golang.org/x/mod v0.6.0
 	golang.org/x/term v0.1.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -141,9 +138,11 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71 // indirect
@@ -151,6 +150,7 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apimachinery v0.21.0 // indirect
 	k8s.io/client-go v0.21.0 // indirect
 	k8s.io/klog/v2 v2.8.0 // indirect

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/astronomer/astro-cli/docker"
 	"github.com/astronomer/astro-cli/pkg/fileutil"


### PR DESCRIPTION
## Description

Right now, we are using two YAML packages

1. gopkg.in/yaml.v2
2. gopkg.in/yaml.v3

We can keep only the latest `gopkg.in/yaml.v3` package.

## 🎟 Issue(s)


## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

`make test`

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] ~~Added/updated applicable tests~~
- [ ] ~~Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).~~
- [ ] ~~Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).~~
- [ ] ~~Communicated to/tagged owners of respective clients potentially impacted by these changes.~~
- [ ] ~~Updated any related [documentation](https://github.com/astronomer/docs/)~~
