### PR TITLE
fix user commands

### DIFF
--- a/cloud/user/user.go
+++ b/cloud/user/user.go
@@ -20,7 +20,7 @@ import (
 var (
 	ErrNoShortName          = errors.New("cannot retrieve organization short name from context")
 	ErrInvalidRole          = errors.New("requested role is invalid. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")
-	ErrInvalidWorkspaceRole = errors.New("requested role is invalid. Possible values are WORKSPACE_MEMBER, WORKSPACE_EDITOR and WORKSPACE_OWNER ")
+	ErrInvalidWorkspaceRole = errors.New("requested role is invalid. Possible values are WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER ")
 	ErrInvalidEmail         = errors.New("no email provided for the invite. Retry with a valid email address")
 	ErrInvalidUserKey       = errors.New("invalid User selected")
 	userPagnationLimit      = 100
@@ -326,7 +326,7 @@ func UpdateWorkspaceUserRole(email, role, workspace string, out io.Writer, clien
 // If the role is valid, it returns nil
 // error ErrInvalidWorkspaceRole is returned if the role is not valid
 func IsWorkspaceRoleValid(role string) error {
-	validRoles := []string{"WORKSPACE_MEMBER", "WORKSPACE_EDITOR", "WORKSPACE_OWNER"}
+	validRoles := []string{"WORKSPACE_MEMBER", "WORKSPACE_OPERATOR", "WORKSPACE_OWNER"}
 	for _, validRole := range validRoles {
 		if role == validRole {
 			return nil

--- a/cloud/user/user_test.go
+++ b/cloud/user/user_test.go
@@ -415,8 +415,8 @@ func TestIsWorkspaceRoleValid(t *testing.T) {
 		err = IsWorkspaceRoleValid("WORKSPACE_MEMBER")
 		assert.NoError(t, err)
 	})
-	t.Run("happy path when role is WORKSPACE_EDITOR", func(t *testing.T) {
-		err = IsWorkspaceRoleValid("WORKSPACE_EDITOR")
+	t.Run("happy path when role is WORKSPACE_OPERATOR", func(t *testing.T) {
+		err = IsWorkspaceRoleValid("WORKSPACE_OPERATOR")
 		assert.NoError(t, err)
 	})
 	t.Run("happy path when role is WORKSPACE_OWNER", func(t *testing.T) {

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -28,6 +28,7 @@ var (
 	auditLogsEarliestParamDefaultValue = 90
 	shouldDisplayLoginLink             bool
 	role                               string
+	updateRole                         string
 )
 
 func newOrganizationCmd(out io.Writer) *cobra.Command {
@@ -168,7 +169,7 @@ func newOrganizationUserUpdateCmd(out io.Writer) *cobra.Command {
 			return userUpdate(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&role, "role", "r", "ORGANIZATION_MEMBER", "The new role for the "+
+	cmd.Flags().StringVarP(&updateRole, "role", "r", "", "The new role for the "+
 		"user. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")
 	return cmd
 }
@@ -244,6 +245,11 @@ func userUpdate(cmd *cobra.Command, args []string, out io.Writer) error {
 		email = strings.ToLower(args[0])
 	}
 
+	if updateRole == "" {
+		// no role was provided so ask the user for it
+		updateRole = input.Text("enter a user organization role(ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN, ORGANIZATION_OWNER) to update user: ")
+	}
+
 	cmd.SilenceUsage = true
-	return user.UpdateUserRole(email, role, out, astroCoreClient)
+	return user.UpdateUserRole(email, updateRole, out, astroCoreClient)
 }

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -321,18 +321,6 @@ func TestUserUpdate(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Contains(t, resp, expectedHelp)
 	})
-	t.Run("valid email with no role keeps the user the same", func(t *testing.T) {
-		expectedOut := "The user user@1.com role was successfully updated to ORGANIZATION_MEMBER"
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrgUsersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgUsersResponseOK, nil).Twice()
-		mockClient.On("MutateOrgUserRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgUserRoleResponseOK, nil).Once()
-		astroCoreClient = mockClient
-		cmdArgs := []string{"user", "update", "user@1.com"}
-		resp, err := execOrganizationCmd(cmdArgs...)
-		assert.NoError(t, err)
-		assert.Contains(t, resp, expectedOut)
-		mockClient.AssertExpectations(t)
-	})
 	t.Run("valid email with valid role updates user", func(t *testing.T) {
 		expectedOut := "The user user@1.com role was successfully updated to ORGANIZATION_MEMBER"
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -381,7 +381,7 @@ func TestUserUpdate(t *testing.T) {
 		expectedOut := "The user user@1.com role was successfully updated to ORGANIZATION_MEMBER"
 		mockClient.On("MutateOrgUserRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgUserRoleResponseOK, nil).Once()
 
-		cmdArgs := []string{"user", "update"}
+		cmdArgs := []string{"user", "update", "--role", "ORGANIZATION_MEMBER"}
 		resp, err := execOrganizationCmd(cmdArgs...)
 		assert.NoError(t, err)
 		assert.Contains(t, resp, expectedOut)

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -6,12 +6,17 @@ import (
 
 	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/cloud/workspace"
+	"github.com/astronomer/astro-cli/pkg/input"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-var workspaceID string
+var (
+	workspaceID string
+	addWorkspaceRole string
+	workspaceRole string
+)
 
 func newWorkspaceCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -77,13 +82,13 @@ func newWorkspaceUserAddCmd(out io.Writer) *cobra.Command {
 		Use:   "add [email]",
 		Short: "Add a user to an Astro Workspace with a specific role",
 		Long: "Add a user to an Astro Workspace with a specific role\n$astro workspace user add [email] --role [WORKSPACE_MEMBER, " +
-			"WORKSPACE_EDITOR, WORKSPACE_OWNER].",
+			"WORKSPACE_OPERATOR, WORKSPACE_OWNER].",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addWorkspaceUser(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&role, "role", "r", "WORKSPACE_MEMBER", "The role for the "+
-		"new user. Possible values are WORKSPACE_MEMBER, WORKSPACE_EDITOR and WORKSPACE_OWNER ")
+	cmd.Flags().StringVarP(&addWorkspaceRole, "role", "r", "WORKSPACE_MEMBER", "The role for the "+
+		"new user. Possible values are WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER ")
 	return cmd
 }
 
@@ -106,13 +111,13 @@ func newWorkspaceUserUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update a the role of a user in an Astro Workspace",
 		Long: "Update the role of a user in an Astro Workspace\n$astro workspace user update [email] --role [WORKSPACE_MEMBER, " +
-			"WORKSPACE_EDITOR, WORKSPACE_OWNER].",
+			"WORKSPACE_OPERATOR, WORKSPACE_OWNER].",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateWorkspaceUser(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&role, "role", "r", "WORKSPACE_MEMBER", "The new role for the "+
-		"user. Possible values are WORKSPACE_MEMBER, WORKSPACE_EDITOR and WORKSPACE_OWNER ")
+	cmd.Flags().StringVarP(&workspaceRole, "role", "r", "", "The new role for the "+
+		"user. Possible values are WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER ")
 	return cmd
 }
 
@@ -158,7 +163,7 @@ func addWorkspaceUser(cmd *cobra.Command, args []string, out io.Writer) error {
 	}
 
 	cmd.SilenceUsage = true
-	return user.AddWorkspaceUser(email, role, "", out, astroCoreClient)
+	return user.AddWorkspaceUser(email, addWorkspaceRole, "", out, astroCoreClient)
 }
 
 func listWorkspaceUser(cmd *cobra.Command, out io.Writer) error {
@@ -175,8 +180,13 @@ func updateWorkspaceUser(cmd *cobra.Command, args []string, out io.Writer) error
 		email = strings.ToLower(args[0])
 	}
 
+	if workspaceRole == "" {
+		// no role was provided so ask the user for it
+		workspaceRole = input.Text("Enter a user workspace role(WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER) to update user: ")
+	}
+
 	cmd.SilenceUsage = true
-	return user.UpdateWorkspaceUserRole(email, role, "", out, astroCoreClient)
+	return user.UpdateWorkspaceUserRole(email, workspaceRole, "", out, astroCoreClient)
 }
 
 func removeWorkspaceUser(cmd *cobra.Command, args []string, out io.Writer) error {

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -15,7 +15,7 @@ import (
 var (
 	workspaceID string
 	addWorkspaceRole string
-	workspaceRole string
+	updateWorkspaceRole string
 )
 
 func newWorkspaceCmd(out io.Writer) *cobra.Command {
@@ -116,7 +116,7 @@ func newWorkspaceUserUpdateCmd(out io.Writer) *cobra.Command {
 			return updateWorkspaceUser(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&workspaceRole, "role", "r", "", "The new role for the "+
+	cmd.Flags().StringVarP(&updateWorkspaceRole, "role", "r", "", "The new role for the "+
 		"user. Possible values are WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER ")
 	return cmd
 }
@@ -180,13 +180,13 @@ func updateWorkspaceUser(cmd *cobra.Command, args []string, out io.Writer) error
 		email = strings.ToLower(args[0])
 	}
 
-	if workspaceRole == "" {
+	if updateWorkspaceRole == "" {
 		// no role was provided so ask the user for it
-		workspaceRole = input.Text("Enter a user workspace role(WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER) to update user: ")
+		updateWorkspaceRole = input.Text("Enter a user workspace role(WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER) to update user: ")
 	}
 
 	cmd.SilenceUsage = true
-	return user.UpdateWorkspaceUserRole(email, workspaceRole, "", out, astroCoreClient)
+	return user.UpdateWorkspaceUserRole(email, updateWorkspaceRole, "", out, astroCoreClient)
 }
 
 func removeWorkspaceUser(cmd *cobra.Command, args []string, out io.Writer) error {

--- a/cmd/cloud/workspace_test.go
+++ b/cmd/cloud/workspace_test.go
@@ -182,7 +182,7 @@ func TestWorkspaceUserList(t *testing.T) {
 }
 
 func TestWorkspacUserUpdate(t *testing.T) {
-	expectedHelp := "astro workspace user update [email] --role [WORKSPACE_MEMBER, WORKSPACE_EDITOR, WORKSPACE_OWNER]"
+	expectedHelp := "astro workspace user update [email] --role [WORKSPACE_MEMBER, WORKSPACE_OPERATOR, WORKSPACE_OWNER]"
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 
 	t.Run("-h prints update help", func(t *testing.T) {
@@ -259,7 +259,7 @@ func TestWorkspacUserUpdate(t *testing.T) {
 }
 
 func TestWorkspaceUserAdd(t *testing.T) {
-	expectedHelp := "astro workspace user add [email] --role [WORKSPACE_MEMBER, WORKSPACE_EDITOR, WORKSPACE_OWNER]"
+	expectedHelp := "astro workspace user add [email] --role [WORKSPACE_MEMBER, WORKSPACE_OPERATOR, WORKSPACE_OWNER]"
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 
 	t.Run("-h prints add help", func(t *testing.T) {


### PR DESCRIPTION
## Description

Fix issues found with the user commands when testing:
- WORKSPACE_EDITOR role replaced with WORKSPACE_OPERATOR
- `workspace user update` and `organization user update` updated to ask users to provide a role instead of using the org mem role by default

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

tested every user command manually

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
