### PR TITLE
cleanup cloud auth code

### DIFF
--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -48,7 +48,6 @@ type AuthConfig struct {
 	ClientID  string `json:"clientId"`
 	Audience  string `json:"audience"`
 	DomainURL string `json:"domainUrl"`
-	AuthFlow  string `json:"authFlow"` // authFlow is either ORG_FIRST or IDENTITY_FIRST
 }
 
 type AuthUser struct {

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -312,7 +312,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		resp, err := mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false, "test-domain", "")
+		resp, err := mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false)
 		assert.NoError(t, err)
 		assert.Equal(t, mockResponse, resp)
 	})
@@ -330,7 +330,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 		mockAuthenticator := Authenticator{orgChecker: orgChecker, callbackHandler: callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false, "test-domain", "")
+		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false)
 		assert.ErrorIs(t, err, errMock)
 	})
 
@@ -350,7 +350,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false, "test-domain", "")
+		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false)
 		assert.ErrorIs(t, err, errMock)
 	})
 
@@ -368,7 +368,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		resp, err := mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, true, "test-domain", "")
+		resp, err := mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, true)
 		assert.NoError(t, err)
 		assert.Equal(t, mockResponse, resp)
 	})
@@ -383,7 +383,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 		mockAuthenticator := Authenticator{orgChecker: orgChecker, callbackHandler: callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, true, "test-domain", "")
+		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, true)
 		assert.ErrorIs(t, err, errMock)
 	})
 
@@ -400,7 +400,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, true, "test-domain", "")
+		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, true)
 		assert.ErrorIs(t, err, errMock)
 	})
 
@@ -421,9 +421,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		resp, err := mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{
-			AuthFlow: "IDENTITY_FIRST",
-		}, false, "test-domain", "")
+		resp, err := mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false)
 		assert.NoError(t, err)
 		assert.Equal(t, mockResponse, resp)
 	})
@@ -465,17 +463,6 @@ func TestSwitchToLastUsedWorkspace(t *testing.T) {
 }
 
 func TestCheckUserSession(t *testing.T) {
-	mockAuthConfig := astro.AuthConfig{
-		ClientID:  "client-id",
-		Audience:  "audience",
-		DomainURL: "https://myURL.com/",
-	}
-	mockIdentityFirstAuthConfig := astro.AuthConfig{
-		ClientID:  "client-id",
-		Audience:  "audience",
-		DomainURL: "https://myURL.com/",
-		AuthFlow:  "IDENTITY_FIRST",
-	}
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	t.Run("success", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
@@ -485,7 +472,7 @@ func TestCheckUserSession(t *testing.T) {
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 		ctx := config.Context{Domain: "test-domain"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -497,7 +484,7 @@ func TestCheckUserSession(t *testing.T) {
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponseEmpty, nil).Once()
 		ctx := config.Context{Domain: "test-domain"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.Contains(t, err.Error(), "Please contact your Astro Organization Owner to be invited to the organization")
 	})
 
@@ -508,7 +495,7 @@ func TestCheckUserSession(t *testing.T) {
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(nil, errNetwork).Once()
 		ctx := config.Context{Domain: "test-domain"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.Contains(t, err.Error(), "network error")
 	})
 
@@ -518,7 +505,7 @@ func TestCheckUserSession(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(nil, errNetwork).Once()
 		ctx := config.Context{Domain: "test-domain"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.Contains(t, err.Error(), "network error")
 	})
 
@@ -528,7 +515,7 @@ func TestCheckUserSession(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfErrorResponse, nil).Once()
 		ctx := config.Context{Domain: "test-domain"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.Contains(t, err.Error(), "failed to fetch self user")
 	})
 
@@ -539,7 +526,7 @@ func TestCheckUserSession(t *testing.T) {
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 		ctx := config.Context{}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.ErrorIs(t, err, config.ErrCtxConfigErr)
 		mockClient.AssertExpectations(t)
 	})
@@ -552,7 +539,7 @@ func TestCheckUserSession(t *testing.T) {
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 		ctx := config.Context{Domain: "test-domain"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -566,7 +553,7 @@ func TestCheckUserSession(t *testing.T) {
 
 		ctx := config.Context{Domain: "test-domain", LastUsedWorkspace: "test-id-1", Organization: "test-org-id"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -581,7 +568,7 @@ func TestCheckUserSession(t *testing.T) {
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: "test-id-1"}, {ID: "test-id-2"}}, nil)
 		ctx := config.Context{Domain: "test-domain", Organization: "test-org-id"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -596,24 +583,10 @@ func TestCheckUserSession(t *testing.T) {
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{}, errMock).Once()
 		ctx := config.Context{Domain: "test-domain", Organization: "test-org-id"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
-	})
-
-	t.Run("success with org first auth flow", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: "test-id"}}, nil).Once()
-		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
-		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
-		// the org return from getSelf "test-org-id" takes precedence over the context org  "test-org-id-2"
-		ctx := config.Context{Domain: "test-domain", Organization: "test-org-id-2"}
-		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockAuthConfig, mockClient, mockCoreClient, buf)
-		assert.NoError(t, err)
-		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("success with identity first auth flow", func(t *testing.T) {
@@ -625,7 +598,7 @@ func TestCheckUserSession(t *testing.T) {
 		// context org  "test-org-id-2" takes precedence over the getSelf org "test-org-id"
 		ctx := config.Context{Domain: "test-domain", Organization: "test-org-id-2"}
 		buf := new(bytes.Buffer)
-		err := CheckUserSession(&ctx, mockIdentityFirstAuthConfig, mockClient, mockCoreClient, buf)
+		err := CheckUserSession(&ctx, mockClient, mockCoreClient, buf)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -655,7 +628,7 @@ func TestLogin(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: "test-id"}}, nil).Once()
-		err := Login("astronomer.io", "", "", mockClient, mockCoreClient, os.Stdout, false)
+		err := Login("astronomer.io", "", mockClient, mockCoreClient, os.Stdout, false)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -698,7 +671,7 @@ func TestLogin(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 
-		err = Login("pr5723.cloud.astronomer-dev.io", "", "", mockClient, mockCoreClient, os.Stdout, false)
+		err = Login("pr5723.cloud.astronomer-dev.io", "", mockClient, mockCoreClient, os.Stdout, false)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -711,14 +684,14 @@ func TestLogin(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 
-		err := Login("astronomer.io", "", "OAuth Token", mockClient, mockCoreClient, os.Stdout, false)
+		err := Login("astronomer.io", "OAuth Token", mockClient, mockCoreClient, os.Stdout, false)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
 	})
 
 	t.Run("invalid domain", func(t *testing.T) {
-		err := Login("fail.astronomer.io", "", "", nil, nil, os.Stdout, false)
+		err := Login("fail.astronomer.io", "", nil, nil, os.Stdout, false)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "Invalid domain.")
 	})
