### PR TITLE
Fetch deployment config options from api

### DIFF
--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -204,6 +204,32 @@ var (
 			channel
 			version
 		}
+		astroMachines {
+			concurrentTasks
+			cpu
+			memory
+			nodePoolType
+			storageSize
+			type
+		}
+		defaultAstroMachine {
+			concurrentTasks
+			cpu
+			memory
+			nodePoolType
+			storageSize
+			type
+		}
+		defaultSchedulerSize {
+			cpu
+			memory
+			size
+		}
+		schedulerSizes {
+			cpu
+			memory
+			size
+		}
 	  }
 	}
   `

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -223,9 +223,78 @@ type Scheduler struct {
 	Replicas int `json:"replicas"`
 }
 
+type AuConfig struct {
+	Default int `json:"default"`
+	Limit   int `json:"limit"`
+	Request int `json:"request"`
+}
+
+type ReplicasConfig struct {
+	Default int `json:"default"`
+	Limit   int `json:"limit"`
+	Minimum int `json:"minimum"`
+}
+
+type WebserverConfig struct {
+	AU AuConfig `json:"au"`
+}
+
+type SchedulerConfig struct {
+	AU       AuConfig       `json:"au"`
+	Replicas ReplicasConfig `json:"replicas"`
+}
+
+type CeleryExecutorConfig struct {
+	Name string `json:"name"`
+}
+
+type KubernetesExecutorDefaultPodConfig struct {
+	CPU           int `json:"cpu"`
+	CPULimitCores int `json:"cpuLimitCores"`
+	Memory        int `json:"memory"`
+	MinPodCount   int `json:"minPodCount"`
+	Concurrency   int `json:"concurrency"`
+}
+
+type KubernetesExecutorConfig struct {
+	Name       string                             `json:"name"`
+	DefaultPod KubernetesExecutorDefaultPodConfig `json:"defaultPod"`
+}
+
+type ExecutorConfig struct {
+	CeleryExecutor     CeleryExecutorConfig     `json:"celeryExecutor"`
+	KubernetesExecutor KubernetesExecutorConfig `json:"kubernetesExecutor"`
+}
+
+type Components struct {
+	Scheduler SchedulerConfig `json:"scheduler"`
+	Webserver WebserverConfig `json:"webserver"`
+	Executor  ExecutorConfig  `json:"executor"`
+}
+
 type DeploymentConfig struct {
-	AstronomerUnit  AstronomerUnit   `json:"astroUnit"`
-	RuntimeReleases []RuntimeRelease `json:"runtimeReleases"`
+	AstronomerUnit       AstronomerUnit   `json:"astroUnit"`
+	RuntimeReleases      []RuntimeRelease `json:"runtimeReleases"`
+	AstroMachines        []Machine        `json:"astroMachines"`
+	DefaultAstroMachine  Machine          `json:"defaultAstroMachine"`
+	SchedulerSizes       []MachineUnit    `json:"schedulerSizes"`
+	DefaultSchedulerSize MachineUnit      `json:"defaultSchedulerSize"`
+	Components           Components       `json:"components"`
+}
+
+type Machine struct {
+	Type            string `json:"type"`
+	CPU             string `json:"cpu"`
+	Memory          string `json:"memory"`
+	StorageSize     string `json:"storageSize"`
+	ConcurrentTasks int    `json:"concurrentTasks"`
+	NodePoolType    string `json:"nodePoolType"`
+}
+
+type MachineUnit struct {
+	CPU    string `json:"cpu"`
+	Memory string `json:"memory"`
+	Size   string `json:"size"`
 }
 
 type AstronomerUnit struct {

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -293,6 +293,21 @@ func TestCreate(t *testing.T) {
 			defer testUtil.MockUserInput(t, "test-worker-queue")()
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Times(2)
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
@@ -340,6 +355,21 @@ func TestCreate(t *testing.T) {
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			defer testUtil.MockUserInput(t, "y")()
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", mock.Anything).Return(astro.Deployment{}, errUpdateDeployment).Once()
@@ -354,6 +384,21 @@ func TestCreate(t *testing.T) {
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			defer testUtil.MockUserInput(t, "y")()
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespNoQueues, nil).Twice()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", mock.Anything).Return(deploymentRespNoQueues[0], nil).Once()
@@ -367,6 +412,21 @@ func TestCreate(t *testing.T) {
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			defer testUtil.MockUserInput(t, "2")()
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
@@ -594,6 +654,21 @@ func TestUpdate(t *testing.T) {
 				defer testUtil.MockUserInput(t, "y")()
 				out := new(bytes.Buffer)
 				mockClient := new(astro_mocks.Client)
+				mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+					Components: astro.Components{
+						Scheduler: astro.SchedulerConfig{
+							AU: astro.AuConfig{
+								Default: 5,
+								Limit:   24,
+							},
+							Replicas: astro.ReplicasConfig{
+								Default: 1,
+								Minimum: 1,
+								Limit:   4,
+							},
+						},
+					},
+				}, nil).Once()
 				mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 				mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 				mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
@@ -619,6 +694,21 @@ func TestUpdate(t *testing.T) {
 			defer testUtil.MockUserInput(t, "2")()
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
@@ -689,6 +779,21 @@ func TestUpdate(t *testing.T) {
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			defer testUtil.MockUserInput(t, "y")()
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", mock.Anything).Return(astro.Deployment{}, errUpdateDeployment).Once()
@@ -702,7 +807,21 @@ func TestUpdate(t *testing.T) {
 			expectedOutMessage := "worker queue " + expectedWorkerQueue.Name + " for test-deployment-label in test-ws-id workspace updated\n"
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
-
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
@@ -735,7 +854,21 @@ func TestUpdate(t *testing.T) {
 			expectedOutMessage := "worker queue default for test-deployment-label in test-ws-id workspace updated\n"
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
-
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(keDeployment, nil).Twice()
 			mockClient.On("UpdateDeployment", &updateKEDeploymentInput).Return(keDeployment[0], nil).Once()
 			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "default", updateAction, "test-instance-type", 0, 0, 0, true, mockClient, out)
@@ -747,6 +880,21 @@ func TestUpdate(t *testing.T) {
 			expectedOutMessage := "worker queue default for test-deployment-label in test-ws-id workspace updated\n"
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			origNodePoolID := updateKEDeploymentInput.WorkerQueues[0].NodePoolID
 			updateKEDeploymentInput.WorkerQueues[0].NodePoolID = "test-pool-id-1"
 			defer func() { updateKEDeploymentInput.WorkerQueues[0].NodePoolID = origNodePoolID }()
@@ -831,6 +979,21 @@ func TestDelete(t *testing.T) {
 	t.Run("happy path worker queue gets deleted", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astro_mocks.Client)
+		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+			Components: astro.Components{
+				Scheduler: astro.SchedulerConfig{
+					AU: astro.AuConfig{
+						Default: 5,
+						Limit:   24,
+					},
+					Replicas: astro.ReplicasConfig{
+						Default: 1,
+						Minimum: 1,
+						Limit:   4,
+					},
+				},
+			},
+		}, nil).Once()
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
 		err := Delete("test-ws-id", "test-deployment-id", "", "test-worker-queue-1", true, mockClient, out)
@@ -842,6 +1005,21 @@ func TestDelete(t *testing.T) {
 		defer testUtil.MockUserInput(t, "2")()
 		out := new(bytes.Buffer)
 		mockClient := new(astro_mocks.Client)
+		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+			Components: astro.Components{
+				Scheduler: astro.SchedulerConfig{
+					AU: astro.AuConfig{
+						Default: 5,
+						Limit:   24,
+					},
+					Replicas: astro.ReplicasConfig{
+						Default: 1,
+						Minimum: 1,
+						Limit:   4,
+					},
+				},
+			},
+		}, nil).Once()
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
 		err := Delete("test-ws-id", "test-deployment-id", "", "", true, mockClient, out)
@@ -853,6 +1031,21 @@ func TestDelete(t *testing.T) {
 			defer testUtil.MockUserInput(t, "y")()
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 			mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
 			err := Delete("test-ws-id", "test-deployment-id", "", "test-worker-queue-1", false, mockClient, out)
@@ -921,6 +1114,21 @@ func TestDelete(t *testing.T) {
 	t.Run("returns an error if deployment update fails", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astro_mocks.Client)
+		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+			Components: astro.Components{
+				Scheduler: astro.SchedulerConfig{
+					AU: astro.AuConfig{
+						Default: 5,
+						Limit:   24,
+					},
+					Replicas: astro.ReplicasConfig{
+						Default: 1,
+						Minimum: 1,
+						Limit:   4,
+					},
+				},
+			},
+		}, nil).Once()
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 		mockClient.On("UpdateDeployment", mock.Anything).Return(astro.Deployment{}, errUpdateDeployment).Once()
 		err := Delete("test-ws-id", "test-deployment-id", "", "test-worker-queue-1", true, mockClient, out)

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -144,15 +144,15 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "disable", "Enables DAG-only deploys for the deployment")
 	cmd.Flags().StringVarP(&executor, "executor", "e", "", "The executor to use for the deployment. Possible values can be CeleryExecutor or KubernetesExecutor.")
 	cmd.Flags().StringVarP(&inputFile, "deployment-file", "", "", "Location of file containing the deployment to create. File can be in either JSON or YAML format.")
-	cmd.Flags().IntVarP(&schedulerAU, "scheduler-au", "s", deployment.SchedulerAuMin, "The Deployment's Scheduler resources in AUs")
-	cmd.Flags().IntVarP(&schedulerReplicas, "scheduler-replicas", "r", deployment.SchedulerReplicasMin, "The number of Scheduler replicas for the Deployment")
+	cmd.Flags().IntVarP(&schedulerAU, "scheduler-au", "s", 0, "The Deployment's Scheduler resources in AUs")
+	cmd.Flags().IntVarP(&schedulerReplicas, "scheduler-replicas", "r", 0, "The number of Scheduler replicas for the Deployment")
 	cmd.Flags().BoolVarP(&waitForStatus, "wait", "i", false, "Wait for the Deployment to become healthy before ending the command")
 	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "", false, "clean output to only include inspect yaml or json file in any situation.")
 	if organization.IsOrgHosted() {
 		cmd.Flags().StringVarP(&cloudProvider, "cloud-provider", "p", "", "The Cloud Provider to use for the Deployment. Possible values can be gcp.")
 		cmd.Flags().StringVarP(&region, "region", "", "", "The Cloud Provider region to use for the deployment.")
-		cmd.Flags().StringVarP(&schedulerSize, "scheduler-size", "", "small", "The size of Scheduler for the Deployment") // Replace the default here
-		cmd.Flags().BoolVarP(&highAvailability, "high-availability", "a", false, "High Availability for the Deployment")  // Replace the default here
+		cmd.Flags().StringVarP(&schedulerSize, "scheduler-size", "", "", "The size of Scheduler for the Deployment. Possible values can be small, medium, large")
+		cmd.Flags().BoolVarP(&highAvailability, "high-availability", "a", false, "High Availability for the Deployment")
 	}
 	return cmd
 }

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -122,11 +122,30 @@ func TestDeploymentCreate(t *testing.T) {
 	}
 
 	mockClient := new(astro_mocks.Client)
-	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{RuntimeReleases: []astro.RuntimeRelease{{Version: "4.2.5"}}}, nil).Times(5)
+	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+		Components: astro.Components{
+			Scheduler: astro.SchedulerConfig{
+				AU: astro.AuConfig{
+					Default: 5,
+					Limit:   24,
+				},
+				Replicas: astro.ReplicasConfig{
+					Default: 1,
+					Minimum: 1,
+					Limit:   4,
+				},
+			},
+		},
+		RuntimeReleases: []astro.RuntimeRelease{
+			{
+				Version: "4.2.5",
+			},
+		},
+	}, nil).Times(10)
 	mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Times(5)
 	mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Times(4)
 	mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{ID: "test-id"}, nil).Twice()
-	mockClient.On("CreateDeployment", &deploymentCreateInput1).Return(astro.Deployment{ID: "test-id"}, nil).Times(3)
+	mockClient.On("CreateDeployment", &deploymentCreateInput1).Return(astro.Deployment{ID: "test-id"}, nil).Times(6)
 	deploymentCreateInput2 := astro.CreateDeploymentInput{
 		WorkspaceID:           ws,
 		ClusterID:             csID,
@@ -392,6 +411,26 @@ func TestDeploymentUpdate(t *testing.T) {
 	}
 
 	mockClient := new(astro_mocks.Client)
+	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+		Components: astro.Components{
+			Scheduler: astro.SchedulerConfig{
+				AU: astro.AuConfig{
+					Default: 5,
+					Limit:   24,
+				},
+				Replicas: astro.ReplicasConfig{
+					Default: 1,
+					Minimum: 1,
+					Limit:   4,
+				},
+			},
+		},
+		RuntimeReleases: []astro.RuntimeRelease{
+			{
+				Version: "4.2.5",
+			},
+		},
+	}, nil).Once()
 	mockClient.On("ListDeployments", mock.Anything, ws).Return([]astro.Deployment{deploymentResp}, nil).Once()
 	mockClient.On("UpdateDeployment", &deploymentUpdateInput).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 	astroClient = mockClient
@@ -517,7 +556,6 @@ deployment:
 				Default: 180,
 			},
 		}
-		mockClient = new(astro_mocks.Client)
 		mockClient.On("ListClusters", orgID).Return(clusters, nil)
 		mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{updatedDeployment}, nil).Once()
 		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()

--- a/cmd/cloud/deployment_workerqueue_test.go
+++ b/cmd/cloud/deployment_workerqueue_test.go
@@ -177,7 +177,26 @@ func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 		// Restore stdin right after the test.
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
-
+		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+			Components: astro.Components{
+				Scheduler: astro.SchedulerConfig{
+					AU: astro.AuConfig{
+						Default: 5,
+						Limit:   24,
+					},
+					Replicas: astro.ReplicasConfig{
+						Default: 1,
+						Minimum: 1,
+						Limit:   4,
+					},
+				},
+			},
+			RuntimeReleases: []astro.RuntimeRelease{
+				{
+					Version: "4.2.5",
+				},
+			},
+		}, nil).Once()
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespDefaultQueue, nil).Twice()
 		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespDefaultQueue[0], nil).Once()
@@ -200,7 +219,26 @@ func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 		// Restore stdin right after the test.
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
-
+		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+			Components: astro.Components{
+				Scheduler: astro.SchedulerConfig{
+					AU: astro.AuConfig{
+						Default: 5,
+						Limit:   24,
+					},
+					Replicas: astro.ReplicasConfig{
+						Default: 1,
+						Minimum: 1,
+						Limit:   4,
+					},
+				},
+			},
+			RuntimeReleases: []astro.RuntimeRelease{
+				{
+					Version: "4.2.5",
+				},
+			},
+		}, nil).Once()
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespDefaultQueue, nil).Twice()
 		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespDefaultQueue[0], nil).Once()
@@ -223,7 +261,26 @@ func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 		// Restore stdin right after the test.
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
-
+		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+			Components: astro.Components{
+				Scheduler: astro.SchedulerConfig{
+					AU: astro.AuConfig{
+						Default: 5,
+						Limit:   24,
+					},
+					Replicas: astro.ReplicasConfig{
+						Default: 1,
+						Minimum: 1,
+						Limit:   4,
+					},
+				},
+			},
+			RuntimeReleases: []astro.RuntimeRelease{
+				{
+					Version: "4.2.5",
+				},
+			},
+		}, nil).Once()
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespDefaultQueue, nil).Twice()
 		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespDefaultQueue[0], nil).Once()
@@ -246,7 +303,26 @@ func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 		// Restore stdin right after the test.
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
-
+		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+			Components: astro.Components{
+				Scheduler: astro.SchedulerConfig{
+					AU: astro.AuConfig{
+						Default: 5,
+						Limit:   24,
+					},
+					Replicas: astro.ReplicasConfig{
+						Default: 1,
+						Minimum: 1,
+						Limit:   4,
+					},
+				},
+			},
+			RuntimeReleases: []astro.RuntimeRelease{
+				{
+					Version: "4.2.5",
+				},
+			},
+		}, nil).Once()
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespDefaultQueue, nil).Twice()
 		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespDefaultQueue[0], nil).Once()
@@ -334,6 +410,26 @@ func TestNewDeploymentWorkerQueueDeleteCmd(t *testing.T) {
 			WorkerQueues: listToDelete,
 		}
 		expectedOutMessage := "worker queue test-worker-queue-1 for test-deployment-label in ck05r3bor07h40d02y2hw4n4v workspace deleted\n"
+		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+			Components: astro.Components{
+				Scheduler: astro.SchedulerConfig{
+					AU: astro.AuConfig{
+						Default: 5,
+						Limit:   24,
+					},
+					Replicas: astro.ReplicasConfig{
+						Default: 1,
+						Minimum: 1,
+						Limit:   4,
+					},
+				},
+			},
+			RuntimeReleases: []astro.RuntimeRelease{
+				{
+					Version: "4.2.5",
+				},
+			},
+		}, nil).Once()
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
 
@@ -463,6 +559,26 @@ func TestNewDeploymentWorkerQueueUpdateCmd(t *testing.T) {
 		}
 
 		expectedOutMessage := "worker queue test-queue-1 for test-deployment-label in ck05r3bor07h40d02y2hw4n4v workspace updated\n"
+		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+			Components: astro.Components{
+				Scheduler: astro.SchedulerConfig{
+					AU: astro.AuConfig{
+						Default: 5,
+						Limit:   24,
+					},
+					Replicas: astro.ReplicasConfig{
+						Default: 1,
+						Minimum: 1,
+						Limit:   4,
+					},
+				},
+			},
+			RuntimeReleases: []astro.RuntimeRelease{
+				{
+					Version: "4.2.5",
+				},
+			},
+		}, nil).Times(2)
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
 		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -97,7 +97,7 @@ func Setup(cmd *cobra.Command, args []string, client astro.Client, coreClient as
 		return nil
 	}
 
-	// if deployment inspect, create, or udpate commands are used
+	// if deployment inspect, create, or update commands are used
 	deploymentCmds := []string{"inspect", "create", "update"}
 	if util.Contains(deploymentCmds, cmd.CalledAs()) && cmd.Parent().Use == deploymentCmd {
 		isDeploymentFile = true


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Fetch deployment config options from api

## 🎟 Issue(s)

Related astronomer/astro#11775

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
