### PR TITLE
Tiny PR to fix a comment typo in 3 files related to DAG integrity testing

### DIFF
--- a/airflow/include/dagintegritytest.py
+++ b/airflow/include/dagintegritytest.py
@@ -28,7 +28,7 @@ def get_import_errors():
         def strip_path_prefix(path):
             return os.path.relpath(path, os.environ.get("AIRFLOW_HOME"))
 
-        # we prepend "(None,None)" to ensure that a test object is always created even if its a no op.
+        # prepend "(None,None)" to ensure that a test object is always created even if it's a no op.
         return [(None, None)] + [
             (strip_path_prefix(k), v.strip()) for k, v in dag_bag.import_errors.items()
         ]

--- a/airflow/include/dagintegritytestdefault.py
+++ b/airflow/include/dagintegritytestdefault.py
@@ -90,7 +90,7 @@ def get_import_errors():
         def strip_path_prefix(path):
             return os.path.relpath(path, os.environ.get("AIRFLOW_HOME"))
 
-        # we prepend "(None,None)" to ensure that a test object is always created even if its a no op.
+        # prepend "(None,None)" to ensure that a test object is always created even if it's a no op.
         return [(None, None)] + [
             (strip_path_prefix(k), v.strip()) for k, v in dag_bag.import_errors.items()
         ]

--- a/airflow/testfiles/test_dag_integrity_file.py
+++ b/airflow/testfiles/test_dag_integrity_file.py
@@ -1,4 +1,4 @@
-"""This is a test file, content of the file isn't important as much as the existence of the file iteslf"""
+"""This is a test file, content of the file isn't important as much as the existence of the file itself"""
 """Test the validity of all DAGs. **USED BY DEV PARSE COMMAND DO NOT EDIT**"""
 from contextlib import contextmanager
 import logging
@@ -34,7 +34,7 @@ def get_import_errors():
         def strip_path_prefix(path):
             return os.path.relpath(path, os.environ.get("AIRFLOW_HOME"))
 
-        # we prepend "(None,None)" to ensure that a test object is always created even if its a no op.
+        # prepend "(None,None)" to ensure that a test object is always created even if it's a no op.
         return [(None, None)] + [
             (strip_path_prefix(k), v.strip()) for k, v in dag_bag.import_errors.items()
         ]


### PR DESCRIPTION
## Description

> Fix 4 typos (3x `its` -> `it's`) in comments.

## 🎟 Issue(s)

No related issue.

## 🧪 Functional Testing

> Only changes comments

## 📸 Screenshots

> -

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
