### PR TITLE
Use core-api list clusters endpoint

### DIFF
--- a/astro-client/astro.go
+++ b/astro-client/astro.go
@@ -30,8 +30,6 @@ type Client interface {
 	// Image
 	CreateImage(input CreateImageInput) (*Image, error)
 	DeployImage(input DeployImageInput) (*Image, error)
-	// Cluster
-	ListClusters(organizationID string) ([]Cluster, error)
 	// WorkerQueues
 	GetWorkerQueueOptions() (WorkerQueueDefaultOptions, error)
 	// Organizations
@@ -206,19 +204,6 @@ func (c *HTTPClient) DeployImage(input DeployImageInput) (*Image, error) {
 		return nil, err
 	}
 	return resp.Data.DeployImage, nil
-}
-
-func (c *HTTPClient) ListClusters(organizationID string) ([]Cluster, error) {
-	req := Request{
-		Query:     GetClusters,
-		Variables: map[string]interface{}{"organizationId": organizationID},
-	}
-
-	resp, err := req.DoWithPublicClient(c)
-	if err != nil {
-		return []Cluster{}, err
-	}
-	return resp.Data.GetClusters, nil
 }
 
 // GetWorkspace returns information about the workspace

--- a/astro-client/astro_test.go
+++ b/astro-client/astro_test.go
@@ -628,52 +628,6 @@ func TestDeployImage(t *testing.T) {
 	})
 }
 
