### PR TITLE
fix workspace resolution with API keys when updating from files

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -78,11 +78,6 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, out io.Writer
 	if err != nil {
 		return err
 	}
-	// map workspace name to id
-	workspaceID, err = getWorkspaceIDFromName(formattedDeployment.Deployment.Configuration.WorkspaceName, c.Organization, client)
-	if err != nil {
-		return err
-	}
 	// map cluster name to id and collect node pools for cluster
 	clusterID, nodePools, err = getClusterInfoFromName(formattedDeployment.Deployment.Configuration.ClusterName, c.Organization, client)
 	if err != nil {
@@ -94,6 +89,11 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, out io.Writer
 	}
 	switch action {
 	case createAction:
+		// map workspace name to id
+		workspaceID, err = getWorkspaceIDFromName(formattedDeployment.Deployment.Configuration.WorkspaceName, c.Organization, client)
+		if err != nil {
+			return err
+		}
 		// check if deployment exists
 		if deploymentExists(existingDeployments, formattedDeployment.Deployment.Configuration.Name) {
 			// create does not allow updating existing deployments
@@ -122,6 +122,8 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, out io.Writer
 		}
 		// this deployment exists so update it
 		existingDeployment = deploymentFromName(existingDeployments, formattedDeployment.Deployment.Configuration.Name)
+		workspaceID = existingDeployment.Workspace.ID
+
 		// transform formattedDeployment to DeploymentUpdateInput
 		_, updateInput, err = getCreateOrUpdateInput(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, client)
 		if err != nil {

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -264,9 +264,9 @@ deployment:
 			},
 		}
 		mockClient = new(astro_mocks.Client)
-		mockClient.On("ListWorkspaces", orgID).Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id", Label: "test-workspace"}}, nil)
+		mockClient.On("ListWorkspaces", orgID).Return([]astro.Workspace{{ID: ws, OrganizationID: orgID, Label: "test-workspace"}}, nil)
 		mockClient.On("ListClusters", orgID).Return(clusters, nil)
-		mockClient.On("ListDeployments", orgID, ws).Return([]astro.Deployment{}, nil).Once()
+		mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil).Once()
 		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 		mockClient.On("CreateDeployment", mock.Anything).Return(createdDeployment, nil)
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, nil)
@@ -446,14 +446,13 @@ deployment:
 			},
 		}
 		mockClient = new(astro_mocks.Client)
-		mockClient.On("ListWorkspaces", orgID).Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id", Label: "test-workspace"}}, nil)
 		mockClient.On("ListClusters", orgID).Return(clusters, nil)
-		mockClient.On("ListDeployments", orgID, ws).Return([]astro.Deployment{updatedDeployment}, nil).Once()
+		mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{updatedDeployment}, nil).Once()
 		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 		mockClient.On("UpdateDeployment", mock.Anything).Return(updatedDeployment, nil)
 		mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, nil)
 		mockClient.On("UpdateAlertEmails", mock.Anything).Return(astro.DeploymentAlerts{}, nil)
-		mockClient.On("ListDeployments", orgID, ws).Return([]astro.Deployment{updatedDeployment}, nil)
+		mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{updatedDeployment}, nil)
 		origClient := astroClient
 		astroClient = mockClient
 		fileutil.WriteStringToFile(filePath, data)


### PR DESCRIPTION

## Description

> This PR refactors the way we derive workspace id when creating or updating deployments with `--deployment-file` and an api key. When creating a deployment from file, the workspace name to ID resolution is done using `getWorkspaceIDFromName()`. When updating a deployment, from file,  the existing deployment's workspace id is used. 

## 🎟 Issue(s)

Related #1076 

## 🧪 Functional Testing

> Update from file
```
# export key_id and key_secret as env vars before the update

$ astro deployment update --deployment-file api-dep.yaml
Using an Astro API key
deployment:
    environment_variables:
        - is_secret: false
          key: foo
          updated_at: "2023-02-17T21:37:30.736Z"
          value: bar
        - is_secret: true
          key: bar
          updated_at: "2023-02-17T21:37:30.736Z"
          value: ""
    configuration:
        name: jp-CE-test
        description: scheduler should be filled in
        runtime_version: 7.1.0
        dag_deploy_enabled: false
        executor: CeleryExecutor
        scheduler_au: 5
        scheduler_count: 1
        cluster_name: gtadi
        workspace_name: CLI Test Workspace
    worker_queues:
        - name: default
          max_worker_count: 15
          min_worker_count: 0
          worker_concurrency: 16
          worker_type: m5.xlarge
    metadata:
        deployment_id: cldyzr9gh3871263idcmuwgj3
        workspace_id: cl0v1p6lc728255byzyfs7lw21
        cluster_id: clbzeum5y000v0tyn8hbv5vsa
        release_name: observational-asterism-3253
        airflow_version: 2.5.0
        current_tag: 7.1.0
        status: UNKNOWN
        created_at: 2023-02-10T20:38:44.897Z
        updated_at: 2023-02-17T21:37:34.037Z
        deployment_url: cloud.astronomer-dev.io/cl0v1p6lc728255byzyfs7lw21/deployments/cldyzr9gh3871263idcmuwgj3/analytics
        webserver_url: astronomer.astronomer-dev.run/dcmuwgj3
    alert_emails:
        - test1@tester.com
        - test2@tester.com
```
## 📸 Screenshots

> API Key created in UI
![Screenshot 2023-02-17 at 1 37 00 PM](https://user-images.githubusercontent.com/37133965/219798476-b2e17806-088b-4524-80da-617a1e026b34.png)


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
