### PR TITLE
Update dagintegritytestdefault.py

### DIFF
--- a/airflow/include/dagintegritytestdefault.py
+++ b/airflow/include/dagintegritytestdefault.py
@@ -25,17 +25,25 @@ BaseHook.get_connection = basehook_get_connection_monkeypatch
 
 
 # =========== MONKEYPATCH OS.GETENV() ===========
-def os_getenv_monkeypatch(key: str, *args, default=None, **kwargs):
-    print(
-        f"Attempted to fetch os environment variable during parse, returning a mocked value for {key}"
-    )
+def os_getenv_monkeypatch(key: str, *args, **kwargs):
+    
+    default=None
+    if args: 
+        default = args[0] # os.getenv should get at most 1 arg after the key
+    if kwargs:
+        default = kwargs.get('default',None) # and sometimes kwarg if people are using the sig
+
+    env_value = os.environ.get(key,None)
+
+    if env_value:
+        return env_value # if the env_value is set, return it
     if (
         key == "JENKINS_HOME" and default is None
     ):  # fix https://github.com/astronomer/astro-cli/issues/601
         return None
     if default:
-        return default
-    return "NON_DEFAULT_OS_ENV_VALUE"
+        return default # otherwise return whatever default has been passed
+    return f"MOCKED_{key.upper()}_VALUE" #if absolutely nothing has been passed - return the mocked value
 
 
 os.getenv = os_getenv_monkeypatch

--- a/airflow/include/dagintegritytestdefault.py
+++ b/airflow/include/dagintegritytestdefault.py
@@ -26,24 +26,25 @@ BaseHook.get_connection = basehook_get_connection_monkeypatch
 
 # =========== MONKEYPATCH OS.GETENV() ===========
 def os_getenv_monkeypatch(key: str, *args, **kwargs):
-    
-    default=None
-    if args: 
-        default = args[0] # os.getenv should get at most 1 arg after the key
+    default = None
+    if args:
+        default = args[0]  # os.getenv should get at most 1 arg after the key
     if kwargs:
-        default = kwargs.get('default',None) # and sometimes kwarg if people are using the sig
+        default = kwargs.get(
+            "default", None
+        )  # and sometimes kwarg if people are using the sig
 
-    env_value = os.environ.get(key,None)
+    env_value = os.environ.get(key, None)
 
     if env_value:
-        return env_value # if the env_value is set, return it
+        return env_value  # if the env_value is set, return it
     if (
         key == "JENKINS_HOME" and default is None
     ):  # fix https://github.com/astronomer/astro-cli/issues/601
         return None
     if default:
-        return default # otherwise return whatever default has been passed
-    return f"MOCKED_{key.upper()}_VALUE" #if absolutely nothing has been passed - return the mocked value
+        return default  # otherwise return whatever default has been passed
+    return f"MOCKED_{key.upper()}_VALUE"  # if absolutely nothing has been passed - return the mocked value
 
 
 os.getenv = os_getenv_monkeypatch


### PR DESCRIPTION
## Description

>Updates the os.getenv monkey patch to manage people who are setting defaults with args instead of kwargs

## 🎟 Issue(s)

Its come up with CRE/Field where customers are using the valid but less explicit `os.getenv(key,default)` in their code and our monkey patch wasn't honoring their default. This SHOULD address both `os.getenv(key,default)` and `os.getenv(key,default=value` patterns that are valid. 


## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.
put a few `os.getenv()` statements in the top of a dag and did some echo debugging

![Screenshot 2023-02-24 094746](https://user-images.githubusercontent.com/6005970/221208199-2486166e-b461-44c7-b655-27642d34c65e.png)




## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.
![Screenshot 2023-02-24 091721](https://user-images.githubusercontent.com/6005970/221200893-61b1a1ef-c950-4234-9dce-5816a4c413aa.png)

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
