### PR TITLE
Replace `(err != nil) != tt.wantErr` with testify's ErrorAssertionFunc

### DIFF
--- a/cmd/software/validation_test.go
+++ b/cmd/software/validation_test.go
@@ -62,30 +62,28 @@ func Test_validateWorkspaceRole(t *testing.T) {
 		role string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name         string
+		args         args
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
 			name: "basic valid case",
 			args: args{
 				role: houston.WorkspaceAdminRole,
 			},
-			wantErr: false,
+			errAssertion: assert.NoError,
 		},
 		{
 			name: "basic invalid case",
 			args: args{
 				role: "ADMIN",
 			},
-			wantErr: true,
+			errAssertion: assert.Error,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateWorkspaceRole(tt.args.role); (err != nil) != tt.wantErr {
-				t.Errorf("validateWorkspaceRole() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			tt.errAssertion(t, validateWorkspaceRole(tt.args.role))
 		})
 	}
 }
@@ -95,30 +93,28 @@ func Test_validateDeploymentRole(t *testing.T) {
 		role string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name         string
+		args         args
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
 			name: "basic valid case",
 			args: args{
 				role: houston.DeploymentAdminRole,
 			},
-			wantErr: false,
+			errAssertion: assert.NoError,
 		},
 		{
 			name: "basic invalid case",
 			args: args{
 				role: "ADMIN",
 			},
-			wantErr: true,
+			errAssertion: assert.Error,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateDeploymentRole(tt.args.role); (err != nil) != tt.wantErr {
-				t.Errorf("validateDeploymentRole() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			tt.errAssertion(t, validateDeploymentRole(tt.args.role))
 		})
 	}
 }
@@ -141,9 +137,8 @@ func Test_ErrParsingKV(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ErrParsingKV{kv: tt.args.kv}
-			if err.Error() != tt.result {
-				t.Errorf("ErrParsingKV invalid error string error = %v, wantErr %v", err.Error(), tt.result)
-			}
+			assert.Error(t, err)
+			assert.Equal(t, err.Error(), tt.result)
 		})
 	}
 }
@@ -166,9 +161,8 @@ func Test_ErrInvalidArg(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ErrInvalidArg{key: tt.args.key}
-			if err.Error() != tt.result {
-				t.Errorf("ErrParsingKV invalid error string error = %v, wantErr %v", err.Error(), tt.result)
-			}
+			assert.Error(t, err)
+			assert.Equal(t, err.Error(), tt.result)
 		})
 	}
 }

