### PR TITLE
Use installed flow version to get compatibiltiies from matrix

### DIFF
--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -29,15 +29,15 @@ var (
 
 // All cmd names
 const (
-	flowCmdName            = "flow"
-	aboutCmdName           = "about"
-	configCmdName          = "config"
-	generateCmdName        = "generate"
-	initCmdName            = "init"
-	runCmdName             = "run"
-	validateCmdName        = "validate"
-	versionCmdName         = "version"
-	deployCmdName          = "deploy"
+	flowCmdName     = "flow"
+	aboutCmdName    = "about"
+	configCmdName   = "config"
+	generateCmdName = "generate"
+	initCmdName     = "init"
+	runCmdName      = "run"
+	validateCmdName = "validate"
+	versionCmdName  = "version"
+	deployCmdName   = "deploy"
 )
 
 // All cmd flags

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -236,7 +236,7 @@ func readConfigCmdOutput(args ...string) (string, error) {
 }
 
 // Read version cmd output for retrieving installed version of SQL CLI
-func getInstalledFlowVersion() (string, error) {
+var getInstalledFlowVersion = func() (string, error) {
 	output, err := readCmdOutput(versionCmd, []string{"--json"})
 	if err != nil {
 		return "", err

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -38,7 +38,6 @@ const (
 	validateCmdName        = "validate"
 	versionCmdName         = "version"
 	deployCmdName          = "deploy"
-	versionCmdOutputPrefix = "Astro SQL CLI"
 )
 
 // All cmd flags

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -60,7 +60,7 @@ var (
 var (
 	ErrInvalidInstalledFlowVersion = errors.New("invalid flow version installed")
 	ErrNotCloudContext             = errors.New("currently, we only support Astronomer cloud deployments. Software deploy support is planned to be added in a later release. ")
-  ErrTooManyArgs                 = errors.New("too many arguments supplied to the command. Refer --help for the usage of the command")
+	ErrTooManyArgs                 = errors.New("too many arguments supplied to the command. Refer --help for the usage of the command")
 	Os                             = sql.NewOsBind
 )
 

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -350,8 +350,11 @@ func TestDebugFlowFlagCmd(t *testing.T) {
 func TestFlowDeployWithWorkflowCmd(t *testing.T) {
 	defer patchDeployCmd()()
 
-	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner) error {
+	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner, string) error {
 		return nil
+	}
+	getInstalledFlowVersion = func() (string, error) {
+		return "", nil
 	}
 
 	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
@@ -362,8 +365,11 @@ func TestFlowDeployWithWorkflowCmd(t *testing.T) {
 func TestFlowDeployNoWorkflowsCmd(t *testing.T) {
 	defer patchDeployCmd()()
 
-	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner) error {
+	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner, string) error {
 		return nil
+	}
+	getInstalledFlowVersion = func() (string, error) {
+		return "", nil
 	}
 	mockOs := mocks.NewOsBind(t)
 	Os = func() sql.OsBind {
@@ -386,8 +392,11 @@ func TestFlowDeployNoWorkflowsCmd(t *testing.T) {
 func TestFlowDeployWorkflowsCmd(t *testing.T) {
 	defer patchDeployCmd()()
 
-	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner) error {
+	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner, string) error {
 		return nil
+	}
+	getInstalledFlowVersion = func() (string, error) {
+		return "", nil
 	}
 	mockOs := mocks.NewOsBind(t)
 	Os = func() sql.OsBind {

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -416,6 +416,33 @@ func TestFlowDeployWorkflowsCmd(t *testing.T) {
 	Os = sql.NewOsBind
 }
 
+func TestFlowDeployCmdInstalledFlowVersionFailure(t *testing.T) {
+	defer patchDeployCmd()()
+
+	getInstalledFlowVersion = func() (string, error) {
+		return "", errMock
+	}
+
+	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	err := execFlowCmd("deploy")
+	assert.ErrorIs(t, err, errMock)
+}
+
+func TestFlowDeployCmdEnsurePythonSDKVersionIsMetFailure(t *testing.T) {
+	defer patchDeployCmd()()
+
+	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner, string) error {
+		return errMock
+	}
+	getInstalledFlowVersion = func() (string, error) {
+		return "", nil
+	}
+
+	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	err := execFlowCmd("deploy")
+	assert.ErrorIs(t, err, errMock)
+}
+
 func TestPromptAstroCloudConfigDeploymentAndWorkspaceUnsetGetWorkspaceSelectionFailure(t *testing.T) {
 	astroWorkspace.GetWorkspaceSelection = mockGetWorkspaceSelectionErr
 	_, _, err := promptAstroCloudConfig("", "")

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -111,7 +111,8 @@ func patchExecuteCmdInDocker(t *testing.T, statusCode int64, err error) func() {
 }
 
 // Mock ExecuteCmdInDocker to return a specific output for "config get --json" calls
-func mockExecuteCmdInDockerOutputForJSONConfig(outputString string) func() {
+func mockExecuteCmdInDockerOutputForJSONConfig() func() {
+	outputString := "{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}"
 	originalExecuteCmdInDocker := sql.ExecuteCmdInDocker
 
 	sql.ExecuteCmdInDocker = func(cmd, mountDirs []string, returnOutput bool) (exitCode int64, output io.ReadCloser, err error) {
@@ -357,7 +358,7 @@ func TestFlowDeployWithWorkflowCmd(t *testing.T) {
 		return "", nil
 	}
 
-	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	defer mockExecuteCmdInDockerOutputForJSONConfig()()
 	err := execFlowCmd("deploy", "--workflow-name", "test.sql")
 	assert.NoError(t, err)
 }
@@ -382,7 +383,7 @@ func TestFlowDeployNoWorkflowsCmd(t *testing.T) {
 		return mockOs
 	}
 
-	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	defer mockExecuteCmdInDockerOutputForJSONConfig()()
 	err := execFlowCmd("deploy")
 	assert.NoError(t, err)
 
@@ -409,7 +410,7 @@ func TestFlowDeployWorkflowsCmd(t *testing.T) {
 		return mockOs
 	}
 
-	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	defer mockExecuteCmdInDockerOutputForJSONConfig()()
 	err := execFlowCmd("deploy")
 	assert.NoError(t, err)
 
@@ -423,7 +424,7 @@ func TestFlowDeployCmdInstalledFlowVersionFailure(t *testing.T) {
 		return "", errMock
 	}
 
-	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	defer mockExecuteCmdInDockerOutputForJSONConfig()
 	err := execFlowCmd("deploy")
 	assert.ErrorIs(t, err, errMock)
 }
@@ -438,7 +439,7 @@ func TestFlowDeployCmdEnsurePythonSDKVersionIsMetFailure(t *testing.T) {
 		return "", nil
 	}
 
-	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	defer mockExecuteCmdInDockerOutputForJSONConfig()()
 	err := execFlowCmd("deploy")
 	assert.ErrorIs(t, err, errMock)
 }

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -366,7 +366,7 @@ func TestFlowDeployWithWorkflowCmd(t *testing.T) {
 func TestFlowDeployWithTooManyArgs(t *testing.T) {
 	defer patchDeployCmd()()
 
-	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner) error {
+	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner, string) error {
 		return nil
 	}
 

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	astroSQLCLIProjectURL     = "https://pypi.org/pypi/astro-sql-cli/json"
-	astroSQLCLIConfigURL      = "https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json"
+	astroSQLCLIConfigURL      = "https://raw.githubusercontent.com/astronomer/astro-sdk/1652-compatibility/sql-cli/config/astro-cli.json"
 	sqlCLIDockerfilePath      = ".Dockerfile.sql_cli"
 	fileWriteMode             = 0o600
 	sqlCLIDockerImageName     = "sql_cli"
@@ -223,19 +223,17 @@ var getAstroDockerfileRuntimeVersion = func() (string, error) {
 	return runtimeVersion, nil
 }
 
-var EnsurePythonSdkVersionIsMet = func(promptRunner input.PromptRunner) error {
+var EnsurePythonSdkVersionIsMet = func(promptRunner input.PromptRunner, installedSQLCLIVersion string) error {
 	astroRuntimeVersion, err := getAstroDockerfileRuntimeVersion()
 	if err != nil {
 		return err
 	}
-	SQLCLIVersion, err := getPypiVersion(astroSQLCLIConfigURL, version.CurrVersion)
+
+	requiredRuntimeVersion, requiredPythonSDKVersion, err := getPythonSDKComptability(astroSQLCLIConfigURL, installedSQLCLIVersion)
 	if err != nil {
 		return err
 	}
-	requiredRuntimeVersion, requiredPythonSDKVersion, err := getPythonSDKComptability(astroSQLCLIConfigURL, SQLCLIVersion.Version)
-	if err != nil {
-		return err
-	}
+
 	runtimeVersionMet, err := util.IsRequiredVersionMet(astroRuntimeVersion, requiredRuntimeVersion)
 	if err != nil {
 		return err

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	astroSQLCLIProjectURL     = "https://pypi.org/pypi/astro-sql-cli/json"
-	astroSQLCLIConfigURL      = "https://raw.githubusercontent.com/astronomer/astro-sdk/1652-compatibility/sql-cli/config/astro-cli.json"
+	astroSQLCLIConfigURL      = "https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json"
 	sqlCLIDockerfilePath      = ".Dockerfile.sql_cli"
 	fileWriteMode             = 0o600
 	sqlCLIDockerImageName     = "sql_cli"


### PR DESCRIPTION
## Description

> Currently, we get the constraint of the SQL CLI python package that is used for installing flow and use the same constraint as a key to match in the compatibility matrix. However the compatibility matrix is meant to contain specific Pypi versions as key and not the constraints itself. We therefore need to get the installed flow version and use that flow version to find the compatibilities. For this reason, we call the `flow version` command which gives us the installed version of flow and we use the same to match it in the matrix.

## 🎟 Issue(s)

closes: https://github.com/astronomer/astro-sdk/issues/1642

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