-func TestListClusters(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	mockResponse := &Response{
-		Data: ResponseData{
-			GetClusters: []Cluster{
-				{
-					ID:            "test-id",
-					Name:          "test-name",
-					CloudProvider: "test-cloud-provider",
-				},
-			},
-		},
-	}
-	jsonResponse, err := json.Marshal(mockResponse)
-	assert.NoError(t, err)
-
-	t.Run("success", func(t *testing.T) {
-		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
-			return &http.Response{
-				StatusCode: 200,
-				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
-				Header:     make(http.Header),
-			}
-		})
-		astroClient := NewAstroClient(client)
-
-		resp, err := astroClient.ListClusters("test-org-id")
-		assert.NoError(t, err)
-		assert.Equal(t, resp, mockResponse.Data.GetClusters)
-	})
-
-	t.Run("error", func(t *testing.T) {
-		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
-			return &http.Response{
-				StatusCode: 500,
-				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
-				Header:     make(http.Header),
-			}
-		})
-		astroClient := NewAstroClient(client)
-
-		_, err := astroClient.ListClusters("test-org-id")
-		assert.Contains(t, err.Error(), "Internal Server Error")
-	})
-}
-
 func TestGetWorkspace(t *testing.T) {
 	expectedWorkspace := Response{
 		Data: ResponseData{

--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -171,22 +171,6 @@ var (
 	}
 	`
 
-	GetClusters = `
-	query clusters($organizationId: Id!) {
-		clusters(organizationId: $organizationId) {
-			id
-			name
-			cloudProvider
-			nodePools {
-				id
-				isDefault
-				maxNodeCount
-				nodeInstanceType
-			}
-		}
-	}
-	`
-
 	GetDeploymentConfigOptions = `
 	query deploymentConfigOptions {
 	  deploymentConfigOptions {

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -15,7 +15,6 @@ type ResponseData struct {
 	GetDeployments            []Deployment                 `json:"deployments,omitempty"`
 	GetWorkspaces             []Workspace                  `json:"workspaces,omitempty"`
 	GetWorkspace              Workspace                    `json:"workspace,omitempty"`
-	GetClusters               []Cluster                    `json:"clusters,omitempty"`
 	RuntimeReleases           []RuntimeRelease             `json:"runtimeReleases,omitempty"`
 	CreateDeployment          Deployment                   `json:"CreateDeployment,omitempty"`
 	GetDeploymentConfig       DeploymentConfig             `json:"deploymentConfigOptions,omitempty"`

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -243,7 +243,7 @@ func Create(label, workspaceID, description, clusterID, runtimeVersion, dagDeplo
 	}
 
 	// select and validate cluster
-	clusterID, err = useSharedClusterOrSelectDedicatedCluster(cloudProvider, region, organizationID, clusterID, coreClient)
+	clusterID, err = useSharedClusterOrSelectDedicatedCluster(cloudProvider, region, c.OrganizationShortName, clusterID, coreClient)
 	if err != nil {
 		return err
 	}
@@ -448,16 +448,11 @@ func selectRegion(cloudProvider, region string, coreClient astrocore.CoreClient)
 	return region, nil
 }
 
-func selectCluster(clusterID, organizationID string, coreClient astrocore.CoreClient) (newClusterID string, err error) {
+func selectCluster(clusterID, organizationShortName string, coreClient astrocore.CoreClient) (newClusterID string, err error) {
 	clusterTab := printutil.Table{
 		Padding:        []int{5, 30, 30, 50},
 		DynamicPadding: true,
 		Header:         []string{"#", "CLUSTER NAME", "CLOUD PROVIDER", "CLUSTER ID"},
-	}
-
-	c, err := config.GetCurrentContext()
-	if err != nil {
-		return "", err
 	}
 
 	clusterType := []astrocore.ListClustersParamsType{astrocore.BRINGYOUROWNCLOUD, astrocore.HOSTED}
@@ -466,7 +461,7 @@ func selectCluster(clusterID, organizationID string, coreClient astrocore.CoreCl
 		Type:  &clusterType,
 		Limit: &limit,
 	}
-	resp, err := coreClient.ListClustersWithResponse(context.Background(), c.OrganizationShortName, clusterListParams)
+	resp, err := coreClient.ListClustersWithResponse(context.Background(), organizationShortName, clusterListParams)
 	if err != nil {
 		return "", err
 	}
@@ -535,7 +530,7 @@ func useSharedCluster(cloudProvider astrocore.SharedClusterCloudProvider, region
 // useSharedClusterOrSelectDedicatedCluster decides how to derive the clusterID to use for a deployment.
 // if cloudProvider and region are provided, it uses a useSharedCluster to get the ClusterID.
 // if not, it uses selectCluster to get the ClusterID.
-func useSharedClusterOrSelectDedicatedCluster(cloudProvider, region, organizationID, clusterID string, coreClient astrocore.CoreClient) (derivedClusterID string, err error) {
+func useSharedClusterOrSelectDedicatedCluster(cloudProvider, region, organizationShortName, clusterID string, coreClient astrocore.CoreClient) (derivedClusterID string, err error) {
 	// if cloud provider and region are requested
 	if cloudProvider != "" && region != "" {
 		// use a shared cluster for the deployment
@@ -545,7 +540,7 @@ func useSharedClusterOrSelectDedicatedCluster(cloudProvider, region, organizatio
 		}
 	} else {
 		// select and validate cluster
-		derivedClusterID, err = selectCluster(clusterID, organizationID, coreClient)
+		derivedClusterID, err = selectCluster(clusterID, organizationShortName, coreClient)
 		if err != nil {
 			return "", err
 		}

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -455,23 +455,10 @@ func selectCluster(clusterID, organizationShortName string, coreClient astrocore
 		Header:         []string{"#", "CLUSTER NAME", "CLOUD PROVIDER", "CLUSTER ID"},
 	}
 
-	clusterType := []astrocore.ListClustersParamsType{astrocore.BRINGYOUROWNCLOUD, astrocore.HOSTED}
-	limit := 1000
-	clusterListParams := &astrocore.ListClustersParams{
-		Type:  &clusterType,
-		Limit: &limit,
-	}
-	resp, err := coreClient.ListClustersWithResponse(context.Background(), organizationShortName, clusterListParams)
+	cs, err := organization.ListClusters(organizationShortName, coreClient)
 	if err != nil {
 		return "", err
 	}
-	err = astrocore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
-	if err != nil {
-		return "", err
-	}
-	csPaginated := *resp.JSON200
-	cs := csPaginated.Clusters
-
 	// select cluster
 	if clusterID == "" {
 		fmt.Println("\nPlease select a Cluster for your Deployment:")

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1171,13 +1171,12 @@ func TestValidateResources(t *testing.T) {
 func TestSelectCluster(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 
-	orgID := "test-org-id"
 	csID := "test-cluster-id"
 	t.Run("list cluster failure", func(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&astrocore.ListClustersResponse{}, errMock).Once()
 
-		_, err := selectCluster("", orgID, mockCoreClient)
+		_, err := selectCluster("", mockOrgShortName, mockCoreClient)
 		assert.ErrorIs(t, err, errMock)
 		mockCoreClient.AssertExpectations(t)
 	})
@@ -1202,7 +1201,7 @@ func TestSelectCluster(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		resp, err := selectCluster("", orgID, mockCoreClient)
+		resp, err := selectCluster("", mockOrgShortName, mockCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, csID, resp)
 	})
@@ -1227,7 +1226,7 @@ func TestSelectCluster(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		_, err = selectCluster("", orgID, mockCoreClient)
+		_, err = selectCluster("", mockOrgShortName, mockCoreClient)
 		assert.ErrorIs(t, err, ErrInvalidDeploymentKey)
 	})
 
@@ -1235,7 +1234,7 @@ func TestSelectCluster(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 
-		_, err := selectCluster("test-invalid-id", orgID, mockCoreClient)
+		_, err := selectCluster("test-invalid-id", mockOrgShortName, mockCoreClient)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to find specified Cluster")
 	})
@@ -2446,7 +2445,6 @@ func TestUseSharedCluster(t *testing.T) {
 func TestUseSharedClusterOrSelectCluster(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 
-	orgID := "test-org-id"
 	csID := "test-cluster-id"
 
 	t.Run("uses shared cluster if cloud provider and region are provided", func(t *testing.T) {
@@ -2482,7 +2480,7 @@ func TestUseSharedClusterOrSelectCluster(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 		defer testUtil.MockUserInput(t, "1")()
-		actual, err := useSharedClusterOrSelectDedicatedCluster("", "", orgID, "", mockCoreClient)
+		actual, err := useSharedClusterOrSelectDedicatedCluster("", "", mockOrgShortName, "", mockCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, csID, actual)
 		mockCoreClient.AssertExpectations(t)
@@ -2490,7 +2488,7 @@ func TestUseSharedClusterOrSelectCluster(t *testing.T) {
 	t.Run("returns error if selecting cluster fails", func(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&astrocore.ListClustersResponse{}, errMock).Once()
-		_, err := useSharedClusterOrSelectDedicatedCluster("", "", orgID, "", mockCoreClient)
+		_, err := useSharedClusterOrSelectDedicatedCluster("", "", mockOrgShortName, "", mockCoreClient)
 		assert.ErrorIs(t, err, errMock)
 		mockCoreClient.AssertExpectations(t)
 	})

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -23,13 +23,49 @@ var (
 	enableCiCdEnforcement  = true
 	disableCiCdEnforcement = false
 	errMock                = errors.New("mock error")
+	limit                  = 1000
+	clusterType            = []astrocore.ListClustersParamsType{astrocore.BRINGYOUROWNCLOUD, astrocore.HOSTED}
+	clusterListParams      = &astrocore.ListClustersParams{
+		Type:  &clusterType,
+		Limit: &limit,
+	}
+	mockListClustersResponse = astrocore.ListClustersResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &astrocore.ClustersPaginated{
+			Clusters: []astrocore.Cluster{
+				{
+					Id:   "test-cluster-id",
+					Name: "test-cluster",
+					NodePools: []astrocore.NodePool{
+						{
+							Id:               "test-pool-id",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-1",
+						},
+						{
+							Id:               "test-pool-id-2",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-2",
+						},
+					},
+				},
+				{
+					Id:   "test-cluster-id-1",
+					Name: "test-cluster-1",
+				},
+			},
+		},
+	}
 )
 
 const (
-	org       = "test-org-id"
-	ws        = "test-ws-id"
-	dagDeploy = "disable"
-	region    = "us-central1"
+	org              = "test-org-id"
+	ws               = "test-ws-id"
+	dagDeploy        = "disable"
+	region           = "us-central1"
+	mockOrgShortName = "test-org-short-name"
 )
 
 func TestList(t *testing.T) {
@@ -549,7 +585,7 @@ func TestCreate(t *testing.T) {
 			},
 		}, nil).Times(2)
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
-		mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 		mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
@@ -583,7 +619,7 @@ func TestCreate(t *testing.T) {
 		deploymentCreateInput.APIKeyOnlyDeployments = true
 		defer func() { deploymentCreateInput.APIKeyOnlyDeployments = false }()
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
-		mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 		mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
@@ -780,7 +816,7 @@ func TestCreate(t *testing.T) {
 		deploymentCreateInput.DeploymentSpec.Executor = "KubeExecutor"
 		defer func() { deploymentCreateInput.DeploymentSpec.Executor = CeleryExecutor }()
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
-		mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 		mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
@@ -813,7 +849,7 @@ func TestCreate(t *testing.T) {
 			},
 		}, nil).Times(4)
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Twice()
-		mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Twice()
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, clusterListParams).Return(&mockListClustersResponse, nil).Twice()
 		mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{ID: "test-id"}, nil).Twice()
 
 		defer testUtil.MockUserInput(t, "test-name")()
@@ -835,6 +871,7 @@ func TestCreate(t *testing.T) {
 		err = Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", 10, 3, mockClient, mockCoreClient, true, &disableCiCdEnforcement)
 		assert.ErrorIs(t, err, errTimedOut)
 		mockClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
 	})
 	t.Run("returns an error when creating a deployment fails", func(t *testing.T) {
 		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
@@ -858,7 +895,7 @@ func TestCreate(t *testing.T) {
 			},
 		}, nil).Times(2)
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
-		mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 		mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{}, errMock).Once()
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
@@ -867,6 +904,7 @@ func TestCreate(t *testing.T) {
 		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", 10, 3, mockClient, mockCoreClient, false, &disableCiCdEnforcement)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
 	})
 	t.Run("failed to validate resources", func(t *testing.T) {
 		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{}, errMock).Once()
@@ -897,10 +935,11 @@ func TestCreate(t *testing.T) {
 			},
 		}, nil).Times(2)
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
-		mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{}, errMock).Once()
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, clusterListParams).Return(&astrocore.ListClustersResponse{}, errMock).Once()
 		err := Create("test-name", ws, "test-desc", "invalid-cluster-id", "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", 10, 3, mockClient, mockCoreClient, false, &disableCiCdEnforcement)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
 	})
 	t.Run("invalid resources", func(t *testing.T) {
 		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
@@ -1012,23 +1051,6 @@ func TestCreate(t *testing.T) {
 		mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
-		provider := astrocore.GetClusterOptionsParamsProvider(astrocore.GetClusterOptionsParamsProviderGcp) //nolint
-		getSharedClusterOptionsParams := &astrocore.GetClusterOptionsParams{
-			Provider: &provider,
-			Type:     astrocore.GetClusterOptionsParamsType(astrocore.GetClusterOptionsParamsTypeSHARED), //nolint
-		}
-
-		mockOKRegionResponse := &astrocore.GetClusterOptionsResponse{
-			HTTPResponse: &http.Response{
-				StatusCode: 200,
-			},
-			JSON200: &[]astrocore.ClusterOptions{
-				{Regions: []astrocore.ProviderRegion{{Name: region}}},
-			},
-		}
-
-		mockCoreClient.On("GetClusterOptionsWithResponse", mock.Anything, getSharedClusterOptionsParams).Return(mockOKRegionResponse, nil).Once()
-
 		getSharedClusterParams := &astrocore.GetSharedClusterParams{
 			Region:        region,
 			CloudProvider: astrocore.GetSharedClusterParamsCloudProvider(astrocore.SharedClusterCloudProviderGcp),
@@ -1047,6 +1069,7 @@ func TestCreate(t *testing.T) {
 		assert.NoError(t, err)
 		ctx.SetContextKey("organization_product", "HYBRID")
 		mockClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
 	})
 	t.Run("success with default config", func(t *testing.T) {
 		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
@@ -1085,7 +1108,7 @@ func TestCreate(t *testing.T) {
 			},
 		}
 		mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id"}}, nil).Once()
-		mockClient.On("ListClusters", "test-org-id").Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 		mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{ID: "test-id"}, nil).Once()
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
@@ -1094,6 +1117,7 @@ func TestCreate(t *testing.T) {
 		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", 0, 0, mockClient, mockCoreClient, false, &disableCiCdEnforcement)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
 	})
 }
 
@@ -1150,17 +1174,17 @@ func TestSelectCluster(t *testing.T) {
 	orgID := "test-org-id"
 	csID := "test-cluster-id"
 	t.Run("list cluster failure", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{}, errMock).Once()
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&astrocore.ListClustersResponse{}, errMock).Once()
 
-		_, err := selectCluster("", orgID, mockClient)
+		_, err := selectCluster("", orgID, mockCoreClient)
 		assert.ErrorIs(t, err, errMock)
-		mockClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
 	})
 
 	t.Run("cluster id via selection", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 
 		// mock os.Stdin
 		input := []byte("1")
@@ -1178,14 +1202,14 @@ func TestSelectCluster(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		resp, err := selectCluster("", orgID, mockClient)
+		resp, err := selectCluster("", orgID, mockCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, csID, resp)
 	})
 
 	t.Run("cluster id invalid selection", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 
 		// mock os.Stdin
 		input := []byte("4")
@@ -1203,15 +1227,15 @@ func TestSelectCluster(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		_, err = selectCluster("", orgID, mockClient)
+		_, err = selectCluster("", orgID, mockCoreClient)
 		assert.ErrorIs(t, err, ErrInvalidDeploymentKey)
 	})
 
 	t.Run("not able to find cluster", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 
-		_, err := selectCluster("test-invalid-id", orgID, mockClient)
+		_, err := selectCluster("test-invalid-id", orgID, mockCoreClient)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to find specified Cluster")
 	})
@@ -2440,7 +2464,7 @@ func TestUseSharedClusterOrSelectCluster(t *testing.T) {
 			JSON200: &astrocore.SharedCluster{Id: csID},
 		}
 		mockCoreClient.On("GetSharedClusterWithResponse", mock.Anything, getSharedClusterParams).Return(mockOKResponse, nil).Once()
-		actual, err := useSharedClusterOrSelectDedicatedCluster(cloudProvider, region, "", "", nil, mockCoreClient)
+		actual, err := useSharedClusterOrSelectDedicatedCluster(cloudProvider, region, "", "", mockCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, csID, actual)
 		mockCoreClient.AssertExpectations(t)
@@ -2450,24 +2474,24 @@ func TestUseSharedClusterOrSelectCluster(t *testing.T) {
 		region := "us-central1"
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("GetSharedClusterWithResponse", mock.Anything, mock.Anything).Return(nil, errMock).Once()
-		_, err := useSharedClusterOrSelectDedicatedCluster(cloudProvider, region, "", "", nil, mockCoreClient)
+		_, err := useSharedClusterOrSelectDedicatedCluster(cloudProvider, region, "", "", mockCoreClient)
 		assert.ErrorIs(t, err, errMock)
 		mockCoreClient.AssertExpectations(t)
 	})
 	t.Run("uses select cluster if cloud provider and region are not provided", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{{ID: csID}}, nil).Once()
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 		defer testUtil.MockUserInput(t, "1")()
-		actual, err := useSharedClusterOrSelectDedicatedCluster("", "", orgID, "", mockClient, nil)
+		actual, err := useSharedClusterOrSelectDedicatedCluster("", "", orgID, "", mockCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, csID, actual)
-		mockClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
 	})
 	t.Run("returns error if selecting cluster fails", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{}, errMock).Once()
