### PR TITLE
add clean-ouput flag to inspect command

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -581,7 +581,7 @@ var SelectDeployment = func(deployments []astro.Deployment, message string) (ast
 	}
 
 	if len(deployments) == 1 {
-		if CleanOutput == false {
+		if !CleanOutput {
 			fmt.Println("Only one Deployment was found. Using the following Deployment by default: \n" +
 				fmt.Sprintf("\n Deployment Name: %s", ansi.Bold(deployments[0].Label)) +
 				fmt.Sprintf("\n Deployment ID: %s\n", ansi.Bold(deployments[0].ID)))
@@ -625,7 +625,7 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 		return astro.Deployment{}, errors.Wrap(err, errInvalidDeployment.Error())
 	}
 
-	if deploymentID != "" && deploymentName != "" && CleanOutput == false {
+	if deploymentID != "" && deploymentName != "" && !CleanOutput {
 		fmt.Printf("Both a Deployment ID and Deployment name have been supplied. The Deployment ID %s will be used\n", deploymentID)
 	}
 	// find deployment by name

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -18,6 +18,7 @@ import (
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
 	"github.com/astronomer/astro-cli/pkg/util"
+
 	"github.com/pkg/errors"
 )
 
@@ -27,6 +28,7 @@ var (
 	errTimedOut             = errors.New("timed out waiting for the deployment to become healthy")
 	// Monkey patched to write unit tests
 	createDeployment = Create
+	CleanOutput      = false
 )
 
 const (
@@ -579,9 +581,11 @@ var SelectDeployment = func(deployments []astro.Deployment, message string) (ast
 	}
 
 	if len(deployments) == 1 {
-		fmt.Println("Only one Deployment was found. Using the following Deployment by default: \n" +
-			fmt.Sprintf("\n Deployment Name: %s", ansi.Bold(deployments[0].Label)) +
-			fmt.Sprintf("\n Deployment ID: %s\n", ansi.Bold(deployments[0].ID)))
+		if CleanOutput == false {
+			fmt.Println("Only one Deployment was found. Using the following Deployment by default: \n" +
+				fmt.Sprintf("\n Deployment Name: %s", ansi.Bold(deployments[0].Label)) +
+				fmt.Sprintf("\n Deployment ID: %s\n", ansi.Bold(deployments[0].ID)))
+		}
 
 		return deployments[0], nil
 	}
@@ -621,7 +625,7 @@ func GetDeployment(ws, deploymentID, deploymentName string, client astro.Client)
 		return astro.Deployment{}, errors.Wrap(err, errInvalidDeployment.Error())
 	}
 
-	if deploymentID != "" && deploymentName != "" {
+	if deploymentID != "" && deploymentName != "" && CleanOutput == false {
 		fmt.Printf("Both a Deployment ID and Deployment name have been supplied. The Deployment ID %s will be used\n", deploymentID)
 	}
 	// find deployment by name

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -139,7 +139,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().IntVarP(&schedulerAU, "scheduler-au", "s", deployment.SchedulerAuMin, "The Deployment's Scheduler resources in AUs")
 	cmd.Flags().IntVarP(&schedulerReplicas, "scheduler-replicas", "r", deployment.SchedulerReplicasMin, "The number of Scheduler replicas for the Deployment")
 	cmd.Flags().BoolVarP(&waitForStatus, "wait", "i", false, "Wait for the Deployment to become healthy before ending the command")
-	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "c", false, "clean output to only include inspect yaml or json file in any situation.")
+	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "", false, "clean output to only include inspect yaml or json file in any situation.")
 	return cmd
 }
 

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -139,6 +139,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().IntVarP(&schedulerAU, "scheduler-au", "s", deployment.SchedulerAuMin, "The Deployment's Scheduler resources in AUs")
 	cmd.Flags().IntVarP(&schedulerReplicas, "scheduler-replicas", "r", deployment.SchedulerReplicasMin, "The number of Scheduler replicas for the Deployment")
 	cmd.Flags().BoolVarP(&waitForStatus, "wait", "i", false, "Wait for the Deployment to become healthy before ending the command")
+	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "c", false, "clean output to only include inspect yaml or json file in any situation.")
 	return cmd
 }
 
