### PR TITLE
fix for updating machine type for hosted deployment

### DIFF
--- a/astro-client/mutations.go
+++ b/astro-client/mutations.go
@@ -45,6 +45,7 @@ var (
 			releaseName
 			dagDeployEnabled
 			schedulerSize
+			type
 			isHighAvailability
 			apiKeyOnlyDeployments
 			cluster {
@@ -59,6 +60,7 @@ var (
 			workerQueues {
 				id
 				name
+				astroMachine
 				isDefault
 				workerConcurrency
 				minWorkerCount
@@ -91,6 +93,7 @@ var (
 			releaseName
 			dagDeployEnabled
 			schedulerSize
+			type
 			isHighAvailability
 			apiKeyOnlyDeployments
 			cluster {
@@ -101,6 +104,18 @@ var (
 			runtimeRelease {
 				version
 				airflowVersion
+			}
+			workerQueues {
+				id
+				name
+				astroMachine
+				isDefault
+				workerConcurrency
+				minWorkerCount
+				maxWorkerCount
+				nodePoolId
+				podCpu
+				podRam
 			}
 			deploymentSpec {
 				image {

--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -22,6 +22,7 @@ var (
 			dagDeployEnabled
 			apiKeyOnlyDeployments
 			schedulerSize
+			type
 			isHighAvailability
 			cluster {
 				id
@@ -38,6 +39,7 @@ var (
 			workerQueues {
 				id
 				name
+				astroMachine
 				isDefault
 				nodePoolId
 				podCpu
@@ -104,6 +106,7 @@ var (
 			status
 			dagDeployEnabled
 			schedulerSize
+			type
 			isHighAvailability
 			runtimeRelease {
 				version
@@ -136,6 +139,7 @@ var (
 			workerQueues {
 				id
 				name
+				astroMachine
 				isDefault
 				nodePoolId
 				workerConcurrency

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -385,6 +385,7 @@ type UserInvite struct {
 type WorkerQueue struct {
 	ID                string `json:"id,omitempty"` // Empty when creating new WorkerQueues
 	Name              string `json:"name"`
+	AstroMachine      string `json:"astroMachine"`
 	IsDefault         bool   `json:"isDefault"`
 	MaxWorkerCount    int    `json:"maxWorkerCount,omitempty"`
 	MinWorkerCount    int    `json:"minWorkerCount"`

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -752,6 +752,10 @@ func Delete(deploymentID, ws, deploymentName string, forceDelete bool, client as
 	return nil
 }
 
+func IsDeploymentHosted(deploymentType string) bool {
+	return deploymentType == "HOSTED_SHARED"
+}
+
 var GetDeployments = func(ws, org string, client astro.Client) ([]astro.Deployment, error) {
 	if org == "" {
 		c, err := config.GetCurrentContext()

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -314,6 +314,18 @@ func TestGetDeployment(t *testing.T) {
 	})
 }
 
+func TestIsDeploymentHosted(t *testing.T) {
+	t.Run("if deployment type is hosted", func(t *testing.T) {
+		out := IsDeploymentHosted("HOSTED_SHARED")
+		assert.Equal(t, out, true)
+	})
+
+	t.Run("if deployment type is hybrid", func(t *testing.T) {
+		out := IsDeploymentHosted("")
+		assert.Equal(t, out, false)
+	})
+}
+
 func TestSelectRegion(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -218,7 +218,7 @@ func ReturnSpecifiedValue(wsID, deploymentName, deploymentID string, client astr
 func getQMap(sourceDeploymentQs []astro.WorkerQueue, sourceNodePools []astro.NodePool, sourceExecutor string) []map[string]interface{} {
 	var resources map[string]interface{}
 	queueMap := make([]map[string]interface{}, 0, len(sourceDeploymentQs))
-	for _, queue := range sourceDeploymentQs {
+	for _, queue := range sourceDeploymentQs { //nolint
 		if sourceExecutor == "CeleryExecutor" {
 			resources = map[string]interface{}{
 				"max_worker_count":   queue.MaxWorkerCount,

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -27,6 +27,7 @@ var (
 	errCannotUpdateExistingQueue = errors.New("worker queue already exists")
 	errCannotCreateNewQueue      = errors.New("worker queue does not exist")
 	errInvalidNodePool           = errors.New("node pool selection failed")
+	errInvalidAstroMachine       = errors.New("invalid astro machine selection failed")
 	errQueueDoesNotExist         = errors.New("worker queue does not exist")
 	errInvalidQueue              = errors.New("worker queue selection failed")
 	errCannotDeleteDefaultQueue  = errors.New("default queue can not be deleted")
@@ -39,6 +40,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 		requestedDeployment                  astro.Deployment
 		err                                  error
 		errHelp, succeededAction, nodePoolID string
+		astroMachine                         astro.Machine
 		queueToCreateOrUpdate                *astro.WorkerQueue
 		listToCreate, existingQueues         []astro.WorkerQueue
 		defaultOptions                       astro.WorkerQueueDefaultOptions
@@ -49,15 +51,26 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 		return err
 	}
 
-	// get the node poolID to use
-	nodePoolID, err = selectNodePool(workerType, requestedDeployment.Cluster.NodePools, out)
-	if err != nil {
-		return err
+	if deployment.IsDeploymentHosted(requestedDeployment.Type) {
+		nodePoolID = requestedDeployment.Cluster.NodePools[0].ID
+		// get the machine to use
+		astroMachine, err = selectAstroMachine(workerType, client, out)
+		if err != nil {
+			return err
+		}
+		wQueueConcurrency = astroMachine.ConcurrentTasks // This is set based on the machine type the user chooses
+	} else {
+		// get the node poolID to use
+		nodePoolID, err = selectNodePool(workerType, requestedDeployment.Cluster.NodePools, out)
+		if err != nil {
+			return err
+		}
 	}
 
 	queueToCreateOrUpdate = &astro.WorkerQueue{
 		Name:              name,
 		IsDefault:         false, // cannot create a default queue
+		AstroMachine:      astroMachine.Type,
 		NodePoolID:        nodePoolID,
 		MinWorkerCount:    wQueueMin,         // use the value from the user input
 		MaxWorkerCount:    wQueueMax,         // use the value from the user input
@@ -239,7 +252,7 @@ func IsKubernetesWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue) 
 // It returns true if queueToCreate exists in []existingQueues
 // It returns false if queueToCreate does not exist in []existingQueues
 func QueueExists(existingQueues []astro.WorkerQueue, queueToCreate *astro.WorkerQueue) bool {
-	for _, queue := range existingQueues {
+	for _, queue := range existingQueues { //nolint
 		if queue.ID == queueToCreate.ID {
 			// queueToCreate exists
 			return true
@@ -250,6 +263,58 @@ func QueueExists(existingQueues []astro.WorkerQueue, queueToCreate *astro.Worker
 		}
 	}
 	return false
+}
+
+func selectAstroMachine(workerType string, client astro.Client, out io.Writer) (astro.Machine, error) {
+	var (
+		machine     astro.Machine
+		errToReturn error
+	)
+
+	configOptions, err := client.GetDeploymentConfig()
+	if err != nil {
+		return astro.Machine{}, err
+	}
+	astroMachines := configOptions.AstroMachines
+
+	switch workerType {
+	case "":
+		tab := printutil.Table{
+			Padding:        []int{5, 30, 20, 50},
+			DynamicPadding: true,
+			Header:         []string{"#", "WORKER TYPE", "CPU", "Memory"},
+		}
+
+		fmt.Println("No worker type was specified. Select the worker type to use")
+
+		machineMap := map[string]astro.Machine{}
+
+		for i := range astroMachines {
+			index := i + 1
+			tab.AddRow([]string{strconv.Itoa(index), astroMachines[i].Type, astroMachines[i].CPU + " vCPU", astroMachines[i].Memory}, false)
+
+			machineMap[strconv.Itoa(index)] = astroMachines[i]
+		}
+
+		tab.Print(out)
+		choice := input.Text("\n> ")
+		selectedPool, ok := machineMap[choice]
+		if !ok {
+			// returning an error as choice was not in nodePoolMap
+			errToReturn = fmt.Errorf("%w: invalid worker type: %s selected", errInvalidAstroMachine, choice)
+			return astro.Machine{}, errToReturn
+		}
+		return selectedPool, nil
+	default:
+		for _, machine = range astroMachines {
+			if machine.Type == workerType {
+				return machine, nil
+			}
+		}
+		// did not find a matching workerType in any node pool
+		errToReturn = fmt.Errorf("%w: workerType %s is not available for this deployment", errInvalidAstroMachine, workerType)
+		return astro.Machine{}, errToReturn
+	}
 }
 
 // selectNodePool takes workerType and []NodePool as arguments
@@ -359,7 +424,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, client as
 		}
 
 		// create a new listToDelete without queueToDelete in it
-		for _, queue = range existingQueues {
+		for _, queue = range existingQueues { //nolint
 			if queue.Name != queueToDelete.Name {
 				listToDelete = append(listToDelete, queue)
 			}
@@ -421,7 +486,7 @@ func selectQueue(queueList []astro.WorkerQueue, out io.Writer) (string, error) {
 // sets the resources for CeleryExecutor and removes all resources for KubernetesExecutor as they get calculated based
 // on the worker type.
 func updateQueueList(existingQueues []astro.WorkerQueue, queueToUpdate *astro.WorkerQueue, executor string, wQueueMin, wQueueMax, wQueueConcurrency int) []astro.WorkerQueue {
-	for i, queue := range existingQueues {
+	for i, queue := range existingQueues { //nolint
 		if queue.Name != queueToUpdate.Name {
 			continue
 		}
@@ -447,6 +512,7 @@ func updateQueueList(existingQueues []astro.WorkerQueue, queueToUpdate *astro.Wo
 			queue.PodCPU = ""
 		}
 		queue.NodePoolID = queueToUpdate.NodePoolID
+		queue.AstroMachine = queueToUpdate.AstroMachine
 		existingQueues[i] = queue
 		return existingQueues
 	}

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -485,6 +485,162 @@ func TestCreate(t *testing.T) {
 	})
 }
 
+func TestCreateHostedShared(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	expectedWorkerQueue := astro.WorkerQueue{
+		Name:              "test-worker-queue",
+		IsDefault:         false,
+		MaxWorkerCount:    0,
+		MinWorkerCount:    0,
+		WorkerConcurrency: 0,
+		NodePoolID:        "",
+	}
+	expectedOutMessage := "worker queue " + expectedWorkerQueue.Name + " for test-deployment-label in test-ws-id workspace created\n"
+	defer testUtil.MockUserInput(t, "test-worker-queue")()
+	out := new(bytes.Buffer)
+	mockClient := new(astro_mocks.Client)
+	mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
+		MinWorkerCount: astro.WorkerQueueOption{
+			Floor:   0,
+			Ceiling: 30,
+			Default: 0,
+		},
+		MaxWorkerCount: astro.WorkerQueueOption{
+			Floor:   1,
+			Ceiling: 30,
+			Default: 10,
+		},
+		WorkerConcurrency: astro.WorkerQueueOption{
+			Floor:   1,
+			Ceiling: 64,
+			Default: 16,
+		},
+	}
+	deploymentRespWithQueues := []astro.Deployment{
+		{
+			ID:    "test-deployment-id",
+			Label: "test-deployment-label",
+			Cluster: astro.Cluster{
+				NodePools: []astro.NodePool{
+					{
+						ID:               "test-pool-id",
+						IsDefault:        true,
+						NodeInstanceType: "test-instance-type",
+						CreatedAt:        time.Now(),
+					},
+				},
+			},
+			Type:           "HOSTED_SHARED",
+			RuntimeRelease: astro.RuntimeRelease{Version: "4.2.5"},
+			DeploymentSpec: astro.DeploymentSpec{
+				Executor: "CeleryExecutor",
+				Scheduler: astro.Scheduler{
+					AU:       5,
+					Replicas: 3,
+				},
+			},
+			WorkerQueues: []astro.WorkerQueue{
+				{
+					ID:                "test-wq-id",
+					Name:              "default",
+					AstroMachine:      "a5",
+					IsDefault:         true,
+					MaxWorkerCount:    12,
+					MinWorkerCount:    1,
+					WorkerConcurrency: 5,
+					NodePoolID:        "test-pool-id",
+				},
+				{
+					ID:                "test-wq-id-1",
+					Name:              "test-queue-1",
+					IsDefault:         false,
+					AstroMachine:      "a10",
+					MaxWorkerCount:    25,
+					MinWorkerCount:    8,
+					WorkerConcurrency: 10,
+					NodePoolID:        "test-pool-id",
+				},
+			},
+		},
+	}
+	updateDeploymentInput := astro.UpdateDeploymentInput{
+		ID:    deploymentRespWithQueues[0].ID,
+		Label: deploymentRespWithQueues[0].Label,
+		DeploymentSpec: astro.DeploymentCreateSpec{
+			Executor:  deploymentRespWithQueues[0].DeploymentSpec.Executor,
+			Scheduler: deploymentRespWithQueues[0].DeploymentSpec.Scheduler,
+		},
+		WorkerQueues: []astro.WorkerQueue{
+			{
+				ID:                "test-wq-id",
+				Name:              "default",
+				IsDefault:         true,
+				AstroMachine:      "a5",
+				MaxWorkerCount:    12,
+				MinWorkerCount:    1,
+				WorkerConcurrency: 5,
+				NodePoolID:        "test-pool-id",
+			},
+			{
+				ID:                "test-wq-id-1",
+				Name:              "test-queue-1",
+				IsDefault:         false,
+				AstroMachine:      "a10",
+				MaxWorkerCount:    25,
+				MinWorkerCount:    8,
+				WorkerConcurrency: 10,
+				NodePoolID:        "test-pool-id",
+			},
+			{
+				Name:              "test-worker-queue",
+				IsDefault:         false,
+				AstroMachine:      "a5",
+				MaxWorkerCount:    10,
+				MinWorkerCount:    0,
+				WorkerConcurrency: 5,
+				NodePoolID:        "test-pool-id",
+			},
+		},
+	}
+	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+		AstroMachines: []astro.Machine{
+			{
+				Type:            "a5",
+				ConcurrentTasks: 5,
+			},
+			{
+				Type:            "a10",
+				ConcurrentTasks: 10,
+			},
+			{
+				Type:            "a20",
+				ConcurrentTasks: 20,
+			},
+		},
+		Components: astro.Components{
+			Scheduler: astro.SchedulerConfig{
+				AU: astro.AuConfig{
+					Default: 5,
+					Limit:   24,
+				},
+				Replicas: astro.ReplicasConfig{
+					Default: 1,
+					Minimum: 1,
+					Limit:   4,
+				},
+			},
+		},
+	}, nil).Times(2)
+	t.Run("for hosted shared deployments", func(t *testing.T) {
+		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentRespWithQueues, nil).Twice()
+		mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
+		mockClient.On("UpdateDeployment", &updateDeploymentInput).Return(deploymentRespWithQueues[0], nil).Once()
+		err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "", createAction, "a5", -1, 0, 0, true, mockClient, out)
+		assert.NoError(t, err)
+		assert.Contains(t, out.String(), expectedOutMessage)
+	})
+}
+
 func TestUpdate(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	expectedWorkerQueue := astro.WorkerQueue{


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

fix for updating machine type for hosted deployment

## 🎟 Issue(s)

Related #1186 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