-		_, err := useSharedClusterOrSelectDedicatedCluster("", "", orgID, "", mockClient, nil)
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&astrocore.ListClustersResponse{}, errMock).Once()
+		_, err := useSharedClusterOrSelectDedicatedCluster("", "", orgID, "", mockCoreClient)
 		assert.ErrorIs(t, err, errMock)
-		mockClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
 	})
 }

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -1,6 +1,7 @@
 package fromfile
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"sort"
 
 	"github.com/astronomer/astro-cli/astro-client"
+	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
 	"github.com/astronomer/astro-cli/cloud/deployment/workerqueue"
@@ -39,7 +41,7 @@ const (
 // CreateOrUpdate takes a file and creates a deployment with the confiuration specified in the file.
 // inputFile can be in yaml or json format
 // It returns an error if any required information is missing or incorrectly specified.
-func CreateOrUpdate(inputFile, action string, client astro.Client, out io.Writer) error {
+func CreateOrUpdate(inputFile, action string, client astro.Client, coreClient astrocore.CoreClient, out io.Writer) error {
 	var (
 		err                                            error
 		errHelp, clusterID, workspaceID, outputFormat  string
@@ -49,7 +51,7 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, out io.Writer
 		updateInput                                    astro.UpdateDeploymentInput
 		existingDeployment, createdOrUpdatedDeployment astro.Deployment
 		existingDeployments                            []astro.Deployment
-		nodePools                                      []astro.NodePool
+		nodePools                                      []astrocore.NodePool
 		jsonOutput                                     bool
 	)
 
@@ -79,7 +81,7 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, out io.Writer
 		return err
 	}
 	// map cluster name to id and collect node pools for cluster
-	clusterID, nodePools, err = getClusterInfoFromName(formattedDeployment.Deployment.Configuration.ClusterName, c.Organization, client)
+	clusterID, nodePools, err = getClusterInfoFromName(formattedDeployment.Deployment.Configuration.ClusterName, c.Organization, coreClient)
 	if err != nil {
 		return err
 	}
@@ -163,7 +165,7 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, out io.Writer
 // It returns an error if getting default options fail.
 // It returns an error if worker-queue options are not valid.
 // It returns an error if node pool id could not be found for the worker type.
-func getCreateOrUpdateInput(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astro.Deployment, nodePools []astro.NodePool, client astro.Client) (astro.CreateDeploymentInput, astro.UpdateDeploymentInput, error) {
+func getCreateOrUpdateInput(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astro.Deployment, nodePools []astrocore.NodePool, client astro.Client) (astro.CreateDeploymentInput, astro.UpdateDeploymentInput, error) {
 	var (
 		defaultOptions astro.WorkerQueueDefaultOptions
 		listQueues     []astro.WorkerQueue
@@ -336,18 +338,37 @@ func deploymentFromName(existingDeployments []astro.Deployment, deploymentName s
 // getClusterInfoFromName takes clusterName and organizationID as its arguments.
 // It returns the clusterID and list of nodepools if the cluster is found in the organization.
 // It returns an errClusterNotFound if the cluster does not exist in the organization.
-func getClusterInfoFromName(clusterName, organizationID string, client astro.Client) (string, []astro.NodePool, error) {
+func getClusterInfoFromName(clusterName, organizationID string, coreClient astrocore.CoreClient) (string, []astrocore.NodePool, error) {
 	var (
-		existingClusters []astro.Cluster
+		existingClusters []astrocore.Cluster
 		err              error
 	)
-	existingClusters, err = client.ListClusters(organizationID)
+	c, err := config.GetCurrentContext()
 	if err != nil {
 		return "", nil, err
 	}
-	for _, cluster := range existingClusters {
+
+	clusterType := []astrocore.ListClustersParamsType{astrocore.BRINGYOUROWNCLOUD, astrocore.HOSTED}
+	limit := 1000
+	clusterListParams := &astrocore.ListClustersParams{
+		Type:  &clusterType,
+		Limit: &limit,
+	}
+
+	resp, err := coreClient.ListClustersWithResponse(context.Background(), c.OrganizationShortName, clusterListParams)
+	if err != nil {
+		return "", nil, err
+	}
+	err = astrocore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+	if err != nil {
+		return "", nil, err
+	}
+	csPaginated := *resp.JSON200
+	existingClusters = csPaginated.Clusters
+
+	for _, cluster := range existingClusters { //nolint
 		if cluster.Name == clusterName {
-			return cluster.ID, cluster.NodePools, nil
+			return cluster.Id, cluster.NodePools, nil
 		}
 	}
 	err = fmt.Errorf("cluster_name: %s %w in organization: %s", clusterName, errNotFound, organizationID)
@@ -377,14 +398,14 @@ func getWorkspaceIDFromName(workspaceName, organizationID string, client astro.C
 
 // getNodePoolIDFromWorkerType maps the node pool id in nodePools to a worker type.
 // It returns an error if the node pool id does not exist in any node pool in nodePools.
-func getNodePoolIDFromWorkerType(workerType, clusterName string, nodePools []astro.NodePool) (string, error) {
+func getNodePoolIDFromWorkerType(workerType, clusterName string, nodePools []astrocore.NodePool) (string, error) {
 	var (
-		pool astro.NodePool
+		pool astrocore.NodePool
 		err  error
 	)
-	for _, pool = range nodePools {
+	for _, pool = range nodePools { //nolint
 		if pool.NodeInstanceType == workerType {
-			return pool.ID, nil
+			return pool.Id, nil
 		}
 	}
 	err = fmt.Errorf("worker_type: %s %w in cluster: %s", workerType, errNotFound, clusterName)
@@ -421,7 +442,7 @@ func createEnvVars(deploymentFromFile *inspect.FormattedDeployment, deploymentID
 
 // getQueues takes a deploymentFromFile as its arguments.
 // It returns a list of worker queues to be created or updated.
-func getQueues(deploymentFromFile *inspect.FormattedDeployment, nodePools []astro.NodePool, existingQueues []astro.WorkerQueue) ([]astro.WorkerQueue, error) {
+func getQueues(deploymentFromFile *inspect.FormattedDeployment, nodePools []astrocore.NodePool, existingQueues []astro.WorkerQueue) ([]astro.WorkerQueue, error) {
 	var (
 		qList      []astro.WorkerQueue
 		nodePoolID string

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -3340,18 +3340,17 @@ func TestDeploymentExists(t *testing.T) {
 
 func TestGetClusterFromName(t *testing.T) {
 	var (
-		clusterName, expectedClusterID, actualClusterID, orgID string
-		actualNodePools                                        []astrocore.NodePool
-		err                                                    error
+		clusterName, expectedClusterID, actualClusterID string
+		actualNodePools                                 []astrocore.NodePool
+		err                                             error
 	)
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	expectedClusterID = "test-cluster-id"
 	clusterName = "test-cluster"
-	orgID = "test-org-id"
 	t.Run("returns a cluster id if cluster exists in organization", func(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, orgID, mockCoreClient)
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgShortName, mockCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedClusterID, actualClusterID)
 		mockCoreClient.AssertExpectations(t)
@@ -3359,7 +3358,7 @@ func TestGetClusterFromName(t *testing.T) {
 	t.Run("returns error from api if listing cluster fails", func(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&astrocore.ListClustersResponse{}, errTest).Once()
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, orgID, mockCoreClient)
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgShortName, mockCoreClient)
 		assert.ErrorIs(t, err, errTest)
 		assert.Equal(t, "", actualClusterID)
 		assert.Equal(t, []astrocore.NodePool(nil), actualNodePools)
@@ -3376,7 +3375,7 @@ func TestGetClusterFromName(t *testing.T) {
 			},
 		}
 		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, orgID, mockCoreClient)
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgShortName, mockCoreClient)
 		assert.ErrorIs(t, err, errNotFound)
 		assert.ErrorContains(t, err, "cluster_name: test-cluster does not exist in organization: test-org-id")
 		assert.Equal(t, "", actualClusterID)

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -3377,7 +3377,7 @@ func TestGetClusterFromName(t *testing.T) {
 		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgShortName, mockCoreClient)
 		assert.ErrorIs(t, err, errNotFound)
-		assert.ErrorContains(t, err, "cluster_name: test-cluster does not exist in organization: test-org-id")
+		assert.ErrorContains(t, err, "cluster_name: test-cluster does not exist in organization: test-org-short-name")
 		assert.Equal(t, "", actualClusterID)
 		assert.Equal(t, []astrocore.NodePool(nil), actualNodePools)
 		mockCoreClient.AssertExpectations(t)

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -3,9 +3,12 @@ package fromfile
 import (
 	"bytes"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/astronomer/astro-cli/astro-client"
+	astrocore "github.com/astronomer/astro-cli/astro-client-core"
+	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
 	astro_mocks "github.com/astronomer/astro-cli/astro-client/mocks"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
@@ -17,13 +20,53 @@ import (
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 )
 
-var errTest = errors.New("test error")
+const (
+	mockOrgShortName = "test-org-short-name"
+)
+
+var (
+	errTest           = errors.New("test error")
+	limit             = 1000
+	clusterType       = []astrocore.ListClustersParamsType{astrocore.BRINGYOUROWNCLOUD, astrocore.HOSTED}
+	clusterListParams = &astrocore.ListClustersParams{
+		Type:  &clusterType,
+		Limit: &limit,
+	}
+	mockListClustersResponse = astrocore.ListClustersResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &astrocore.ClustersPaginated{
+			Clusters: []astrocore.Cluster{
+				{
+					Id:   "test-cluster-id",
+					Name: "test-cluster",
+					NodePools: []astrocore.NodePool{
+						{
+							Id:               "test-pool-id",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-1",
+						},
+						{
+							Id:               "test-pool-id-2",
+							IsDefault:        false,
+							NodeInstanceType: "test-worker-2",
+						},
+					},
+				},
+				{
+					Id:   "test-cluster-id-1",
+					Name: "test-cluster-1",
+				},
+			},
+		},
+	}
+)
 
 func TestCreateOrUpdate(t *testing.T) {
 	var (
 		err                           error
 		filePath, data, orgID         string
-		existingClusters              []astro.Cluster
 		existingWorkspaces            []astro.Workspace
 		mockWorkerQueueDefaultOptions astro.WorkerQueueDefaultOptions
 		emails                        []string
@@ -33,7 +76,7 @@ func TestCreateOrUpdate(t *testing.T) {
 
 	t.Run("common across create or update", func(t *testing.T) {
 		t.Run("returns an error if file does not exist", func(t *testing.T) {
-			err = CreateOrUpdate("deployment.yaml", "create", nil, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil)
 			assert.ErrorContains(t, err, "open deployment.yaml: no such file or directory")
 		})
 		t.Run("returns an error if file exists but user provides incorrect path", func(t *testing.T) {
@@ -42,7 +85,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			err = fileutil.WriteStringToFile(filePath, data)
 			assert.NoError(t, err)
 			defer afero.NewOsFs().RemoveAll("./2")
-			err = CreateOrUpdate("1/deployment.yaml", "create", nil, nil)
+			err = CreateOrUpdate("1/deployment.yaml", "create", nil, nil, nil)
 			assert.ErrorContains(t, err, "open 1/deployment.yaml: no such file or directory")
 		})
 		t.Run("returns an error if file is empty", func(t *testing.T) {
@@ -50,7 +93,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			data = ""
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			err = CreateOrUpdate("deployment.yaml", "create", nil, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil)
 			assert.ErrorIs(t, err, errEmptyFile)
 			assert.ErrorContains(t, err, "deployment.yaml has no content")
 		})
@@ -59,7 +102,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			data = "test"
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			err = CreateOrUpdate("deployment.yaml", "create", nil, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil)
 			assert.ErrorContains(t, err, "error unmarshaling JSON:")
 		})
 		t.Run("returns an error if required fields are missing", func(t *testing.T) {
@@ -112,12 +155,13 @@ deployment:
 `
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			err = CreateOrUpdate("deployment.yaml", "create", nil, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil)
 			assert.ErrorContains(t, err, "missing required field: deployment.configuration.name")
 		})
 		t.Run("returns an error if getting context fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.ErrorReturningContext)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `
 deployment:
@@ -171,13 +215,14 @@ deployment:
 
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorContains(t, err, "no context set")
 			mockClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if cluster does not exist", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `
 deployment:
@@ -228,16 +273,6 @@ deployment:
     - test1@test.com
     - test2@test.com
 `
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -251,14 +286,16 @@ deployment:
 			orgID = "test-org-id"
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorIs(t, err, errNotFound)
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if listing cluster fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `
 deployment:
@@ -322,14 +359,16 @@ deployment:
 			}
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return([]astro.Cluster{}, errTest)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&astrocore.ListClustersResponse{}, errTest).Once()
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorIs(t, err, errTest)
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if listing deployment fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `
 deployment:
@@ -380,16 +419,6 @@ deployment:
     - test1@test.com
     - test2@test.com
 `
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -403,15 +432,17 @@ deployment:
 			orgID = "test-org-id"
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, errTest)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorIs(t, err, errTest)
+			mockClient.AssertExpectations(t)
 			mockClient.AssertExpectations(t)
 		})
 		t.Run("does not update environment variables if input is empty", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			out := new(bytes.Buffer)
 			filePath = "./deployment.yaml"
 			data = `{
@@ -464,28 +495,6 @@ deployment:
         ]
     }
 }`
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -521,20 +530,22 @@ deployment:
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
 			mockClient.On("ListWorkspaces", orgID).Return(existingWorkspaces, nil)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil).Once()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{}, nil)
 			mockClient.On("UpdateAlertEmails", mock.Anything).Return(astro.DeploymentAlerts{}, nil)
 			mockClient.On("ListDeployments", orgID, "test-workspace-id").Return([]astro.Deployment{createdDeployment}, nil)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, out)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, out)
 			assert.NoError(t, err)
 			assert.NotNil(t, out)
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("does not update alert emails if input is empty", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			out := new(bytes.Buffer)
 			filePath = "./deployment.yaml"
 			data = `
@@ -584,28 +595,6 @@ deployment:
     webserver_url: some-url
   alert_emails: []
 `
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -641,20 +630,22 @@ deployment:
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
 			mockClient.On("ListWorkspaces", orgID).Return(existingWorkspaces, nil)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil).Once()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{}, nil)
 			mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, nil)
 			mockClient.On("ListDeployments", orgID, "test-workspace-id").Return([]astro.Deployment{createdDeployment}, nil)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, out)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, out)
 			assert.NoError(t, err)
 			assert.NotNil(t, out)
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error from the api if creating environment variables fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `{
     "deployment": {
@@ -719,28 +710,6 @@ deployment:
         ]
     }
 }`
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -772,19 +741,21 @@ deployment:
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
 			mockClient.On("ListWorkspaces", orgID).Return(existingWorkspaces, nil)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil)
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{}, nil)
 			mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, errTest)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorIs(t, err, errTest)
 			assert.ErrorContains(t, err, "\n failed to create alert emails")
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error from the api if creating alert emails fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `{
     "deployment": {
@@ -849,28 +820,6 @@ deployment:
         ]
     }
 }`
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -902,15 +851,16 @@ deployment:
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
 			mockClient.On("ListWorkspaces", orgID).Return(existingWorkspaces, nil)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil)
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{}, nil)
 			mockClient.On("ModifyDeploymentVariable", mock.Anything).Return([]astro.EnvironmentVariablesObject{}, nil)
 			mockClient.On("UpdateAlertEmails", mock.Anything).Return(astro.DeploymentAlerts{}, errTest)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorIs(t, err, errTest)
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 	})
 	t.Run("when action is create", func(t *testing.T) {
@@ -918,6 +868,7 @@ deployment:
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `
 deployment:
@@ -968,28 +919,6 @@ deployment:
     - test1@test.com
     - test2@test.com
 `
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -1041,23 +970,25 @@ deployment:
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
 			mockClient.On("ListWorkspaces", orgID).Return(existingWorkspaces, nil)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil).Once()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("CreateDeployment", mock.Anything).Return(createdDeployment, nil)
 			mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockEnvVarResponse, nil)
 			mockClient.On("UpdateAlertEmails", mock.Anything).Return(mockAlertEmailResponse, nil)
 			mockClient.On("ListDeployments", orgID, "test-workspace-id").Return([]astro.Deployment{createdDeployment}, nil)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, out)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, out)
 			assert.NoError(t, err)
 			assert.Contains(t, out.String(), "configuration:\n        name: "+createdDeployment.Label)
 			assert.Contains(t, out.String(), "metadata:\n        deployment_id: "+createdDeployment.ID)
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("reads the json file and creates a deployment", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `{
     "deployment": {
@@ -1122,28 +1053,6 @@ deployment:
         ]
     }
 }`
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -1195,22 +1104,24 @@ deployment:
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
 			mockClient.On("ListWorkspaces", orgID).Return(existingWorkspaces, nil)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil).Once()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("CreateDeployment", mock.Anything).Return(createdDeployment, nil)
 			mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockEnvVarResponse, nil)
 			mockClient.On("UpdateAlertEmails", mock.Anything).Return(mockAlertEmailResponse, nil)
 			mockClient.On("ListDeployments", orgID, "test-workspace-id").Return([]astro.Deployment{createdDeployment}, nil)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, out)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, out)
 			assert.NoError(t, err)
 			assert.Contains(t, out.String(), "\"configuration\": {\n            \"name\": \""+createdDeployment.Label+"\"")
 			assert.Contains(t, out.String(), "\"metadata\": {\n            \"deployment_id\": \""+createdDeployment.ID+"\"")
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if workspace does not exist", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `
 deployment:
