### PR TITLE
Move from jq to sed & grep to validate versions

### DIFF
--- a/godownloader.sh
+++ b/godownloader.sh
@@ -301,13 +301,13 @@ github_release() {
   owner_repo=$1
   version=$2
   if [[ $version = "" ]]; then
-    version=$(curl https://api.github.com/repos/${owner_repo}/releases/latest -s | jq -r '.tag_name')
+    version=$(curl https://api.github.com/repos/${owner_repo}/releases/latest -s | tr -s '\n' ' ' | sed 's/.*"tag_name": "//' | sed 's/".*//')
   elif [[ "$version" =~ ^v[0-9]+\.[0-9]+$ ]]; then
     escaped_version=$(echo $version | sed -e 's/[]\/$*.^[]/\\&/g') # escape the version string
-    version=$(curl https://api.github.com/repos/${owner_repo}/releases -s | jq -r '.[] | .tag_name' | grep '^'"$escaped_version"'\.[0-9]*$' -m1)
+    version=$(curl https://api.github.com/repos/${owner_repo}/releases -s | grep ''\"$escaped_version'\.[0-9]"' -m1 | sed 's/.*"tag_name": "//' | sed 's/".*//')
   else
     escaped_version=$(echo $version | sed -e 's/[]\/$*.^[]/\\&/g') # escape the version string
-    version=$(curl https://api.github.com/repos/${owner_repo}/releases -s | jq -r '.[] | .tag_name' | grep '^'"$escaped_version"'$' -m1)
+    version=$(curl https://api.github.com/repos/${owner_repo}/releases -s | grep ''\"$escaped_version\"'' -m1 | sed 's/.*"tag_name": "//' | sed 's/".*//')
   fi
   test -z "$version" && return 1
   echo "$version"


### PR DESCRIPTION
## Description
Changes:
- Move from using `jq` to `sed` & `grep` command to query JSON response from `api.github.com` to validate user passed versions or fetch latest version

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots
<img width="1051" alt="Screenshot 2023-02-07 at 8 05 37 PM" src="https://user-images.githubusercontent.com/92356010/217275027-c35f11b9-83ed-4d10-8744-f5e62fcf9d88.png">


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
