### PR TITLE
allow home astro config file location to be override via env var

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,12 @@ func initHome(fs afero.Fs) {
 	viperHome.SetFs(fs)
 	viperHome.SetConfigName(ConfigFileName)
 	viperHome.SetConfigType(ConfigFileType)
+
+	configPath := os.Getenv("ASTRO_HOME")
+	if configPath != "" {
+		HomeConfigPath = filepath.Join(configPath, ConfigDir)
+		HomeConfigFile = filepath.Join(HomeConfigPath, ConfigFileNameWithExt)
+	}
 	viperHome.SetConfigFile(HomeConfigFile)
 
 	for _, cfg := range CFGStrMap {


### PR DESCRIPTION
## Description
Changes:
- Added `ASTRO_HOME` env var to allow override the astro cli base config yaml file location 

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

```
neel@Neels-MacBook-Pro airflow-test-15 % export ASTRO_HOME=/Users/neel/go/src/github.com/astronomer/astro-cli/test-config-path
neel@Neels-MacBook-Pro airflow-test-15 % ../astro context list                                                                
Error: no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again
neel@Neels-MacBook-Pro airflow-test-15 % 
neel@Neels-MacBook-Pro airflow-test-15 % 
neel@Neels-MacBook-Pro airflow-test-15 % ../astro login astronomer.io

Welcome to the Astro CLI 🚀

To learn more about Astro, go to https://docs.astronomer.io

Please enter your account email: ^C
neel@Neels-MacBook-Pro airflow-test-15 % cat /Users/neel/go/src/github.com/astronomer/astro-cli/test-config-path/.astro/config.yaml
neel@Neels-MacBook-Pro airflow-test-15 % 
neel@Neels-MacBook-Pro airflow-test-15 % 
neel@Neels-MacBook-Pro airflow-test-15 % ../astro login astronomer.io                                                              

Welcome to the Astro CLI 🚀

To learn more about Astro, go to https://docs.astronomer.io

Please enter your account email: neel.dalsania@astronomer.io

Press Enter to open the browser to log in or ^C to quit…
done

"ADE - Sandbox" Workspace found. This is your default Workspace.

Successfully authenticated to Astronomer
neel@Neels-MacBook-Pro airflow-test-15 % 
neel@Neels-MacBook-Pro airflow-test-15 % 
neel@Neels-MacBook-Pro airflow-test-15 % ../astro context list       
 NAME                                        
 astronomer.io                               
neel@Neels-MacBook-Pro airflow-test-15 % ../astro deployment ls                   
 NAME                 NAMESPACE                         CLUSTER                  DEPLOYMENT ID                   RUNTIME VERSION                    DAG DEPLOY ENABLED     
 neel-test-2          extraterrestrial-horizon-5600     AstroDataEngineering     clfqv6s0o1008887cyynp2c6w9u     7.4.1 (based on Airflow 2.5.2)     false                  
 neel-cli-test        geosynchronous-rings-9432         AstroDataEngineering     clfqv4kou996157cyy7ifr2uaq      7.3.0 (based on Airflow 2.5.1)     false                  
 fritz-test           glowing-perihelion-2842           AstroDataEngineering     clf8l28911113266v1rzyy1p0kt     7.3.0 (based on Airflow 2.5.1)     false                  
 fritz-kexec-test     bitter-gegenschein-2487           AstroDataEngineering     clflix3cu1841113cx4ohn6plb9     7.4.1 (based on Airflow 2.5.2)     false                  
 david test           prehistoric-solar-4891            AstroDataEngineering     cle4p0fdt325082f05nco4rt6pu     7.4.1 (based on Airflow 2.5.2)     true                   
 cosmos-dev           positional-horizon-5437           AstroDataEngineering     cldl3kjnq1958232cyqq1m0sh2w     7.2.0 (based on Airflow 2.5.1)     true                   
neel@Neels-MacBook-Pro airflow-test-15 % ../astro deploy -f    
Select a Deployment
 #     DEPLOYMENT NAME      RELEASE NAME                      DEPLOYMENT ID                   
 1     cosmos-dev           positional-horizon-5437           cldl3kjnq1958232cyqq1m0sh2w     
 2     david test           prehistoric-solar-4891            cle4p0fdt325082f05nco4rt6pu     
 3     fritz-test           glowing-perihelion-2842           clf8l28911113266v1rzyy1p0kt     
 4     fritz-kexec-test     bitter-gegenschein-2487           clflix3cu1841113cx4ohn6plb9     
 5     neel-cli-test        geosynchronous-rings-9432         clfqv4kou996157cyy7ifr2uaq      
 6     neel-test-2          extraterrestrial-horizon-5600     clfqv6s0o1008887cyynp2c6w9u     

> 5
Building image...
[+] Building 1.3s (11/11) FINISHED                                                                                                                                    
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 36B                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                0.0s
 => => transferring context: 34B                                                                                                                                 0.0s
 => [internal] load metadata for quay.io/astronomer/astro-runtime:7.3.0                                                                                          1.1s
 => [1/1] FROM quay.io/astronomer/astro-runtime:7.3.0@sha256:8d5693c643ecdefad3a83e419685c223ef53fff12e1c9748d9a162ebebe3b340                                    0.0s
 => [internal] load build context                                                                                                                                0.0s
 => => transferring context: 619B                                                                                                                                0.0s
 => CACHED [2/1] COPY packages.txt .                                                                                                                             0.0s
 => CACHED [3/1] RUN if [[ -s packages.txt ]]; then     apt-get update && cat packages.txt | tr '\r\n' '\n' | sed -e 's/#.*//' | xargs apt-get install -y --no-  0.0s
 => CACHED [4/1] COPY requirements.txt .                                                                                                                         0.0s
 => CACHED [5/1] RUN if grep -Eqx 'apache-airflow\s*[=~>]{1,2}.*' requirements.txt; then     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your re  0.0s
 => CACHED [6/1] COPY --chown=astro:0 . .                                                                                                                        0.0s
 => exporting to image                                                                                                                                           0.1s
 => => exporting layers                                                                                                                                          0.0s
 => => writing image sha256:00a772df3c016ff2547672d73928efd1bd1c01b4813a5aef658953de0b19ba01                                                                     0.0s
 => => naming to docker.io/geosynchronous-rings-9432/airflow:latest                                                                                              0.0s
WARNING! You are currently running Astro Runtime Version 7.3.0
Consider upgrading to the latest version, Astro Runtime 7.4.1
testing geosynchronous-rings-9432/airflow:latest
Pushing image to Astronomer registry
The push refers to repository [images.astronomer.cloud/cknaqyipv05731evsry6cj4n0/clfqv4kou996157cyy7ifr2uaq]
1a59b13f5d52: Layer already exists 
51d2472991cb: Layer already exists 
069f53cdce60: Layer already exists 
e021ee9fcdfd: Layer already exists 
86a9818a4fab: Layer already exists 
5f70bf18a086: Layer already exists 
09ebab052a88: Layer already exists 
309e7efde888: Layer already exists 
39a47a9b5657: Layer already exists 
4b59a6e79c5d: Layer already exists 
5de6d96d74d8: Layer already exists 
362d0cb79f00: Layer already exists 
8e040dda9133: Layer already exists 
2be6435c59f1: Layer already exists 
304655fa658d: Layer already exists 
1135fa7dd315: Layer already exists 
ea602fc98564: Layer already exists 
d443f1df463f: Layer already exists 
d878dd054bd3: Layer already exists 
e8c3d13a6a84: Layer already exists 
a0ee07d9f4a4: Layer already exists 
9cf5e9114ae0: Layer already exists 
a4c22e014045: Layer already exists 
51ea39aba9dc: Layer already exists 
6d9155421032: Layer already exists 
07c264c4c297: Layer already exists 
249e01eee848: Layer already exists 
43b1c6b4f686: Layer already exists 
7ca0a8cd8bdd: Layer already exists 
36e5ac463d7d: Layer already exists 
4695cdfb426a: Layer already exists 
deploy-2023-03-27T13-40: digest: sha256:45e0469e84ed45284dfd16a7772076b4f9c1fbd142e96223773ae7cf4d4c8f3e size: 6776
Deployed Image Tag:  deploy-2023-03-27T13-40
Successfully pushed Docker image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful.

 Access your Deployment: 

 Deployment View: cloud.astronomer.io/cl1vvhd0c85301fyobcagec1c/deployments/clfqv4kou996157cyy7ifr2uaq/analytics
 Airflow UI: astronomer.astronomer.run/difr2uaq
neel@Neels-MacBook-Pro airflow-test-15 % cat /Users/neel/go/src/github.com/astronomer/astro-cli/test-config-path/.astro/config.yaml
airflow:
  expose_port: "false"
beta:
  audit_logs: "false"
  sql_cli: "false"
cloud:
  api:
    port: "443"
    protocol: https
    ws_protocol: wss
container:
  binary: docker
context: astronomer.io
contexts:
  astronomer_io:
    expiresin: 2023-03-28T19:10:24.375582+05:30
    last_used_workspace: cl1vvhd0c85301fyobcagec1c
    organization: cknaqyipv05731evsry6cj4n0
    organization_short_name: astronomer
    refreshtoken: 1RIPHwnm3MOOU_50l0amVd2S8lfD26vlt2j2Qlgf13QWM
    token: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjRmeDJYNVFNa2o3Q25ycVNyX1ZuTyJ9.eyJodHRwczovL2FzdHJvbm9tZXIuaW8vand0L2F1dGhfY29ubmVjdGlvbiI6eyJpZCI6ImNvbl9VazNBeTNDZGZ4Q1J5Z3BmIiwibmFtZSI6Imdvb2dsZS1vYXV0aDIiLCJzdHJhdGVneSI6Imdvb2dsZS1vYXV0aDIifSwiaXNzIjoiaHR0cHM6Ly9hdXRoLmFzdHJvbm9tZXIuaW8vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMTM2ODkzMDAwNzkwNjczNjMwMTEiLCJhdWQiOlsiYXN0cm9ub21lci1lZSIsImh0dHBzOi8vYXN0cm9ub21lci1wcm9kLnVzLmF1dGgwLmNvbS91c2VyaW5mbyJdLCJpYXQiOjE2Nzk5MjQ0MjQsImV4cCI6MTY4MDAxMDgyNCwiYXpwIjoiNVhZSlpZZjV4WjBlS0FMZ0JIM08wOFd6Z2ZVZno3eTkiLCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIGVtYWlsIG9mZmxpbmVfYWNjZXNzIiwicGVybWlzc2lvbnMiOltdfQ.Pjh2aJm3qioI-ybIcu4ByPt49qaKicGeKUkrxvjS4KC-cYuXzfEINgN-aOHQKE23ZjVstoZiTITIEJxhY_eweRdaonDM4r0prcITo4BoKVNj4ctTxVGPvDvK8XesV3run8zpSo8AXj7CYRLAhBnEcF4FmBCRTZQOY-ZeeXHrpOBS35fZP-ZuVxDF3u1gxSPFxoUemgUDxtQ8VVsCF6ppD1zU9yWQ4N5HV6nJN5WH60qiMzkca2Ko9DLrrS0sQN-2ZtHLEUsTGpyKqtbwl_ReR7UreMZb_ZGsQLEMRozr_Xrv-Hirv2HHv3uyTCQMDoJV7EMdTIX6Ybd9qXHvEQd0Yg
    user_email: neel.dalsania@astronomer.io
    workspace: cl1vvhd0c85301fyobcagec1c
disable_astro_run: "false"
duplicate_volumes: "true"
houston:
  dial_timeout: "10"
  skip_verify_tls: "false"
interactive: "false"
local:
  astrohub: http://localhost:8871/v1
  core: http://localhost:8888/v1alpha1
  platform: cloud
  public_astrohub: http://localhost:8871/graphql
  registry: localhost:5555
page_size: "20"
postgres:
  host: postgres
  password: postgres
  port: "5432"
  user: postgres
show_warnings: "true"
skip_parse: "false"
upgrade_message: "true"
verbosity: warning
webserver:
  port: "8080"
neel@Neels-MacBook-Pro airflow-test-15 % 
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
