### PR TITLE
Check minor version and default keys to match in compatibility matrix

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -89,7 +89,9 @@ services:
     ports:
       - 127.0.0.1:5432:5432
     volumes:
+      
       - postgres_data:/var/lib/postgresql/data
+      
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -115,7 +117,9 @@ services:
       - airflow_home/include:/usr/local/airflow/include:z
       - airflow_home/tests:/usr/local/airflow/tests:z
 
+      
       - airflow_logs:/usr/local/airflow/logs
+      
     
 
   webserver:
@@ -146,7 +150,9 @@ services:
       - airflow_home/plugins:/usr/local/airflow/plugins:z
       - airflow_home/include:/usr/local/airflow/include:z
       - airflow_home/tests:/usr/local/airflow/tests:z
+      
       - airflow_logs:/usr/local/airflow/logs
+      
     healthcheck:
       test: curl --fail http://webserver:8080/health || exit 1
       interval: 2s
@@ -200,7 +206,9 @@ services:
     ports:
       - 127.0.0.1:5432:5432
     volumes:
+      
       - postgres_data:/var/lib/postgresql/data
+      
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -226,7 +234,9 @@ services:
       - airflow_home/include:/usr/local/airflow/include:z
       - airflow_home/tests:/usr/local/airflow/tests:z
 
+      
       - airflow_logs:/usr/local/airflow/logs
+      
     
 
   webserver:
@@ -257,7 +267,9 @@ services:
       - airflow_home/plugins:/usr/local/airflow/plugins:z
       - airflow_home/include:/usr/local/airflow/include:z
       - airflow_home/tests:/usr/local/airflow/tests:z
+      
       - airflow_logs:/usr/local/airflow/logs
+      
     healthcheck:
       test: curl --fail http://webserver:8080/health || exit 1
       interval: 2s
@@ -285,7 +297,9 @@ services:
       - airflow_home/dags:/usr/local/airflow/dags:z
       - airflow_home/plugins:/usr/local/airflow/plugins:z
       - airflow_home/include:/usr/local/airflow/include:z
+      
       - airflow_logs:/usr/local/airflow/logs
