### PR TITLE
settings file not needed for env export

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -547,14 +547,6 @@ func (d *DockerCompose) ExportSettings(settingsFile, envFile string, connections
 		return err
 	}
 
-	fileState, err := fileutil.Exists(settingsFile, nil)
-	if err != nil {
-		return errors.Wrap(err, errSettingsPath)
-	}
-	if !fileState {
-		return errNoFile
-	}
-
 	if envExport {
 		err = envExportSettings(containerID, envFile, airflowDockerVersion, connections, variables)
 		if err != nil {
@@ -562,6 +554,14 @@ func (d *DockerCompose) ExportSettings(settingsFile, envFile string, connections
 		}
 		fmt.Println("\nAirflow objects exported to env file")
 		return nil
+	}
+
+	fileState, err := fileutil.Exists(settingsFile, nil)
+	if err != nil {
+		return errors.Wrap(err, errSettingsPath)
+	}
+	if !fileState {
+		return errNoFile
 	}
 
 	err = exportSettings(containerID, settingsFile, airflowDockerVersion, connections, variables, pools)


### PR DESCRIPTION
## Description

The order of the code is making it so a settings file is needed for `astro dev object --env-export`. This is not intended

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
