### PR TITLE
fix org short name from claims

### DIFF
--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -398,7 +398,7 @@ func checkAPIToken(isDeploymentFile bool, coreClient astrocore.CoreClient, args 
 
 	workspaceID = strings.Replace(claims.Permissions[1], "workspaceId:", "", 1)
 	orgID := strings.Replace(claims.Permissions[2], "organizationId:", "", 1)
-	orgShortName := strings.Replace(claims.Permissions[3], "orgShortNameId:", "", 1)
+	orgShortName := strings.Replace(claims.Permissions[3], "orgShortName:", "", 1)
 
 	orgs, err := organization.ListOrganizations(coreClient)
 	if err != nil {

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -357,7 +357,7 @@ func TestCheckAPIToken(t *testing.T) {
 			"",
 			"workspaceId:workspace-id",
 			"organizationId:org-ID",
-			"orgShortNameId:org-short-name",
+			"orgShortName:org-short-name",
 		}
 		mockClaims := util.CustomClaims{
 			Permissions: permissions,


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

fix org short name from claims for api tokens

## 🎟 Issue(s)

Related #1160 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