@@ -1262,40 +1173,20 @@ deployment:
     - test2@test.com
 `
 			orgID = "test-org-id"
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil)
 			mockClient.On("ListWorkspaces", orgID).Return([]astro.Workspace{}, nil)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorIs(t, err, errNotFound)
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if listing workspace fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `
 deployment:
@@ -1347,39 +1238,19 @@ deployment:
     - test2@test.com
 `
 			orgID = "test-org-id"
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil)
 			mockClient.On("ListWorkspaces", orgID).Return([]astro.Workspace{}, errTest)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorIs(t, err, errTest)
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if deployment already exists", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			existingDeployments := []astro.Deployment{
 				{
 					Label:       "test-deployment-label",
@@ -1451,29 +1322,21 @@ deployment:
     - test1@test.com
     - test2@test.com
 `
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			orgID = "test-org-id"
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
 			mockClient.On("ListWorkspaces", orgID).Return(existingWorkspaces, nil)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return(existingDeployments, nil)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorContains(t, err, "deployment: test-deployment-label already exists: use deployment update --deployment-file deployment.yaml instead")
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if creating deployment input fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `{
     "deployment": {
@@ -1538,28 +1401,6 @@ deployment:
         ]
     }
 }`
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -1591,17 +1432,19 @@ deployment:
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
 			mockClient.On("ListWorkspaces", orgID).Return(existingWorkspaces, nil)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil)
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "worker queue option is invalid: worker concurrency")
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error from the api if create deployment fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `{
     "deployment": {
@@ -1666,28 +1509,6 @@ deployment:
         ]
     }
 }`
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -1719,14 +1540,15 @@ deployment:
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
 			mockClient.On("ListWorkspaces", orgID).Return(existingWorkspaces, nil)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil)
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("CreateDeployment", mock.Anything).Return(astro.Deployment{}, errTest)
-			err = CreateOrUpdate("deployment.yaml", "create", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "create", mockClient, mockCoreClient, nil)
 			assert.ErrorIs(t, err, errCreateFailed)
 			assert.ErrorContains(t, err, "test error: failed to create deployment with input")
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 	})
 	t.Run("when action is update", func(t *testing.T) {
@@ -1734,6 +1556,7 @@ deployment:
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `
 deployment:
@@ -1784,28 +1607,6 @@ deployment:
     - test1@test.com
     - test2@test.com
 `
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -1878,24 +1679,26 @@ deployment:
 			}
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{existingDeployment}, nil).Once()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", mock.Anything).Return(updatedDeployment, nil)
 			mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockEnvVarResponse, nil)
 			mockClient.On("UpdateAlertEmails", mock.Anything).Return(mockAlertEmailResponse, nil)
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{updatedDeployment}, nil)
-			err = CreateOrUpdate("deployment.yaml", "update", mockClient, out)
+			err = CreateOrUpdate("deployment.yaml", "update", mockClient, mockCoreClient, out)
 			assert.NoError(t, err)
 			assert.Contains(t, out.String(), "configuration:\n        name: "+existingDeployment.Label)
 			assert.Contains(t, out.String(), "\n        description: "+updatedDeployment.Description)
 			assert.Contains(t, out.String(), "metadata:\n        deployment_id: "+existingDeployment.ID)
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("reads the json file and updates an existing deployment", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `{
     "deployment": {
@@ -1960,28 +1763,6 @@ deployment:
         ]
     }
 }`
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -2054,19 +1835,20 @@ deployment:
 			}
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{existingDeployment}, nil).Once()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", mock.Anything).Return(updatedDeployment, nil)
 			mockClient.On("ModifyDeploymentVariable", mock.Anything).Return(mockEnvVarResponse, nil)
 			mockClient.On("UpdateAlertEmails", mock.Anything).Return(mockAlertEmailResponse, nil)
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{updatedDeployment}, nil)
-			err = CreateOrUpdate("deployment.yaml", "update", mockClient, out)
+			err = CreateOrUpdate("deployment.yaml", "update", mockClient, mockCoreClient, out)
 			assert.NoError(t, err)
 			assert.Contains(t, out.String(), "\"configuration\": {\n            \"name\": \""+existingDeployment.Label+"\"")
 			assert.Contains(t, out.String(), "\n            \"description\": \""+updatedDeployment.Description+"\"")
 			assert.Contains(t, out.String(), "\"metadata\": {\n            \"deployment_id\": \""+existingDeployment.ID+"\"")
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if deployment does not exist", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
@@ -2081,6 +1863,7 @@ deployment:
 				},
 			}
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `
 deployment:
@@ -2131,28 +1914,20 @@ deployment:
     - test1@test.com
     - test2@test.com
 `
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			orgID = "test-org-id"
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil)
-			err = CreateOrUpdate("deployment.yaml", "update", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "update", mockClient, mockCoreClient, nil)
 			assert.ErrorContains(t, err, "deployment: test-deployment-label does not exist: use deployment create --deployment-file deployment.yaml instead")
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if creating update deployment input fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `{
     "deployment": {
@@ -2217,28 +1992,6 @@ deployment:
         ]
     }
 }`
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -2274,17 +2027,19 @@ deployment:
 			}
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{existingDeployment}, nil)
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-			err = CreateOrUpdate("deployment.yaml", "update", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "update", mockClient, mockCoreClient, nil)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "worker queue option is invalid: worker concurrency")
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error from the api if update deployment fails", func(t *testing.T) {
 			testUtil.InitTestConfig(testUtil.CloudPlatform)
 			mockClient := new(astro_mocks.Client)
