### PR TITLE
Sql cli/compat matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .vscode/
 airflow/pod-config.yml
 airflow_settings*
+airflow/Dockerfile
+cmd/dags/.airflowignore
 astro
 astro-cli
 cover.out

--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,12 @@
 .env
 .idea/
 .vscode/
+airflow/Dockerfile
 airflow/pod-config.yml
 airflow_settings*
-airflow/Dockerfile
-cmd/dags/.airflowignore
 astro
 astro-cli
+cmd/dags/.airflowignore
 cover.out
 coverage.txt
 dist/

--- a/cmd/sql/e2e/flow_test.go
+++ b/cmd/sql/e2e/flow_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/astronomer/astro-cli/version"
+
 	sql "github.com/astronomer/astro-cli/cmd/sql"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +34,7 @@ func chdir(t *testing.T, dir string) func() {
 
 func execFlowCmd(args ...string) error {
 	cmd := sql.NewFlowCommand()
+	version.CurrVersion = "1.8"
 	cmd.SetArgs(args)
 	_, err := cmd.ExecuteC()
 	return err
@@ -157,6 +160,7 @@ func TestE2EFlowRunCmd(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			version.CurrVersion = "1.8"
 			err := execFlowCmd("init", tc.args[3])
 			assert.NoError(t, err)
 

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -125,6 +125,15 @@ func chdir(t *testing.T, dir string) func() {
 }
 
 func execFlowCmd(args ...string) error {
+	version.CurrVersion = "1.8"
+	cmd := NewFlowCommand()
+	cmd.SetArgs(args)
+	_, err := cmd.ExecuteC()
+	return err
+}
+
+func execFlowCmdWrongVersion(args ...string) error {
+	version.CurrVersion = "foo"
 	cmd := NewFlowCommand()
 	cmd.SetArgs(args)
 	_, err := cmd.ExecuteC()
@@ -133,9 +142,12 @@ func execFlowCmd(args ...string) error {
 
 func TestFlowCmd(t *testing.T) {
 	defer patchExecuteCmdInDocker(t, 0, nil)()
-	version.CurrVersion = "1.8"
 	err := execFlowCmd()
 	assert.NoError(t, err)
+}
+
+func TestFlowCmdWrongVersion(t *testing.T) {
+	assert.PanicsWithError(t, "error running []: error parsing response for SQL CLI version %!w(<nil>)", func() { execFlowCmdWrongVersion() })
 }
 
 func TestFlowCmdError(t *testing.T) {

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -17,6 +17,7 @@ import (
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	sql "github.com/astronomer/astro-cli/sql"
 	"github.com/astronomer/astro-cli/sql/mocks"
+	"github.com/astronomer/astro-cli/version"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -132,6 +133,7 @@ func execFlowCmd(args ...string) error {
 
 func TestFlowCmd(t *testing.T) {
 	defer patchExecuteCmdInDocker(t, 0, nil)()
+	version.CurrVersion = "1.8"
 	err := execFlowCmd()
 	assert.NoError(t, err)
 }

--- a/sql/flow_config_test.go
+++ b/sql/flow_config_test.go
@@ -26,6 +26,12 @@ func TestGetPypiVersionInvalidHTTPRequestFailure(t *testing.T) {
 	assert.ErrorContains(t, err, expectedErrContains)
 }
 
+func TestGetPypiVersionInvalidAstroCliVersionFailure(t *testing.T) {
+	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json", "foo")
+	expectedErrContains := "error parsing response for SQL CLI version"
+	assert.ErrorContains(t, err, expectedErrContains)
+}
+
 func TestGetBaseDockerImageURIInvalidURLFailure(t *testing.T) {
 	_, err := GetBaseDockerImageURI("http://efgh")
 	expectedErrContains := "error retrieving the latest configuration http://efgh,  Get \"http://efgh\": dial tcp: lookup efgh"

--- a/sql/flow_config_test.go
+++ b/sql/flow_config_test.go
@@ -9,19 +9,19 @@ import (
 )
 
 func TestGetPypiVersionInvalidHostFailure(t *testing.T) {
-	_, err := GetPypiVersion("http://abcd")
+	_, err := GetPypiVersion("http://abcd", "0.1")
 	expectedErrContains := "error getting latest release version for project url http://abcd,  Get \"http://abcd\": dial tcp: lookup abcd"
 	assert.ErrorContains(t, err, expectedErrContains)
 }
 
 func TestGetPypiVersionInvalidJSONFailure(t *testing.T) {
-	_, err := GetPypiVersion("https://pypi.org")
+	_, err := GetPypiVersion("https://pypi.org", "0.1")
 	expectedErrContains := "error parsing response for project version invalid character '<' looking for beginning of value"
 	assert.ErrorContains(t, err, expectedErrContains)
 }
 
 func TestGetPypiVersionInvalidHTTPRequestFailure(t *testing.T) {
-	_, err := GetPypiVersion("gs://pyconuk-workshop/")
+	_, err := GetPypiVersion("gs://pyconuk-workshop/", "0.1")
 	expectedErrContains := "error getting latest release version for project url gs://pyconuk-workshop/"
 	assert.ErrorContains(t, err, expectedErrContains)
 }

--- a/sql/flow_test.go
+++ b/sql/flow_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/astronomer/astro-cli/version"
+
 	"github.com/astronomer/astro-cli/sql/mocks"
 	"github.com/astronomer/astro-cli/sql/testutil"
 	"github.com/docker/docker/api/types"
@@ -34,8 +36,8 @@ var (
 	mockDisplayMessagesErr = func(r io.Reader) error {
 		return errMock
 	}
-	mockGetPypiVersionErr = func(projectURL string) (string, error) {
-		return "", errMock
+	mockGetPypiVersionErr = func(configUrl string, cliVersion string) (AstroSQLCliVersion, error) {
+		return AstroSQLCliVersion{}, errMock
 	}
 	mockBaseDockerImageURIErr = func(astroSQLCLIConfigURL string) (string, error) {
 		return "", errMock
@@ -44,8 +46,8 @@ var (
 	mockGetAstroDockerfileRuntimeVersion     = func() (string, error) {
 		return "7.1.0", nil
 	}
-	mockGetPypiVersion = func(projectURL string) (string, error) {
-		return "", nil
+	mockGetPypiVersion = func(configUrl string, cliVersion string) (AstroSQLCliVersion, error) {
+		return AstroSQLCliVersion{}, nil
 	}
 	mockGetPythonSDKComptabilityUnMatch = func(configURL, sqlCliVersion string) (astroRuntimeVersion, astroSDKPythonVersion string, err error) {
 		return ">7.1.0", "==1.3.0", nil
@@ -84,6 +86,7 @@ func TestExecuteCmdInDockerWithReturnValue(t *testing.T) {
 		return mockDockerBinder, nil
 	}
 	DisplayMessages = mockDisplayMessagesNil
+	version.CurrVersion = "1.8"
 	_, output, err := ExecuteCmdInDocker(testCommand, nil, true)
 	assert.NoError(t, err)
 

--- a/sql/include/dockerfile_content.go
+++ b/sql/include/dockerfile_content.go
@@ -14,7 +14,7 @@ ENV AIRFLOW__ASTRONOMER__UPDATE_CHECK_INTERVAL 0
 RUN apt-install-and-clean \
         build-essential
 
-RUN pip install astro-sql-cli==%s
+RUN pip install "astro-sql-cli %s" %s
 
 RUN id -u %s 2>/dev/null || useradd --uid %s --create-home %s
 # This is necessary to run the docker image in GNU Linux since Astro CLI 1.8


### PR DESCRIPTION
## Description

This pull requests allows the Astro CLI to consult the SQL CLI for a compatibility check before adding the SQL CLI to the docker image. This ensures that we do not download a new version of the SQL CLI that breaks the Astro CLI

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
