### PR TITLE
deprecate astro user invite command and remove astro auth commands

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -112,13 +112,3 @@ func logout(cmd *cobra.Command, args []string, out io.Writer) error {
 	}
 	return nil
 }
-
-// This is to ensure we throw a meaningful error in case someone is using deprecated `astro auth login` or `astro auth logout` cmd
-func newAuthCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:        "auth",
-		Deprecated: "use 'astro login' or 'astro logout' instead.\n\nWelcome to the Astro CLI v1.0.0, go to https://github.com/astronomer/astro-cli/blob/main/CHANGELOG.md#100---2022-05-23 to see a full list of breaking changes.\n",
-		Hidden:     true,
-	}
-	return cmd
-}

--- a/cmd/cloud/user.go
+++ b/cmd/cloud/user.go
@@ -22,9 +22,10 @@ func newUserCmd(out io.Writer) *cobra.Command {
 
 func newUserInviteCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "invite [email]",
-		Aliases: []string{"inv"},
-		Short:   "Invite a user to your Astro Organization",
+		Use:        "invite [email]",
+		Aliases:    []string{"inv"},
+		Deprecated: "WARNING: 'astro user invite' will be deprecated in Astro CLI v1.15.0. Any use of this command in your projects or automation needs to be updated to 'astro organization user invite' before Astro CLI v1.15.0 is released.\n",
+		Short:      "Invite a user to your Astro Organization",
 		Long: "Invite a user to your Astro Organization\n$astro user invite [email] --role [ORGANIZATION_MEMBER, " +
 			"ORGANIZATION_BILLING_ADMIN, ORGANIZATION_OWNER].",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,7 +98,6 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 		newDevRootCmd(),
 		newContextCmd(os.Stdout),
 		newConfigRootCmd(os.Stdout),
-		newAuthCommand(),
 		newRunCommand(),
 	)
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

deprecate astro user invite command and remove astro auth commands

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