+			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
 			data = `{
     "deployment": {
@@ -2349,28 +2104,6 @@ deployment:
         ]
     }
 }`
-			existingClusters = []astro.Cluster{
-				{
-					ID:   "test-cluster-id",
-					Name: "test-cluster",
-					NodePools: []astro.NodePool{
-						{
-							ID:               "test-pool-id",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-1",
-						},
-						{
-							ID:               "test-pool-id-2",
-							IsDefault:        false,
-							NodeInstanceType: "test-worker-2",
-						},
-					},
-				},
-				{
-					ID:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			}
 			existingWorkspaces = []astro.Workspace{
 				{
 					ID:    "test-workspace-id",
@@ -2422,14 +2155,15 @@ deployment:
 			}
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
-			mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
+			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{existingDeployment}, nil)
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
 			mockClient.On("UpdateDeployment", mock.Anything).Return(astro.Deployment{}, errTest)
-			err = CreateOrUpdate("deployment.yaml", "update", mockClient, nil)
+			err = CreateOrUpdate("deployment.yaml", "update", mockClient, mockCoreClient, nil)
 			assert.ErrorIs(t, err, errUpdateFailed)
 			assert.ErrorContains(t, err, "test error: failed to update deployment with input")
 			mockClient.AssertExpectations(t)
+			mockCoreClient.AssertExpectations(t)
 		})
 	})
 }
