### PR TITLE
use min,max,conc from user input

### DIFF
--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2753,7 +2753,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
 				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
-				assert.ErrorContains(t, err, "KubernetesExecutor does not support min_worker_count in the request. It can only be used with CeleryExecutor")
+				assert.ErrorContains(t, err, "KubernetesExecutor does not support minimum worker count in the request. It can only be used with CeleryExecutor")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
 			})
@@ -2790,7 +2790,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
 				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
-				assert.ErrorContains(t, err, "KubernetesExecutor does not support max_worker_count in the request. It can only be used with CeleryExecutor")
+				assert.ErrorContains(t, err, "KubernetesExecutor does not support maximum worker count in the request. It can only be used with CeleryExecutor")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
 			})
@@ -2827,7 +2827,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
 				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
-				assert.ErrorContains(t, err, "KubernetesExecutor does not support worker_concurrency in the request. It can only be used with CeleryExecutor")
+				assert.ErrorContains(t, err, "KubernetesExecutor does not support worker concurrency in the request. It can only be used with CeleryExecutor")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
 			})
@@ -2864,7 +2864,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
 				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
-				assert.ErrorContains(t, err, "KubernetesExecutor does not support pod_ram in the request. It will be calculated based on the requested worker_type")
+				assert.ErrorContains(t, err, "KubernetesExecutor does not support pod ram in the request. It will be calculated based on the requested worker type")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
 			})

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -56,9 +56,12 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	}
 
 	queueToCreateOrUpdate = &astro.WorkerQueue{
-		Name:       name,
-		IsDefault:  false, // cannot create a default queue
-		NodePoolID: nodePoolID,
+		Name:              name,
+		IsDefault:         false, // cannot create a default queue
+		NodePoolID:        nodePoolID,
+		MinWorkerCount:    wQueueMin,         // use the value from the user input
+		MaxWorkerCount:    wQueueMax,         // use the value from the user input
+		WorkerConcurrency: wQueueConcurrency, // use the value from the user input
 	}
 
 	if name == "" {
@@ -135,25 +138,18 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 // SetWorkerQueueValues sets values for MinWorkerCount, MaxWorkerCount and WorkerConcurrency
 // Default values are used if the user did not request any
 func SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency int, workerQueueToCreate *astro.WorkerQueue, workerQueueDefaultOptions astro.WorkerQueueDefaultOptions) *astro.WorkerQueue {
-	if wQueueMin != 0 {
-		// use the value from the user input
-		workerQueueToCreate.MinWorkerCount = wQueueMin
-	} else {
+	if wQueueMin == 0 {
 		// set default value as user input did not have it
 		workerQueueToCreate.MinWorkerCount = workerQueueDefaultOptions.MinWorkerCount.Default
 	}
 
-	if wQueueMax != 0 {
-		// use the value from the user input
-		workerQueueToCreate.MaxWorkerCount = wQueueMax
-	} else {
+	if wQueueMax == 0 {
 		// set default value as user input did not have it
 		workerQueueToCreate.MaxWorkerCount = workerQueueDefaultOptions.MaxWorkerCount.Default
 	}
 
-	if wQueueConcurrency != 0 {
-		workerQueueToCreate.WorkerConcurrency = wQueueConcurrency
-	} else {
+	if wQueueConcurrency == 0 {
+		// set default value as user input did not have it
 		workerQueueToCreate.WorkerConcurrency = workerQueueDefaultOptions.WorkerConcurrency.Default
 	}
 	return workerQueueToCreate

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -212,23 +212,23 @@ func IsKubernetesWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue) 
 		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.PodCPU != "" {
-		errorMessage = "pod_cpu in the request. It will be calculated based on the requested worker_type"
+		errorMessage = "pod cpu in the request. It will be calculated based on the requested worker type"
 		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.PodRAM != "" {
-		errorMessage = "pod_ram in the request. It will be calculated based on the requested worker_type"
+		errorMessage = "pod ram in the request. It will be calculated based on the requested worker type"
 		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.MinWorkerCount != 0 {
-		errorMessage = "min_worker_count in the request. It can only be used with CeleryExecutor"
+		errorMessage = "minimum worker count in the request. It can only be used with CeleryExecutor"
 		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.MaxWorkerCount != 0 {
-		errorMessage = "max_worker_count in the request. It can only be used with CeleryExecutor"
+		errorMessage = "maximum worker count in the request. It can only be used with CeleryExecutor"
 		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 	if requestedWorkerQueue.WorkerConcurrency != 0 {
-		errorMessage = "worker_concurrency in the request. It can only be used with CeleryExecutor"
+		errorMessage = "worker concurrency in the request. It can only be used with CeleryExecutor"
 		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
 

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -1128,7 +1128,7 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
 		assert.ErrorIs(t, err, ErrNotSupported)
-		assert.Contains(t, err.Error(), "KubernetesExecutor does not support pod_cpu in the request. It will be calculated based on the requested worker_type")
+		assert.Contains(t, err.Error(), "KubernetesExecutor does not support pod cpu in the request. It will be calculated based on the requested worker type")
 	})
 	t.Run("returns an error when pod_ram is in input", func(t *testing.T) {
 		requestedWorkerQueue.PodRAM = "1.0"
@@ -1140,7 +1140,7 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
 		assert.ErrorIs(t, err, ErrNotSupported)
-		assert.Contains(t, err.Error(), "KubernetesExecutor does not support pod_ram in the request. It will be calculated based on the requested worker_type")
+		assert.Contains(t, err.Error(), "KubernetesExecutor does not support pod ram in the request. It will be calculated based on the requested worker type")
 	})
 	t.Run("returns an error when min_worker_count is in input", func(t *testing.T) {
 		requestedWorkerQueue.MinWorkerCount = 8
@@ -1152,7 +1152,7 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
 		assert.ErrorIs(t, err, ErrNotSupported)
-		assert.Contains(t, err.Error(), "KubernetesExecutor does not support min_worker_count in the request. It can only be used with CeleryExecutor")
+		assert.Contains(t, err.Error(), "KubernetesExecutor does not support minimum worker count in the request. It can only be used with CeleryExecutor")
 	})
 	t.Run("returns an error when max_worker_count is in input", func(t *testing.T) {
 		requestedWorkerQueue.MaxWorkerCount = 25
@@ -1164,7 +1164,7 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
 		assert.ErrorIs(t, err, ErrNotSupported)
-		assert.Contains(t, err.Error(), "KubernetesExecutor does not support max_worker_count in the request. It can only be used with CeleryExecutor")
+		assert.Contains(t, err.Error(), "KubernetesExecutor does not support maximum worker count in the request. It can only be used with CeleryExecutor")
 	})
 	t.Run("returns an error when worker_concurrency is in input", func(t *testing.T) {
 		requestedWorkerQueue.WorkerConcurrency = 350
@@ -1176,7 +1176,7 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
 		assert.ErrorIs(t, err, ErrNotSupported)
-		assert.Contains(t, err.Error(), "KubernetesExecutor does not support worker_concurrency in the request. It can only be used with CeleryExecutor")
+		assert.Contains(t, err.Error(), "KubernetesExecutor does not support worker concurrency in the request. It can only be used with CeleryExecutor")
 	})
 }
 


### PR DESCRIPTION
## Description

> This PR enables user input to be assigned to queue properties so that if a user uses min, max or conc flags while updating a deployment with `KubernetesExecutor`, an error is returned. Before this we only used the user input values for min, max or concurrency when validating queues for a deployment with `CeleryExecutor`.


## 🎟 Issue(s)

Related #1066 

## 🧪 Functional Testing

#### return error if `max-count` flag was used
```
$ astro deployment worker-queue update -d cldnr7khw245262z0bvht8is7h  --max-count 10 -t m5.xlarge

 #     WORKER QUEUE     ISDEFAULT     ID
 1     default          true          cldnr7khw245292z0b0ffoe6c9

> 1
Error: KubernetesExecutor does not support max_worker_count in the request. It can only be used with CeleryExecutor
```
#### return error if `min-count` flag was used
```
$ astro deployment worker-queue update -d cldnr7khw245262z0bvht8is7h  --min-count 10 -t m5.xlarge

 #     WORKER QUEUE     ISDEFAULT     ID
 1     default          true          cldnr7khw245292z0b0ffoe6c9

> 1
Error: KubernetesExecutor does not support min_worker_count in the request. It can only be used with CeleryExecutor
```
#### return error if `concurrency` flag was used
```
$ astro deployment worker-queue update -d cldnr7khw245262z0bvht8is7h  --concurrency 10 -t m5.xlarge

 #     WORKER QUEUE     ISDEFAULT     ID
 1     default          true          cldnr7khw245292z0b0ffoe6c9

> 1
Error: KubernetesExecutor does not support worker_concurrency in the request. It can only be used with CeleryExecutor
```
## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
