### PR TITLE
put up a message for switching org

### DIFF
--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -17,11 +17,12 @@ import (
 )
 
 var (
-	errInvalidOrganizationKey  = errors.New("invalid organization selection")
-	errInvalidOrganizationName = errors.New("invalid organization name")
-	Login                      = auth.Login
-	CheckUserSession           = auth.CheckUserSession
-	FetchDomainAuthConfig      = auth.FetchDomainAuthConfig
+	errInvalidOrganizationKey   = errors.New("invalid organization selection")
+	errInvalidOrganizationName  = errors.New("invalid organization name")
+	Login                       = auth.Login
+	CheckUserSession            = auth.CheckUserSession
+	FetchDomainAuthConfig       = auth.FetchDomainAuthConfig
+	switchedOrganizationMessage = "\nSuccessfully switched organization"
 )
 
 func newTableOut() *printutil.Table {
@@ -122,7 +123,12 @@ func SwitchWithContext(domain string, targetOrg *astrocore.Organization, astroCl
 	_ = c.SetContextKey("user_email", c.UserEmail)
 	c, _ = context.GetCurrentContext()
 	// call check user session which will trigger workspace switcher flow
-	return CheckUserSession(&c, astroClient, coreClient, out)
+	err := CheckUserSession(&c, astroClient, coreClient, out)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(out, switchedOrganizationMessage)
+	return nil
 }
 
 // Switch switches organizations

--- a/cloud/organization/organization_test.go
+++ b/cloud/organization/organization_test.go
@@ -164,6 +164,7 @@ func TestSwitch(t *testing.T) {
 		buf := new(bytes.Buffer)
 		err := Switch("org1", mockGQLClient, mockCoreClient, buf, false)
 		assert.NoError(t, err)
+		assert.Equal(t, "\nSuccessfully switched organization\n", buf.String())
 		mockCoreClient.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
## Description

Our e2e testing is search for a particular output to validate if the operation is successfully or not. As part of the login refactor the "Successfully authenticated to Astronomer" message is removed from org switch and caused issue.

This PR introduced a new message "Successfully switched organization" that will be used by e2e tests.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
