### PR TITLE
improve cli login

### DIFF
--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -25,7 +25,6 @@ import (
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
-	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
 
@@ -34,7 +33,6 @@ const (
 	AuthFlowIdentityFirst = "IDENTITY_FIRST"
 
 	authConfigEndpoint = "auth-config"
-	orgLookupEndpoint  = "organization-lookup"
 
 	cliChooseWorkspace     = "Please choose a workspace:"
 	cliSetWorkspaceExample = "\nNo default workspace detected, you can list workspaces with \n\tastro workspace list\nand set your default workspace with \n\tastro workspace switch [WORKSPACEID]\n\n"
@@ -47,7 +45,7 @@ const (
 var (
 	httpClient          = httputil.NewHTTPClient()
 	openURL             = browser.OpenURL
-	ErrorNoOrganization = errors.New("no Organization found. Please contact your Astro Organization Owner to be invited to the organization")
+	ErrorNoOrganization = errors.New("no organization found. Please contact your Astro Organization Owner to be invited to the organization")
 )
 
 var (
@@ -56,45 +54,38 @@ var (
 	callbackTimeout = time.Second * 300
 	redirectURI     = "http://localhost:12345/callback"
 	callbackServer  = "localhost:12345"
-	userEmail       = ""
 )
 
 var authenticator = Authenticator{
-	orgChecker:      orgLookup,
-	tokenRequester:  requestToken,
-	callbackHandler: authorizeCallbackHandler,
+	userInfoRequester: requestUserInfo,
+	tokenRequester:    requestToken,
+	callbackHandler:   authorizeCallbackHandler,
 }
 
-func orgLookup(domain string) (string, error) {
-	addr := domainutil.GetURLToEndpoint("https", domain, orgLookupEndpoint)
-
+func requestUserInfo(authConfig astro.AuthConfig, accessToken string) (UserInfo, error) {
+	addr := authConfig.DomainURL + "userinfo"
 	ctx := http_context.Background()
-	reqData, err := json.Marshal(orgLookupRequest{Email: userEmail})
-	if err != nil {
-		return "", err
-	}
 	doOptions := &httputil.DoOptions{
-		Data:    reqData,
 		Context: ctx,
-		Headers: map[string]string{"x-request-id": "cli-auth-" + cuid.New(), "Content-Type": "application/json; charset=utf-8"},
+		Headers: map[string]string{"Content-Type": "application/json", "Authorization": fmt.Sprintf("Bearer %s", accessToken)},
 		Path:    addr,
-		Method:  http.MethodPost,
+		Method:  http.MethodGet,
 	}
 	res, err := httpClient.Do(doOptions)
 	if err != nil {
-		return "", err
+		return UserInfo{}, fmt.Errorf("cannot retrieve userinfo: %w", err)
 	}
 	defer res.Body.Close()
 
-	orgs := orgLookupResults{}
-	err = json.NewDecoder(res.Body).Decode(&orgs)
+	var user UserInfo
+	err = json.NewDecoder(res.Body).Decode(&user)
 	if err != nil {
-		return "", fmt.Errorf("cannot decode response: %w", err)
+		return UserInfo{}, fmt.Errorf("cannot decode userinfo response: %w", err)
 	}
-	if len(orgs.OrganizationIds) == 0 {
-		return "", errors.New("")
+	if user.Email == "" {
+		return UserInfo{}, fmt.Errorf("cannot retrieve email")
 	}
-	return orgs.OrganizationIds[0], nil
+	return user, nil
 }
 
 // request a device code from auth0 for the user's cli
@@ -118,7 +109,7 @@ func requestToken(authConfig astro.AuthConfig, verifier, code string) (Result, e
 	}
 	res, err := httpClient.Do(doOptions)
 	if err != nil {
-		return Result{}, fmt.Errorf("could not retrieve token: %w", err)
+		return Result{}, fmt.Errorf("cannot retrieve token: %w", err)
 	}
 	defer res.Body.Close()
 
@@ -186,32 +177,7 @@ func authorizeCallbackHandler() (string, error) {
 	return authorizationCode, nil
 }
 
-func getUserEmail(c config.Context) (string, error) { //nolint:gocritic
-	// Try to get the user's email from the config first
-	email := c.UserEmail
-
-	// If email is in config, use that and don't prompt, else prompt for email
-	if email == "" {
-		userEmail = input.Text("Please enter your account email: ")
-	} else {
-		userEmail = email
-		fmt.Printf("Logging in with saved user %s\n", userEmail)
-	}
-
-	return userEmail, err
-}
-
 func (a *Authenticator) authDeviceLogin(c config.Context, authConfig astro.AuthConfig, shouldDisplayLoginLink bool) (Result, error) { //nolint:gocritic
-	// try to get UserEmail from config first
-	userEmail, err := getUserEmail(c)
-	if err != nil {
-		return Result{}, err
-	}
-
-	if userEmail == "" {
-		userEmail = input.Text("Please enter your account email: ")
-	}
-
 	// Generate PKCE verifier and challenge
 	token := make([]byte, 32)                            //nolint:gomnd
 	r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
@@ -224,12 +190,11 @@ func (a *Authenticator) authDeviceLogin(c config.Context, authConfig astro.AuthC
 	var res Result
 
 	authorizeURL := fmt.Sprintf(
-		"%sauthorize?audience=%s&client_id=%s&redirect_uri=%s&login_hint=%s&scope=openid profile email offline_access&response_type=code&response_mode=query&code_challenge=%s&code_challenge_method=S256",
+		"%sauthorize?prompt=login&audience=%s&client_id=%s&redirect_uri=%s&scope=openid profile email offline_access&response_type=code&response_mode=query&code_challenge=%s&code_challenge_method=S256",
 		authConfig.DomainURL,
 		authConfig.Audience,
 		authConfig.ClientID,
 		redirectURI,
-		userEmail,
 		challenge,
 	)
 
@@ -268,7 +233,6 @@ func (a *Authenticator) authDeviceLogin(c config.Context, authConfig astro.AuthC
 		}
 	}
 
-	res.UserEmail = userEmail
 	return res, nil
 }
 
@@ -366,8 +330,6 @@ func CheckUserSession(c *config.Context, client astro.Client, coreClient astroco
 		}
 	}
 
-	fmt.Println(registryAuthSuccessMsg)
-
 	return nil
 }
 
@@ -391,12 +353,20 @@ func Login(domain, token string, client astro.Client, coreClient astrocore.CoreC
 			return err
 		}
 	} else {
-		fmt.Println("You are logging into Astro via an OAuth token\nThis token will expire in 24 hours and will not refresh")
+		fmt.Print("You are logging into Astro via an OAuth token\nThis token will expire in 24 hours and will not refresh\n\n")
 		res = Result{
 			AccessToken: token,
 			ExpiresIn:   86400, //nolint:gomnd
 		}
 	}
+
+	// fetch user info base on access token
+	userInfo, err := authenticator.userInfoRequester(authConfig, res.AccessToken)
+	if err != nil {
+		return err
+	}
+	// set email base on userinfo so it always match with access token
+	res.UserEmail = userInfo.Email
 
 	// Create context if it does not exist
 	if domain != "" {
@@ -406,7 +376,6 @@ func Login(domain, token string, client astro.Client, coreClient astrocore.CoreC
 			return err
 		}
 	}
-
 	c, err = context.GetCurrentContext()
 	if err != nil {
 		return err
@@ -417,11 +386,14 @@ func Login(domain, token string, client astro.Client, coreClient astrocore.CoreC
 		return err
 	}
 
+	fmt.Printf("Logging in as %s\n", ansi.Green(res.UserEmail))
+
 	err = CheckUserSession(&c, client, coreClient, out)
 	if err != nil {
 		return err
 	}
 
+	fmt.Println(registryAuthSuccessMsg)
 	return nil
 }
 

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -156,26 +155,31 @@ func Test_FetchDomainAuthConfig(t *testing.T) {
 	})
 }
 
-func TestOrgLookup(t *testing.T) {
+func TestRequestUserInfo(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	mockResponse := orgLookupResults{
-		OrganizationIds: []string{"test-org-id"},
+	mockUserInfo := UserInfo{
+		Email:      "test@astronomer.test",
+		Name:       "astro.crush",
+		FamilyName: "Crush",
+		GivenName:  "Astro",
 	}
-	jsonResponse, err := json.Marshal(mockResponse)
+	emptyUserInfo := UserInfo{}
+	mockAccessToken := "access-token"
+	userInfoResponse, err := json.Marshal(mockUserInfo)
+	emptyResponse, err := json.Marshal(emptyUserInfo)
 	assert.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		httpClient = testUtil.NewTestClient(func(req *http.Request) *http.Response {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Body:       io.NopCloser(bytes.NewBuffer(userInfoResponse)),
 				Header:     make(http.Header),
 			}
 		})
-
-		resp, err := orgLookup("cloud.test-org.io")
+		resp, err := requestUserInfo(astro.AuthConfig{}, mockAccessToken)
 		assert.NoError(t, err)
-		assert.Equal(t, mockResponse.OrganizationIds[0], resp)
+		assert.Equal(t, mockUserInfo, resp)
 	})
 
 	t.Run("failure", func(t *testing.T) {
@@ -187,8 +191,21 @@ func TestOrgLookup(t *testing.T) {
 			}
 		})
 
-		_, err := orgLookup("cloud.test-org.io")
+		_, err := requestUserInfo(astro.AuthConfig{}, mockAccessToken)
 		assert.Contains(t, err.Error(), "Internal Server Error")
+	})
+
+	t.Run("fail with no email", func(t *testing.T) {
+		assert.NoError(t, err)
+		httpClient = testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(emptyResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		_, err := requestUserInfo(astro.AuthConfig{}, mockAccessToken)
+		assert.Contains(t, err.Error(), "cannot retrieve email")
 	})
 }
 
