### PR TITLE
Change startup message if old image is used on M1

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -42,6 +42,7 @@ const (
 	defaultAirflowVersion          = uint64(0x2) //nolint:gomnd
 	triggererAllowedRuntimeVersion = "4.0.0"
 	triggererAllowedAirflowVersion = "2.2.0"
+	M1ImageRuntimeVersion          = "6.0.4"
 	pytestDirectory                = "tests"
 	OpenCmd                        = "open"
 
@@ -225,8 +226,14 @@ func (d *DockerCompose) Start(imageName, settingsFile string, noCache, noBrowser
 	if err != nil {
 		return errors.Wrap(err, composeRecreateErrMsg)
 	}
+	var airflowMessage string
+	if CheckM1Image(imageLabels) {
+		airflowMessage = " This might take a few minutes…"
+	} else {
+		airflowMessage = ""
+	}
 
-	fmt.Println("\n\nAirflow is starting up! This might take a few minutes…")
+	fmt.Println("\n\nAirflow is starting up!" + airflowMessage)
 
 	airflowDockerVersion, err := d.checkAiflowVersion()
 	if err != nil {
@@ -825,6 +832,23 @@ var CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
 	}
 
 	return versions.GreaterThanOrEqualTo(runtimeVersion, triggererAllowedRuntimeVersion), nil
+}
+
+// CheckM1Image checks if the CLI is currently running on M1 archetecture
+// next it checks if the runtime version of the image building is above 6.0.4
+// if the image is M1 archetecture and runtime version is less than or equal to 6.0.4 it will print true
+var CheckM1Image = func(imageLabels map[string]string) bool {
+	if runtime.GOARCH != "arm64" {
+		// the architecture is not arm64 no need to print message
+		return false
+	}
+	runtimeVersion, ok := imageLabels[runtimeVersionLabelName]
+	if !ok {
+		// cannot determine runtime version print message by default
+		return true
+	}
+
+	return versions.LessThanOrEqualTo(runtimeVersion, M1ImageRuntimeVersion)
 }
 
 func checkServiceState(serviceState, expectedState string) bool {

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -834,9 +834,9 @@ var CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
 	return versions.GreaterThanOrEqualTo(runtimeVersion, triggererAllowedRuntimeVersion), nil
 }
 
-// CheckM1Image checks if the CLI is currently running on M1 archetecture
+// CheckM1Image checks if the CLI is currently running on M1 architecture
 // next it checks if the runtime version of the image building is above 6.0.4
-// if the image is M1 archetecture and runtime version is less than or equal to 6.0.4 it will print true
+// if the image is M1 architecture and runtime version is less than or equal to 6.0.4 it will print true
 var CheckM1Image = func(imageLabels map[string]string) bool {
 	if runtime.GOARCH != "arm64" {
 		// the architecture is not arm64 no need to print message

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -838,7 +838,7 @@ var CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
 // next it checks if the runtime version of the image building is above 6.0.4
 // if the image is M1 architecture and runtime version is less than or equal to 6.0.4 it will print true
 var CheckM1Image = func(imageLabels map[string]string) bool {
-	if runtime.GOARCH != "arm64" {
+	if !isM1(runtime.GOOS, runtime.GOARCH) {
 		// the architecture is not arm64 no need to print message
 		return false
 	}


### PR DESCRIPTION
## Description

We only need to tell users that it may take a few minutes if they are starting airflow on an M1 mac and using a runtime image less than or equal to 6.0.4

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1164

## 🧪 Functional Testing

manual testing

## 📸 Screenshots


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
