### PR TITLE
trim out quotes from the beginning/end of .env vars

### DIFF
--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -279,6 +279,11 @@ func addVariablesFromFile(envFile string, oldKeyList []string, oldEnvironmentVar
 			fmt.Printf("key %s already exists within the file specified, skipping creation\n", key)
 			continue
 		}
+		
+		fmt.Printf("Cleaning quotes from variable value - %s", value)
+		value = strings.Trim(value, `"`)
+		value = strings.Trim(value, `'`)
+
 		// check if key already exists
 		exist, num := contains(oldKeyList, key)
 		if exist {


### PR DESCRIPTION
## Description

Quotes currently are parsed from `.env` files which can cause a breakage. This trims them from the beginning and end of a variable. 

Would appreciate help testing as I do not have a dev environment set up, and discussion about any possible impacts of the change.

## 🎟 Issue(s)

Related #871

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
