### PR TITLE
Adjust mocked version to adjust with compatibilty matrix update

### DIFF
--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -164,7 +164,7 @@ func chdir(t *testing.T, dir string) func() {
 }
 
 func execFlowCmd(args ...string) error {
-	version.CurrVersion = "1.8"
+	version.CurrVersion = "1.8.0"
 	cmd := NewFlowCommand()
 	cmd.SetArgs(args)
 	_, err := cmd.ExecuteC()

--- a/sql/flow_test.go
+++ b/sql/flow_test.go
@@ -86,7 +86,7 @@ func TestExecuteCmdInDockerWithReturnValue(t *testing.T) {
 		return mockDockerBinder, nil
 	}
 	DisplayMessages = mockDisplayMessagesNil
-	version.CurrVersion = "1.8"
+	version.CurrVersion = "1.8.0"
 	_, output, err := ExecuteCmdInDocker(testCommand, nil, true)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
With respect to the update in compatibility matrix in PR: https://github.com/astronomer/astro-sdk/pull/1671/files,
need to correct to version to include patch version to match in the matrix.