@@ -297,9 +314,6 @@ func TestAuthDeviceLogin(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	t.Run("success without login link", func(t *testing.T) {
 		mockResponse := Result{RefreshToken: "test-token", AccessToken: "test-token", ExpiresIn: 300}
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
 		callbackHandler := func() (string, error) {
 			return "test-code", nil
 		}
@@ -309,7 +323,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 		openURL = func(url string) error {
 			return nil
 		}
-		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
+		mockAuthenticator := Authenticator{tokenRequester: tokenRequester, callbackHandler: callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		resp, err := mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false)
@@ -318,16 +332,13 @@ func TestAuthDeviceLogin(t *testing.T) {
 	})
 
 	t.Run("openURL & callback failure", func(t *testing.T) {
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
 		openURL = func(url string) error {
 			return errMock
 		}
 		callbackHandler := func() (string, error) {
 			return "", errMock
 		}
-		mockAuthenticator := Authenticator{orgChecker: orgChecker, callbackHandler: callbackHandler}
+		mockAuthenticator := Authenticator{callbackHandler: callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false)
@@ -335,9 +346,6 @@ func TestAuthDeviceLogin(t *testing.T) {
 	})
 
 	t.Run("token requester failure", func(t *testing.T) {
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
 		callbackHandler := func() (string, error) {
 			return "test-code", nil
 		}
@@ -347,7 +355,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 		openURL = func(url string) error {
 			return nil
 		}
-		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
+		mockAuthenticator := Authenticator{tokenRequester: tokenRequester, callbackHandler: callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false)
@@ -356,16 +364,13 @@ func TestAuthDeviceLogin(t *testing.T) {
 
 	t.Run("success with login link", func(t *testing.T) {
 		mockResponse := Result{RefreshToken: "test-token", AccessToken: "test-token", ExpiresIn: 300}
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
 		callbackHandler := func() (string, error) {
 			return "test-code", nil
 		}
 		tokenRequester := func(authConfig astro.AuthConfig, verifier, code string) (Result, error) {
 			return mockResponse, nil
 		}
-		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
+		mockAuthenticator := Authenticator{tokenRequester: tokenRequester, callbackHandler: callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		resp, err := mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, true)
@@ -374,13 +379,10 @@ func TestAuthDeviceLogin(t *testing.T) {
 	})
 
 	t.Run("callback failure with login link", func(t *testing.T) {
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
 		callbackHandler := func() (string, error) {
 			return "", errMock
 		}
-		mockAuthenticator := Authenticator{orgChecker: orgChecker, callbackHandler: callbackHandler}
+		mockAuthenticator := Authenticator{callbackHandler: callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, true)
@@ -388,43 +390,19 @@ func TestAuthDeviceLogin(t *testing.T) {
 	})
 
 	t.Run("token requester failure with login link", func(t *testing.T) {
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
 		callbackHandler := func() (string, error) {
 			return "test-code", nil
 		}
 		tokenRequester := func(authConfig astro.AuthConfig, verifier, code string) (Result, error) {
 			return Result{}, errMock
 		}
-		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
+		mockAuthenticator := Authenticator{tokenRequester: tokenRequester, callbackHandler: callbackHandler}
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		_, err = mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, true)
 		assert.ErrorIs(t, err, errMock)
 	})
 
-	t.Run("do not call org lookup in identity first flow", func(t *testing.T) {
-		mockResponse := Result{RefreshToken: "test-token", AccessToken: "test-token", ExpiresIn: 300}
-		orgChecker := func(domain string) (string, error) {
-			return "", errMock
-		}
-		callbackHandler := func() (string, error) {
-			return "test-code", nil
-		}
-		tokenRequester := func(authConfig astro.AuthConfig, verifier, code string) (Result, error) {
-			return mockResponse, nil
-		}
-		openURL = func(url string) error {
-			return nil
-		}
-		mockAuthenticator := Authenticator{orgChecker, tokenRequester, callbackHandler}
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		resp, err := mockAuthenticator.authDeviceLogin(c, astro.AuthConfig{}, false)
-		assert.NoError(t, err)
-		assert.Equal(t, mockResponse, resp)
-	})
 }
 
 func TestSwitchToLastUsedWorkspace(t *testing.T) {
@@ -609,19 +587,20 @@ func TestLogin(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	t.Run("success", func(t *testing.T) {
 		mockResponse := Result{RefreshToken: "test-token", AccessToken: "test-token", ExpiresIn: 300}
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
+		mockUserInfo := UserInfo{Email: "test@astronomer.test"}
 		callbackHandler := func() (string, error) {
 			return "test-code", nil
 		}
 		tokenRequester := func(authConfig astro.AuthConfig, verifier, code string) (Result, error) {
 			return mockResponse, nil
 		}
+		userInfoRequester := func(authConfig astro.AuthConfig, accessToken string) (UserInfo, error) {
+			return mockUserInfo, nil
+		}
 		openURL = func(url string) error {
 			return nil
 		}
-		authenticator = Authenticator{orgChecker, tokenRequester, callbackHandler}
+		authenticator = Authenticator{userInfoRequester, tokenRequester, callbackHandler}
 
 		mockClient := new(astro_mocks.Client)
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -651,20 +630,20 @@ func TestLogin(t *testing.T) {
 			}
 		})
 		mockResponse := Result{RefreshToken: "test-token", AccessToken: "test-token", ExpiresIn: 300}
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
+		mockUserInfo := UserInfo{Email: "test@astronomer.test"}
 		callbackHandler := func() (string, error) {
 			return "test-code", nil
 		}
 		tokenRequester := func(authConfig astro.AuthConfig, verifier, code string) (Result, error) {
 			return mockResponse, nil
 		}
+		userInfoRequester := func(authConfig astro.AuthConfig, accessToken string) (UserInfo, error) {
+			return mockUserInfo, nil
+		}
 		openURL = func(url string) error {
 			return nil
 		}
-		authenticator = Authenticator{orgChecker, tokenRequester, callbackHandler}
-
+		authenticator = Authenticator{userInfoRequester, tokenRequester, callbackHandler}
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: "test-id"}}, nil).Once()
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -697,32 +676,30 @@ func TestLogin(t *testing.T) {
 	})
 
 	t.Run("auth failure", func(t *testing.T) {
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
 		callbackHandler := func() (string, error) {
 			return "", errMock
 		}
-		authenticator = Authenticator{orgChecker: orgChecker, callbackHandler: callbackHandler}
+		authenticator = Authenticator{callbackHandler: callbackHandler}
 		err := Login("cloud.astronomer.io", "", nil, nil, os.Stdout, false)
 		assert.ErrorIs(t, err, errMock)
 	})
 
 	t.Run("check token failure", func(t *testing.T) {
 		mockResponse := Result{RefreshToken: "test-token", AccessToken: "test-token", ExpiresIn: 300}
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
-		}
+		mockUserInfo := UserInfo{Email: "test@astronomer.test"}
 		callbackHandler := func() (string, error) {
 			return "test-code", nil
 		}
 		tokenRequester := func(authConfig astro.AuthConfig, verifier, code string) (Result, error) {
 			return mockResponse, nil
 		}
+		userInfoRequester := func(authConfig astro.AuthConfig, accessToken string) (UserInfo, error) {
+			return mockUserInfo, nil
+		}
 		openURL = func(url string) error {
 			return nil
 		}
-		authenticator = Authenticator{orgChecker, tokenRequester, callbackHandler}
+		authenticator = Authenticator{userInfoRequester, tokenRequester, callbackHandler}
 
 		mockClient := new(astro_mocks.Client)
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -746,12 +723,13 @@ func TestLogin(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 		// initialize the test authenticator
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
+		mockUserInfo := UserInfo{Email: "test@astronomer.test"}
+		userInfoRequester := func(authConfig astro.AuthConfig, accessToken string) (UserInfo, error) {
+			return mockUserInfo, nil
 		}
 		authenticator = Authenticator{
-			orgChecker:      orgChecker,
-			callbackHandler: func() (string, error) { return "authorizationCode", nil },
+			userInfoRequester: userInfoRequester,
+			callbackHandler:   func() (string, error) { return "authorizationCode", nil },
 			tokenRequester: func(authConfig astro.AuthConfig, verifier, code string) (Result, error) {
 				return Result{
 					RefreshToken: "refresh_token",
@@ -782,12 +760,13 @@ func TestLogin(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 		// initialize the test authenticator
-		orgChecker := func(domain string) (string, error) {
-			return "test-org-id", nil
+		mockUserInfo := UserInfo{Email: "test@astronomer.test"}
+		userInfoRequester := func(authConfig astro.AuthConfig, accessToken string) (UserInfo, error) {
+			return mockUserInfo, nil
 		}
 		authenticator = Authenticator{
-			orgChecker:      orgChecker,
-			callbackHandler: func() (string, error) { return "authorizationCode", nil },
+			userInfoRequester: userInfoRequester,
+			callbackHandler:   func() (string, error) { return "authorizationCode", nil },
 			tokenRequester: func(authConfig astro.AuthConfig, verifier, code string) (Result, error) {
 				return Result{
 					RefreshToken: "refresh_token",
@@ -848,45 +827,6 @@ func TestLogout(t *testing.T) {
 		// test after logout
 		assertions("", "")
 	})
-}
-
-func Test_getUserEmail_FromConfig(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	c, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	err = c.SetContextKey("user_email", "test.user@astronomer.io")
-	assert.NoError(t, err)
-	c, err = config.GetCurrentContext()
-	assert.NoError(t, err)
-	userEmail, err := getUserEmail(c)
-	assert.NoError(t, err)
-	assert.Equal(t, "test.user@astronomer.io", userEmail)
-}
-
-func testGetsInputHelper(t *testing.T, c config.Context) { //nolint:gocritic
-	defer testUtil.MockUserInput(t, "test.user@astronomer.io")()
-	userEmail, err := getUserEmail(c)
-	assert.NoError(t, err)
-	// print a new line so that goland recognizes the test
-	fmt.Println("")
-	assert.Equal(t, "test.user@astronomer.io", userEmail)
-}
-
-func Test_getUserEmail_FromStdin(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	c, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	err = c.SetContextKey("user_email", "")
-	assert.NoError(t, err)
-	// TODO: remove set user email and get user email
-	testGetsInputHelper(t, c)
-}
-
-func Test_getUserEmail_OldStyleConfig(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	c, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	testGetsInputHelper(t, c)
 }
 
 func Test_writeResultToContext(t *testing.T) {

--- a/cloud/auth/types.go
+++ b/cloud/auth/types.go
@@ -7,15 +7,23 @@ import (
 
 // higher order functions to facilate writing unit test cases
 type (
-	OrgLookup                func(domain string) (string, error)
 	RequestToken             func(authConfig astro.AuthConfig, verifier, code string) (Result, error)
+	RequestUserInfo          func(authConfig astro.AuthConfig, accessToken string) (UserInfo, error)
 	AuthorizeCallbackHandler func() (string, error)
 )
 
 type Authenticator struct {
-	orgChecker      OrgLookup
-	tokenRequester  RequestToken
-	callbackHandler AuthorizeCallbackHandler
+	userInfoRequester RequestUserInfo
+	tokenRequester    RequestToken
+	callbackHandler   AuthorizeCallbackHandler
+}
+
+type UserInfo struct {
+	Email      string `json:"email"`
+	Picture    string `json:"picture"`
+	Name       string `json:"name"`
+	GivenName  string `json:"given_name"`
+	FamilyName string `json:"family_name"`
 }
 
 type postTokenResponse struct {
@@ -27,14 +35,6 @@ type postTokenResponse struct {
 	TokenType        string  `json:"token_type"`
 	Error            *string `json:"error,omitempty"`
 	ErrorDescription string  `json:"error_description,omitempty"`
-}
-
-type orgLookupRequest struct {
-	Email string `json:"email"`
-}
-
-type orgLookupResults struct {
-	OrganizationIds []string
 }
 
 type Result struct {

--- a/pkg/ansi/spinner.go
+++ b/pkg/ansi/spinner.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	spinnerTextEllipsis = "…"
-	spinnerTextDone     = "done"
+	spinnerTextDone     = ""
 	spinnerTextFailed   = "failed"
 
 	spinnerColor = "cyan"


### PR DESCRIPTION
## Description

This PR improves the cli login and cleanup legacy codes.

1.  Remove the email input step. `astro login` will open the browser directly and ask the user to type in their email in the login form.
2. After getting the access token, we make call to auth0 `userinfo` endpoint to retrieve the user's email and use the returned email for the login session. No more dirty tokens when switching between accounts.
3. remove the org lookup code.

## 🎟 Issue(s)


## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

```
➜  astro-cli git:(mluo/improve-login-flow) ✗ ./astro login

Welcome to the Astro CLI 🚀

To learn more about Astro, go to https://docs.astronomer.io


Press Enter to open the browser to log in or ^C to quit…

Logging in as michael.luo@astronomer.io

"Astronomer Data Science" Workspace found. This is your default Workspace.

Successfully authenticated to Astronomer
```

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
