### PR TITLE
Fix API key context issue

### DIFF
--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -213,13 +213,14 @@ func checkAPIKeys(astroClient astro.Client, coreClient astrocore.CoreClient, arg
 			if err != nil {
 				return false, err
 			}
-
-			// Switch context
-			err = context.Switch(domain)
-			if err != nil {
-				return false, err
-			}
 		}
+
+		// Switch context
+		err = context.Switch(domain)
+		if err != nil {
+			return false, err
+		}
+
 		c, err = context.GetContext(domain) // get current context
 		if err != nil {
 			return false, err
@@ -282,6 +283,7 @@ func checkAPIKeys(astroClient astro.Client, coreClient astrocore.CoreClient, arg
 	if err != nil {
 		return false, err
 	}
+
 	org := orgs[0]
 	orgID := org.Id
 	orgShortName := org.ShortName


### PR DESCRIPTION
## Description

Fix API key issue. if user is not in any context make sure that they switch to astronomer.io by default when using API keys

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1072

## 🧪 Functional Testing

manual testing

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