@@ -731,7 +704,7 @@ func TestLogin(t *testing.T) {
 			return "", errMock
 		}
 		authenticator = Authenticator{orgChecker: orgChecker, callbackHandler: callbackHandler}
-		err := Login("cloud.astronomer.io", "", "", nil, nil, os.Stdout, false)
+		err := Login("cloud.astronomer.io", "", nil, nil, os.Stdout, false)
 		assert.ErrorIs(t, err, errMock)
 	})
 
@@ -754,7 +727,7 @@ func TestLogin(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfErrorResponse, nil).Once()
-		err := Login("", "", "", mockClient, mockCoreClient, os.Stdout, false)
+		err := Login("", "", mockClient, mockCoreClient, os.Stdout, false)
 		assert.Contains(t, err.Error(), "failed to fetch self user")
 		mockClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -790,7 +763,7 @@ func TestLogin(t *testing.T) {
 		// initialize stdin with user email input
 		defer testUtil.MockUserInput(t, "test.user@astronomer.io")()
 		// do the test
-		err = Login("astronomer.io", "", "", mockClient, mockCoreClient, os.Stdout, true)
+		err = Login("astronomer.io", "", mockClient, mockCoreClient, os.Stdout, true)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -825,7 +798,7 @@ func TestLogin(t *testing.T) {
 		}
 		// initialize user input with email
 		defer testUtil.MockUserInput(t, "test.user@astronomer.io")()
-		err := Login("astronomer.io", "", "", mockClient, mockCoreClient, os.Stdout, true)
+		err := Login("astronomer.io", "", mockClient, mockCoreClient, os.Stdout, true)
 		assert.NoError(t, err)
 		// assert that everything got set in the right spot
 		domainContext, err := context.GetContext("astronomer.io")

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -112,11 +112,7 @@ func getOrganizationSelection(out io.Writer, coreClient astrocore.CoreClient) (*
 	return &selected, nil
 }
 
-func SwitchWithLogin(domain string, targetOrg *astrocore.Organization, astroClient astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
-	return Login(domain, targetOrg.AuthServiceId, "", astroClient, coreClient, out, shouldDisplayLoginLink)
-}
-
-func SwitchWithContext(domain string, targetOrg *astrocore.Organization, authConfig astro.AuthConfig, astroClient astro.Client, coreClient astrocore.CoreClient, out io.Writer) error {
+func SwitchWithContext(domain string, targetOrg *astrocore.Organization, astroClient astro.Client, coreClient astrocore.CoreClient, out io.Writer) error {
 	c, _ := context.GetCurrentContext()
 	// reset org context
 	_ = c.SetOrganizationContext(targetOrg.Id, targetOrg.ShortName)
@@ -126,7 +122,7 @@ func SwitchWithContext(domain string, targetOrg *astrocore.Organization, authCon
 	_ = c.SetContextKey("user_email", c.UserEmail)
 	c, _ = context.GetCurrentContext()
 	// call check user session which will trigger workspace switcher flow
-	return CheckUserSession(&c, authConfig, astroClient, coreClient, out)
+	return CheckUserSession(&c, astroClient, coreClient, out)
 }
 
 // Switch switches organizations
@@ -161,15 +157,7 @@ func Switch(orgNameOrID string, astroClient astro.Client, coreClient astrocore.C
 	if targetOrg == nil {
 		return errInvalidOrganizationName
 	}
-	// fetch auth config
-	authConfig, err := FetchDomainAuthConfig(c.Domain)
-	if err != nil {
-		return err
-	}
-	if authConfig.AuthFlow == auth.AuthFlowIdentityFirst {
-		return SwitchWithContext(c.Domain, targetOrg, authConfig, astroClient, coreClient, out)
-	}
-	return SwitchWithLogin(c.Domain, targetOrg, astroClient, coreClient, out, shouldDisplayLoginLink)
+	return SwitchWithContext(c.Domain, targetOrg, astroClient, coreClient, out)
 }
 
 // Write the audit logs to the provided io.Writer.

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -77,15 +77,15 @@ func login(cmd *cobra.Command, args []string, astroClient astro.Client, coreClie
 			}
 			return softwareLogin(args[0], oAuth, "", "", houstonVersion, houstonClient, out)
 		}
-		return cloudLogin(args[0], "", token, astroClient, coreClient, out, shouldDisplayLoginLink)
+		return cloudLogin(args[0], token, astroClient, coreClient, out, shouldDisplayLoginLink)
 	}
 	// Log back into the current context in case no domain is passed
 	ctx, err := context.GetCurrentContext()
 	if err != nil || ctx.Domain == "" {
 		// Default case when no domain is passed, and error getting current context
-		return cloudLogin(domainutil.DefaultDomain, "", token, astroClient, coreClient, out, shouldDisplayLoginLink)
+		return cloudLogin(domainutil.DefaultDomain, token, astroClient, coreClient, out, shouldDisplayLoginLink)
 	} else if context.IsCloudDomain(ctx.Domain) {
-		return cloudLogin(ctx.Domain, "", token, astroClient, coreClient, out, shouldDisplayLoginLink)
+		return cloudLogin(ctx.Domain, token, astroClient, coreClient, out, shouldDisplayLoginLink)
 	}
 	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, houstonClient, out)
 }

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -27,7 +27,7 @@ func TestLogin(t *testing.T) {
 	cloudDomain := "astronomer.io"
 	softwareDomain := "astronomer_dev.com"
 
-	cloudLogin = func(domain, id, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+	cloudLogin = func(domain, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 		assert.Equal(t, cloudDomain, domain)
 		return nil
 	}

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -108,7 +108,7 @@ func checkToken(client astro.Client, coreClient astrocore.CoreClient, out io.Wri
 	// check if user is logged in
 	if c.Token == "Bearer " || c.Token == "" || c.Domain == "" {
 		// guide the user through the login process if not logged in
-		err := authLogin(c.Domain, "", "", client, coreClient, out, false)
+		err := authLogin(c.Domain, "", client, coreClient, out, false)
 		if err != nil {
 			return err
 		}
@@ -122,7 +122,7 @@ func checkToken(client astro.Client, coreClient astrocore.CoreClient, out io.Wri
 		res, err := refresh(c.RefreshToken, authConfig)
 		if err != nil {
 			// guide the user through the login process if refresh doesn't work
-			err := authLogin(c.Domain, "", "", client, coreClient, out, false)
+			err := authLogin(c.Domain, "", client, coreClient, out, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -120,7 +120,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, id, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -156,7 +156,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, id, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -204,7 +204,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, id, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -255,7 +255,7 @@ func TestCheckAPIKeys(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrgsResponse, nil).Once()
 
-		authLogin = func(domain, id, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -294,7 +294,7 @@ func TestCheckToken(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
-		authLogin = func(domain, id, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 		// run checkToken
@@ -306,7 +306,7 @@ func TestCheckToken(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
-		authLogin = func(domain, id, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return errorLogin
 		}
 


### PR DESCRIPTION
## Description

Since we already migrated to the new auth model, we can clean up legacy code. This PR does 2 things.
* Cleanup auth code that always runs on identity first flow.
* Append `prompt=login` in login request. This will bypass the current login session and always display the login prompt when user type `astro login`. I think this is the right thing to do as it will fix the dirty login session issue.

## 🎟 Issue(s)

https://github.com/astronomer/astro/issues/10320

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
