### PR TITLE
Use a sentinel value when mocking Variable.get

### DIFF
--- a/airflow/include/dagintegritytestdefault.py
+++ b/airflow/include/dagintegritytestdefault.py
@@ -64,12 +64,15 @@ class magic_dict(dict):
         return {}.get(key, "MOCKED_KEY_VALUE")
 
 
-def variable_get_monkeypatch(key: str, default_var=None, deserialize_json=False):
+_no_default = object()  # allow falsey defaults
+
+
+def variable_get_monkeypatch(key: str, default_var=_no_default, deserialize_json=False):
     print(
         f"Attempted to get Variable value during parse, returning a mocked value for {key}"
     )
 
-    if default_var:
+    if default_var is not _no_default:
         return default_var
     if deserialize_json:
         return magic_dict()


### PR DESCRIPTION
## Description

This allows for falsey defaults like `None`. This is particularly useful when your variable is for schedules.
Consider a minimal DAG with `schedule=Variable.get("THE_SCHEDULE", None)`. This'll fail when running `astro dev parse` (as well as when trying to deploy). This PR should fix that.

## 🧪 Functional Testing

Applied the change to my local `.astro/test_dag_integrity_default.py` and then I could `astro dev parse` and `astro deploy` without error.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft -- error while running go install; seems
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
