### PR TITLE
Use workflowName as an arg instead of a flag

### DIFF
--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -54,11 +54,11 @@ var (
 	outputDir         string
 	projectDir        string
 	verbose           bool
-	workflowName      string
 )
 
 var (
 	ErrNotCloudContext = errors.New("currently, we only support Astronomer cloud deployments. Software deploy support is planned to be added in a later release. ")
+	ErrTooManyArgs     = errors.New("too many arguments supplied to the command. Refer --help for the usage of the command.")
 	Os                 = sql.NewOsBind
 )
 
@@ -427,7 +427,7 @@ func executeCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func generateWorkflows(dagsPath string) error {
+func generateWorkflows(dagsPath, workflowName string) error {
 	generateCmdArgs := []string{"--output-dir", dagsPath}
 	if workflowName != "" {
 		generateCmdArgs = append(generateCmdArgs, workflowName)
@@ -461,6 +461,10 @@ func executeDeployCmd(cmd *cobra.Command, args []string) error {
 		return ErrNotCloudContext
 	}
 
+	if len(args) > 1 {
+		return ErrTooManyArgs
+	}
+
 	pythonSDKPromptContent := input.PromptContent{
 		Label: "Would you like to add the required version of Python SDK dependency to requirements.txt? Otherwise, the deployment will not proceed.",
 	}
@@ -478,7 +482,11 @@ func executeDeployCmd(cmd *cobra.Command, args []string) error {
 	if err := os.MkdirAll(dagsPath, os.ModePerm); err != nil {
 		return fmt.Errorf("error creating directories for %v: %w", dagsPath, err)
 	}
-	if err := generateWorkflows(dagsPath); err != nil {
+	var workflowName string
+	if len(args) > 0 {
+		workflowName = args[0]
+	}
+	if err := generateWorkflows(dagsPath, workflowName); err != nil {
 		return err
 	}
 
@@ -648,7 +656,6 @@ func deployCommand() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.Flags().StringVar(&env, "env", "default", "")
-	cmd.Flags().StringVar(&workflowName, "workflow-name", "", "")
 	cmd.Flags().StringVar(&projectDir, "project-dir", ".", "")
 	return cmd
 }

--- a/cmd/sql/flow.go
+++ b/cmd/sql/flow.go
@@ -58,7 +58,7 @@ var (
 
 var (
 	ErrNotCloudContext = errors.New("currently, we only support Astronomer cloud deployments. Software deploy support is planned to be added in a later release. ")
-	ErrTooManyArgs     = errors.New("too many arguments supplied to the command. Refer --help for the usage of the command.")
+	ErrTooManyArgs     = errors.New("too many arguments supplied to the command. Refer --help for the usage of the command")
 	Os                 = sql.NewOsBind
 )
 

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -355,7 +355,7 @@ func TestFlowDeployWithWorkflowCmd(t *testing.T) {
 	}
 
 	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
-	err := execFlowCmd("deploy", "--workflow-name", "test.sql")
+	err := execFlowCmd("deploy", "test.sql")
 	assert.NoError(t, err)
 }
 

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -359,6 +359,18 @@ func TestFlowDeployWithWorkflowCmd(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestFlowDeployWithTooManyArgs(t *testing.T) {
+	defer patchDeployCmd()()
+
+	sql.EnsurePythonSdkVersionIsMet = func(input.PromptRunner) error {
+		return nil
+	}
+
+	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	err := execFlowCmd("deploy", "test.sql", "abc")
+	assert.ErrorIs(t, err, ErrTooManyArgs)
+}
+
 func TestFlowDeployNoWorkflowsCmd(t *testing.T) {
 	defer patchDeployCmd()()
 

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -111,7 +111,8 @@ func patchExecuteCmdInDocker(t *testing.T, statusCode int64, err error) func() {
 }
 
 // Mock ExecuteCmdInDocker to return a specific output for "config get --json" calls
-func mockExecuteCmdInDockerOutputForJSONConfig(outputString string) func() {
+func mockExecuteCmdInDockerOutputForJSONConfig() func() {
+	outputString := "{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}"
 	originalExecuteCmdInDocker := sql.ExecuteCmdInDocker
 
 	sql.ExecuteCmdInDocker = func(cmd, mountDirs []string, returnOutput bool) (exitCode int64, output io.ReadCloser, err error) {
@@ -354,7 +355,7 @@ func TestFlowDeployWithWorkflowCmd(t *testing.T) {
 		return nil
 	}
 
-	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	defer mockExecuteCmdInDockerOutputForJSONConfig()()
 	err := execFlowCmd("deploy", "test.sql")
 	assert.NoError(t, err)
 }
@@ -366,7 +367,7 @@ func TestFlowDeployWithTooManyArgs(t *testing.T) {
 		return nil
 	}
 
-	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	defer mockExecuteCmdInDockerOutputForJSONConfig()()
 	err := execFlowCmd("deploy", "test.sql", "abc")
 	assert.ErrorIs(t, err, ErrTooManyArgs)
 }
@@ -388,7 +389,7 @@ func TestFlowDeployNoWorkflowsCmd(t *testing.T) {
 		return mockOs
 	}
 
-	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	defer mockExecuteCmdInDockerOutputForJSONConfig()()
 	err := execFlowCmd("deploy")
 	assert.NoError(t, err)
 
@@ -412,7 +413,7 @@ func TestFlowDeployWorkflowsCmd(t *testing.T) {
 		return mockOs
 	}
 
-	defer mockExecuteCmdInDockerOutputForJSONConfig("{\"default\": {\"deployment\": {\"astro_deployment_id\": \"foo\", \"astro_workspace_id\": \"bar\"}}}")()
+	defer mockExecuteCmdInDockerOutputForJSONConfig()()
 	err := execFlowCmd("deploy")
 	assert.NoError(t, err)
 


### PR DESCRIPTION
## Description
> User workflow name as an argument instead of a flag for the deploy cobra command.

## 🎟 Issue(s)
closes: https://github.com/astronomer/astro-sdk/issues/1651

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
