### PR TITLE
copy connection/variable warning message

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -786,9 +786,9 @@ var SelectDeployment = func(deployments []astro.Deployment, message string) (ast
 	}
 
 	tab := printutil.Table{
-		Padding:        []int{5, 30, 30, 50},
+		Padding:        []int{5, 30, 30, 30, 50},
 		DynamicPadding: true,
-		Header:         []string{"#", "DEPLOYMENT NAME", "RELEASE NAME", "DEPLOYMENT ID"},
+		Header:         []string{"#", "DEPLOYMENT NAME", "RELEASE NAME", "DEPLOYMENT ID", "DAG DEPLOY ENABLED"},
 	}
 
 	fmt.Println(message)
@@ -800,7 +800,7 @@ var SelectDeployment = func(deployments []astro.Deployment, message string) (ast
 	deployMap := map[string]astro.Deployment{}
 	for i := range deployments {
 		index := i + 1
-		tab.AddRow([]string{strconv.Itoa(index), deployments[i].Label, deployments[i].ReleaseName, deployments[i].ID}, false)
+		tab.AddRow([]string{strconv.Itoa(index), deployments[i].Label, deployments[i].ReleaseName, deployments[i].ID, strconv.FormatBool(deployments[i].DagDeployEnabled)}, false)
 
 		deployMap[strconv.Itoa(index)] = deployments[i]
 	}

--- a/cmd/cloud/deployment_objects.go
+++ b/cmd/cloud/deployment_objects.go
@@ -30,7 +30,7 @@ var (
 
 const (
 	requestString            = "metadata.webserver_url"
-	warningConnectionCopyCMD = "WARNING! The passoword and extra field are not copied over. You will need to manually add these values"
+	warningConnectionCopyCMD = "WARNING! The password and extra field are not copied over. You will need to manually add these values"
 	warningVariableCopyCMD   = "WARNING! Secret values are not copied over. You will need to manually add these values"
 )
 

--- a/cmd/cloud/deployment_objects.go
+++ b/cmd/cloud/deployment_objects.go
@@ -28,7 +28,11 @@ var (
 	slots              int
 )
 
-const requestString = "metadata.webserver_url"
+const (
+	requestString            = "metadata.webserver_url"
+	warningConnectionCopyCMD = "WARNING! The passoword and extra field are not copied over. You will need to manually add these values"
+	warningVariableCopyCMD   = "WARNING! Secret values are not copied over. You will need to manually add these values"
+)
 
 func newDeploymentConnectionRootCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -422,7 +426,7 @@ func deploymentConnectionCopy(cmd *cobra.Command, out io.Writer) error {
 	}
 
 	toAirlfowURL := fmt.Sprintf("%v", value)
-
+	fmt.Println(warningConnectionCopyCMD)
 	return deployment.CopyConnection(fromAirlfowURL, toAirlfowURL, airflowAPIClient, out)
 }
 
@@ -534,6 +538,7 @@ func deploymentAirflowVariableCopy(cmd *cobra.Command, out io.Writer) error {
 
 	toAirlfowURL := fmt.Sprintf("%v", value)
 
+	fmt.Println(warningVariableCopyCMD)
 	return deployment.CopyVariable(fromAirlfowURL, toAirlfowURL, airflowAPIClient, out)
 }
 


### PR DESCRIPTION
## Description

warning message tells users that secret values can't be copied between deployments

Also add dag deploy enabled to all deployment selections

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
