### PR TITLE
deployment name not found returns error

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -646,6 +646,7 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 		}
 		if len(stageDeployments) < 1 {
 			fmt.Printf("No Deployment with the name %s was found\n", deploymentName)
+			return astro.Deployment{}, errInvalidDeployment
 		}
 	}
 

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -79,7 +79,7 @@ func TestGetDeployment(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{Label: "test", ID: "test-id"}}, nil).Once()
 
 		_, err := GetDeployment(ws, "", deploymentName, mockClient)
-		assert.ErrorIs(t, err, errMock)
+		assert.ErrorIs(t, err, errors.New("the Deployment specified was not found in this workspace. Your account or API Key may not have access to the deployment specified"))
 		mockClient.AssertExpectations(t)
 	})
 

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -74,13 +74,12 @@ func TestGetDeployment(t *testing.T) {
 	})
 	deploymentName := "test-wrong"
 	deploymentID = "test-id"
-	t.Run("auto select after invalid deployment Name", func(t *testing.T) {
+	t.Run("error after invalid deployment Name", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{Label: "test", ID: "test-id"}}, nil).Once()
 
 		deployment, err := GetDeployment(ws, "", deploymentName, mockClient)
-		assert.NoError(t, err)
-		assert.Equal(t, deploymentID, deployment.ID)
+		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
 

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -79,7 +79,7 @@ func TestGetDeployment(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{Label: "test", ID: "test-id"}}, nil).Once()
 
 		_, err := GetDeployment(ws, "", deploymentName, mockClient)
-		assert.ErrorIs(t, err, errors.New("the Deployment specified was not found in this workspace. Your account or API Key may not have access to the deployment specified"))
+		assert.ErrorIs(t, err, errInvalidDeployment)
 		mockClient.AssertExpectations(t)
 	})
 

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -78,7 +78,7 @@ func TestGetDeployment(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{Label: "test", ID: "test-id"}}, nil).Once()
 
-		deployment, err := GetDeployment(ws, "", deploymentName, mockClient)
+		_, err := GetDeployment(ws, "", deploymentName, mockClient)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})


### PR DESCRIPTION
## Description

If the user supplies a deployment name that does not exist an error is returned similar to what happens if a user supplies a deployment ID that does not exits

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1071

## 🧪 Functional Testing

manual testing

## 📸 Screenshots

<img width="963" alt="Screenshot 2023-02-09 at 9 49 14 AM" src="https://user-images.githubusercontent.com/63181127/217846159-cc321d38-2030-499c-907c-cc62fb86b2c8.png">

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
