### PR TITLE
Updated copy for the Monitoring DAG that is visible to users in the Airflow UI

### DIFF
--- a/airflow/include/astronomermonitoringdag.py
+++ b/airflow/include/astronomermonitoringdag.py
@@ -1,4 +1,4 @@
-"""A Monitoring DAG used by Astronomer to alert users via Control Plane when tasks aren't executing"""
+"""A Monitoring DAG used and maintained by Astronomer. All tasks in this DAG are executed by workers in the default worker queue. When tasks in the Monitoring DAG fail, it might indicate a problem with your Deployment. Astronomer will alert you via email."""
 
 import os
 from datetime import timedelta


### PR DESCRIPTION
## Description

This text currently appears in the Airflow UI when a user clicks or hovers over the **Monitoring DAG**. The problem is that:

- This copy is poorly written
- It's also incorrect. We do _not_ alert customers in the control plane -- our CRE team receives an alert, and may or may not reach out to the customer via email

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/31111752/216152612-8d82837f-ad58-46ca-b652-40eb34737c0a.png">

## 🎟 Issue(s)

https://github.com/astronomer/astro/issues/8774

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
