### PR TITLE
Fix advanced example DAG and modernize

### DIFF
--- a/airflow/include/advancedexampledag.py
+++ b/airflow/include/advancedexampledag.py
@@ -66,6 +66,7 @@ DAY_ACTIVITY_MAPPING = {
 # to learn more.
 #   https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html
 
+
 # This is the TaskFlow equivalent of the PythonOperator:
 #   https://registry.astronomer.io/providers/apache-airflow/modules/pythonoperator
 @task(
@@ -124,7 +125,9 @@ def inviting_friends(subject: str, body: str) -> None:
     default_args={
         "owner": "community",  # Defines the value of the "owner" column in the DAG view of the Airflow UI
         "retries": 2,  # If a task fails, it will retry 2 times.
-        "retry_delay": duration(minutes=3),  # A task that fails will wait 3 minutes to retry.
+        "retry_delay": duration(
+            minutes=3
+        ),  # A task that fails will wait 3 minutes to retry.
     },
     default_view="graph",  # This defines the default view for this DAG in the Airflow UI
     # When catchup=False, your DAG will only run for the latest schedule interval. In this case, this means
@@ -162,7 +165,9 @@ def example_dag_advanced():
         # multiple tasks and want to use different task attributes.
         # See this tutorial for more information:
         #   https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html#reusing-a-decorated-task
-        which_weekday_activity_day = get_activity.override(task_id="which_weekday_activity_day")(day_name)
+        which_weekday_activity_day = get_activity.override(
+            task_id="which_weekday_activity_day"
+        )(day_name)
 
         for day, day_info in DAY_ACTIVITY_MAPPING.items():
             if day_info["is_weekday"]:
@@ -183,14 +188,18 @@ def example_dag_advanced():
     # Tasks within this TaskGroup will be grouped together in the UI
     @task_group
     def weekend_activities():
-        which_weekend_activity_day = get_activity.override(task_id="which_weekend_activity_day")(day_name)
+        which_weekend_activity_day = get_activity.override(
+            task_id="which_weekend_activity_day"
+        )(day_name)
 
         # Labels that will appear in the Graph view of the Airflow UI
         saturday = Label(label="saturday")
         sunday = Label(label="sunday")
 
         # This task runs the Sunday activity of sleeping for a random interval between 1 and 30 seconds
-        sleeping_in = BashOperator(task_id="sleeping_in", bash_command="sleep $[ (1 + $RANDOM % 30) ]s")
+        sleeping_in = BashOperator(
+            task_id="sleeping_in", bash_command="sleep $[ (1 + $RANDOM % 30) ]s"
+        )
 
         going_to_the_beach = _going_to_the_beach()  # Calling the TaskFlow task
 


### PR DESCRIPTION
## Description

The current advanced example DAG has a bug which causes task failures when executed on weekends. Also, the DAG wouldn't be able to run out of the box due to the use of the EmailOperator and it's required SMTP configurations to execute successfully.

This PR fixes said weekend-execution bug, replaces the EmailOperator with another TaskFlow function, and also modernizes the DAG to use TaskFlow API equivalents and syntax that's available with Airflow 2.5.1.

## 🎟 Issue(s)

None formally logged that I'm aware of other than word-of-mouth.

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
