### PR TITLE
Allow airflow ports to be exposed on all network

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -148,6 +148,7 @@ func generateConfig(projectName, airflowHome, envFile, buildImage, settingsFile 
 		AirflowUser:           "astro",
 		AirflowWebserverPort:  config.CFG.WebserverPort.GetString(),
 		AirflowEnvFile:        envFile,
+		AirflowExposePort:     config.CFG.AirflowExposePort.GetBool(),
 		MountLabel:            "z",
 		SettingsFile:          settingsFile,
 		SettingsFileExist:     settingsFileExist,

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -91,6 +91,7 @@ type ComposeConfig struct {
 	AirflowHome           string
 	AirflowUser           string
 	AirflowWebserverPort  string
+	AirflowExposePort     bool
 	MountLabel            string
 	SettingsFile          string
 	SettingsFileExist     bool

--- a/airflow/include/composeyml.yml
+++ b/airflow/include/composeyml.yml
@@ -31,7 +31,11 @@ services:
       io.astronomer.docker: "true"
       io.astronomer.docker.cli: "true"
     ports:
+      {{- if not .AirflowExposePort }}
       - 127.0.0.1:{{ .PostgresPort }}:5432
+      {{- else }}
+      - {{ .PostgresPort }}:5432
+      {{- end }}
     volumes:
       {{if .DuplicateImageVolumes}}
       - postgres_data:/var/lib/postgresql/data
@@ -92,7 +96,11 @@ services:
       - postgres
     environment: *common-env-vars
     ports:
+      {{- if not .AirflowExposePort }}
       - 127.0.0.1:{{ .AirflowWebserverPort }}:8080
+      {{- else }}
+      - {{ .AirflowWebserverPort }}:8080
+      {{- end }}
     volumes:
       - {{ .AirflowHome }}/dags:/usr/local/airflow/dags:{{ .MountLabel }}
       - {{ .AirflowHome }}/plugins:/usr/local/airflow/plugins:{{ .MountLabel }}

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ var (
 		ProjectName:           newCfg("project.name", ""),
 		ProjectWorkspace:      newCfg("project.workspace", ""),
 		WebserverPort:         newCfg("webserver.port", "8080"),
+		AirflowExposePort:     newCfg("airflow.expose_port", "false"),
 		ShowWarnings:          newCfg("show_warnings", "true"),
 		Verbosity:             newCfg("verbosity", "warning"),
 		HoustonDialTimeout:    newCfg("houston.dial_timeout", "10"),

--- a/config/types.go
+++ b/config/types.go
@@ -31,6 +31,7 @@ type cfgs struct {
 	ProjectDeployment     cfg
 	ProjectWorkspace      cfg
 	WebserverPort         cfg
+	AirflowExposePort     cfg
 	ShowWarnings          cfg
 	Verbosity             cfg
 	HoustonDialTimeout    cfg


### PR DESCRIPTION
## Description
Changes:
- Added a config `airflow.expose_port` to the CLI (default value `false`) which if set to `true` would expose webserver & postgres ports of the local project on all networks thus allowing easy access to the local project running on remote machines.

## 🎟 Issue(s)

Related #878 #1082 #1103

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots
Case when `airflow.expose_port` is set to `false`
<img width="1187" alt="Screenshot 2023-03-14 at 12 23 06 PM" src="https://user-images.githubusercontent.com/92356010/224919449-2541a944-82c9-4345-aed0-22d67c38a063.png">


Case when `airflow.expose_port` is set to `true`
<img width="1192" alt="Screenshot 2023-03-14 at 12 22 58 PM" src="https://user-images.githubusercontent.com/92356010/224919404-7b34ea8d-76f5-4763-9f72-912b900d68b1.png">


## 📋 Checklist
- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
