### PR TITLE
Add error check for if there is a version mismatch

### DIFF
--- a/sql/flow_config.go
+++ b/sql/flow_config.go
@@ -119,5 +119,8 @@ func GetPythonSDKComptability(configURL, sqlCliVersion string) (astroRuntimeVers
 	}
 
 	SQLCLICompatibilityVersions := resp.Compatibility[sqlCliVersion]
+	if SQLCLICompatibilityVersions.AstroRuntime == "" {
+		return "", "", fmt.Errorf("could not find a matching SQL CLI compatibility version: current version %s version map: %v  %w", sqlCliVersion, resp.Compatibility, err)
+	}
 	return SQLCLICompatibilityVersions.AstroRuntime, SQLCLICompatibilityVersions.AstroSdkPython, nil
 }

--- a/sql/flow_config_test.go
+++ b/sql/flow_config_test.go
@@ -99,3 +99,21 @@ func TestGetPythonSDKCompatabilitySuccess(t *testing.T) {
 	assert.Equal(t, ">=8.0.0, <8.1.0", astroRuntime)
 	assert.Equal(t, ">=1.3.0, <1.5", astroSdkPython)
 }
+
+func TestGetPythonSDKCompatabilityNoVersionMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"baseDockerImage": "quay.io/astronomer/astro-runtime:6.0.4-base",
+			"compatibility": {
+			  "0.1": {
+				"astroRuntimeVersion": ">=8.0.0, <8.1.0",
+				"astroSDKPythonVersion": ">=1.3.0, <1.5"
+			  }
+			}
+		}`))
+	}))
+	_, _, err := GetPythonSDKComptability(server.URL, "0.1.0")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not find a matching SQL CLI compatibility version")
+}


### PR DESCRIPTION


## Description

Currently, if a user does not have a matching version of the SQL CLI to our version map, they get the following error:

astro flow deploy
Error: Malformed constraint:

This does not help much in determining why the deployment is failing.

This PR adds better context so that future CREs can better aide customers.
## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