@@ -162,6 +163,7 @@ func newDeploymentUpdateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&forceUpdate, "force", "f", false, "Force update: Don't prompt a user before Deployment update")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment to update")
 	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "", "Enables DAG-only deploys for the deployment")
+	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "c", false, "clean output to only include inspect yaml or json file in any situation.")
 	return cmd
 }
 
@@ -304,6 +306,9 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
+	// clean output
+	deployment.CleanOutput = cleanOutput
+
 	// set default executor if none was specified
 	if executor == "" {
 		executor = deployment.CeleryExecutor
@@ -347,6 +352,9 @@ func deploymentUpdate(cmd *cobra.Command, args []string, out io.Writer) error {
 
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
+
+	// clean output
+	deployment.CleanOutput = cleanOutput
 
 	// check if executor is valid
 	if !isValidExecutor(executor) {

--- a/cmd/cloud/deployment_inspect.go
+++ b/cmd/cloud/deployment_inspect.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"io"
 
+	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
 
 	"github.com/spf13/cobra"
@@ -11,6 +12,7 @@ import (
 var (
 	outputFormat, requestedField string
 	template                     bool
+	cleanOutput                  bool
 )
 
 func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
@@ -27,6 +29,7 @@ func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format can be one of: yaml or json. By default the inspected deployment will be in YAML format.")
 	cmd.Flags().BoolVarP(&template, "template", "t", false, "Create a template from the deployment being inspected.")
 	cmd.Flags().StringVarP(&requestedField, "key", "k", "", "A specific key for the deployment. Use --key configuration.cluster_id to get a deployment's cluster id.")
+	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "c", false, "clean output to only include inspect yaml or json file in any situation.")
 	return cmd
 }
 
@@ -41,5 +44,7 @@ func deploymentInspect(cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) > 0 {
 		deploymentID = args[0]
 	}
+
+	deployment.CleanOutput = cleanOutput
 	return inspect.Inspect(wsID, deploymentName, deploymentID, outputFormat, astroClient, out, requestedField, template)
 }

--- a/cmd/cloud/deployment_inspect.go
+++ b/cmd/cloud/deployment_inspect.go
@@ -45,6 +45,8 @@ func deploymentInspect(cmd *cobra.Command, args []string, out io.Writer) error {
 		deploymentID = args[0]
 	}
 
+	// clean output
 	deployment.CleanOutput = cleanOutput
+
 	return inspect.Inspect(wsID, deploymentName, deploymentID, outputFormat, astroClient, out, requestedField, template)
 }

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -113,7 +113,7 @@ func Setup(cmd *cobra.Command, args []string, client astro.Client, coreClient as
 	}
 
 	// run auth setup for any command that requires auth
-	apiKey, err := checkAPIKeys(client, coreClient, args)
+	apiKey, err := checkAPIKeys(client, coreClient, isDeploymentFile, args)
 	if err != nil {
 		return err
 	}
@@ -226,14 +226,16 @@ func refresh(refreshToken string, authConfig astro.AuthConfig) (TokenResponse, e
 	return tokenRes, nil
 }
 
-func checkAPIKeys(astroClient astro.Client, coreClient astrocore.CoreClient, args []string) (bool, error) {
+func checkAPIKeys(astroClient astro.Client, coreClient astrocore.CoreClient, isDeploymentFile bool, args []string) (bool, error) {
 	// check os variables
 	astronomerKeyID := os.Getenv("ASTRONOMER_KEY_ID")
 	astronomerKeySecret := os.Getenv("ASTRONOMER_KEY_SECRET")
 	if astronomerKeyID == "" || astronomerKeySecret == "" {
 		return false, nil
 	}
-	fmt.Println("Using an Astro API key")
+	if !isDeploymentFile {
+		fmt.Println("Using an Astro API key")
+	}
 
 	// get authConfig
 	c, err := context.GetCurrentContext() // get current context

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -301,7 +301,7 @@ func TestCheckAPIKeys(t *testing.T) {
 		assert.NoError(t, err)
 
 		// run CheckAPIKeys
-		_, err = checkAPIKeys(mockClient, mockCoreClient, []string{})
+		_, err = checkAPIKeys(mockClient, mockCoreClient, false, []string{})
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Description

This flag hides output that is not related to the yaml, json file, or error message to give users a clean yaml or json output to add to an env var or file

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1125


## 🧪 Functional Testing

manual testing

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