+      
     
 
 `

--- a/cmd/sql/flow_test.go
+++ b/cmd/sql/flow_test.go
@@ -172,22 +172,10 @@ func execFlowCmd(args ...string) error {
 	return err
 }
 
-func execFlowCmdWrongVersion(args ...string) error {
-	version.CurrVersion = "foo"
-	cmd := NewFlowCommand()
-	cmd.SetArgs(args)
-	_, err := cmd.ExecuteC()
-	return err
-}
-
 func TestFlowCmd(t *testing.T) {
 	defer patchExecuteCmdInDocker(t, 0, nil)()
 	err := execFlowCmd()
 	assert.NoError(t, err)
-}
-
-func TestFlowCmdWrongVersion(t *testing.T) {
-	assert.PanicsWithError(t, "error running []: error parsing response for SQL CLI version %!w(<nil>)", func() { execFlowCmdWrongVersion() })
 }
 
 func TestFlowCmdError(t *testing.T) {

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -58,6 +58,7 @@ func NewTestConfig(platform string) []byte {
 local:
   enabled: true
   host: http://localhost:8871/v1
+duplicate_volumes: true
 context: %s
 contexts:
   %s:

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	astroSQLCLIProjectURL     = "https://pypi.org/pypi/astro-sql-cli/json"
-	astroSQLCLIConfigURL      = "https://raw.githubusercontent.com/astronomer/astro-sdk/1673-minor-version-match/sql-cli/config/astro-cli.json"
+	astroSQLCLIConfigURL      = "https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json"
 	sqlCLIDockerfilePath      = ".Dockerfile.sql_cli"
 	fileWriteMode             = 0o600
 	sqlCLIDockerImageName     = "sql_cli"

--- a/sql/flow.go
+++ b/sql/flow.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	astroSQLCLIProjectURL     = "https://pypi.org/pypi/astro-sql-cli/json"
-	astroSQLCLIConfigURL      = "https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json"
+	astroSQLCLIConfigURL      = "https://raw.githubusercontent.com/astronomer/astro-sdk/1673-minor-version-match/sql-cli/config/astro-cli.json"
 	sqlCLIDockerfilePath      = ".Dockerfile.sql_cli"
 	fileWriteMode             = 0o600
 	sqlCLIDockerImageName     = "sql_cli"

--- a/sql/flow_config.go
+++ b/sql/flow_config.go
@@ -39,7 +39,7 @@ var (
 
 var httpClient = &http.Client{}
 
-var semVerRegex = regexp.MustCompile(`^(\d{1,})[.](\d{1,})[.](\d{1,})$`)
+var semVerRegex = regexp.MustCompile(`^(\d+)[.](\d+)[.](\d+)$`)
 
 const (
 	trimmedMinorVersionRegexMatchString = "$1.$2"

--- a/sql/flow_config.go
+++ b/sql/flow_config.go
@@ -39,7 +39,7 @@ var (
 
 var httpClient = &http.Client{}
 
-var semVerRegex = regexp.MustCompile("^(\d{1,})[.](\d{1,})[.](\d{1,})$")
+var semVerRegex = regexp.MustCompile(`^(\d{1,})[.](\d{1,})[.](\d{1,})$`)
 
 const (
 	trimmedMinorVersionRegexMatchString = "$1.$2"

--- a/sql/flow_config.go
+++ b/sql/flow_config.go
@@ -39,7 +39,7 @@ var (
 
 var httpClient = &http.Client{}
 
-var semVerRegex = regexp.MustCompile("^(.*)[.](.*)[.](.*)$")
+var semVerRegex = regexp.MustCompile("^(\d{1,})[.](\d{1,})[.](\d{1,})$")
 
 const (
 	trimmedMinorVersionRegexMatchString = "$1.$2"

--- a/sql/flow_config_test.go
+++ b/sql/flow_config_test.go
@@ -27,17 +27,17 @@ func TestGetPypiVersionInvalidHTTPRequestFailure(t *testing.T) {
 }
 
 func TestGetPypiVersionInvalidAstroCliVersionExactMatchSuccess(t *testing.T) {
-	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/1673-minor-version-match/sql-cli/config/astro-cli.json", "1.9.0")
+	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json", "1.9.0")
 	assert.NoError(t, err)
 }
 
 func TestGetPypiVersionInvalidAstroCliVersionMinorVersionMatchSuccess(t *testing.T) {
-	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/1673-minor-version-match/sql-cli/config/astro-cli.json", "1.10.1")
+	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json", "1.10.1")
 	assert.NoError(t, err)
 }
 
 func TestGetPypiVersionInvalidAstroCliVersionDefaultMatchSuccess(t *testing.T) {
-	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/1673-minor-version-match/sql-cli/config/astro-cli.json", "x.y.z")
+	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json", "x.y.z")
 	assert.NoError(t, err)
 }
 

--- a/sql/flow_config_test.go
+++ b/sql/flow_config_test.go
@@ -26,17 +26,17 @@ func TestGetPypiVersionInvalidHTTPRequestFailure(t *testing.T) {
 	assert.ErrorContains(t, err, expectedErrContains)
 }
 
-func TestGetPypiVersionInvalidAstroCliVersionExactMatchSuccess(t *testing.T) {
+func TestGetPypiVersionAstroCliVersionExactMatchSuccess(t *testing.T) {
 	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json", "1.9.0")
 	assert.NoError(t, err)
 }
 
-func TestGetPypiVersionInvalidAstroCliVersionMinorVersionMatchSuccess(t *testing.T) {
+func TestGetPypiVersionAstroCliVersionMinorVersionMatchSuccess(t *testing.T) {
 	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json", "1.10.1")
 	assert.NoError(t, err)
 }
 
-func TestGetPypiVersionInvalidAstroCliVersionDefaultMatchSuccess(t *testing.T) {
+func TestGetPypiVersionAstroCliVersionDefaultMatchSuccess(t *testing.T) {
 	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json", "x.y.z")
 	assert.NoError(t, err)
 }

--- a/sql/flow_config_test.go
+++ b/sql/flow_config_test.go
@@ -26,10 +26,19 @@ func TestGetPypiVersionInvalidHTTPRequestFailure(t *testing.T) {
 	assert.ErrorContains(t, err, expectedErrContains)
 }
 
-func TestGetPypiVersionInvalidAstroCliVersionFailure(t *testing.T) {
-	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/astro-cli/sql-cli/config/astro-cli.json", "foo")
-	expectedErrContains := "error parsing response for SQL CLI version"
-	assert.ErrorContains(t, err, expectedErrContains)
+func TestGetPypiVersionInvalidAstroCliVersionExactMatchSuccess(t *testing.T) {
+	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/1673-minor-version-match/sql-cli/config/astro-cli.json", "1.9.0")
+	assert.NoError(t, err)
+}
+
+func TestGetPypiVersionInvalidAstroCliVersionMinorVersionMatchSuccess(t *testing.T) {
+	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/1673-minor-version-match/sql-cli/config/astro-cli.json", "1.10.1")
+	assert.NoError(t, err)
+}
+
+func TestGetPypiVersionInvalidAstroCliVersionDefaultMatchSuccess(t *testing.T) {
+	_, err := GetPypiVersion("https://raw.githubusercontent.com/astronomer/astro-sdk/1673-minor-version-match/sql-cli/config/astro-cli.json", "x.y.z")
+	assert.NoError(t, err)
 }
 
 func TestGetBaseDockerImageURIInvalidURLFailure(t *testing.T) {


### PR DESCRIPTION
The plan is that Astro CLI integration should allow version match as per the below steps:
1. Try to find an exact match of Astro CLI version in the compatibility matrix e.g. 1.10.0
2. If no exact match is found, trim the version to remove the patch version and match until the minor version e.g. 1.10
3. If still does not match, match a key named 'default' which is set to install the latest SQL CLI version.

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-sdk/issues/1673

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