@@ -2440,7 +2174,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 		expectedUpdateDeploymentInput, actualUpdateInput astro.UpdateDeploymentInput
 		deploymentFromFile                               inspect.FormattedDeployment
 		qList                                            []inspect.Workerq
-		existingPools                                    []astro.NodePool
+		existingPools                                    []astrocore.NodePool
 		expectedQList                                    []astro.WorkerQueue
 		clusterID, workspaceID, deploymentID             string
 		err                                              error
@@ -2477,14 +2211,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				},
 			}
 			deploymentFromFile.Deployment.WorkerQs = qList
-			existingPools = []astro.NodePool{
+			existingPools = []astrocore.NodePool{
 				{
-					ID:               "test-pool-id",
+					Id:               "test-pool-id",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-1",
 				},
 				{
-					ID:               "test-pool-id-2",
+					Id:               "test-pool-id-2",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-2",
 				},
@@ -2544,14 +2278,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					},
 				}
 				deploymentFromFile.Deployment.WorkerQs = qList
-				existingPools = []astro.NodePool{
+				existingPools = []astrocore.NodePool{
 					{
-						ID:               "test-pool-id",
+						Id:               "test-pool-id",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-1",
 					},
 					{
-						ID:               "test-pool-id-2",
+						Id:               "test-pool-id-2",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-2",
 					},
@@ -2611,14 +2345,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					},
 				}
 				deploymentFromFile.Deployment.WorkerQs = qList
-				existingPools = []astro.NodePool{
+				existingPools = []astrocore.NodePool{
 					{
-						ID:               "test-pool-id",
+						Id:               "test-pool-id",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-1",
 					},
 					{
-						ID:               "test-pool-id-2",
+						Id:               "test-pool-id-2",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-2",
 					},
@@ -2655,14 +2389,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					},
 				}
 				deploymentFromFile.Deployment.WorkerQs = qList
-				existingPools = []astro.NodePool{
+				existingPools = []astrocore.NodePool{
 					{
-						ID:               "test-pool-id",
+						Id:               "test-pool-id",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-1",
 					},
 					{
-						ID:               "test-pool-id-2",
+						Id:               "test-pool-id-2",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-2",
 					},
@@ -2749,14 +2483,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					},
 				}
 				deploymentFromFile.Deployment.WorkerQs = qList
-				existingPools = []astro.NodePool{
+				existingPools = []astrocore.NodePool{
 					{
-						ID:               "test-pool-id",
+						Id:               "test-pool-id",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-1",
 					},
 					{
-						ID:               "test-pool-id-2",
+						Id:               "test-pool-id-2",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-2",
 					},
@@ -2787,14 +2521,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					},
 				}
 				deploymentFromFile.Deployment.WorkerQs = qList
-				existingPools = []astro.NodePool{
+				existingPools = []astrocore.NodePool{
 					{
-						ID:               "test-pool-id",
+						Id:               "test-pool-id",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-1",
 					},
 					{
-						ID:               "test-pool-id-2",
+						Id:               "test-pool-id-2",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-2",
 					},
@@ -2824,14 +2558,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					},
 				}
 				deploymentFromFile.Deployment.WorkerQs = qList
-				existingPools = []astro.NodePool{
+				existingPools = []astrocore.NodePool{
 					{
-						ID:               "test-pool-id",
+						Id:               "test-pool-id",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-1",
 					},
 					{
-						ID:               "test-pool-id-2",
+						Id:               "test-pool-id-2",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-2",
 					},
@@ -2861,14 +2595,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					},
 				}
 				deploymentFromFile.Deployment.WorkerQs = qList
