### PR TITLE
Add headers to api to collect more metrics from cli

### DIFF
--- a/astro-client-core/client.go
+++ b/astro-client-core/client.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"runtime"
 
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/version"
 )
 
 var (
@@ -27,6 +29,8 @@ func requestEditor(ctx httpContext.Context, req *http.Request) error {
 	if err != nil {
 		return nil
 	}
+	os := runtime.GOOS
+	arch := runtime.GOARCH
 	baseURL := currentCtx.GetPublicRESTAPIURL()
 	requestURL, err := url.Parse(baseURL + req.URL.String())
 	if err != nil {
@@ -34,6 +38,9 @@ func requestEditor(ctx httpContext.Context, req *http.Request) error {
 	}
 	req.URL = requestURL
 	req.Header.Add("authorization", currentCtx.Token)
+	req.Header.Add("x-astro-client-identifier", "cli")
+	req.Header.Add("x-astro-client-version", version.CurrVersion)
+	req.Header.Add("x-client-os-identifier", os+"-"+arch)
 	return nil
 }
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Add headers to api to collect more metrics from cli

## 🎟 Issue(s)

Related #1065 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
