### PR TITLE
change direct docker calls to use :rw instead of :z for volume flags

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -95,15 +95,15 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile string, pytestArgs
 		"--name",
 		"astro-pytest",
 		"-v",
-		airflowHome + "/dags:/usr/local/airflow/dags:ro",
+		airflowHome + "/dags:/usr/local/airflow/dags:rw",
 		"-v",
-		airflowHome + "/plugins:/usr/local/airflow/plugins:z",
+		airflowHome + "/plugins:/usr/local/airflow/plugins:rw",
 		"-v",
-		airflowHome + "/include:/usr/local/airflow/include:z",
+		airflowHome + "/include:/usr/local/airflow/include:rw",
 		"-v",
-		airflowHome + "/.astro:/usr/local/airflow/.astro:z",
+		airflowHome + "/.astro:/usr/local/airflow/.astro:rw",
 		"-v",
-		airflowHome + "/tests:/usr/local/airflow/tests:z",
+		airflowHome + "/tests:/usr/local/airflow/tests:rw",
 	}
 	fileExist, err := util.Exists(airflowHome + "/" + envFile)
 	if err != nil {
@@ -309,11 +309,11 @@ func (d *DockerImage) Run(dagID, envFile, settingsFile, containerName, dagFile s
 			"--name",
 			astroRunContainer,
 			"-v",
-			config.WorkingPath + "/dags:/usr/local/airflow/dags:ro",
+			config.WorkingPath + "/dags:/usr/local/airflow/dags:rw",
 			"-v",
-			config.WorkingPath + "/plugins:/usr/local/airflow/plugins:z",
+			config.WorkingPath + "/plugins:/usr/local/airflow/plugins:rw",
 			"-v",
-			config.WorkingPath + "/include:/usr/local/airflow/include:z",
+			config.WorkingPath + "/include:/usr/local/airflow/include:rw",
 		}
 		// if settings file exists append it to args
 		if settingsFileExist {


### PR DESCRIPTION
## Description

This change improves compatability with podman on OS X.

Changes the volume flags use by astro dev parse and other astro dev commands that directly call docker to not attempt to mount the volume for sharing across multiple containers and to explicitly mount these as read-write instead of read-write shared.

Since these are one-shot containers, this setting will not impact users and will remove attempts to by certain container binaries to set extended attributes which are not valid on OS X.

## 🧪 Functional Testing

Built from source and ran ~/astro-cli/astro dev parse under podman on OS X.

## 📸 Screenshots

<img width="578" alt="image" src="https://user-images.githubusercontent.com/89029510/215859908-28dfacbc-4235-4f61-9c2d-eb2831cf1d0e.png">


## 📋 Checklist

- [ x ] Rebased from the main (or release if patching) branch (before testing)
- [ x ] Ran `make test` before taking out of draft (FAILS pre-existing code-coverage tests)
- [ x ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