-				existingPools = []astro.NodePool{
+				existingPools = []astrocore.NodePool{
 					{
-						ID:               "test-pool-id",
+						Id:               "test-pool-id",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-1",
 					},
 					{
-						ID:               "test-pool-id-2",
+						Id:               "test-pool-id-2",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-2",
 					},
@@ -2898,14 +2632,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					},
 				}
 				deploymentFromFile.Deployment.WorkerQs = qList
-				existingPools = []astro.NodePool{
+				existingPools = []astrocore.NodePool{
 					{
-						ID:               "test-pool-id",
+						Id:               "test-pool-id",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-1",
 					},
 					{
-						ID:               "test-pool-id-2",
+						Id:               "test-pool-id-2",
 						IsDefault:        false,
 						NodeInstanceType: "test-worker-2",
 					},
@@ -2977,14 +2711,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					NodePoolID: "test-pool-id",
 				},
 			}
-			existingPools = []astro.NodePool{
+			existingPools = []astrocore.NodePool{
 				{
-					ID:               "test-pool-id",
+					Id:               "test-pool-id",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-1",
 				},
 				{
-					ID:               "test-pool-id-2",
+					Id:               "test-pool-id-2",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-2",
 				},
@@ -3039,14 +2773,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				},
 			}
 			deploymentFromFile.Deployment.WorkerQs = qList
-			existingPools = []astro.NodePool{
+			existingPools = []astrocore.NodePool{
 				{
-					ID:               "test-pool-id",
+					Id:               "test-pool-id",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-1",
 				},
 				{
-					ID:               "test-pool-id-2",
+					Id:               "test-pool-id-2",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-2",
 				},
@@ -3191,7 +2925,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
 
-			existingPools = []astro.NodePool{
+			existingPools := []astro.NodePool{
 				{
 					ID:               "test-pool-id",
 					IsDefault:        false,
@@ -3262,7 +2996,19 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					NodePoolID: "test-pool-id",
 				},
 			}
-			existingPools = []astro.NodePool{
+			existingPools = []astrocore.NodePool{
+				{
+					Id:               "test-pool-id",
+					IsDefault:        false,
+					NodeInstanceType: "test-worker-1",
+				},
+				{
+					Id:               "test-pool-id-2",
+					IsDefault:        false,
+					NodeInstanceType: "test-worker-2",
+				},
+			}
+			existingPools1 := []astro.NodePool{
 				{
 					ID:               "test-pool-id",
 					IsDefault:        false,
@@ -3280,7 +3026,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				Cluster: astro.Cluster{
 					ID:        "test-cluster-id",
 					Name:      "test-cluster",
-					NodePools: existingPools,
+					NodePools: existingPools1,
 				},
 				DeploymentSpec: astro.DeploymentSpec{
 					Executor: deployment.CeleryExecutor,
@@ -3338,14 +3084,14 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				},
 			}
 			deploymentFromFile.Deployment.WorkerQs = qList
-			existingPools = []astro.NodePool{
+			existingPools = []astrocore.NodePool{
 				{
-					ID:               "test-pool-id",
+					Id:               "test-pool-id",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-1",
 				},
 				{
-					ID:               "test-pool-id-2",
+					Id:               "test-pool-id-2",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-2",
 				},
@@ -3595,62 +3341,47 @@ func TestDeploymentExists(t *testing.T) {
 func TestGetClusterFromName(t *testing.T) {
 	var (
 		clusterName, expectedClusterID, actualClusterID, orgID string
-		existingPools, actualNodePools                         []astro.NodePool
+		actualNodePools                                        []astrocore.NodePool
 		err                                                    error
 	)
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	expectedClusterID = "test-cluster-id"
 	clusterName = "test-cluster"
-	existingPools = []astro.NodePool{
-		{
-			ID:               "test-pool-id",
-			IsDefault:        false,
-			NodeInstanceType: "worker-1",
-		},
-		{
-			ID:               "test-pool-id",
-			IsDefault:        false,
-			NodeInstanceType: "worker-2",
-		},
-	}
 	orgID = "test-org-id"
 	t.Run("returns a cluster id if cluster exists in organization", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		existingClusters := []astro.Cluster{
-			{
-				ID:        "test-cluster-id",
-				Name:      "test-cluster",
-				NodePools: existingPools,
-			},
-			{
-				ID:   "test-cluster-id-1",
-				Name: "test-cluster-1",
-			},
-		}
-		mockClient.On("ListClusters", orgID).Return(existingClusters, nil)
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, orgID, mockClient)
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, orgID, mockCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedClusterID, actualClusterID)
-		mockClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
 	})
 	t.Run("returns error from api if listing cluster fails", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{}, errTest)
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, orgID, mockClient)
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&astrocore.ListClustersResponse{}, errTest).Once()
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, orgID, mockCoreClient)
 		assert.ErrorIs(t, err, errTest)
 		assert.Equal(t, "", actualClusterID)
-		assert.Equal(t, []astro.NodePool(nil), actualNodePools)
-		mockClient.AssertExpectations(t)
+		assert.Equal(t, []astrocore.NodePool(nil), actualNodePools)
+		mockCoreClient.AssertExpectations(t)
 	})
 	t.Run("returns an error if cluster does not exist in organization", func(t *testing.T) {
-		mockClient := new(astro_mocks.Client)
-		mockClient.On("ListClusters", orgID).Return([]astro.Cluster{}, nil)
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, orgID, mockClient)
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockListClustersResponse = astrocore.ListClustersResponse{
+			HTTPResponse: &http.Response{
+				StatusCode: 200,
+			},
+			JSON200: &astrocore.ClustersPaginated{
+				Clusters: []astrocore.Cluster{},
+			},
+		}
+		mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, orgID, mockCoreClient)
 		assert.ErrorIs(t, err, errNotFound)
 		assert.ErrorContains(t, err, "cluster_name: test-cluster does not exist in organization: test-org-id")
 		assert.Equal(t, "", actualClusterID)
-		assert.Equal(t, []astro.NodePool(nil), actualNodePools)
-		mockClient.AssertExpectations(t)
+		assert.Equal(t, []astrocore.NodePool(nil), actualNodePools)
+		mockCoreClient.AssertExpectations(t)
 	})
 }
 
