### PR TITLE
Hide namespace and display cluster region for hosted shared

### DIFF
--- a/astro-client/mutations.go
+++ b/astro-client/mutations.go
@@ -49,6 +49,7 @@ var (
 			cluster {
 				id
 				name
+				region
 			}
 			runtimeRelease {
 				version
@@ -93,6 +94,7 @@ var (
 			cluster {
 				id
 				name
+				region
 			}
 			runtimeRelease {
 				version

--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -26,6 +26,7 @@ var (
 				id
 				name
 				cloudProvider
+				region
 				nodePools {
 					id
 					isDefault

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -74,6 +74,7 @@ type Cluster struct {
 	ID            string     `json:"id"`
 	Name          string     `json:"name"`
 	CloudProvider string     `json:"cloudProvider"`
+	Region        string     `json:"region"`
 	NodePools     []NodePool `json:"nodePools"`
 }
 

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -87,14 +87,17 @@ func List(ws string, all bool, client astro.Client, out io.Writer) error {
 	for i := range deployments {
 		d := deployments[i]
 		clusterName := d.Cluster.Name
-		if organization.IsOrgHosted() {
-			clusterName = notApplicable
-		}
 		runtimeVersionText := d.RuntimeRelease.Version + " (based on Airflow " + d.RuntimeRelease.AirflowVersion + ")"
+		releaseName := d.ReleaseName
+		if organization.IsOrgHosted() {
+			clusterName = d.Cluster.Region
+			releaseName = notApplicable
+		}
+
 		if all {
-			tab.AddRow([]string{d.Label, d.Workspace.Label, d.ReleaseName, clusterName, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
+			tab.AddRow([]string{d.Label, d.Workspace.Label, releaseName, clusterName, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
 		} else {
-			tab.AddRow([]string{d.Label, d.ReleaseName, clusterName, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
+			tab.AddRow([]string{d.Label, releaseName, clusterName, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
 		}
 	}
 
@@ -308,10 +311,12 @@ func createOutput(workspaceID string, d *astro.Deployment) error {
 
 	runtimeVersionText := d.RuntimeRelease.Version + " (based on Airflow " + d.RuntimeRelease.AirflowVersion + ")"
 	clusterName := d.Cluster.Name
+	releaseName := d.ReleaseName
 	if organization.IsOrgHosted() {
-		clusterName = notApplicable
+		clusterName = d.Cluster.Region
+		releaseName = notApplicable
 	}
-	tab.AddRow([]string{d.Label, d.ReleaseName, clusterName, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
+	tab.AddRow([]string{d.Label, releaseName, clusterName, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
 
 	deploymentURL, err := GetDeploymentURL(d.ID, workspaceID)
 	if err != nil {
@@ -692,10 +697,12 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy, exe
 
 		runtimeVersionText := d.RuntimeRelease.Version + " (based on Airflow " + d.RuntimeRelease.AirflowVersion + ")"
 		clusterName := d.Cluster.Name
+		releaseName := d.ReleaseName
 		if organization.IsOrgHosted() {
-			clusterName = notApplicable
+			clusterName = d.Cluster.Region
+			releaseName = notApplicable
 		}
-		tabDeployment.AddRow([]string{d.Label, d.ReleaseName, clusterName, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
+		tabDeployment.AddRow([]string{d.Label, releaseName, clusterName, d.ID, runtimeVersionText, strconv.FormatBool(d.DagDeployEnabled)}, false)
 		tabDeployment.SuccessMsg = "\n Successfully updated Deployment"
 		tabDeployment.Print(os.Stdout)
 	}

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -136,8 +136,10 @@ func getDeploymentInfo(sourceDeployment *astro.Deployment) (map[string]interface
 		return nil, err
 	}
 	clusterID := sourceDeployment.Cluster.ID
+	releaseName := sourceDeployment.ReleaseName
 	if organization.IsOrgHosted() {
-		clusterID = notApplicable
+		clusterID = sourceDeployment.Cluster.Region
+		releaseName = notApplicable
 	}
 	return map[string]interface{}{
 		"deployment_id":   sourceDeployment.ID,
@@ -145,7 +147,7 @@ func getDeploymentInfo(sourceDeployment *astro.Deployment) (map[string]interface
 		"cluster_id":      clusterID,
 		"airflow_version": sourceDeployment.RuntimeRelease.AirflowVersion,
 		"current_tag":     sourceDeployment.DeploymentSpec.Image.Tag,
-		"release_name":    sourceDeployment.ReleaseName,
+		"release_name":    releaseName,
 		"deployment_url":  deploymentURL,
 		"webserver_url":   sourceDeployment.DeploymentSpec.Webserver.URL,
 		"created_at":      sourceDeployment.CreatedAt,
@@ -157,7 +159,7 @@ func getDeploymentInfo(sourceDeployment *astro.Deployment) (map[string]interface
 func getDeploymentConfig(sourceDeployment *astro.Deployment) map[string]interface{} {
 	clusterName := sourceDeployment.Cluster.Name
 	if organization.IsOrgHosted() {
-		clusterName = notApplicable
+		clusterName = sourceDeployment.Cluster.Region
 	}
 	return map[string]interface{}{
 		"name":               sourceDeployment.Label,

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -59,7 +59,8 @@ func TestInspect(t *testing.T) {
 			ReleaseName: "great-release-name",
 			Workspace:   astro.Workspace{ID: workspaceID},
 			Cluster: astro.Cluster{
-				ID: "cluster-id",
+				ID:     "cluster-id",
+				Region: "us-central1",
 				NodePools: []astro.NodePool{
 					{
 						ID:               "test-pool-id",
@@ -238,7 +239,7 @@ func TestInspect(t *testing.T) {
 		assert.ErrorContains(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 		mockClient.AssertExpectations(t)
 	})
-	t.Run("Hide Cluster Info if an org is hosted", func(t *testing.T) {
+	t.Run("Display Cluster Region and hide Release Name if an org is hosted", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := context.GetCurrentContext()
 		assert.NoError(t, err)
@@ -248,10 +249,10 @@ func TestInspect(t *testing.T) {
 		mockClient.On("ListDeployments", mock.Anything, workspaceID).Return(deploymentResponse, nil).Once()
 		err = Inspect(workspaceID, "", deploymentID, "yaml", mockClient, out, "", false)
 		assert.NoError(t, err)
-		assert.Contains(t, out.String(), deploymentResponse[0].ReleaseName)
+		assert.Contains(t, out.String(), "N/A")
 		assert.Contains(t, out.String(), deploymentName)
 		assert.Contains(t, out.String(), deploymentResponse[0].RuntimeRelease.Version)
-		assert.Contains(t, out.String(), "N/A")
+		assert.Contains(t, out.String(), "us-central1")
 		mockClient.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Hide namespace and display cluster region for hosted shared

## 🎟 Issue(s)

Related #1187 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## Hiding Namespace and displaying cluster region in hosted shared
![Screenshot 2023-05-09 at 11 42 57](https://github.com/astronomer/astro-cli/assets/65428224/265cc165-9e19-463f-9440-436e419a2d3d)

## Displaying Namespace and displaying cluster name in hybrid
![Screenshot 2023-05-09 at 11 43 08](https://github.com/astronomer/astro-cli/assets/65428224/f6f93cc2-10bd-45b2-88bc-25410c20fc11)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
