### PR TITLE
fix to display error with no deployments on delete

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -366,7 +366,7 @@ func getDeploymentInfo(deploymentID, wsID, deploymentName string, prompt bool, c
 
 	// check if deploymentID or if force prompt was requested was given by user
 	if deploymentID == "" || prompt {
-		currentDeployment, err := deployment.GetDeployment(wsID, deploymentID, deploymentName, client, nil)
+		currentDeployment, err := deployment.GetDeployment(wsID, deploymentID, deploymentName, false, client, nil)
 		if err != nil {
 			return deploymentInfo{}, err
 		}

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -154,7 +154,7 @@ func TestGetDeployment(t *testing.T) {
 	t.Run("invalid deployment ID", func(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
-		_, err := GetDeployment(ws, deploymentID, "", mockClient, nil)
+		_, err := GetDeployment(ws, deploymentID, "", false, mockClient, nil)
 		assert.ErrorIs(t, err, errInvalidDeployment)
 		mockClient.AssertExpectations(t)
 	})
@@ -163,7 +163,7 @@ func TestGetDeployment(t *testing.T) {
 	t.Run("error after invalid deployment Name", func(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{Label: "test", ID: "test-id"}}, nil).Once()
 
-		_, err := GetDeployment(ws, "", deploymentName, mockClient, nil)
+		_, err := GetDeployment(ws, "", deploymentName, false, mockClient, nil)
 		assert.ErrorIs(t, err, errInvalidDeployment)
 		mockClient.AssertExpectations(t)
 	})
@@ -171,7 +171,7 @@ func TestGetDeployment(t *testing.T) {
 	t.Run("correct deployment ID", func(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
-		deployment, err := GetDeployment(ws, deploymentID, "", mockClient, nil)
+		deployment, err := GetDeployment(ws, deploymentID, "", false, mockClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, deploymentID, deployment.ID)
 		mockClient.AssertExpectations(t)
@@ -180,7 +180,7 @@ func TestGetDeployment(t *testing.T) {
 	t.Run("correct deployment Name", func(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{Label: "test"}}, nil).Once()
 
-		deployment, err := GetDeployment(ws, "", deploymentName, mockClient, nil)
+		deployment, err := GetDeployment(ws, "", deploymentName, false, mockClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, deploymentName, deployment.Label)
 		mockClient.AssertExpectations(t)
@@ -205,7 +205,7 @@ func TestGetDeployment(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		deployment, err := GetDeployment(ws, "", deploymentName, mockClient, nil)
+		deployment, err := GetDeployment(ws, "", deploymentName, false, mockClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, deploymentName, deployment.Label)
 		mockClient.AssertExpectations(t)
@@ -214,7 +214,7 @@ func TestGetDeployment(t *testing.T) {
 	t.Run("deployment name and deployment id", func(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id"}}, nil).Once()
 
-		deployment, err := GetDeployment(ws, deploymentID, deploymentName, mockClient, nil)
+		deployment, err := GetDeployment(ws, deploymentID, deploymentName, false, mockClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, deploymentID, deployment.ID)
 		mockClient.AssertExpectations(t)
@@ -223,7 +223,7 @@ func TestGetDeployment(t *testing.T) {
 	t.Run("bad deployment call", func(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{}, errMock).Once()
 
-		_, err := GetDeployment(ws, deploymentID, "", mockClient, nil)
+		_, err := GetDeployment(ws, deploymentID, "", false, mockClient, nil)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -266,7 +266,7 @@ func TestGetDeployment(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		_, err = GetDeployment(ws, "", "", mockClient, nil)
+		_, err = GetDeployment(ws, "", "", false, mockClient, nil)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -309,7 +309,7 @@ func TestGetDeployment(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		_, err = GetDeployment(ws, "", "", mockClient, nil)
+		_, err = GetDeployment(ws, "", "", false, mockClient, nil)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})
@@ -353,7 +353,7 @@ func TestGetDeployment(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		deployment, err := GetDeployment(ws, "", "", mockClient, nil)
+		deployment, err := GetDeployment(ws, "", "", false, mockClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, deploymentID, deployment.ID)
 		mockClient.AssertExpectations(t)
@@ -362,7 +362,7 @@ func TestGetDeployment(t *testing.T) {
 		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{}, nil).Once()
 		mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{}, errMock).Once()
 
-		_, err := GetDeployment(ws, "", "", mockClient, nil)
+		_, err := GetDeployment(ws, "", "", false, mockClient, nil)
 		assert.ErrorIs(t, err, errMock)
 		mockClient.AssertExpectations(t)
 	})

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -84,6 +84,17 @@ func TestList(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
+	t.Run("success with no deployments in a workspace", func(t *testing.T) {
+		mockClient := new(astro_mocks.Client)
+		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{}, nil).Once()
+
+		buf := new(bytes.Buffer)
+		err := List(ws, false, mockClient, buf)
+		assert.NoError(t, err)
+
+		mockClient.AssertExpectations(t)
+	})
+
 	t.Run("success with all true", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", org, "").Return([]astro.Deployment{{ID: "test-id-1"}, {ID: "test-id-2"}}, nil).Once()
@@ -165,6 +176,14 @@ func TestGetDeployment(t *testing.T) {
 
 		_, err := GetDeployment(ws, "", deploymentName, false, mockClient, nil)
 		assert.ErrorIs(t, err, errInvalidDeployment)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("no deployments in workspace", func(t *testing.T) {
+		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{}, nil).Once()
+
+		_, err := GetDeployment(ws, "", deploymentName, true, mockClient, nil)
+		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
 
@@ -2246,6 +2265,15 @@ func TestDelete(t *testing.T) {
 
 		err := Delete("test-id", ws, "", false, mockClient)
 		assert.ErrorIs(t, err, errMock)
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("no deployments in a workspace", func(t *testing.T) {
+		mockClient := new(astro_mocks.Client)
+		mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{}, nil).Once()
+
+		err := Delete("test-id", ws, "", true, mockClient)
+		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
 

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -26,7 +26,7 @@ func VariableList(deploymentID, variableKey, ws, envFile, deploymentName string,
 	}
 
 	// get deployment
-	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, client, nil)
+	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, false, client, nil)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func VariableModify(deploymentID, variableKey, variableValue, ws, envFile, deplo
 	}
 
 	// get deployment
-	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, client, nil)
+	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, false, client, nil)
 	if err != nil {
 		return err
 	}

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -100,7 +100,7 @@ func Inspect(wsID, deploymentName, deploymentID, outputFormat string, client ast
 		deploymentInfoMap, deploymentConfigMap, additionalMap, printableDeployment map[string]interface{}
 	)
 	// get or select the deployment
-	requestedDeployment, err = deployment.GetDeployment(wsID, deploymentID, deploymentName, client, nil)
+	requestedDeployment, err = deployment.GetDeployment(wsID, deploymentID, deploymentName, false, client, nil)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func ReturnSpecifiedValue(wsID, deploymentName, deploymentID string, client astr
 		deploymentInfoMap, deploymentConfigMap, additionalMap, printableDeployment map[string]interface{}
 	)
 	// get or select the deployment
-	requestedDeployment, err = deployment.GetDeployment(wsID, deploymentID, deploymentName, client, nil)
+	requestedDeployment, err = deployment.GetDeployment(wsID, deploymentID, deploymentName, false, client, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -46,7 +46,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 		defaultOptions                       astro.WorkerQueueDefaultOptions
 	)
 	// get or select the deployment
-	requestedDeployment, err = deployment.GetDeployment(ws, deploymentID, deploymentName, client, nil)
+	requestedDeployment, err = deployment.GetDeployment(ws, deploymentID, deploymentName, false, client, nil)
 	if err != nil {
 		return err
 	}
@@ -387,7 +387,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, client as
 		queue                        astro.WorkerQueue
 	)
 	// get or select the deployment
-	requestedDeployment, err = deployment.GetDeployment(ws, deploymentID, deploymentName, client, nil)
+	requestedDeployment, err = deployment.GetDeployment(ws, deploymentID, deploymentName, false, client, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

fix to display error with no deployments on delete

## 🎟 Issue(s)

Related #1245

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screenshot 2023-06-12 at 14 14 03](https://github.com/astronomer/astro-cli/assets/65428224/d0382925-1517-4c09-95a1-6736932b862c)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
