### PR TITLE
update audit-logs export

### DIFF
--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -184,6 +184,7 @@ func ExportAuditLogs(client astro.Client, out io.Writer, orgName string, earlies
 		return err
 	}
 	logStreamBuffer.Close()
+	fmt.Println("Done")
 	return nil
 }
 

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -184,7 +184,7 @@ func ExportAuditLogs(client astro.Client, out io.Writer, orgName string, earlies
 		return err
 	}
 	logStreamBuffer.Close()
-	fmt.Println("Done")
+	fmt.Println("Finished exporting logs to local GZIP file")
 	return nil
 }
 

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -210,7 +210,7 @@ func organizationExportAuditLogs(cmd *cobra.Command) error {
 		return err
 	}
 	out := bufio.NewWriter(f)
-	fmt.Println("This may take some time depending on how many days are bing exported…")
+	fmt.Println("This may take some time depending on how many days are being exported.")
 	return orgExportAuditLogs(astroClient, out, orgName, auditLogsEarliestParam)
 }
 

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -25,7 +25,7 @@ var (
 	orgName                            string
 	auditLogsOutputFilePath            string
 	auditLogsEarliestParam             int
-	auditLogsEarliestParamDefaultValue = 90
+	auditLogsEarliestParamDefaultValue = 1
 	shouldDisplayLoginLink             bool
 	role                               string
 	updateRole                         string
@@ -85,11 +85,6 @@ func newOrganizationAuditLogs(out io.Writer) *cobra.Command {
 		Short:   "Manage your organization audit logs.",
 		Long:    "Manage your organization audit logs.",
 	}
-	cmd.PersistentFlags().StringVarP(&orgName, "organization-name", "n", "", "Name of the organization to manage audit logs for.")
-	err := cmd.MarkPersistentFlagRequired("organization-name")
-	if err != nil {
-		log.Fatalf("Error marking organization-name flag as required in astro organization audit-logs command: %s", err.Error())
-	}
 	cmd.AddCommand(
 		newOrganizationExportAuditLogs(out),
 	)
@@ -106,9 +101,13 @@ func newOrganizationExportAuditLogs(_ io.Writer) *cobra.Command {
 			return organizationExportAuditLogs(cmd)
 		},
 	}
+	cmd.PersistentFlags().StringVarP(&orgName, "organization-name", "n", "", "Name of the organization to manage audit logs for.")
+	err := cmd.MarkPersistentFlagRequired("organization-name")
+	if err != nil {
+		log.Fatalf("Error marking organization-name flag as required in astro organization audit-logs command: %s", err.Error())
+	}
 	cmd.Flags().StringVarP(&auditLogsOutputFilePath, "output-file", "o", "", "Path to a file for storing exported audit logs")
-	cmd.Flags().IntVarP(
-		&auditLogsEarliestParam, "earliest", "e", auditLogsEarliestParamDefaultValue,
+	cmd.Flags().IntVarP(&auditLogsEarliestParam, "include", "i", auditLogsEarliestParamDefaultValue,
 		"Number of days in the past to start exporting logs from. Minimum: 1. Maximum: 90.")
 	return cmd
 }
@@ -211,7 +210,7 @@ func organizationExportAuditLogs(cmd *cobra.Command) error {
 		return err
 	}
 	out := bufio.NewWriter(f)
-
+	fmt.Println("This may take some time depending on how many days are bing exported…")
 	return orgExportAuditLogs(astroClient, out, orgName, auditLogsEarliestParam)
 }
 


### PR DESCRIPTION
## Description
This PR makes the command astro organization audit-logs export work a little better. renames earliest flag to include. Makes export day default 1 day so the command doesn't take a login time to execute. Adds some text telling the user what's going on.
## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

manually tested

## 📸 Screenshots

<img width="610" alt="Screenshot 2023-04-12 at 1 20 53 PM" src="https://user-images.githubusercontent.com/63181127/231535012-0e5d3e02-bb61-4b79-977f-c7eccfb9b59e.png">

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
