### PR TITLE
set default git-sync interval to 60s

### DIFF
--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -245,11 +245,13 @@ $ astro deployment update [deployment ID] --dag-deployment-type=volume --nfs-loc
 }
 
 func addGitSyncDeploymentFlags(cmd *cobra.Command) {
+	const defaultSyncInterval = 60
+
 	cmd.Flags().StringVarP(&gitRevision, "git-revision", "v", "", "Git revision (tag or hash) to check out")
 	cmd.Flags().StringVarP(&gitRepoURL, "git-repository-url", "u", "", "The repository URL of the git repo")
 	cmd.Flags().StringVarP(&gitBranchName, "git-branch-name", "b", "", "The Branch name of the git repo we will be syncing from")
 	cmd.Flags().StringVarP(&gitDAGDir, "dag-directory-path", "p", "", "The directory where dags are stored in repo")
-	cmd.Flags().IntVarP(&gitSyncInterval, "sync-interval", "s", 60, "The interval in seconds in which git-sync will be polling git for updates")
+	cmd.Flags().IntVarP(&gitSyncInterval, "sync-interval", "s", defaultSyncInterval, "The interval in seconds in which git-sync will be polling git for updates")
 	cmd.Flags().StringVarP(&sshKey, "ssh-key", "", "", "Path to the ssh public key file to use to clone your git repo")
 	cmd.Flags().StringVarP(&knowHosts, "known-hosts", "", "", "Path to the known hosts file to use to clone your git repo")
 }

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -249,7 +249,7 @@ func addGitSyncDeploymentFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&gitRepoURL, "git-repository-url", "u", "", "The repository URL of the git repo")
 	cmd.Flags().StringVarP(&gitBranchName, "git-branch-name", "b", "", "The Branch name of the git repo we will be syncing from")
 	cmd.Flags().StringVarP(&gitDAGDir, "dag-directory-path", "p", "", "The directory where dags are stored in repo")
-	cmd.Flags().IntVarP(&gitSyncInterval, "sync-interval", "s", 1, "The interval in seconds in which git-sync will be polling git for updates")
+	cmd.Flags().IntVarP(&gitSyncInterval, "sync-interval", "s", 60, "The interval in seconds in which git-sync will be polling git for updates")
 	cmd.Flags().StringVarP(&sshKey, "ssh-key", "", "", "Path to the ssh public key file to use to clone your git repo")
 	cmd.Flags().StringVarP(&knowHosts, "known-hosts", "", "", "Path to the known hosts file to use to clone your git repo")
 }


### PR DESCRIPTION
## Description

The 1s default made sense before we had git-sync relay, but now with the relay, 60s is what we have settled on as a sane default.

## 🎟 Issue(s)

Related astronomer/issues#5587

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