@@ -3704,21 +3435,21 @@ func TestGetWorkspaceIDFromName(t *testing.T) {
 func TestGetNodePoolIDFromName(t *testing.T) {
 	var (
 		workerType, expectedPoolID, actualPoolID, clusterID string
-		existingPools                                       []astro.NodePool
+		existingPools                                       []astrocore.NodePool
 		err                                                 error
 	)
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	expectedPoolID = "test-pool-id"
 	workerType = "worker-1"
 	clusterID = "test-cluster-id"
-	existingPools = []astro.NodePool{
+	existingPools = []astrocore.NodePool{
 		{
-			ID:               "test-pool-id",
+			Id:               "test-pool-id",
 			IsDefault:        false,
 			NodeInstanceType: "worker-1",
 		},
 		{
-			ID:               "test-pool-id",
+			Id:               "test-pool-id",
 			IsDefault:        false,
 			NodeInstanceType: "worker-2",
 		},
@@ -3904,7 +3635,7 @@ func TestGetQueues(t *testing.T) {
 	var (
 		deploymentFromFile           inspect.FormattedDeployment
 		actualWQList, existingWQList []astro.WorkerQueue
-		existingPools                []astro.NodePool
+		existingPools                []astrocore.NodePool
 		err                          error
 	)
 	t.Run("when the executor is celery", func(t *testing.T) {
@@ -3944,14 +3675,14 @@ func TestGetQueues(t *testing.T) {
 					WorkerType:        "test-worker-2",
 				},
 			}
-			existingPools = []astro.NodePool{
+			existingPools = []astrocore.NodePool{
 				{
-					ID:               "test-pool-id",
+					Id:               "test-pool-id",
 					IsDefault:        true,
 					NodeInstanceType: "test-worker-1",
 				},
 				{
-					ID:               "test-pool-id-2",
+					Id:               "test-pool-id-2",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-2",
 				},
@@ -4012,14 +3743,14 @@ func TestGetQueues(t *testing.T) {
 					WorkerType:        "test-worker-2",
 				},
 			}
-			existingPools = []astro.NodePool{
+			existingPools = []astrocore.NodePool{
 				{
-					ID:               "test-pool-id",
+					Id:               "test-pool-id",
 					IsDefault:        true,
 					NodeInstanceType: "test-worker-1",
 				},
 				{
-					ID:               "test-pool-id-2",
+					Id:               "test-pool-id-2",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-2",
 				},
@@ -4089,14 +3820,14 @@ func TestGetQueues(t *testing.T) {
 					WorkerType:        "test-worker-2",
 				},
 			}
-			existingPools = []astro.NodePool{
+			existingPools = []astrocore.NodePool{
 				{
-					ID:               "test-pool-id",
+					Id:               "test-pool-id",
 					IsDefault:        true,
 					NodeInstanceType: "test-worker-1",
 				},
 				{
-					ID:               "test-pool-id-2",
+					Id:               "test-pool-id-2",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-2",
 				},
@@ -4147,14 +3878,14 @@ func TestGetQueues(t *testing.T) {
 					WorkerType: "test-worker-1",
 				},
 			}
-			existingPools = []astro.NodePool{
+			existingPools = []astrocore.NodePool{
 				{
-					ID:               "test-pool-id",
+					Id:               "test-pool-id",
 					IsDefault:        true,
 					NodeInstanceType: "test-worker-1",
 				},
 				{
-					ID:               "test-pool-id-2",
+					Id:               "test-pool-id-2",
 					IsDefault:        false,
 					NodeInstanceType: "test-worker-2",
 				},
@@ -4185,14 +3916,14 @@ func TestGetQueues(t *testing.T) {
 				WorkerType:        "test-worker-4",
 			},
 		}
-		existingPools = []astro.NodePool{
+		existingPools = []astrocore.NodePool{
 			{
-				ID:               "test-pool-id",
+				Id:               "test-pool-id",
 				IsDefault:        true,
 				NodeInstanceType: "test-worker-1",
 			},
 			{
-				ID:               "test-pool-id-2",
+				Id:               "test-pool-id-2",
 				IsDefault:        false,
 				NodeInstanceType: "test-worker-2",
 			},

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -192,3 +192,24 @@ func IsOrgHosted() bool {
 	c, _ := context.GetCurrentContext()
 	return c.OrganizationProduct == "HOSTED"
 }
+
+func ListClusters(organizationShortName string, coreClient astrocore.CoreClient) ([]astrocore.Cluster, error) {
+	clusterType := []astrocore.ListClustersParamsType{astrocore.BRINGYOUROWNCLOUD, astrocore.HOSTED}
+	limit := 1000
+	clusterListParams := &astrocore.ListClustersParams{
+		Type:  &clusterType,
+		Limit: &limit,
+	}
+	resp, err := coreClient.ListClustersWithResponse(http_context.Background(), organizationShortName, clusterListParams)
+	if err != nil {
+		return nil, err
+	}
+	err = astrocore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	csPaginated := *resp.JSON200
+	cs := csPaginated.Clusters
+
+	return cs, nil
+}

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -355,7 +355,7 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error {
 			return errFlag
 		}
 
-		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), astroClient, out)
+		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), astroClient, astroCoreClient, out)
 	}
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {
 		return errors.New("Invalid --dag-deploy value)")
@@ -402,7 +402,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, out io.Writer) error {
 			// other flags were requested
 			return errFlag
 		}
-		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), astroClient, out)
+		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), astroClient, astroCoreClient, out)
 	}
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {
 		return errors.New("Invalid --dag-deploy value")

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -24,6 +24,26 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+var (
+	mockListClustersResponse = astrocore.ListClustersResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &astrocore.ClustersPaginated{
+			Clusters: []astrocore.Cluster{
+				{
+					Id:   "test-cluster-id",
+					Name: "test-cluster",
+				},
+				{
+					Id:   "test-cluster-id-1",
+					Name: "test-cluster-1",
+				},
+			},
+		},
+	}
+)
+
 func execDeploymentCmd(args ...string) (string, error) {
 	buf := new(bytes.Buffer)
 	cmd := newDeploymentRootCmd(buf)
@@ -90,26 +110,6 @@ func TestDeploymentCreate(t *testing.T) {
 	csID := "test-cluster-id"
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
-	// var (
-	// 	mockListClustersResponse = astrocore.ListClustersResponse{
-	// 		HTTPResponse: &http.Response{
-	// 			StatusCode: 200,
-	// 		},
-	// 		JSON200: &astrocore.ClustersPaginated{
-	// 			Clusters: []astrocore.Cluster{
-	// 				{
-	// 					Id:   "test-cluster-id",
-	// 					Name: "test-cluster",
-	// 				},
-	// 				{
-	// 					Id:   "test-cluster-id-1",
-	// 					Name: "test-cluster-1",
-	// 				},
-	// 			},
-	// 		},
-	// 	}
-	// )
-
 	deploymentCreateInput := astro.CreateDeploymentInput{
 		WorkspaceID:           ws,
 		ClusterID:             csID,
@@ -164,23 +164,6 @@ func TestDeploymentCreate(t *testing.T) {
 		},
 	}, nil).Times(10)
 	mockClient.On("ListWorkspaces", "test-org-id").Return([]astro.Workspace{{ID: ws, OrganizationID: "test-org-id", Label: "test-ws"}}, nil).Times(5)
-	mockListClustersResponse := astrocore.ListClustersResponse{
-		HTTPResponse: &http.Response{
-			StatusCode: 200,
-		},
-		JSON200: &astrocore.ClustersPaginated{
-			Clusters: []astrocore.Cluster{
-				{
-					Id:   "test-cluster-id",
-					Name: "test-cluster",
-				},
-				{
-					Id:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
-			},
-		},
-	}
 	mockCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(4)
 	mockClient.On("CreateDeployment", &deploymentCreateInput).Return(astro.Deployment{ID: "test-id"}, nil).Twice()
 	mockClient.On("CreateDeployment", &deploymentCreateInput1).Return(astro.Deployment{ID: "test-id"}, nil).Times(6)

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -24,25 +24,23 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var (
-	mockListClustersResponse = astrocore.ListClustersResponse{
-		HTTPResponse: &http.Response{
-			StatusCode: 200,
-		},
-		JSON200: &astrocore.ClustersPaginated{
-			Clusters: []astrocore.Cluster{
-				{
-					Id:   "test-cluster-id",
-					Name: "test-cluster",
-				},
-				{
-					Id:   "test-cluster-id-1",
-					Name: "test-cluster-1",
-				},
+var mockListClustersResponse = astrocore.ListClustersResponse{
+	HTTPResponse: &http.Response{
+		StatusCode: 200,
+	},
+	JSON200: &astrocore.ClustersPaginated{
+		Clusters: []astrocore.Cluster{
+			{
+				Id:   "test-cluster-id",
+				Name: "test-cluster",
+			},
+			{
+				Id:   "test-cluster-id-1",
+				Name: "test-cluster-1",
 			},
 		},
-	}
-)
+	},
+}
 
 func execDeploymentCmd(args ...string) (string, error) {
 	buf := new(bytes.Buffer)
@@ -369,7 +367,6 @@ deployment:
 			},
 			JSON200: &astrocore.SharedCluster{Id: csID},
 		}
-		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		astroCoreClient = mockCoreClient
 		mockCoreClient.On("GetSharedClusterWithResponse", mock.Anything, mock.Anything).Return(mockOKResponse, nil).Once()
 		cmdArgs := []string{


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Use core-api list clusters endpoint to display list of clusters on creating a deployment

## 🎟 Issue(s)

Related astronomer/astro#12938

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
