### PR TITLE
Persist deployment and workspace IDs for flow command

### DIFF
--- a/cmd/sql/e2e/flow_test.go
+++ b/cmd/sql/e2e/flow_test.go
@@ -33,8 +33,9 @@ func chdir(t *testing.T, dir string) func() {
 }
 
 func execFlowCmd(args ...string) error {
+	// Set the astro-cli version to a specific version we want to test for
+	version.CurrVersion = "1.10.0"
 	cmd := sql.NewFlowCommand()
-	version.CurrVersion = "1.8"
 	cmd.SetArgs(args)
 	_, err := cmd.ExecuteC()
 	return err
@@ -160,7 +161,6 @@ func TestE2EFlowRunCmd(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
-			version.CurrVersion = "1.8"
 			err := execFlowCmd("init", tc.args[3])
 			assert.NoError(t, err)
 

--- a/cmd/sql/e2e/flow_test.go
+++ b/cmd/sql/e2e/flow_test.go
@@ -33,7 +33,7 @@ func chdir(t *testing.T, dir string) func() {
 }
 
 func execFlowCmd(args ...string) error {
-	// Set the astro-cli version to a specific version we want to test for
+	// Set the astro-cli version to a version compatible with the latest sql-cli version for e2e tests
 	version.CurrVersion = "1.10.0"
 	cmd := sql.NewFlowCommand()
 	cmd.SetArgs(args)

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -122,6 +122,9 @@ func promptAstroCloudConfig(astroDeploymentID, astroWorkspaceID string) (selecte
 		}
 		selectedAstroDeploymentID = astroDeploymentID
 		selectedAstroWorkspaceID = workspace
+	} else {
+		selectedAstroDeploymentID = astroDeploymentID
+		selectedAstroWorkspaceID = astroWorkspaceID
 	}
 
 	return selectedAstroDeploymentID, selectedAstroWorkspaceID, err

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -97,7 +97,7 @@ func promptAstroCloudConfig(astroDeploymentID, astroWorkspaceID string) (selecte
 		if err != nil {
 			return "", "", err
 		}
-		deployment, err := astroDeployment.SelectDeployment(deployments, "Which Astro Cloud deployment should be associated with"+env+"?")
+		deployment, err := astroDeployment.SelectDeployment(deployments, "Which Astro Cloud deployment should be associated with "+env+"?")
 		if err != nil {
 			return "", "", err
 		}
@@ -108,7 +108,7 @@ func promptAstroCloudConfig(astroDeploymentID, astroWorkspaceID string) (selecte
 		if err != nil {
 			return "", "", err
 		}
-		deployment, err := astroDeployment.SelectDeployment(deployments, "Which Astro Cloud deployment should be associated with"+env+"?")
+		deployment, err := astroDeployment.SelectDeployment(deployments, "Which Astro Cloud deployment should be associated with "+env+"?")
 		if err != nil {
 			return "", "", err
 		}

--- a/sql/include/dockerfile_content.go
+++ b/sql/include/dockerfile_content.go
@@ -14,7 +14,7 @@ ENV AIRFLOW__ASTRONOMER__UPDATE_CHECK_INTERVAL 0
 RUN apt-install-and-clean \
         build-essential
 
-RUN pip install "astro-sql-cli %s" %s
+RUN pip install "astro-sql-cli%s" %s
 
 RUN id -u %s 2>/dev/null || useradd --uid %s --create-home %s
 # This is necessary to run the docker image in GNU Linux since Astro CLI 1.8


### PR DESCRIPTION
## Description

This PR fixes the following issues:

* whitespace issues in flow dockerfile and deploy cmd
* reset of deployment config values
* e2e tests to run on latest version

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
