### PR TITLE
add init db to parse test

### DIFF
--- a/airflow/include/dagintegritytestdefault.py
+++ b/airflow/include/dagintegritytestdefault.py
@@ -7,7 +7,10 @@ import pytest
 
 from airflow.models import DagBag, Variable, Connection
 from airflow.hooks.base import BaseHook
+from airflow.utils.db import initdb
 
+# init airflow database
+initdb()
 
 # The following code patches errors caused by missing OS Variables, Airflow Connections, and Airflow Variables
 


### PR DESCRIPTION
## Description

Add init db to the parse test so that it is effective in parsing more DAGs

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1096

## 🧪 Functional Testing

I manually tested the astro dev parse command locally

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
