### PR TITLE
Check requirements.txt does not already contain required PythonSDK version

### DIFF
--- a/sql/flow_test.go
+++ b/sql/flow_test.go
@@ -433,6 +433,11 @@ func TestEnsurePythonSdkVersionSelectNoPrompt(t *testing.T) {
 	getAstroDockerfileRuntimeVersion = mockGetAstroDockerfileRuntimeVersion
 	getPypiVersion = mockGetPypiVersion
 	getPythonSDKComptability = mockGetPythonSDKComptabilityUnMatch
+	mockOs := mocks.NewOsBind(t)
+	Os = func() OsBind {
+		mockOs.On("ReadFile", mock.Anything).Return([]byte("\nastro-sdk-python"), nil)
+		return mockOs
+	}
 	err := EnsurePythonSdkVersionIsMet(testutil.PromptSelectNoMock{})
 	assert.ErrorIs(t, err, ErrPythonSDKVersionNotMet)
 	getAstroDockerfileRuntimeVersion = originalGetAstroDockerfileRuntimeVersion
@@ -444,6 +449,11 @@ func TestEnsurePythonSdkVersionSelectErrPrompt(t *testing.T) {
 	getAstroDockerfileRuntimeVersion = mockGetAstroDockerfileRuntimeVersion
 	getPypiVersion = mockGetPypiVersion
 	getPythonSDKComptability = mockGetPythonSDKComptabilityUnMatch
+	mockOs := mocks.NewOsBind(t)
+	Os = func() OsBind {
+		mockOs.On("ReadFile", mock.Anything).Return([]byte("\nastro-sdk-python"), nil)
+		return mockOs
+	}
 	err := EnsurePythonSdkVersionIsMet(testutil.PromptSelectErrMock{})
 	assert.EqualError(t, err, errMock.Error())
 	getAstroDockerfileRuntimeVersion = originalGetAstroDockerfileRuntimeVersion


### PR DESCRIPTION
## Description
Currently, we only check that the runtime image is incompatible meaning that it does not have the required PythonSDK version installed in it before prompting the user to add the required version to requirements.txt.
We should also check that the same version has not already been added to the requirements.txt before prompting the user for confirmation.


## 🎟 Issue(s)

closes: https://github.com/astronomer/astro-sdk/issues/1640

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
