### PR TITLE
deployment queries return `description`

### DIFF
--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -18,6 +18,7 @@ var (
 		deployments(organizationId: $organizationId, workspaceId: $workspaceId) {
 			id
 			label
+			description
 			releaseName
 			dagDeployEnabled
 			cluster {
@@ -84,6 +85,7 @@ var (
 		deployment(id: $deploymentId) {
 			id
 			label
+			description
 			releaseName
 			cluster {
 				id


### PR DESCRIPTION
## Description

> This PR ensures that correct value for description is returned from astrohub when querying deployments. Without this PR, when a deployment was inspected using `astro deployment inspect`, the description would always be `""`.

## 🎟 Issue(s)

Related #1039 

## 🧪 Functional Testing

> astro deployment inspect -n <name of a deployment>

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
