### PR TITLE
Inform user of preinstalled providers packages

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -45,6 +45,9 @@ var (
 
 	//go:embed include/settingsyml.yml
 	Settingsyml string
+
+	//go:embed include/requirements.txt
+	RequirementsTxt string
 )
 
 func initDirs(root string, dirs []string) error {
@@ -104,7 +107,7 @@ func Init(path, airflowImageName, airflowImageTag string) error {
 		"Dockerfile":                           fmt.Sprintf(Dockerfile, airflowImageName, airflowImageTag),
 		".gitignore":                           Gitignore,
 		"packages.txt":                         "",
-		"requirements.txt":                     "",
+		"requirements.txt":                     RequirementsTxt,
 		".env":                                 "",
 		"airflow_settings.yaml":                Settingsyml,
 		"dags/example_dag_basic.py":            ExampleDagBasic,

--- a/airflow/include/requirements.txt
+++ b/airflow/include/requirements.txt
@@ -1,0 +1,1 @@
+# Astro Runtime includes the following pre-installed providers packages: https://docs.astronomer.io/astro/runtime-image-architecture#provider-packages


### PR DESCRIPTION
## Description

I find myself having to search the docs for preinstalled providers packages, or start a local Astro project and exec into a container, to know which providers packages are installed. To make this easier, I suggest adding a comment in the generated requirements.txt file to direct users to the doc.

This PR now generates a requirements.txt with the following comment:

```
# Astro Runtime includes the following pre-installed providers packages: https://docs.astronomer.io/astro/runtime-image-architecture#provider-packages
```

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

I built the Astro CLI and ran `astro dev init` to verify.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
