### PR TITLE
better auth error handling

### DIFF
--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -55,6 +55,7 @@ var (
 	callbackChannel = make(chan CallbackMessage, 1)
 	callbackTimeout = time.Second * 300
 	redirectURI     = "http://localhost:12345/callback"
+	callbackServer  = "localhost:12345"
 	userEmail       = ""
 )
 
@@ -139,7 +140,7 @@ func requestToken(authConfig astro.AuthConfig, verifier, code string) (Result, e
 
 func authorizeCallbackHandler() (string, error) {
 	m := http.NewServeMux()
-	s := http.Server{Addr: "localhost:12345", Handler: m, ReadHeaderTimeout: 0}
+	s := http.Server{Addr: callbackServer, Handler: m, ReadHeaderTimeout: 0}
 	m.HandleFunc("/callback", func(w http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
 		if errorCode, ok := req.URL.Query()["error"]; ok {

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -269,6 +269,20 @@ func TestAuthorizeCallbackHandler(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("error", func(t *testing.T) {
+		go func() {
+			time.Sleep(2 * time.Second) // time to spinup the server in authorizeCallbackHandler
+			opts := &httputil.DoOptions{
+				Method: http.MethodGet,
+				Path:   "http://localhost:12345/callback?error=error&error_description=fatal_error",
+			}
+			_, err = httpClient.Do(opts) //nolint
+			assert.NoError(t, err)
+		}()
+		_, err := authorizeCallbackHandler()
+		assert.Contains(t, err.Error(), "fatal_error")
+	})
+
 	t.Run("timeout", func(t *testing.T) {
 		callbackTimeout = 5 * time.Millisecond
 		_, err := authorizeCallbackHandler()

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -254,6 +254,7 @@ func TestRequestToken(t *testing.T) {
 func TestAuthorizeCallbackHandler(t *testing.T) {
 	httpClient = httputil.NewHTTPClient()
 	t.Run("success", func(t *testing.T) {
+		callbackServer = "localhost:12345"
 		go func() {
 			time.Sleep(2 * time.Second) // time to spinup the server in authorizeCallbackHandler
 
@@ -270,11 +271,12 @@ func TestAuthorizeCallbackHandler(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
+		callbackServer = "localhost:12346"
 		go func() {
 			time.Sleep(2 * time.Second) // time to spinup the server in authorizeCallbackHandler
 			opts := &httputil.DoOptions{
 				Method: http.MethodGet,
-				Path:   "http://localhost:12345/callback?error=error&error_description=fatal_error",
+				Path:   "http://localhost:12346/callback?error=error&error_description=fatal_error",
 			}
 			_, err = httpClient.Do(opts) //nolint
 			assert.NoError(t, err)
@@ -284,6 +286,7 @@ func TestAuthorizeCallbackHandler(t *testing.T) {
 	})
 
 	t.Run("timeout", func(t *testing.T) {
+		callbackServer = "localhost:12347"
 		callbackTimeout = 5 * time.Millisecond
 		_, err := authorizeCallbackHandler()
 		assert.Contains(t, err.Error(), "the operation has timed out")

--- a/cloud/auth/types.go
+++ b/cloud/auth/types.go
@@ -44,6 +44,11 @@ type Result struct {
 	UserEmail    string
 }
 
+type CallbackMessage struct {
+	authorizationCode string
+	errorMessage      string
+}
+
 func (res Result) writeToContext(c *config.Context) error {
 	err = c.SetContextKey("token", "Bearer "+res.AccessToken)
 	if err != nil {


### PR DESCRIPTION
## Description

When auth0 login failed, despite we displayed an error message in the console. The current implementation is stuck at `localhost:12345` page.

This PR improved the error handling that displays the standard auth0 denied page

https://auth.astronomer.io/device/denied


## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
