### PR TITLE
add disable run config

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -149,6 +149,8 @@ func DockerComposeInit(airflowHome, envFile, dockerfile, imageName string) (*Doc
 }
 
 // Start starts a local airflow development cluster
+//
+//nolint:gocognit
 func (d *DockerCompose) Start(imageName, settingsFile string, noCache, noBrowser bool, waitTime time.Duration) error {
 	// check if docker is up for macOS
 	if runtime.GOOS == "darwin" {

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -176,16 +176,20 @@ func (d *DockerCompose) Start(imageName, settingsFile string, noCache, noBrowser
 
 	// Build this project image
 	if imageName == "" {
-		// add astro-run-dag package
-		err = fileutil.AddLineToFile("./requirements.txt", "astro-run-dag", "# This package is needed for the astro run command. It will be removed before a deploy")
-		if err != nil {
-			fmt.Printf("Adding 'astro-run-dag' package to requirements.txt unsuccessful: %s\nManually add package to requirements.txt", err.Error())
+		if !config.CFG.DisableAstroRun.GetBool() {
+			// add astro-run-dag package
+			err = fileutil.AddLineToFile("./requirements.txt", "astro-run-dag", "# This package is needed for the astro run command. It will be removed before a deploy")
+			if err != nil {
+				fmt.Printf("Adding 'astro-run-dag' package to requirements.txt unsuccessful: %s\nManually add package to requirements.txt", err.Error())
+			}
 		}
 		imageBuildErr := d.imageHandler.Build(airflowTypes.ImageBuildConfig{Path: d.airflowHome, Output: true, NoCache: noCache})
-		// remove astro-run-dag from requirments.txt
-		err = fileutil.RemoveLineFromFile("./requirements.txt", "astro-run-dag", " # This package is needed for the astro run command. It will be removed before a deploy")
-		if err != nil {
-			fmt.Printf("Removing line 'astro-run-dag' package from requirements.txt unsuccessful: %s\n", err.Error())
+		if !config.CFG.DisableAstroRun.GetBool() {
+			// remove astro-run-dag from requirments.txt
+			err = fileutil.RemoveLineFromFile("./requirements.txt", "astro-run-dag", " # This package is needed for the astro run command. It will be removed before a deploy")
+			if err != nil {
+				fmt.Printf("Removing line 'astro-run-dag' package from requirements.txt unsuccessful: %s\n", err.Error())
+			}
 		}
 		if imageBuildErr != nil {
 			return imageBuildErr

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/astronomer/astro-cli/cmd/utils"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/spf13/cobra"
@@ -35,6 +37,12 @@ func newRunCommand() *cobra.Command {
 func run(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
+
+	if config.CFG.DisableAstroRun.GetBool() {
+		fmt.Println("The 'astro run' command is currently disabled run 'astro config set disable_astro_run false' to enable it")
+
+		return nil
+	}
 
 	if len(args) > 0 {
 		dagID = args[0]

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,7 @@ var (
 		SQLCLI:                newCfg("beta.sql_cli", "false"),
 		AuditLogs:             newCfg("beta.audit_logs", "false"),
 		UpgradeMessage:        newCfg("upgrade_message", "true"),
+		DisableAstroRun:       newCfg("disable_astro_run", "false"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/types.go
+++ b/config/types.go
@@ -41,6 +41,7 @@ type cfgs struct {
 	SQLCLI                cfg
 	AuditLogs             cfg
 	UpgradeMessage        cfg
+	DisableAstroRun       cfg
 }
 
 // Creates a new cfg struct


### PR DESCRIPTION
## Description

Allow users to disable astro run if they don't want the `astro-run-dag` package to be in their image

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
