### PR TITLE
Fix Homebrew link in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use these instructions to install, upgrade, or uninstall the Astro CLI.
 
 To install the Astro CLI on Mac, you'll need:
 
-- [Homebrew](https://docs.docker.com/get-docker/)
+- [Homebrew](https://brew.sh/)
 - [Docker Desktop](https://docs.docker.com/get-docker/) (v18.09 or higher)
 
 To install the Astro CLI on Windows, you'll need:


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s) 

The link in the README file for homebrew points to Docker. Replacing it to point to https://brew.sh

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix. --

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
