### PR TITLE
skip health check for podman

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -766,7 +766,6 @@ var checkWebserverHealth = func(settingsFile string, project *types.Project, com
 	})
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			fmt.Println(err)
 			fmt.Printf("\n")
 			return fmt.Errorf("there might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out", timeout) //nolint:goerr113
 		}

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	componentName                  = "airflow"
+	podman                         = "podman"
 	dockerStateUp                  = "running"
 	defaultAirflowVersion          = uint64(0x2) //nolint:gomnd
 	triggererAllowedRuntimeVersion = "4.0.0"
@@ -716,7 +717,7 @@ var checkWebserverHealth = func(settingsFile string, project *types.Project, com
 			if err != nil {
 				return err
 			}
-			if string(marshal) == `{"action":"health_status: healthy"}` || config.CFG.DockerCommand.GetString() == "podman" {
+			if string(marshal) == `{"action":"health_status: healthy"}` || config.CFG.DockerCommand.GetString() == podman {
 				psInfo, err := composeService.Ps(context.Background(), project.Name, api.PsOptions{
 					All: true,
 				})
@@ -740,7 +741,7 @@ var checkWebserverHealth = func(settingsFile string, project *types.Project, com
 						}
 					}
 				}
-				if config.CFG.DockerCommand.GetString() == "podman" {
+				if config.CFG.DockerCommand.GetString() == podman {
 					fmt.Println("\nComponents will be available soon. If they are not running in the next few minutes, run 'astro dev logs --webserver | --scheduler' for details.")
 				} else {
 					fmt.Println("\nProject is running! All components are now available.")


### PR DESCRIPTION
## Description

Health check does not work when running `astro dev start` with podman. This Pr skips the health check when the user is using podman

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1061

## 🧪 Functional Testing

manual testing

## 📸 Screenshots

<img width="1011" alt="Screenshot 2023-02-09 at 4 30 47 PM" src="https://user-images.githubusercontent.com/63181127/217943603-e32fcdf0-85c2-465f-91f9-a739141d9c53.png">

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
