### PR TITLE
Add https:// to cli deployment message

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -323,8 +323,8 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 
 		fmt.Println("Successfully pushed Docker image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful." +
 			"\n\n Access your Deployment: \n" +
-			fmt.Sprintf("\n Deployment View: %s", ansi.Bold(deploymentURL)) +
-			fmt.Sprintf("\n Airflow UI: %s", ansi.Bold(deployInfo.webserverURL)))
+			    fmt.Sprintf("\n Deployment View: %s", ansi.Bold("https://" + deploymentURL)) +
+			fmt.Sprintf("\n Airflow UI: %s", ansi.Bold("https://" + deployInfo.webserverURL)))
 	}
 
 	return nil

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -323,8 +323,8 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 
 		fmt.Println("Successfully pushed Docker image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful." +
 			"\n\n Access your Deployment: \n" +
-			fmt.Sprintf("\n Deployment View: %s", ansi.Bold("https://" + deploymentURL)) +
-			fmt.Sprintf("\n Airflow UI: %s", ansi.Bold("https://" + deployInfo.webserverURL)))
+			fmt.Sprintf("\n Deployment View: %s", ansi.Bold("https://"+deploymentURL)) +
+			fmt.Sprintf("\n Airflow UI: %s", ansi.Bold("https://"+deployInfo.webserverURL)))
 	}
 
 	return nil

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -323,7 +323,7 @@ func Deploy(deployInput InputDeploy, client astro.Client) error { //nolint
 
 		fmt.Println("Successfully pushed Docker image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful." +
 			"\n\n Access your Deployment: \n" +
-			    fmt.Sprintf("\n Deployment View: %s", ansi.Bold("https://" + deploymentURL)) +
+			fmt.Sprintf("\n Deployment View: %s", ansi.Bold("https://" + deploymentURL)) +
 			fmt.Sprintf("\n Airflow UI: %s", ansi.Bold("https://" + deployInfo.webserverURL)))
 	}
 


### PR DESCRIPTION
## Description

This adds https:// to the deployment view and airflow ui urls when deploying with the cli. This lets terminals recognize the urls as links and allows you to cmd+click to directly access the website instead of need to copy paste the links.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

There were no tests that test the log outputs of the deployment command and this change feels small and low risk enough that it doesn't warrant a whole new test.

## 📸 Screenshots

![image](https://user-images.githubusercontent.com/10968348/230737654-8500acd3-876b-4958-8cb2-b2c23db874ce.png)

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