--- a/pkg/ansi/spinner_test.go
+++ b/pkg/ansi/spinner_test.go
@@ -3,6 +3,8 @@ package ansi
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var errMock = errors.New("mock error")
@@ -13,26 +15,26 @@ func TestSpinner(t *testing.T) {
 		fn   func() error
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name         string
+		args         args
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "basic case",
-			args:    args{text: "testing", fn: func() error { return nil }},
-			wantErr: false,
+			name:         "basic case",
+			args:         args{text: "testing", fn: func() error { return nil }},
+			errAssertion: assert.NoError,
 		},
 		{
-			name:    "basic error case",
-			args:    args{text: "testing", fn: func() error { return errMock }},
-			wantErr: true,
+			name: "basic error case",
+			args: args{text: "testing", fn: func() error { return errMock }},
+			errAssertion: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+				return assert.ErrorIs(t, err, errMock, msgAndArgs...)
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := Spinner(tt.args.text, tt.args.fn); (err != nil) != tt.wantErr && !errors.Is(err, errMock) {
-				t.Errorf("Spinner() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			tt.errAssertion(t, Spinner(tt.args.text, tt.args.fn))
 		})
 	}
 }

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -113,21 +113,21 @@ func TestWriteStringToFile(t *testing.T) {
 		s    string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name         string
+		args         args
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "basic case",
-			args:    args{path: "./test.out", s: "testing"},
-			wantErr: false,
+			name:         "basic case",
+			args:         args{path: "./test.out", s: "testing"},
+			errAssertion: assert.NoError,
 		},
 	}
 	defer afero.NewOsFs().Remove("./test.out")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := WriteStringToFile(tt.args.path, tt.args.s); (err != nil) != tt.wantErr {
-				t.Errorf("WriteStringToFile() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.errAssertion(t, WriteStringToFile(tt.args.path, tt.args.s)) {
+				return
 			}
 			if _, err := os.Open(tt.args.path); err != nil {
 				t.Errorf("Error opening file %s", tt.args.path)
@@ -147,14 +147,14 @@ func TestTar(t *testing.T) {
 		target string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name         string
+		args         args
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "basic case",
-			args:    args{source: "./test", target: "/tmp"},
-			wantErr: false,
+			name:         "basic case",
+			args:         args{source: "./test", target: "/tmp"},
+			errAssertion: assert.NoError,
 		},
 	}
 	defer afero.NewOsFs().Remove(path)
@@ -163,8 +163,8 @@ func TestTar(t *testing.T) {
 	defer afero.NewOsFs().Remove("/tmp/test.tar")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := Tar(tt.args.source, tt.args.target); (err != nil) != tt.wantErr {
-				t.Errorf("Tar() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.errAssertion(t, Tar(tt.args.source, tt.args.target)) {
+				return
 			}
 			filePath := "/tmp/test.tar"
 			if _, err := os.Create(filePath); err != nil {

--- a/pkg/fileutil/paths_test.go
+++ b/pkg/fileutil/paths_test.go
@@ -3,27 +3,29 @@ package fileutil
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetWorkingDir(t *testing.T) {
 	tests := []struct {
-		name    string
-		want    string
-		wantErr bool
+		name         string
+		want         string
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "basic case",
-			want:    "fileutil",
-			wantErr: false,
+			name:         "basic case",
+			want:         "fileutil",
+			errAssertion: assert.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetWorkingDir()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetWorkingDir() error = %v, wantErr %v", err, tt.wantErr)
+			if !tt.errAssertion(t, err) {
 				return
 			}
+
 			if !strings.Contains(got, tt.want) {
 				t.Errorf("GetWorkingDir() = %v, want %v", got, tt.want)
 			}
@@ -33,23 +35,23 @@ func TestGetWorkingDir(t *testing.T) {
 
 func TestGetHomeDir(t *testing.T) {
 	tests := []struct {
-		name    string
-		want    string
-		wantErr bool
+		name         string
+		want         string
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "basic case",
-			want:    "/",
-			wantErr: false,
+			name:         "basic case",
+			want:         "/",
+			errAssertion: assert.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetHomeDir()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetHomeDir() error = %v, wantErr %v", err, tt.wantErr)
+			if !tt.errAssertion(t, err) {
 				return
 			}
+
 			if !strings.Contains(got, tt.want) {
 				t.Errorf("GetHomeDir() = %v, want %v", got, tt.want)
 			}

--- a/pkg/input/input_test.go
+++ b/pkg/input/input_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/manifoldco/promptui"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestText(t *testing.T) {
@@ -57,32 +58,32 @@ func TestConfirm(t *testing.T) {
 		promptText string
 	}
 	tests := []struct {
-		name        string
-		inputString string
-		args        args
-		want        bool
-		wantErr     bool
+		name         string
+		inputString  string
+		args         args
+		want         bool
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:        "no case",
-			inputString: "n",
-			args:        args{promptText: "enter y or n"},
-			want:        false,
-			wantErr:     false,
+			name:         "no case",
+			inputString:  "n",
+			args:         args{promptText: "enter y or n"},
+			want:         false,
+			errAssertion: assert.NoError,
 		},
 		{
-			name:        "yes case",
-			inputString: "y",
-			args:        args{promptText: "enter y or n"},
-			want:        true,
-			wantErr:     false,
+			name:         "yes case",
+			inputString:  "y",
+			args:         args{promptText: "enter y or n"},
+			want:         true,
+			errAssertion: assert.NoError,
 		},
 		{
-			name:        "no input",
-			inputString: "",
-			args:        args{promptText: "enter y or n"},
-			want:        false,
-			wantErr:     false,
+			name:         "no input",
+			inputString:  "",
+			args:         args{promptText: "enter y or n"},
+			want:         false,
+			errAssertion: assert.NoError,
 		},
 	}
 	for _, tt := range tests {
@@ -102,10 +103,10 @@ func TestConfirm(t *testing.T) {
 			os.Stdin = r
 
 			got, err := Confirm(tt.args.promptText)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Confirm() error = %v, wantErr %v", err, tt.wantErr)
+			if !tt.errAssertion(t, err) {
 				return
 			}
+
 			if got != tt.want {
 				t.Errorf("Confirm() = %v, want %v", got, tt.want)
 			}
@@ -121,18 +122,18 @@ func TestPassword(t *testing.T) {
 		promptText string
 	}
 	tests := []struct {
-		name        string
-		inputString string
-		args        args
-		want        string
-		wantErr     bool
+		name         string
+		inputString  string
+		args         args
+		want         string
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:        "unsupported error",
-			inputString: "",
-			args:        args{"enter pass"},
-			want:        "",
-			wantErr:     true,
+			name:         "unsupported error",
+			inputString:  "",
+			args:         args{"enter pass"},
+			want:         "",
+			errAssertion: assert.Error,
 		},
 	}
 	for _, tt := range tests {
@@ -152,10 +153,10 @@ func TestPassword(t *testing.T) {
 			os.Stdin = r
 
 			got, err := Password(tt.args.promptText)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Password() error = %v, wantErr %v", err, tt.wantErr)
+			if !tt.errAssertion(t, err) {
 				return
 			}
+
 			if got != tt.want {
 				t.Errorf("Password() = %v, want %v", got, tt.want)
 			}
@@ -170,38 +171,38 @@ func TestPromptGetConfirmation(t *testing.T) {
 	runner := GetYesNoSelector(PromptContent{Label: "test label, enter y/n"})
 	runner.Keys = &promptui.SelectKeys{Next: promptui.Key{Code: rune('S')}, Prev: promptui.Key{Code: rune('W')}, PageUp: promptui.Key{Code: rune('D')}, PageDown: promptui.Key{Code: rune('A')}}
 	tests := []struct {
-		name        string
-		inputString string
-		want        bool
-		wantErr     bool
+		name         string
+		inputString  string
+		want         bool
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:        "basic yes case",
-			inputString: "\n",
-			want:        true,
-			wantErr:     false,
+			name:         "basic yes case",
+			inputString:  "\n",
+			want:         true,
+			errAssertion: assert.NoError,
 		},
 		{
-			name:        "basic no case",
-			inputString: "S\n",
-			want:        false,
-			wantErr:     false,
+			name:         "basic no case",
+			inputString:  "S\n",
+			want:         false,
+			errAssertion: assert.NoError,
 		},
 		{
-			name:        "no input case",
-			inputString: "",
-			want:        false,
-			wantErr:     true,
+			name:         "no input case",
+			inputString:  "",
+			want:         false,
+			errAssertion: assert.Error,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			runner.Stdin = io.NopCloser(strings.NewReader(tt.inputString))
 			got, err := PromptGetConfirmation(runner)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("PromptGetConfirmation() error = %v, wantErr %v", err, tt.wantErr)
+			if !tt.errAssertion(t, err) {
 				return
 			}
+
 			if got != tt.want {
 				t.Errorf("PromptGetConfirmation() = %v, want %v", got, tt.want)
 			}

--- a/pkg/printutil/printutil_test.go
+++ b/pkg/printutil/printutil_test.go
@@ -48,22 +48,22 @@ func TestTablePrint(t *testing.T) {
 		DynamicPadding  bool
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		wantOut string
-		wantErr bool
+		name         string
+		fields       fields
+		wantOut      string
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "empty table case",
-			fields:  fields{NoResultsMsg: "no rows present"},
-			wantOut: "no rows present",
-			wantErr: false,
+			name:         "empty table case",
+			fields:       fields{NoResultsMsg: "no rows present"},
+			wantOut:      "no rows present",
+			errAssertion: assert.NoError,
 		},
 		{
-			name:    "basic case",
-			fields:  fields{SuccessMsg: "printed all rows", Rows: []Row{{Raw: []string{"testing"}}}},
-			wantOut: "printed all rows",
-			wantErr: false,
+			name:         "basic case",
+			fields:       fields{SuccessMsg: "printed all rows", Rows: []Row{{Raw: []string{"testing"}}}},
+			wantOut:      "printed all rows",
+			errAssertion: assert.NoError,
 		},
 	}
 	for _, tt := range tests {
@@ -83,8 +83,7 @@ func TestTablePrint(t *testing.T) {
 				DynamicPadding:  tt.fields.DynamicPadding,
 			}
 			out := &bytes.Buffer{}
-			if err := tr.Print(out); (err != nil) != tt.wantErr {
-				t.Errorf("Table.Print() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.errAssertion(t, tr.Print(out)) {
 				return
 			}
 			if gotOut := out.String(); !strings.Contains(gotOut, tt.wantOut) {
@@ -110,22 +109,22 @@ func TestTablePrintWithIndex(t *testing.T) {
 		DynamicPadding  bool
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		wantOut string
-		wantErr bool
+		name         string
+		fields       fields
+		wantOut      string
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "empty table case",
-			fields:  fields{NoResultsMsg: "no rows present"},
-			wantOut: "no rows present",
-			wantErr: false,
+			name:         "empty table case",
+			fields:       fields{NoResultsMsg: "no rows present"},
+			wantOut:      "no rows present",
+			errAssertion: assert.NoError,
 		},
 		{
-			name:    "basic case",
-			fields:  fields{SuccessMsg: "printed all rows", Rows: []Row{{Raw: []string{"testing"}}}},
-			wantOut: "printed all rows",
-			wantErr: false,
+			name:         "basic case",
+			fields:       fields{SuccessMsg: "printed all rows", Rows: []Row{{Raw: []string{"testing"}}}},
+			wantOut:      "printed all rows",
+			errAssertion: assert.NoError,
 		},
 	}
 	for _, tt := range tests {
@@ -145,8 +144,7 @@ func TestTablePrintWithIndex(t *testing.T) {
 				DynamicPadding:  tt.fields.DynamicPadding,
 			}
 			out := &bytes.Buffer{}
-			if err := tr.PrintWithPageNumber(10, out); (err != nil) != tt.wantErr {
-				t.Errorf("Table.PrintWithPageNumber() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.errAssertion(t, tr.PrintWithPageNumber(10, out)) {
 				return
 			}
 			if gotOut := out.String(); !strings.Contains(gotOut, tt.wantOut) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -118,31 +118,31 @@ func TestExists(t *testing.T) {
 		path string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    bool
-		wantErr bool
+		name         string
+		args         args
+		want         bool
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "valid case",
-			args:    args{"./util_test.go"},
-			want:    true,
-			wantErr: false,
+			name:         "valid case",
+			args:         args{"./util_test.go"},
+			want:         true,
+			errAssertion: assert.NoError,
 		},
 		{
-			name:    "invalid case",
-			args:    args{"./test.go"},
-			want:    false,
-			wantErr: false,
+			name:         "invalid case",
+			args:         args{"./test.go"},
+			want:         false,
+			errAssertion: assert.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Exists(tt.args.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Exists() error = %v, wantErr %v", err, tt.wantErr)
+			if !tt.errAssertion(t, err) {
 				return
 			}
+
 			if got != tt.want {
 				t.Errorf("Exists() = %v, want %v", got, tt.want)
 			}

--- a/software/user/user_test.go
+++ b/software/user/user_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/astronomer/astro-cli/houston"
 	houstonMocks "github.com/astronomer/astro-cli/houston/mocks"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -22,29 +23,28 @@ func TestCreateSuccess(t *testing.T) {
 		password string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantOut string
-		wantErr bool
+		name         string
+		args         args
+		wantOut      string
+		errAssertion assert.ErrorAssertionFunc
 	}{
 		{
-			name:    "test with email & password provided",
-			args:    args{email: "test@test.com", password: "test"},
-			wantOut: "Successfully created user test@test.com",
-			wantErr: false,
+			name:         "test with email & password provided",
+			args:         args{email: "test@test.com", password: "test"},
+			wantOut:      "Successfully created user test@test.com",
+			errAssertion: assert.NoError,
 		},
 		{
-			name:    "test with email & password not provided",
-			args:    args{},
-			wantOut: "Successfully created user",
-			wantErr: false,
+			name:         "test with email & password not provided",
+			args:         args{},
+			wantOut:      "Successfully created user",
+			errAssertion: assert.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
-			if err := Create(tt.args.email, tt.args.password, houstonMock, out); (err != nil) != tt.wantErr {
-				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.errAssertion(t, Create(tt.args.email, tt.args.password, houstonMock, out)) {
 				return
 			}
 			if gotOut := out.String(); !strings.Contains(gotOut, tt.wantOut) {
@@ -60,8 +60,7 @@ func TestCreateFailure(t *testing.T) {
 	houstonMock.On("CreateUser", mock.Anything).Return(nil, errMockHouston)
 
 	out := &bytes.Buffer{}
-	if err := Create("test@test.com", "test", houstonMock, out); !errors.Is(err, errUserCreationDisabled) {
-		t.Errorf("Create() error = %v, wantErr %v", err, errUserCreationDisabled)
+	if !assert.ErrorIs(t, Create("test@test.com", "test", houstonMock, out), errUserCreationDisabled) {
 		return
 	}
 
@@ -73,8 +72,7 @@ func TestCreatePending(t *testing.T) {
 	houstonMock.On("CreateUser", mock.Anything).Return(&houston.AuthUser{User: houston.User{Status: "pending"}}, nil)
 
 	out := &bytes.Buffer{}
-	if err := Create("test@test.com", "test", houstonMock, out); err != nil {
-		t.Errorf("Create() error = %v, wantErr %v", err, nil)
+	if !assert.NoError(t, Create("test@test.com", "test", houstonMock, out)) {
 		return
 	}
 	if gotOut := out.String(); !strings.Contains(gotOut, "Check your email for a verification.") && !strings.Contains(gotOut, "Successfully created user") {


### PR DESCRIPTION
## Description

This is prep work for easily switching to testify suites (where not calling `t.ErrorF()` is better) -- this also greatly simplifies many of the conditionals in the tests

## 🎟 Issue(s)

Related #1185 -- as it makes that automatic translation easier if we do smaller changes like this first

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
