### PR TITLE
Add org token commands

### DIFF
--- a/astro-client-core/client.go
+++ b/astro-client-core/client.go
@@ -19,6 +19,7 @@ var (
 	ErrorRequest  = errors.New("failed to perform request")
 	ErrorBaseURL  = errors.New("invalid baseurl")
 	HTTPStatus200 = 200
+	HTTPStatus204 = 204
 )
 
 // a shorter alias
@@ -53,7 +54,7 @@ func NewCoreClient(c *httputil.HTTPClient) *ClientWithResponses {
 }
 
 func NormalizeAPIError(httpResp *http.Response, body []byte) error {
-	if httpResp.StatusCode != HTTPStatus200 {
+	if httpResp.StatusCode != HTTPStatus200 && httpResp.StatusCode != HTTPStatus204 {
 		decode := Error{}
 		err := json.NewDecoder(bytes.NewReader(body)).Decode(&decode)
 		if err != nil {

--- a/cloud/organization/organization_token.go
+++ b/cloud/organization/organization_token.go
@@ -2,13 +2,13 @@ package organization
 
 import (
 	httpContext "context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"time"
 
-	"errors"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/context"

--- a/cloud/organization/organization_token.go
+++ b/cloud/organization/organization_token.go
@@ -3,6 +3,11 @@ package organization
 import (
 	httpContext "context"
 	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/astronomer/astro-cli/astro-client"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/cloud/user"
@@ -11,10 +16,6 @@ import (
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
 	"github.com/pkg/errors"
-	"io"
-	"os"
-	"strconv"
-	"time"
 )
 
 var (

--- a/cloud/organization/organization_token.go
+++ b/cloud/organization/organization_token.go
@@ -8,14 +8,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/astronomer/astro-cli/astro-client"
+	"errors"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -244,7 +243,7 @@ func ListTokens(client astrocore.CoreClient, out io.Writer) error {
 
 	apiTokens, err := getOrganizationTokens(client)
 	if err != nil {
-		return errors.Wrap(err, astro.AstronomerConnectionErrMsg)
+		return err
 	}
 
 	tab := newTokenTableOut()

--- a/cloud/organization/organization_token.go
+++ b/cloud/organization/organization_token.go
@@ -396,6 +396,17 @@ func UpdateToken(id, name, newName, description, role, organization string, out 
 		UpdateOrganizationAPITokenRequest.Description = description
 	}
 
+	//if role == "" {
+	//
+	//	UpdateOrganizationAPITokenRequest.Roles = token.Roles
+	//} else {
+	//	err := user.IsOrganizationRoleValid(role)
+	//	if err != nil {
+	//		return err
+	//	}
+	//	UpdateOrganizationAPITokenRequest.Roles = role
+	//}
+
 	err = user.IsOrganizationRoleValid(role)
 	if err != nil {
 		return err

--- a/cloud/organization/organization_token.go
+++ b/cloud/organization/organization_token.go
@@ -4,18 +4,17 @@ import (
 	httpContext "context"
 	"fmt"
 	"github.com/astronomer/astro-cli/astro-client"
+	astrocore "github.com/astronomer/astro-cli/astro-client-core"
+	"github.com/astronomer/astro-cli/cloud/user"
+	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/input"
+	"github.com/astronomer/astro-cli/pkg/printutil"
+	"github.com/pkg/errors"
 	"io"
 	"os"
 	"strconv"
 	"time"
-
-	astrocore "github.com/astronomer/astro-cli/astro-client-core"
-	"github.com/astronomer/astro-cli/cloud/user"
-	"github.com/astronomer/astro-cli/context"
-	"github.com/astronomer/astro-cli/pkg/input"
-	"github.com/astronomer/astro-cli/pkg/printutil"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/cloud/organization/organization_token.go
+++ b/cloud/organization/organization_token.go
@@ -77,7 +77,7 @@ func AddOrgTokenToWorkspace(id, name, role, workspace string, out io.Writer, cli
 			return err
 		}
 	} else {
-		token, err = getOrganizationTokenById(id, ctx.OrganizationShortName, client)
+		token, err = getOrganizationTokenByID(id, ctx.OrganizationShortName, client)
 		if err != nil {
 			return err
 		}
@@ -182,7 +182,7 @@ func getOrganizationTokens(client astrocore.CoreClient) ([]astrocore.ApiToken, e
 	return APITokens, nil
 }
 
-func getOrganizationTokenById(id string, orgShortName string, client astrocore.CoreClient) (token astrocore.ApiToken, err error) {
+func getOrganizationTokenByID(id, orgShortName string, client astrocore.CoreClient) (token astrocore.ApiToken, err error) {
 	resp, err := client.GetOrganizationApiTokenWithResponse(httpContext.Background(), orgShortName, id)
 	if err != nil {
 		return astrocore.ApiToken{}, err
@@ -285,7 +285,7 @@ func ListTokenRoles(id string, client astrocore.CoreClient, out io.Writer) (err 
 		if err != nil {
 			return err
 		}
-		apiToken, err = getOrganizationTokenById(id, ctx.OrganizationShortName, client)
+		apiToken, err = getOrganizationTokenByID(id, ctx.OrganizationShortName, client)
 		if err != nil {
 			return err
 		}
@@ -369,7 +369,7 @@ func UpdateToken(id, name, newName, description, role string, out io.Writer, cli
 			return err
 		}
 	} else {
-		token, err = getOrganizationTokenById(id, ctx.OrganizationShortName, client)
+		token, err = getOrganizationTokenByID(id, ctx.OrganizationShortName, client)
 		if err != nil {
 			return err
 		}
@@ -459,7 +459,7 @@ func RotateToken(id, name string, cleanOutput, force bool, out io.Writer, client
 			return err
 		}
 	} else {
-		token, err = getOrganizationTokenById(id, ctx.OrganizationShortName, client)
+		token, err = getOrganizationTokenByID(id, ctx.OrganizationShortName, client)
 		if err != nil {
 			return err
 		}
@@ -518,7 +518,7 @@ func DeleteToken(id, name string, force bool, out io.Writer, client astrocore.Co
 			return err
 		}
 	} else {
-		token, err = getOrganizationTokenById(id, ctx.OrganizationShortName, client)
+		token, err = getOrganizationTokenByID(id, ctx.OrganizationShortName, client)
 		if err != nil {
 			return err
 		}

--- a/cloud/organization/organization_token.go
+++ b/cloud/organization/organization_token.go
@@ -454,7 +454,7 @@ func RotateToken(id, name string, cleanOutput, force bool, out io.Writer, client
 		if err != nil {
 			return err
 		}
-		token, err = getOrganizationToken(id, name, "\nPlease select the Organization API token you would like to add to the Workspace:", tokens)
+		token, err = getOrganizationToken(id, name, "\nPlease select the Organization API token you would like to rotate:", tokens)
 		if err != nil {
 			return err
 		}
@@ -513,7 +513,7 @@ func DeleteToken(id, name string, force bool, out io.Writer, client astrocore.Co
 		if err != nil {
 			return err
 		}
-		token, err = getOrganizationToken(id, name, "\nPlease select the Organization API token you would like to add to the Workspace:", tokens)
+		token, err = getOrganizationToken(id, name, "\nPlease select the Organization API token you would like to delete:", tokens)
 		if err != nil {
 			return err
 		}

--- a/cloud/organization/organization_token_test.go
+++ b/cloud/organization/organization_token_test.go
@@ -22,9 +22,9 @@ var (
 	fullName1    = "User 1"
 	fullName2    = "User 2"
 	token        = "token"
-	workspaceId  = "ck05r3bor07h40d02y2hw4n4v"
+	workspaceID  = "ck05r3bor07h40d02y2hw4n4v"
 
-	apiToken1 = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityType: "WORKSPACE", EntityId: workspaceId, Role: "ORGANIZATION_MEMBER"}, {EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
+	apiToken1 = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityType: "WORKSPACE", EntityId: workspaceID, Role: "ORGANIZATION_MEMBER"}, {EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
 	apiToken2 = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityType: "ORGANIZATION", EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
 
 	apiTokens = []astrocore.ApiToken{
@@ -145,7 +145,7 @@ var (
 
 func TestAddOrgTokenToWorkspace(t *testing.T) {
 	var (
-		workspace          = workspaceId
+		workspace          = workspaceID
 		role               = "WORKSPACE_MEMBER"
 		selectedTokenID    = "token1"
 		selectedTokenName  = "Token 1"
@@ -308,7 +308,7 @@ func TestCreateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateOrganizationAPITokenResponseOK, nil)
 
-		err := CreateToken("Token 1", "Description 1", "ORGANIZATION_MEMBER", "", 0, false, out, mockClient)
+		err := CreateToken("Token 1", "Description 1", "ORGANIZATION_MEMBER", 0, false, out, mockClient)
 
 		assert.NoError(t, err)
 	})
@@ -318,7 +318,7 @@ func TestCreateToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
-		err := CreateToken("Token 1", "Description 1", "ORGANIZATION_MEMBER", "", 0, false, out, mockClient)
+		err := CreateToken("Token 1", "Description 1", "ORGANIZATION_MEMBER", 0, false, out, mockClient)
 
 		assert.Error(t, err)
 	})
@@ -328,7 +328,7 @@ func TestCreateToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
-		err := CreateToken("Token 1", "Description 1", "InvalidRole", "", 0, false, out, mockClient)
+		err := CreateToken("Token 1", "Description 1", "InvalidRole", 0, false, out, mockClient)
 
 		assert.Error(t, err)
 	})
@@ -338,7 +338,7 @@ func TestCreateToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
-		err := CreateToken("", "Description 1", "ORGANIZATION_MEMBER", "", 0, true, out, mockClient)
+		err := CreateToken("", "Description 1", "ORGANIZATION_MEMBER", 0, true, out, mockClient)
 
 		assert.Equal(t, ErrInvalidName, err)
 	})
@@ -351,7 +351,7 @@ func TestUpdateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
-		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
+		err := UpdateToken("token1", "", "", "", "", out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -372,7 +372,7 @@ func TestUpdateToken(t *testing.T) {
 		// Restore stdin right after the test.
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
-		err = UpdateToken("", "", "", "", "", "", out, mockClient)
+		err = UpdateToken("", "", "", "", "", out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -393,7 +393,7 @@ func TestUpdateToken(t *testing.T) {
 		// Restore stdin right after the test.
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
-		err = UpdateToken("", "Token 1", "", "", "", "", out, mockClient)
+		err = UpdateToken("", "Token 1", "", "", "", out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -403,7 +403,7 @@ func TestUpdateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
-		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
+		err := UpdateToken("token1", "", "", "", "", out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -412,7 +412,7 @@ func TestUpdateToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
-		err := UpdateToken("", "", "", "", "", "", out, mockClient)
+		err := UpdateToken("", "", "", "", "", out, mockClient)
 		assert.ErrorContains(t, err, "failed to list tokens")
 	})
 
@@ -421,7 +421,7 @@ func TestUpdateToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
-		err := UpdateToken("", "invalid name", "", "", "", "", out, mockClient)
+		err := UpdateToken("", "invalid name", "", "", "", out, mockClient)
 		assert.Equal(t, errOrganizationTokenNotFound, err)
 	})
 
@@ -430,7 +430,7 @@ func TestUpdateToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
-		err := UpdateToken("tokenId", "", "", "", "", "", out, mockClient)
+		err := UpdateToken("tokenId", "", "", "", "", out, mockClient)
 		assert.ErrorContains(t, err, "failed to get token")
 	})
 
@@ -440,7 +440,7 @@ func TestUpdateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseError, nil)
-		err := UpdateToken("token3", "", "", "", "", "", out, mockClient)
+		err := UpdateToken("token3", "", "", "", "", out, mockClient)
 		assert.Equal(t, "failed to update token", err.Error())
 	})
 
@@ -448,7 +448,7 @@ func TestUpdateToken(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
+		err := UpdateToken("token1", "", "", "", "", out, mockClient)
 		assert.Error(t, err)
 	})
 
@@ -458,7 +458,7 @@ func TestUpdateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
-		err := UpdateToken("token1", "", "", "", "Invalid Role", "", out, mockClient)
+		err := UpdateToken("token1", "", "", "", "Invalid Role", out, mockClient)
 		assert.Equal(t, user.ErrInvalidOrganizationRole.Error(), err.Error())
 	})
 	t.Run("Happy path when applying workspace role", func(t *testing.T) {
@@ -467,7 +467,7 @@ func TestUpdateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
-		err := UpdateToken("", apiToken1.Name, "", "", "ORGANIZATION_MEMBER", "", out, mockClient)
+		err := UpdateToken("", apiToken1.Name, "", "", "ORGANIZATION_MEMBER", out, mockClient)
 		assert.NoError(t, err)
 	})
 }
@@ -479,7 +479,7 @@ func TestRotateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
 		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseOK, nil)
-		err := RotateToken("token1", "", "", false, true, out, mockClient)
+		err := RotateToken("token1", "", false, true, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -489,7 +489,7 @@ func TestRotateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseOK, nil)
-		err := RotateToken("", apiToken1.Name, "", false, true, out, mockClient)
+		err := RotateToken("", apiToken1.Name, false, true, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -499,7 +499,7 @@ func TestRotateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseOK, nil)
-		err := RotateToken("", apiToken1.Name, "", true, false, out, mockClient)
+		err := RotateToken("", apiToken1.Name, true, false, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -507,7 +507,7 @@ func TestRotateToken(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err := RotateToken("token1", "", "", false, false, out, mockClient)
+		err := RotateToken("token1", "", false, false, out, mockClient)
 		assert.Error(t, err)
 	})
 
@@ -516,7 +516,7 @@ func TestRotateToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
-		err := RotateToken("", "", "", false, false, out, mockClient)
+		err := RotateToken("", "", false, false, out, mockClient)
 		assert.ErrorContains(t, err, "failed to list tokens")
 	})
 
@@ -525,7 +525,7 @@ func TestRotateToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
-		err := RotateToken("", "invalid name", "", false, false, out, mockClient)
+		err := RotateToken("", "invalid name", false, false, out, mockClient)
 		assert.Equal(t, errOrganizationTokenNotFound, err)
 	})
 
@@ -534,7 +534,7 @@ func TestRotateToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
-		err := RotateToken("token1", "", "", false, false, out, mockClient)
+		err := RotateToken("token1", "", false, false, out, mockClient)
 		assert.ErrorContains(t, err, "failed to get token")
 	})
 
@@ -544,7 +544,7 @@ func TestRotateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseError, nil)
-		err := RotateToken("", apiToken1.Name, "", false, true, out, mockClient)
+		err := RotateToken("", apiToken1.Name, false, true, out, mockClient)
 		assert.Equal(t, "failed to update token", err.Error())
 	})
 }
@@ -556,7 +556,7 @@ func TestDeleteToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
 		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseOK, nil)
-		err := DeleteToken("", apiToken1.Name, "", false, out, mockClient)
+		err := DeleteToken("", apiToken1.Name, false, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -566,7 +566,7 @@ func TestDeleteToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
 		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseOK, nil)
-		err := DeleteToken("token1", "", "", false, out, mockClient)
+		err := DeleteToken("token1", "", false, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -576,7 +576,7 @@ func TestDeleteToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
 		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseOK, nil)
-		err := DeleteToken("", apiToken1.Name, "", false, out, mockClient)
+		err := DeleteToken("", apiToken1.Name, false, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -584,7 +584,7 @@ func TestDeleteToken(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err := DeleteToken("token1", "", "", false, out, mockClient)
+		err := DeleteToken("token1", "", false, out, mockClient)
 		assert.Error(t, err)
 	})
 
@@ -593,7 +593,7 @@ func TestDeleteToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
-		err := DeleteToken("token1", "", "", false, out, mockClient)
+		err := DeleteToken("token1", "", false, out, mockClient)
 		assert.ErrorContains(t, err, "failed to get token")
 	})
 
@@ -602,7 +602,7 @@ func TestDeleteToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
-		err := DeleteToken("", apiToken1.Name, "", false, out, mockClient)
+		err := DeleteToken("", apiToken1.Name, false, out, mockClient)
 		assert.ErrorContains(t, err, "failed to list tokens")
 	})
 
@@ -611,7 +611,7 @@ func TestDeleteToken(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
-		err := DeleteToken("", "invalid name", "", false, out, mockClient)
+		err := DeleteToken("", "invalid name", false, out, mockClient)
 		assert.Equal(t, errOrganizationTokenNotFound, err)
 	})
 
@@ -621,7 +621,7 @@ func TestDeleteToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseError, nil)
-		err := DeleteToken("", apiToken1.Name, "", true, out, mockClient)
+		err := DeleteToken("", apiToken1.Name, true, out, mockClient)
 		assert.Equal(t, "failed to update token", err.Error())
 	})
 }

--- a/cloud/organization/organization_token_test.go
+++ b/cloud/organization/organization_token_test.go
@@ -470,6 +470,16 @@ func TestUpdateToken(t *testing.T) {
 		err := UpdateToken("", apiToken1.Name, "", "", "ORGANIZATION_MEMBER", out, mockClient)
 		assert.NoError(t, err)
 	})
+
+	t.Run("Happy path when applying organization role using id", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
+		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
+		err := UpdateToken("token1", "", "", "", "ORGANIZATION_MEMBER", out, mockClient)
+		assert.NoError(t, err)
+	})
 }
 
 func TestRotateToken(t *testing.T) {

--- a/cloud/organization/organization_token_test.go
+++ b/cloud/organization/organization_token_test.go
@@ -22,11 +22,14 @@ var (
 	fullName1    = "User 1"
 	fullName2    = "User 2"
 	token        = "token"
-	apiToken1    = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityId: "WORKSPACE", Role: "WORKSPACE_MEMBER"}, {EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
-	apiToken2    = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
-	apiTokens    = []astrocore.ApiToken{
+	workspaceId  = "ck05r3bor07h40d02y2hw4n4v"
+
+	apiToken1 = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityType: "WORKSPACE", EntityId: workspaceId, Role: "ORGANIZATION_MEMBER"}, {EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
+	apiToken2 = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityType: "ORGANIZATION", EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
+
+	apiTokens = []astrocore.ApiToken{
 		apiToken1,
-		{Id: "token2", Name: "Token 2", Description: description2, Type: "Type 2", Roles: []astrocore.ApiTokenRole{{EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
+		{Id: "token2", Name: "Token 2", Description: description2, Type: "Type 2", Roles: []astrocore.ApiTokenRole{{EntityType: "ORGANIZATION", EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
 	}
 	apiTokens2 = []astrocore.ApiToken{
 		apiToken1,
@@ -42,7 +45,7 @@ var (
 			Offset:    0,
 		},
 	}
-	ListOrganizationAPITokensResponse2OK = astrocore.ListOrganizationApiTokensResponse{
+	ListOrganizationAPITokensResponse2O0 = astrocore.ListOrganizationApiTokensResponse{
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
 		},
@@ -62,14 +65,50 @@ var (
 		Body:    errorBodyList,
 		JSON200: nil,
 	}
+
+	GetOrganizationAPITokenResponseOK = astrocore.GetOrganizationApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &apiToken2,
+	}
+	getTokenErrorBodyList, _ = json.Marshal(astrocore.Error{
+		Message: "failed to get token",
+	})
+	GetOrganizationAPITokenResponseError = astrocore.GetOrganizationApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 500,
+		},
+		Body:    getTokenErrorBodyList,
+		JSON200: nil,
+	}
+
+	CreateOrganizationAPITokenResponseOK = astrocore.CreateOrganizationApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &apiToken1,
+	}
+
+	errorBodyCreate, _ = json.Marshal(astrocore.Error{
+		Message: "failed to create token",
+	})
+	CreateOrganizationAPITokenResponseError = astrocore.CreateOrganizationApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 500,
+		},
+		Body:    errorBodyCreate,
+		JSON200: nil,
+	}
 	UpdateOrganizationAPITokenResponseOK = astrocore.UpdateOrganizationApiTokenResponse{
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
 		},
 		JSON200: &apiToken1,
 	}
+
 	errorBodyUpdate, _ = json.Marshal(astrocore.Error{
-		Message: "failed to update tokens",
+		Message: "failed to update token",
 	})
 	UpdateOrganizationAPITokenResponseError = astrocore.UpdateOrganizationApiTokenResponse{
 		HTTPResponse: &http.Response{
@@ -78,15 +117,39 @@ var (
 		Body:    errorBodyUpdate,
 		JSON200: nil,
 	}
+	RotateOrganizationAPITokenResponseOK = astrocore.RotateOrganizationApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &apiToken1,
+	}
+	RotateOrganizationAPITokenResponseError = astrocore.RotateOrganizationApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 500,
+		},
+		Body:    errorBodyUpdate,
+		JSON200: nil,
+	}
+	DeleteOrganizationAPITokenResponseOK = astrocore.DeleteOrganizationApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+	}
+	DeleteOrganizationAPITokenResponseError = astrocore.DeleteOrganizationApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 500,
+		},
+		Body: errorBodyUpdate,
+	}
 )
 
 func TestAddOrgTokenToWorkspace(t *testing.T) {
 	var (
-		workspace         = "testWorkspace"
-		role              = "WORKSPACE_MEMBER"
-		selectedTokenID   = "token1"
-		selectedTokenName = "Token 1"
-		selectedTokenID2  = "token2"
+		workspace          = workspaceId
+		role               = "WORKSPACE_MEMBER"
+		selectedTokenID    = "token1"
+		selectedTokenName  = "Token 1"
+		selectedTokenName2 = "Token 2"
 	)
 
 	t.Run("return error for invalid workspace role", func(t *testing.T) {
@@ -108,7 +171,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
 
-		err := AddOrgTokenToWorkspace(selectedTokenID, selectedTokenName, role, workspace, nil, mockClient)
+		err := AddOrgTokenToWorkspace("", selectedTokenName, role, workspace, nil, mockClient)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "failed to list tokens")
 	})
@@ -119,19 +182,9 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
 
-		err := AddOrgTokenToWorkspace("INVALID_ID", "", role, workspace, nil, mockClient)
+		err := AddOrgTokenToWorkspace("", "Invalid name", role, workspace, nil, mockClient)
 		assert.Error(t, err)
 		assert.Equal(t, errOrganizationTokenNotFound, err)
-	})
-
-	t.Run("return error for specifying both name and id", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
-
-		err := AddOrgTokenToWorkspace(selectedTokenID, selectedTokenName, role, workspace, nil, mockClient)
-		assert.Error(t, err)
-		assert.Equal(t, errBothNameAndID, err)
 	})
 
 	t.Run("return error for organization token already in workspace", func(t *testing.T) {
@@ -139,9 +192,30 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 
-		err := AddOrgTokenToWorkspace(selectedTokenID, "", role, workspace, nil, mockClient)
+		err := AddOrgTokenToWorkspace("", selectedTokenName, role, workspace, nil, mockClient)
 		assert.Error(t, err)
 		assert.Equal(t, errOrgTokenInWorkspace, err)
+	})
+
+	t.Run("successfully add organization token to workspace using id", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
+		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
+
+		err := AddOrgTokenToWorkspace(selectedTokenID, "", role, workspace, out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("return error for failed to get organization token", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
+
+		err := AddOrgTokenToWorkspace(selectedTokenID, "", role, workspace, nil, mockClient)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed to get token")
 	})
 
 	t.Run("successfully add organization token to workspace", func(t *testing.T) {
@@ -151,7 +225,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
 
-		err := AddOrgTokenToWorkspace(selectedTokenID2, "", role, workspace, out, mockClient)
+		err := AddOrgTokenToWorkspace("", selectedTokenName2, role, workspace, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -176,11 +250,11 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("successfully select and add organization token to workspace", func(t *testing.T) {
+	t.Run("successfully select and add organization token to workspace 2", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponse2OK, nil)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponse2O0, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
 		// mock os.Stdin
 		expectedInput := []byte("2")
@@ -195,5 +269,420 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 		os.Stdin = r
 		err = AddOrgTokenToWorkspace("", selectedTokenName, role, workspace, out, mockClient)
 		assert.NoError(t, err)
+	})
+}
+
+func TestListTokens(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
+		err := ListTokens(mockClient, out)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error path when ListOrganizationApiTokensWithResponse returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil).Twice()
+		err := ListTokens(mockClient, out)
+		assert.ErrorContains(t, err, "failed to list tokens")
+	})
+
+	t.Run("error getting current context", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.Initial)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		err := ListTokens(mockClient, out)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestCreateToken(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("CreateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateOrganizationAPITokenResponseOK, nil)
+
+		err := CreateToken("Token 1", "Description 1", "ORGANIZATION_MEMBER", "", 0, false, out, mockClient)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("error getting current context", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.Initial)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+
+		err := CreateToken("Token 1", "Description 1", "ORGANIZATION_MEMBER", "", 0, false, out, mockClient)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid role", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+
+		err := CreateToken("Token 1", "Description 1", "InvalidRole", "", 0, false, out, mockClient)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+
+		err := CreateToken("", "Description 1", "ORGANIZATION_MEMBER", "", 0, true, out, mockClient)
+
+		assert.Equal(t, ErrInvalidName, err)
+	})
+}
+
+func TestUpdateToken(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
+		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
+		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("happy path no id", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
+		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
+		// mock os.Stdin
+		expectedInput := []byte("2")
+		r, w, err := os.Pipe()
+		assert.NoError(t, err)
+		_, err = w.Write(expectedInput)
+		assert.NoError(t, err)
+		w.Close()
+		stdin := os.Stdin
+		// Restore stdin right after the test.
+		defer func() { os.Stdin = stdin }()
+		os.Stdin = r
+		err = UpdateToken("", "", "", "", "", "", out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("happy path multiple name", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponse2O0, nil).Twice()
+		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
+		// mock os.Stdin
+		expectedInput := []byte("2")
+		r, w, err := os.Pipe()
+		assert.NoError(t, err)
+		_, err = w.Write(expectedInput)
+		assert.NoError(t, err)
+		w.Close()
+		stdin := os.Stdin
+		// Restore stdin right after the test.
+		defer func() { os.Stdin = stdin }()
+		os.Stdin = r
+		err = UpdateToken("", "Token 1", "", "", "", "", out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
+		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
+		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error path when listOrganizationTokens returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
+		err := UpdateToken("", "", "", "", "", "", out, mockClient)
+		assert.ErrorContains(t, err, "failed to list tokens")
+	})
+
+	t.Run("error path when listOrganizationToken returns an not found error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
+		err := UpdateToken("", "invalid name", "", "", "", "", out, mockClient)
+		assert.Equal(t, errOrganizationTokenNotFound, err)
+	})
+
+	t.Run("error path when getOrganizationToken returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
+		err := UpdateToken("tokenId", "", "", "", "", "", out, mockClient)
+		assert.ErrorContains(t, err, "failed to get token")
+	})
+
+	t.Run("error path when UpdateOrganizationApiTokenWithResponse returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
+		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseError, nil)
+		err := UpdateToken("token3", "", "", "", "", "", out, mockClient)
+		assert.Equal(t, "failed to update token", err.Error())
+	})
+
+	t.Run("error path when there is no context", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.Initial)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
+		assert.Error(t, err)
+	})
+
+	t.Run("error path when workspace role is invalid returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
+		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
+		err := UpdateToken("token1", "", "", "", "Invalid Role", "", out, mockClient)
+		assert.Equal(t, user.ErrInvalidOrganizationRole.Error(), err.Error())
+	})
+	t.Run("Happy path when applying workspace role", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
+		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
+		err := UpdateToken("", apiToken1.Name, "", "", "ORGANIZATION_MEMBER", "", out, mockClient)
+		assert.NoError(t, err)
+	})
+}
+
+func TestRotateToken(t *testing.T) {
+	t.Run("happy path - id provided", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
+		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseOK, nil)
+		err := RotateToken("token1", "", "", false, true, out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("happy path name provided", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
+		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseOK, nil)
+		err := RotateToken("", apiToken1.Name, "", false, true, out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("happy path with confirmation", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
+		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseOK, nil)
+		err := RotateToken("", apiToken1.Name, "", true, false, out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error path when there is no context", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.Initial)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		err := RotateToken("token1", "", "", false, false, out, mockClient)
+		assert.Error(t, err)
+	})
+
+	t.Run("error path when listOrganizationTokens returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
+		err := RotateToken("", "", "", false, false, out, mockClient)
+		assert.ErrorContains(t, err, "failed to list tokens")
+	})
+
+	t.Run("error path when listOrganizationToken returns an not found error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
+		err := RotateToken("", "invalid name", "", false, false, out, mockClient)
+		assert.Equal(t, errOrganizationTokenNotFound, err)
+	})
+
+	t.Run("error path when getOrganizationToken returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
+		err := RotateToken("token1", "", "", false, false, out, mockClient)
+		assert.ErrorContains(t, err, "failed to get token")
+	})
+
+	t.Run("error path when RotateOrganizationApiTokenWithResponse returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
+		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseError, nil)
+		err := RotateToken("", apiToken1.Name, "", false, true, out, mockClient)
+		assert.Equal(t, "failed to update token", err.Error())
+	})
+}
+
+func TestDeleteToken(t *testing.T) {
+	t.Run("happy path - delete workspace token - by name", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
+		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseOK, nil)
+		err := DeleteToken("", apiToken1.Name, "", false, out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("happy path - delete workspace token - by id", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
+		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseOK, nil)
+		err := DeleteToken("token1", "", "", false, out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("happy path - remove organization token", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
+		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseOK, nil)
+		err := DeleteToken("", apiToken1.Name, "", false, out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error path when there is no context", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.Initial)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		err := DeleteToken("token1", "", "", false, out, mockClient)
+		assert.Error(t, err)
+	})
+
+	t.Run("error path when getOrganizationToken returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
+		err := DeleteToken("token1", "", "", false, out, mockClient)
+		assert.ErrorContains(t, err, "failed to get token")
+	})
+
+	t.Run("error path when listOrganizationTokens returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
+		err := DeleteToken("", apiToken1.Name, "", false, out, mockClient)
+		assert.ErrorContains(t, err, "failed to list tokens")
+	})
+
+	t.Run("error path when listOrganizationToken returns a not found error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
+		err := DeleteToken("", "invalid name", "", false, out, mockClient)
+		assert.Equal(t, errOrganizationTokenNotFound, err)
+	})
+
+	t.Run("error path when DeleteOrganizationApiTokenWithResponse returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
+		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseError, nil)
+		err := DeleteToken("", apiToken1.Name, "", true, out, mockClient)
+		assert.Equal(t, "failed to update token", err.Error())
+	})
+}
+
+func TestGetOrganizationToken(t *testing.T) {
+	t.Run("select token by id when name is empty", func(t *testing.T) {
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
+		token, err := getOrganizationToken("token1", "", "\nPlease select the workspace token you would like to delete or remove:", apiTokens)
+		assert.NoError(t, err)
+		assert.Equal(t, apiToken1, token)
+	})
+
+	t.Run("select token by name when id is empty and there is only one matching token", func(t *testing.T) {
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
+		token, err := getOrganizationToken("", "Token 2", "\nPlease select the workspace token you would like to delete or remove:", apiTokens)
+		assert.NoError(t, err)
+		assert.Equal(t, apiTokens[1], token)
+	})
+
+	t.Run("return error when token is not found by id", func(t *testing.T) {
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
+		token, err := getOrganizationToken("nonexistent", "", "\nPlease select the workspace token you would like to delete or remove:", apiTokens)
+		assert.Equal(t, errOrganizationTokenNotFound, err)
+		assert.Equal(t, astrocore.ApiToken{}, token)
+	})
+
+	t.Run("return error when token is not found by name", func(t *testing.T) {
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
+		token, err := getOrganizationToken("", "Nonexistent Token", "\nPlease select the workspace token you would like to delete or remove:", apiTokens)
+		assert.Equal(t, errOrganizationTokenNotFound, err)
+		assert.Equal(t, astrocore.ApiToken{}, token)
+	})
+}
+
+func TestTimeAgo(t *testing.T) {
+	currentTime := time.Now()
+
+	t.Run("return 'Just now' for current time", func(t *testing.T) {
+		result := TimeAgo(currentTime)
+		assert.Equal(t, "Just now", result)
+	})
+
+	t.Run("return '30 minutes ago' for 30 minutes ago", func(t *testing.T) {
+		pastTime := currentTime.Add(-30 * time.Minute)
+		result := TimeAgo(pastTime)
+		assert.Equal(t, "30 minutes ago", result)
+	})
+
+	t.Run("return '5 hours ago' for 5 hours ago", func(t *testing.T) {
+		pastTime := currentTime.Add(-5 * time.Hour)
+		result := TimeAgo(pastTime)
+		assert.Equal(t, "5 hours ago", result)
+	})
+
+	t.Run("return '10 days ago' for 10 days ago", func(t *testing.T) {
+		pastTime := currentTime.Add(-10 * 24 * time.Hour)
+		result := TimeAgo(pastTime)
+		assert.Equal(t, "10 days ago", result)
 	})
 }

--- a/cloud/user/user.go
+++ b/cloud/user/user.go
@@ -18,13 +18,14 @@ import (
 )
 
 var (
-	ErrNoShortName          = errors.New("cannot retrieve organization short name from context")
-	ErrInvalidRole          = errors.New("requested role is invalid. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")
-	ErrInvalidWorkspaceRole = errors.New("requested role is invalid. Possible values are WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER ")
-	ErrInvalidEmail         = errors.New("no email provided for the invite. Retry with a valid email address")
-	ErrInvalidUserKey       = errors.New("invalid User selected")
-	userPagnationLimit      = 100
-	ErrUserNotFound         = errors.New("no user was found for the email you provided")
+	ErrNoShortName             = errors.New("cannot retrieve organization short name from context")
+	ErrInvalidRole             = errors.New("requested role is invalid. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")
+	ErrInvalidWorkspaceRole    = errors.New("requested role is invalid. Possible values are WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER ")
+	ErrInvalidOrganizationRole = errors.New("requested role is invalid. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")
+	ErrInvalidEmail            = errors.New("no email provided for the invite. Retry with a valid email address")
+	ErrInvalidUserKey          = errors.New("invalid User selected")
+	userPagnationLimit         = 100
+	ErrUserNotFound            = errors.New("no user was found for the email you provided")
 )
 
 func CreateInvite(email, role string, out io.Writer, client astrocore.CoreClient) error {
@@ -332,6 +333,19 @@ func IsWorkspaceRoleValid(role string) error {
 		}
 	}
 	return ErrInvalidWorkspaceRole
+}
+
+// IsOrgnaizationRoleValid checks if the requested role is valid
+// If the role is valid, it returns nil
+// error ErrInvalidOrgnaizationRole is returned if the role is not valid
+func IsOrganizationRoleValid(role string) error {
+	validRoles := []string{"ORGANIZATION_MEMBER", "ORGANIZATION_BILLING_ADMIN", "ORGANIZATION_OWNER"}
+	for _, validRole := range validRoles {
+		if role == validRole {
+			return nil
+		}
+	}
+	return ErrInvalidOrganizationRole
 }
 
 // Returns a list of all of an organizations users

--- a/cloud/user/user_test.go
+++ b/cloud/user/user_test.go
@@ -798,3 +798,16 @@ func TestGetUser(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 }
+
+func TestIsOrganizationRoleValid(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		err := IsOrganizationRoleValid("ORGANIZATION_MEMBER")
+		assert.NoError(t, err)
+	})
+
+	t.Run("error path", func(t *testing.T) {
+		err := IsOrganizationRoleValid("Invalid Role")
+		assert.Error(t, err)
+		assert.Equal(t, ErrInvalidOrganizationRole, err)
+	})
+}

--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -21,6 +21,7 @@ import (
 var (
 	errInvalidWorkspaceKey = errors.New("invalid workspace selection")
 	ErrInvalidName         = errors.New("no name provided for the workspace. Retry with a valid name")
+	ErrInvalidTokenName    = errors.New("no name provided for the workspace token. Retry with a valid name")
 	ErrWorkspaceNotFound   = errors.New("no workspace was found for the ID you provided")
 	ErrWrongEnforceInput   = errors.New("the input to the `--enforce-cicd` flag")
 )

--- a/cloud/workspace/workspace_token.go
+++ b/cloud/workspace/workspace_token.go
@@ -149,7 +149,7 @@ func UpdateToken(id, name, newName, description, role, workspace string, out io.
 			return err
 		}
 	} else {
-		token, err = getWorkspaceTokenById(id, workspace, ctx.OrganizationShortName, client)
+		token, err = getWorkspaceTokenByID(id, workspace, ctx.OrganizationShortName, client)
 		if err != nil {
 			return err
 		}
@@ -225,7 +225,7 @@ func RotateToken(id, name, workspace string, cleanOutput, force bool, out io.Wri
 			return err
 		}
 	} else {
-		token, err = getWorkspaceTokenById(id, workspace, ctx.OrganizationShortName, client)
+		token, err = getWorkspaceTokenByID(id, workspace, ctx.OrganizationShortName, client)
 		if err != nil {
 			return err
 		}
@@ -285,7 +285,7 @@ func DeleteToken(id, name, workspace string, force bool, out io.Writer, client a
 			return err
 		}
 	} else {
-		token, err = getWorkspaceTokenById(id, workspace, ctx.OrganizationShortName, client)
+		token, err = getWorkspaceTokenByID(id, workspace, ctx.OrganizationShortName, client)
 		if err != nil {
 			return err
 		}
@@ -456,7 +456,7 @@ func TimeAgo(date time.Time) string {
 	}
 }
 
-func getWorkspaceTokenById(id, workspaceId, orgShortName string, client astrocore.CoreClient) (token astrocore.ApiToken, err error) {
+func getWorkspaceTokenByID(id, workspaceId, orgShortName string, client astrocore.CoreClient) (token astrocore.ApiToken, err error) {
 	resp, err := client.GetWorkspaceApiTokenWithResponse(httpContext.Background(), orgShortName, workspaceId, id)
 	if err != nil {
 		return astrocore.ApiToken{}, err

--- a/cloud/workspace/workspace_token.go
+++ b/cloud/workspace/workspace_token.go
@@ -35,7 +35,6 @@ func newTokenSelectionTableOut() *printutil.Table {
 var (
 	errInvalidWorkspaceTokenKey = errors.New("invalid Workspace API token selection")
 	ErrWorkspaceTokenNotFound   = errors.New("no Workspace API token was found for the API token name you provided")
-	errBothNameAndID            = errors.New("both an API token name and id were specified. Specify either the name or the id not both")
 )
 
 const (
@@ -459,6 +458,9 @@ func TimeAgo(date time.Time) string {
 
 func getWorkspaceTokenById(id, workspaceId, orgShortName string, client astrocore.CoreClient) (token astrocore.ApiToken, err error) {
 	resp, err := client.GetWorkspaceApiTokenWithResponse(httpContext.Background(), orgShortName, workspaceId, id)
+	if err != nil {
+		return astrocore.ApiToken{}, err
+	}
 	err = astrocore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
 	if err != nil {
 		return astrocore.ApiToken{}, err

--- a/cloud/workspace/workspace_token.go
+++ b/cloud/workspace/workspace_token.go
@@ -456,8 +456,8 @@ func TimeAgo(date time.Time) string {
 	}
 }
 
-func getWorkspaceTokenByID(id, workspaceId, orgShortName string, client astrocore.CoreClient) (token astrocore.ApiToken, err error) {
-	resp, err := client.GetWorkspaceApiTokenWithResponse(httpContext.Background(), orgShortName, workspaceId, id)
+func getWorkspaceTokenByID(id, workspaceID, orgShortName string, client astrocore.CoreClient) (token astrocore.ApiToken, err error) {
+	resp, err := client.GetWorkspaceApiTokenWithResponse(httpContext.Background(), orgShortName, workspaceID, id)
 	if err != nil {
 		return astrocore.ApiToken{}, err
 	}

--- a/cloud/workspace/workspace_token.go
+++ b/cloud/workspace/workspace_token.go
@@ -20,7 +20,6 @@ import (
 
 func newTokenTableOut() *printutil.Table {
 	return &printutil.Table{
-		Padding:        []int{30, 50, 10, 50, 10, 10, 10},
 		DynamicPadding: true,
 		Header:         []string{"ID", "NAME", "DESCRIPTION", "SCOPE", "WORKSPACE ROLE", "CREATED", "CREATED BY"},
 	}
@@ -28,7 +27,6 @@ func newTokenTableOut() *printutil.Table {
 
 func newTokenSelectionTableOut() *printutil.Table {
 	return &printutil.Table{
-		Padding:        []int{30, 50, 10, 50, 10, 10, 10},
 		DynamicPadding: true,
 		Header:         []string{"#", "ID", "NAME", "DESCRIPTION", "SCOPE", "WORKSPACE ROLE", "CREATED", "CREATED BY"},
 	}
@@ -88,7 +86,7 @@ func CreateToken(name, description, role, workspace string, expiration int, clea
 		return err
 	}
 	if name == "" {
-		return ErrInvalidName
+		return ErrInvalidTokenName
 	}
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
@@ -164,11 +162,8 @@ func UpdateToken(id, name, newName, description, role, workspace string, out io.
 		UpdateWorkspaceAPITokenRequest.Description = description
 	}
 	if role == "" {
-		for i := range token.Roles {
-			if token.Roles[i].EntityId == workspaceEntity {
-				role = token.Roles[i].Role
-			}
-		}
+		// no role was provided so ask the user for it
+		role = input.Text("enter a user Organization role(WORKSPACE_MEMBER, WORKSPACE_OPERATOR, WORKSPACE_OWNER) to update user: ")
 		err := user.IsWorkspaceRoleValid(role)
 		if err != nil {
 			return err

--- a/cloud/workspace/workspace_token.go
+++ b/cloud/workspace/workspace_token.go
@@ -8,14 +8,13 @@ import (
 	"strconv"
 	"time"
 
-	astro "github.com/astronomer/astro-cli/astro-client"
+	"errors"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
-	"github.com/pkg/errors"
 )
 
 func newTokenTableOut() *printutil.Table {
@@ -54,7 +53,7 @@ func ListTokens(client astrocore.CoreClient, workspace string, out io.Writer) er
 
 	apiTokens, err := getWorkspaceTokens(workspace, client)
 	if err != nil {
-		return errors.Wrap(err, astro.AstronomerConnectionErrMsg)
+		return err
 	}
 
 	tab := newTokenTableOut()

--- a/cloud/workspace/workspace_token.go
+++ b/cloud/workspace/workspace_token.go
@@ -2,13 +2,13 @@ package workspace
 
 import (
 	httpContext "context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"time"
 
-	"errors"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/context"

--- a/cloud/workspace/workspace_token_test.go
+++ b/cloud/workspace/workspace_token_test.go
@@ -30,7 +30,6 @@ var (
 	}
 	apiTokens2 = []astrocore.ApiToken{
 		apiToken1,
-		apiToken1,
 		{Id: "token2", Name: "Token 2", Description: description2, Type: "WORKSPACE", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceId, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
 	}
 	GetWorkspaceAPITokenResponseOK = astrocore.GetWorkspaceApiTokenResponse{

--- a/cloud/workspace/workspace_token_test.go
+++ b/cloud/workspace/workspace_token_test.go
@@ -17,20 +17,20 @@ import (
 )
 
 var (
-	workspaceId  = "ck05r3bor07h40d02y2hw4n4v"
+	workspaceID  = "ck05r3bor07h40d02y2hw4n4v"
 	description1 = "Description 1"
 	description2 = "Description 2"
 	fullName1    = "User 1"
 	fullName2    = "User 2"
 	token        = "token"
-	apiToken1    = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "WORKSPACE", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceId, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
+	apiToken1    = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "WORKSPACE", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceID, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
 	apiTokens    = []astrocore.ApiToken{
 		apiToken1,
-		{Id: "token2", Name: "Token 2", Description: description2, Type: "ORGANIZATION", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceId, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
+		{Id: "token2", Name: "Token 2", Description: description2, Type: "ORGANIZATION", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceID, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
 	}
 	apiTokens2 = []astrocore.ApiToken{
 		apiToken1,
-		{Id: "token2", Name: "Token 2", Description: description2, Type: "WORKSPACE", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceId, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
+		{Id: "token2", Name: "Token 2", Description: description2, Type: "WORKSPACE", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceID, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
 	}
 	GetWorkspaceAPITokenResponseOK = astrocore.GetWorkspaceApiTokenResponse{
 		HTTPResponse: &http.Response{

--- a/cloud/workspace/workspace_token_test.go
+++ b/cloud/workspace/workspace_token_test.go
@@ -17,20 +17,37 @@ import (
 )
 
 var (
+	workspaceId  = "ck05r3bor07h40d02y2hw4n4v"
 	description1 = "Description 1"
 	description2 = "Description 2"
 	fullName1    = "User 1"
 	fullName2    = "User 2"
 	token        = "token"
-	apiToken1    = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "WORKSPACE", Roles: []astrocore.ApiTokenRole{{EntityId: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
+	apiToken1    = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "WORKSPACE", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceId, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
 	apiTokens    = []astrocore.ApiToken{
 		apiToken1,
-		{Id: "token2", Name: "Token 2", Description: description2, Type: "ORGANIZATION", Roles: []astrocore.ApiTokenRole{{EntityId: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
+		{Id: "token2", Name: "Token 2", Description: description2, Type: "ORGANIZATION", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceId, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
 	}
 	apiTokens2 = []astrocore.ApiToken{
 		apiToken1,
 		apiToken1,
-		{Id: "token2", Name: "Token 2", Description: description2, Type: "WORKSPACE", Roles: []astrocore.ApiTokenRole{{EntityId: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
+		{Id: "token2", Name: "Token 2", Description: description2, Type: "WORKSPACE", Roles: []astrocore.ApiTokenRole{{EntityId: workspaceId, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
+	}
+	GetWorkspaceAPITokenResponseOK = astrocore.GetWorkspaceApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &apiToken1,
+	}
+	getTokenErrorBodyList, _ = json.Marshal(astrocore.Error{
+		Message: "failed to get token",
+	})
+	GetWorkspaceAPITokenResponseError = astrocore.GetWorkspaceApiTokenResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 500,
+		},
+		Body:    getTokenErrorBodyList,
+		JSON200: nil,
 	}
 	ListWorkspaceAPITokensResponseOK = astrocore.ListWorkspaceApiTokensResponse{
 		HTTPResponse: &http.Response{
@@ -42,7 +59,7 @@ var (
 			Offset:    0,
 		},
 	}
-	ListWorkspaceAPITokensResponse2OK = astrocore.ListWorkspaceApiTokensResponse{
+	ListWorkspaceAPITokensResponse2O0 = astrocore.ListWorkspaceApiTokensResponse{
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
 		},
@@ -193,7 +210,7 @@ func TestCreateToken(t *testing.T) {
 
 		err := CreateToken("", "Description 1", "WORKSPACE_MEMBER", "", 0, true, out, mockClient)
 
-		assert.Equal(t, ErrInvalidName, err)
+		assert.Equal(t, ErrInvalidTokenName, err)
 	})
 }
 
@@ -202,7 +219,7 @@ func TestUpdateToken(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
+		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil).Twice()
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
 		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
 		assert.NoError(t, err)
@@ -233,7 +250,7 @@ func TestUpdateToken(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponse2OK, nil).Twice()
+		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponse2O0, nil).Twice()
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
 		// mock os.Stdin
 		expectedInput := []byte("2")
@@ -254,47 +271,46 @@ func TestUpdateToken(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
+		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil).Twice()
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
 		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
 		assert.NoError(t, err)
 	})
 
-	t.Run("error both id and name", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
-		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
-		err := UpdateToken("token1", "Token 1", "", "", "", "", out, mockClient)
-		assert.ErrorIs(t, errBothNameAndID, err)
-	})
-
-	t.Run("error path when getWorkspaceTokens returns an error", func(t *testing.T) {
+	t.Run("error path when listWorkspaceTokens returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseError, nil)
-		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
+		err := UpdateToken("", "", "", "", "", "", out, mockClient)
 		assert.ErrorContains(t, err, "failed to list tokens")
+	})
+
+	t.Run("error path when listWorkspaceToken returns an not found error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
+		err := UpdateToken("", "invalid name", "", "", "", "", out, mockClient)
+		assert.Equal(t, ErrWorkspaceTokenNotFound, err)
 	})
 
 	t.Run("error path when getWorkspaceToken returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
-		err := UpdateToken("token3", "", "", "", "", "", out, mockClient)
-		assert.Equal(t, ErrWorkspaceTokenNotFound, err)
+		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseError, nil)
+		err := UpdateToken("tokenId", "", "", "", "", "", out, mockClient)
+		assert.ErrorContains(t, err, "failed to get token")
 	})
 
 	t.Run("error path when UpdateWorkspaceApiTokenWithResponse returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
+		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil)
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseError, nil)
-		err := UpdateToken("token1", "", "", "", "", "", out, mockClient)
+		err := UpdateToken("token3", "", "", "", "", "", out, mockClient)
 		assert.Equal(t, "failed to update workspace", err.Error())
 	})
 
@@ -310,7 +326,7 @@ func TestUpdateToken(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
+		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil)
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
 		err := UpdateToken("token1", "", "", "", "Invalid Role", "", out, mockClient)
 		assert.Equal(t, user.ErrInvalidWorkspaceRole.Error(), err.Error())
@@ -321,19 +337,29 @@ func TestUpdateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
-		err := UpdateToken("token1", "", "", "", "WORKSPACE_MEMBER", "", out, mockClient)
+		err := UpdateToken("", apiToken1.Name, "", "", "WORKSPACE_MEMBER", "", out, mockClient)
 		assert.NoError(t, err)
 	})
 }
 
 func TestRotateToken(t *testing.T) {
-	t.Run("happy path", func(t *testing.T) {
+	t.Run("happy path - id provided", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil)
+		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseOK, nil)
+		err := RotateToken("token1", "", "", false, true, out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("happy path name provided", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseOK, nil)
-		err := RotateToken("token1", "", "", false, true, out, mockClient)
+		err := RotateToken("", apiToken1.Name, "", false, true, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -343,7 +369,7 @@ func TestRotateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseOK, nil)
-		err := RotateToken("token1", "", "", true, false, out, mockClient)
+		err := RotateToken("", apiToken1.Name, "", true, false, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -355,22 +381,31 @@ func TestRotateToken(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("error path when getWorkspaceTokens returns an error", func(t *testing.T) {
+	t.Run("error path when listWorkspaceTokens returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseError, nil)
-		err := RotateToken("token1", "", "", false, false, out, mockClient)
+		err := RotateToken("", "", "", false, false, out, mockClient)
 		assert.ErrorContains(t, err, "failed to list tokens")
+	})
+
+	t.Run("error path when listWorkspaceToken returns an not found error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
+		err := RotateToken("", "invalid name", "", false, false, out, mockClient)
+		assert.Equal(t, ErrWorkspaceTokenNotFound, err)
 	})
 
 	t.Run("error path when getWorkspaceToken returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
-		err := RotateToken("token3", "", "", false, false, out, mockClient)
-		assert.Equal(t, ErrWorkspaceTokenNotFound, err)
+		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseError, nil)
+		err := RotateToken("token1", "", "", false, false, out, mockClient)
+		assert.ErrorContains(t, err, "failed to get token")
 	})
 
 	t.Run("error path when RotateWorkspaceApiTokenWithResponse returns an error", func(t *testing.T) {
@@ -379,17 +414,27 @@ func TestRotateToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseError, nil)
-		err := RotateToken("token1", "", "", false, true, out, mockClient)
+		err := RotateToken("", apiToken1.Name, "", false, true, out, mockClient)
 		assert.Equal(t, "failed to update workspace", err.Error())
 	})
 }
 
 func TestDeleteToken(t *testing.T) {
-	t.Run("happy path - delete workspace token", func(t *testing.T) {
+	t.Run("happy path - delete workspace token - by name", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
+		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseOK, nil)
+		err := DeleteToken("", apiToken1.Name, "", false, out, mockClient)
+		assert.NoError(t, err)
+	})
+
+	t.Run("happy path - delete workspace token - by id", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil).Twice()
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseOK, nil)
 		err := DeleteToken("token1", "", "", false, out, mockClient)
 		assert.NoError(t, err)
@@ -401,7 +446,7 @@ func TestDeleteToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseOK, nil)
-		err := DeleteToken("token2", "", "", false, out, mockClient)
+		err := DeleteToken("", apiToken1.Name, "", false, out, mockClient)
 		assert.NoError(t, err)
 	})
 
@@ -413,21 +458,30 @@ func TestDeleteToken(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("error path when getWorkspaceTokens returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseError, nil)
-		err := DeleteToken("token1", "", "", false, out, mockClient)
-		assert.ErrorContains(t, err, "failed to list tokens")
-	})
-
 	t.Run("error path when getWorkspaceToken returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseError, nil)
+		err := DeleteToken("token1", "", "", false, out, mockClient)
+		assert.ErrorContains(t, err, "failed to get token")
+	})
+
+	t.Run("error path when listWorkspaceTokens returns an error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseError, nil)
+		err := DeleteToken("", apiToken1.Name, "", false, out, mockClient)
+		assert.ErrorContains(t, err, "failed to list tokens")
+	})
+
+	t.Run("error path when listWorkspaceToken returns a not found error", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
-		err := DeleteToken("token3", "", "", false, out, mockClient)
+		err := DeleteToken("", "invalid name", "", false, out, mockClient)
 		assert.Equal(t, ErrWorkspaceTokenNotFound, err)
 	})
 
@@ -437,7 +491,7 @@ func TestDeleteToken(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseError, nil)
-		err := DeleteToken("token1", "", "", true, out, mockClient)
+		err := DeleteToken("", apiToken1.Name, "", true, out, mockClient)
 		assert.Equal(t, "failed to update workspace", err.Error())
 	})
 }

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -601,16 +601,6 @@ func updateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) e
 		tokenID = strings.ToLower(args[0])
 	}
 
-	if tokenRole == "" {
-		fmt.Println("select a Organization Role for the API token:")
-		// no role was provided so ask the user for it
-		var err error
-		tokenRole, err = selectOrganizationRole()
-		if err != nil {
-			return err
-		}
-	}
-
 	cmd.SilenceUsage = true
 	return organization.UpdateToken(tokenID, name, tokenName, tokenDescription, tokenRole, organizationID, out, astroCoreClient)
 }

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -2,8 +2,8 @@ package cloud
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
-	"github.com/astronomer/astro-cli/pkg/printutil"
 	"io"
 	"io/fs"
 	"log"
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/astronomer/astro-cli/pkg/printutil"
+
 	"github.com/spf13/cobra"
 
-	"errors"
 	"github.com/astronomer/astro-cli/cloud/organization"
 	"github.com/astronomer/astro-cli/cloud/team"
 	"github.com/astronomer/astro-cli/cloud/user"

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -445,6 +445,7 @@ func listUsersCmd(cmd *cobra.Command, out io.Writer) error {
 
 // org tokens
 
+//nolint:dupl
 func newOrganizationTokenRootCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "token",
@@ -465,6 +466,7 @@ func newOrganizationTokenRootCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newOrganizationTokenListCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -478,6 +480,7 @@ func newOrganizationTokenListCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newOrganizationTokenListRolesCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "roles",
@@ -490,6 +493,7 @@ func newOrganizationTokenListRolesCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newOrganizationTokenCreateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
@@ -510,6 +514,7 @@ func newOrganizationTokenCreateCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newOrganizationTokenUpdateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update [TOKEN_ID]",
@@ -529,6 +534,7 @@ func newOrganizationTokenUpdateCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newOrganizationTokenRotateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rotate [TOKEN_ID]",
@@ -546,6 +552,7 @@ func newOrganizationTokenRotateCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newOrganizationTokenDeleteCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [TOKEN_ID]",
@@ -562,11 +569,13 @@ func newOrganizationTokenDeleteCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func listOrganizationToken(cmd *cobra.Command, out io.Writer) error {
 	cmd.SilenceUsage = true
 	return organization.ListTokens(astroCoreClient, out)
 }
 
+//nolint:dupl
 func listOrganizationTokenRoles(cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) > 0 {
 		// make sure the id is lowercase
@@ -577,6 +586,7 @@ func listOrganizationTokenRoles(cmd *cobra.Command, args []string, out io.Writer
 	return organization.ListTokenRoles(tokenID, astroCoreClient, out)
 }
 
+//nolint:dupl
 func createOrganizationToken(cmd *cobra.Command, out io.Writer) error {
 	if tokenName == "" {
 		// no role was provided so ask the user for it
@@ -596,6 +606,7 @@ func createOrganizationToken(cmd *cobra.Command, out io.Writer) error {
 	return organization.CreateToken(tokenName, tokenDescription, tokenRole, tokenExpiration, cleanTokenOutput, out, astroCoreClient)
 }
 
+//nolint:dupl
 func updateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) error {
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -607,6 +618,7 @@ func updateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) e
 	return organization.UpdateToken(tokenID, name, tokenName, tokenDescription, tokenRole, out, astroCoreClient)
 }
 
+//nolint:dupl
 func rotateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) error {
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -618,6 +630,7 @@ func rotateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) e
 	return organization.RotateToken(tokenID, name, cleanTokenOutput, forceRotate, out, astroCoreClient)
 }
 
+//nolint:dupl
 func deleteOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) error {
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -629,6 +642,7 @@ func deleteOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) e
 	return organization.DeleteToken(tokenID, name, forceDelete, out, astroCoreClient)
 }
 
+//nolint:dupl
 func selectOrganizationRole() (string, error) {
 	tokenRolesMap := map[string]string{}
 	tab := &printutil.Table{

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -591,7 +591,7 @@ func createOrganizationToken(cmd *cobra.Command, out io.Writer) error {
 	}
 	cmd.SilenceUsage = true
 
-	return organization.CreateToken(tokenName, tokenDescription, tokenRole, organizationID, tokenExpiration, cleanTokenOutput, out, astroCoreClient)
+	return organization.CreateToken(tokenName, tokenDescription, tokenRole, tokenExpiration, cleanTokenOutput, out, astroCoreClient)
 }
 
 func updateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) error {
@@ -602,7 +602,7 @@ func updateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) e
 	}
 
 	cmd.SilenceUsage = true
-	return organization.UpdateToken(tokenID, name, tokenName, tokenDescription, tokenRole, organizationID, out, astroCoreClient)
+	return organization.UpdateToken(tokenID, name, tokenName, tokenDescription, tokenRole, out, astroCoreClient)
 }
 
 func rotateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) error {
@@ -613,7 +613,7 @@ func rotateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) e
 	}
 
 	cmd.SilenceUsage = true
-	return organization.RotateToken(tokenID, name, organizationID, cleanTokenOutput, forceRotate, out, astroCoreClient)
+	return organization.RotateToken(tokenID, name, cleanTokenOutput, forceRotate, out, astroCoreClient)
 }
 
 func deleteOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) error {
@@ -624,7 +624,7 @@ func deleteOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) e
 	}
 
 	cmd.SilenceUsage = true
-	return organization.DeleteToken(tokenID, name, organizationID, forceDelete, out, astroCoreClient)
+	return organization.DeleteToken(tokenID, name, forceDelete, out, astroCoreClient)
 }
 
 func selectOrganizationRole() (string, error) {

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -493,8 +493,8 @@ func newOrganizationTokenCreateCmd(out io.Writer) *cobra.Command {
 		Use:     "create",
 		Aliases: []string{"cr"},
 		Short:   "Create an API token in an Astro Organization",
-		Long: "Create an API token in an Astro Organization\n$astro organization token create --name [token name] --role [WORKSPACE_MEMBER, " +
-			"WORKSPACE_OPERATOR, WORKSPACE_OWNER].",
+		Long: "Create an API token in an Astro Organization\n$astro organization token create --name [token name] --role [ORGANIZATION_MEMBER, " +
+			"ORGANIZATION_BILLING_ADMIN, ORGANIZATION_MEMBER].",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return createOrganizationToken(cmd, out)
 		},
@@ -503,7 +503,7 @@ func newOrganizationTokenCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&cleanTokenOutput, "clean-output", "c", false, "Print only the token as output. For use of the command in scripts")
 	cmd.Flags().StringVarP(&tokenDescription, "description", "d", "", "Description of the token. If the description contains a space, specify the entire description within quotes \"\"")
 	cmd.Flags().StringVarP(&tokenRole, "role", "r", "", "The role for the "+
-		"token. Possible values are WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER")
+		"token. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER")
 	cmd.Flags().IntVarP(&tokenExpiration, "expiration", "e", 0, "Expiration of the token in days. If the flag isn't used the token won't have an expiration. Must be between 1 and 3650 days. ")
 	return cmd
 }
@@ -513,8 +513,8 @@ func newOrganizationTokenUpdateCmd(out io.Writer) *cobra.Command {
 		Use:     "update [TOKEN_ID]",
 		Aliases: []string{"up"},
 		Short:   "Update a Organization or Organaization API token",
-		Long: "Update a Organization or Organaization API token that has a role in an Astro Organization\n$astro organization token update [TOKEN_ID] --name [new token name] --role [WORKSPACE_MEMBER, " +
-			"WORKSPACE_OPERATOR, WORKSPACE_OWNER].",
+		Long: "Update a Organization or Organaization API token that has a role in an Astro Organization\n$astro organization token update [TOKEN_ID] --name [new token name] --role [ORGANIZATION_MEMBER, " +
+			"ORGANIZATION_BILLING_ADMIN, ORGANIZATION_OWNER].",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateOrganizationToken(cmd, args, out)
 		},
@@ -523,7 +523,7 @@ func newOrganizationTokenUpdateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&tokenName, "new-name", "n", "", "The token's new name. If the name contains a space, specify the entire name within quotes \"\" ")
 	cmd.Flags().StringVarP(&tokenDescription, "description", "d", "", "updated description of the token. If the description contains a space, specify the entire description in quotes \"\"")
 	cmd.Flags().StringVarP(&tokenRole, "role", "r", "", "The new role for the "+
-		"token. Possible values are WORKSPACE_MEMBER, WORKSPACE_OPERATOR and WORKSPACE_OWNER ")
+		"token. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")
 	return cmd
 }
 

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -484,7 +484,7 @@ func newOrganizationTokenListCmd(out io.Writer) *cobra.Command {
 //nolint:dupl
 func newOrganizationTokenListRolesCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "roles",
+		Use:   "roles [TOKEN_ID]",
 		Short: "List roles for an organization API token",
 		Long:  "List roles for an organization API token\n$astro organization token roles [TOKEN_ID] ",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -582,7 +582,6 @@ func listOrganizationTokenRoles(cmd *cobra.Command, args []string, out io.Writer
 		// make sure the id is lowercase
 		tokenID = strings.ToLower(args[0])
 	}
-
 	cmd.SilenceUsage = true
 	return organization.ListTokenRoles(tokenID, astroCoreClient, out)
 }

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -453,6 +453,7 @@ func newOrganizationTokenRootCmd(out io.Writer) *cobra.Command {
 	cmd.SetOut(out)
 	cmd.AddCommand(
 		newOrganizationTokenListCmd(out),
+		newOrganizationTokenListRolesCmd(out),
 		newOrganizationTokenCreateCmd(out),
 		newOrganizationTokenUpdateCmd(out),
 		newOrganizationTokenRotateCmd(out),
@@ -470,6 +471,18 @@ func newOrganizationTokenListCmd(out io.Writer) *cobra.Command {
 		Long:    "List all the API tokens in an Astro Organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listOrganizationToken(cmd, out)
+		},
+	}
+	return cmd
+}
+
+func newOrganizationTokenListRolesCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "roles",
+		Short: "List roles for an organization API token",
+		Long:  "List roles for an organization API token\n$astro organization token roles [TOKEN_ID] ",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listOrganizationTokenRoles(cmd, args, out)
 		},
 	}
 	return cmd
@@ -552,6 +565,16 @@ func listOrganizationToken(cmd *cobra.Command, out io.Writer) error {
 	return organization.ListTokens(astroCoreClient, out)
 }
 
+func listOrganizationTokenRoles(cmd *cobra.Command, args []string, out io.Writer) error {
+	if len(args) > 0 {
+		// make sure the id is lowercase
+		tokenID = strings.ToLower(args[0])
+	}
+
+	cmd.SilenceUsage = true
+	return organization.ListTokenRoles(tokenID, astroCoreClient, out)
+}
+
 func createOrganizationToken(cmd *cobra.Command, out io.Writer) error {
 	if tokenName == "" {
 		// no role was provided so ask the user for it
@@ -576,6 +599,16 @@ func updateOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) e
 	if len(args) > 0 {
 		// make sure the id is lowercase
 		tokenID = strings.ToLower(args[0])
+	}
+
+	if tokenRole == "" {
+		fmt.Println("select a Organization Role for the API token:")
+		// no role was provided so ask the user for it
+		var err error
+		tokenRole, err = selectOrganizationRole()
+		if err != nil {
+			return err
+		}
 	}
 
 	cmd.SilenceUsage = true

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"errors"
 	"github.com/astronomer/astro-cli/cloud/organization"
 	"github.com/astronomer/astro-cli/cloud/team"
 	"github.com/astronomer/astro-cli/cloud/user"
@@ -21,6 +22,7 @@ import (
 )
 
 var (
+	errInvalidOrganizationRoleKey      = errors.New("invalid organization role selection")
 	orgList                            = organization.List
 	orgSwitch                          = organization.Switch
 	orgExportAuditLogs                 = organization.ExportAuditLogs
@@ -630,7 +632,6 @@ func deleteOrganizationToken(cmd *cobra.Command, args []string, out io.Writer) e
 func selectOrganizationRole() (string, error) {
 	tokenRolesMap := map[string]string{}
 	tab := &printutil.Table{
-		Padding:        []int{44, 50},
 		DynamicPadding: true,
 		Header:         []string{"#", "ROLE"},
 	}
@@ -648,7 +649,7 @@ func selectOrganizationRole() (string, error) {
 	choice := input.Text("\n> ")
 	selected, ok := tokenRolesMap[choice]
 	if !ok {
-		return "", errInvalidWorkspaceRoleKey
+		return "", errInvalidOrganizationRoleKey
 	}
 	return selected, nil
 }

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -1047,47 +1047,6 @@ func TestOrganizationTokenList(t *testing.T) {
 	})
 }
 
-func TestOrganizationTokenListRoles(t *testing.T) {
-	expectedHelp := "List roles for an organization API token"
-	mockTokenID := "mockTokenID"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
-
-	t.Run("-h prints list help", func(t *testing.T) {
-		cmdArgs := []string{"token", "roles", "-h"}
-		resp, err := execOrganizationCmd(cmdArgs...)
-		assert.NoError(t, err)
-		assert.Contains(t, resp, expectedHelp)
-	})
-	t.Run("any errors from api are returned and token roles are not listed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil).Twice()
-		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "roles", mockTokenID}
-		_, err := execOrganizationCmd(cmdArgs...)
-		assert.ErrorContains(t, err, "failed to get token")
-	})
-	t.Run("any context errors from api are returned and token roles are not listed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.Initial)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
-		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "roles", mockTokenID}
-		_, err := execOrganizationCmd(cmdArgs...)
-		assert.Error(t, err)
-	})
-
-	t.Run("token roles are listed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
-		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "roles", mockTokenID}
-		_, err := execOrganizationCmd(cmdArgs...)
-		assert.NoError(t, err)
-	})
-}
-
 func TestOrganizationTokenCreate(t *testing.T) {
 	expectedHelp := "Create an API token in an Astro Organization"
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
@@ -1394,6 +1353,47 @@ func TestOrganizationTokenDelete(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"token", "delete", "--name", tokenName1}
 		_, err = execOrganizationCmd(cmdArgs...)
+		assert.NoError(t, err)
+	})
+}
+
+func TestOrganizationTokenListRoles(t *testing.T) {
+	expectedHelp := "List roles for an organization API token"
+	mockTokenID := "mockTokenID"
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+
+	t.Run("-h prints list help", func(t *testing.T) {
+		cmdArgs := []string{"token", "roles", "-h"}
+		resp, err := execOrganizationCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, expectedHelp)
+	})
+	t.Run("any errors from api are returned and token roles are not listed", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil).Twice()
+		astroCoreClient = mockClient
+		cmdArgs := []string{"token", "roles", mockTokenID}
+		_, err := execOrganizationCmd(cmdArgs...)
+		assert.ErrorContains(t, err, "failed to get token")
+	})
+	t.Run("any context errors from api are returned and token roles are not listed", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.Initial)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
+		astroCoreClient = mockClient
+		cmdArgs := []string{"token", "roles", mockTokenID}
+		_, err := execOrganizationCmd(cmdArgs...)
+		assert.Error(t, err)
+	})
+
+	t.Run("token roles are listed", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
+		astroCoreClient = mockClient
+		cmdArgs := []string{"token", "roles", mockTokenID}
+		_, err := execOrganizationCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})
 }

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -1046,7 +1046,7 @@ func TestOrganizationTokenCreate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateOrganizationAPITokenResponseError, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "create", "--name", "Token 1", "--role", "WORKSPACE_MEMBER"}
+		cmdArgs := []string{"token", "create", "--name", "Token 1", "--role", "ORGANIZATION_MEMBER"}
 		_, err := execOrganizationCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "failed to create workspace")
 	})
@@ -1064,7 +1064,7 @@ func TestOrganizationTokenCreate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateOrganizationAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "create", "--name", "Token 1", "--role", "WORKSPACE_MEMBER"}
+		cmdArgs := []string{"token", "create", "--name", "Token 1", "--role", "ORGANIZATION_MEMBER"}
 		_, err := execOrganizationCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})
@@ -1084,7 +1084,7 @@ func TestOrganizationTokenCreate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "create", "--role", "WORKSPACE_MEMBER"}
+		cmdArgs := []string{"token", "create", "--role", "ORGANIZATION_MEMBER"}
 		_, err = execOrganizationCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -574,16 +574,6 @@ func updateWorkspaceToken(cmd *cobra.Command, args []string, out io.Writer) erro
 		tokenID = strings.ToLower(args[0])
 	}
 
-	if tokenRole == "" {
-		fmt.Println("select a Workspace Role for the API token:")
-		// no role was provided so ask the user for it
-		var err error
-		tokenRole, err = selectWorkspaceRole()
-		if err != nil {
-			return err
-		}
-	}
-
 	cmd.SilenceUsage = true
 	return workspace.UpdateToken(tokenID, name, tokenName, tokenDescription, tokenRole, workspaceID, out, astroCoreClient)
 }

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -574,6 +574,16 @@ func updateWorkspaceToken(cmd *cobra.Command, args []string, out io.Writer) erro
 		tokenID = strings.ToLower(args[0])
 	}
 
+	if tokenRole == "" {
+		fmt.Println("select a Workspace Role for the API token:")
+		// no role was provided so ask the user for it
+		var err error
+		tokenRole, err = selectWorkspaceRole()
+		if err != nil {
+			return err
+		}
+	}
+
 	cmd.SilenceUsage = true
 	return workspace.UpdateToken(tokenID, name, tokenName, tokenDescription, tokenRole, workspaceID, out, astroCoreClient)
 }

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -584,7 +584,6 @@ func rotateWorkspaceToken(cmd *cobra.Command, args []string, out io.Writer) erro
 		// make sure the id is lowercase
 		tokenID = strings.ToLower(args[0])
 	}
-
 	cmd.SilenceUsage = true
 	return workspace.RotateToken(tokenID, name, workspaceID, cleanTokenOutput, forceRotate, out, astroCoreClient)
 }
@@ -616,7 +615,7 @@ func addOrgTokenToWorkspace(cmd *cobra.Command, args []string, out io.Writer) er
 		}
 	}
 	cmd.SilenceUsage = true
-	return organization.AddOrgTokenToWorkspace(orgTokenID, tokenName, tokenRole, workspaceID, out, astroCoreClient)
+	return organization.AddOrgTokenToWorkspace(orgTokenID, orgTokenName, tokenRole, workspaceID, out, astroCoreClient)
 }
 
 func coalesceWorkspace() (string, error) {

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -207,6 +207,7 @@ func newWorkspaceUserRemoveCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newWorkspaceTokenRootCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "token",
@@ -227,6 +228,7 @@ func newWorkspaceTokenRootCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newWorkspaceTokenListCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -240,6 +242,7 @@ func newWorkspaceTokenListCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newWorkspaceTeamRootCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "team",
@@ -257,6 +260,7 @@ func newWorkspaceTeamRootCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newWorkspaceTeamListCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -270,6 +274,7 @@ func newWorkspaceTeamListCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newWorkspaceTokenCreateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
@@ -290,6 +295,7 @@ func newWorkspaceTokenCreateCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newWorkspaceTokenUpdateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update [TOKEN_ID]",
@@ -309,6 +315,7 @@ func newWorkspaceTokenUpdateCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newWorkspaceTokenRotateCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rotate [TOKEN_ID]",
@@ -326,6 +333,7 @@ func newWorkspaceTokenRotateCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newWorkspaceTokenDeleteCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [TOKEN_ID]",
@@ -342,6 +350,7 @@ func newWorkspaceTokenDeleteCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
+//nolint:dupl
 func newWorkspaceTokenAddCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add [ORG_TOKEN_ID]",

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -314,7 +314,7 @@ func newWorkspaceTokenRotateCmd(out io.Writer) *cobra.Command {
 		Use:     "rotate [TOKEN_ID]",
 		Aliases: []string{"ro"},
 		Short:   "Rotate a Workspace API token",
-		Long:    "Rotate a Workspace API token. You can only rotate Worspace API tokens. You cannot rotate Organization API tokens with this command",
+		Long:    "Rotate a Workspace API token. You can only rotate Workspace API tokens. You cannot rotate Organization API tokens with this command",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rotateWorkspaceToken(cmd, args, out)
 		},

--- a/cmd/cloud/workspace_test.go
+++ b/cmd/cloud/workspace_test.go
@@ -1229,6 +1229,7 @@ func TestWorkspaceTokenCreate(t *testing.T) {
 func TestWorkspaceTokenUpdate(t *testing.T) {
 	expectedHelp := "Update a Workspace or Organaization API token"
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	tokenID = ""
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "update", "-h"}

--- a/cmd/cloud/workspace_test.go
+++ b/cmd/cloud/workspace_test.go
@@ -1003,15 +1003,18 @@ func TestWorkspaceTeamRemove(t *testing.T) {
 // test workspace token commands
 
 var (
-	description1 = "Description 1"
-	description2 = "Description 2"
-	fullName1    = "User 1"
-	fullName2    = "User 2"
-	token        = "token"
-	apiToken1    = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityId: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
-	apiTokens    = []astrocore.ApiToken{
+	mockWorkspaceID    = "ck05r3bor07h40d02y2hw4n4v"
+	mockOrganizationID = "orgID"
+	description1       = "Description 1"
+	description2       = "Description 2"
+	fullName1          = "User 1"
+	fullName2          = "User 2"
+	token              = "token"
+	tokenName1         = "Token 1"
+	apiToken1          = astrocore.ApiToken{Id: "token1", Name: tokenName1, Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityId: mockWorkspaceID, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
+	apiTokens          = []astrocore.ApiToken{
 		apiToken1,
-		{Id: "token2", Name: "Token 2", Description: description2, Type: "Type 2", Roles: []astrocore.ApiTokenRole{{EntityId: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
+		{Id: "token2", Name: "Token 2", Description: description2, Type: "Type 2", Roles: []astrocore.ApiTokenRole{{EntityId: mockWorkspaceID, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
 	}
 	ListWorkspaceAPITokensResponseOK = astrocore.ListWorkspaceApiTokensResponse{
 		HTTPResponse: &http.Response{
@@ -1239,7 +1242,7 @@ func TestWorkspaceTokenUpdate(t *testing.T) {
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseError, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "update", "token1"}
+		cmdArgs := []string{"token", "update", "--name", tokenName1}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "failed to update token")
 	})
@@ -1249,7 +1252,7 @@ func TestWorkspaceTokenUpdate(t *testing.T) {
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "update", "token1"}
+		cmdArgs := []string{"token", "update", "--name", tokenName1}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
@@ -1259,7 +1262,7 @@ func TestWorkspaceTokenUpdate(t *testing.T) {
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "update", "token1"}
+		cmdArgs := []string{"token", "update", "--name", tokenName1}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})
@@ -1302,7 +1305,7 @@ func TestWorkspaceTokenRotate(t *testing.T) {
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseError, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "rotate", "token1", "--force"}
+		cmdArgs := []string{"token", "rotate", "--name", tokenName1, "--force"}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "failed to rotate token")
 	})
@@ -1312,7 +1315,7 @@ func TestWorkspaceTokenRotate(t *testing.T) {
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "rotate", "token1"}
+		cmdArgs := []string{"token", "rotate", "--name", tokenName1}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
@@ -1322,7 +1325,7 @@ func TestWorkspaceTokenRotate(t *testing.T) {
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "rotate", "token1", "--force"}
+		cmdArgs := []string{"token", "rotate", "--name", tokenName1, "--force"}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})
@@ -1364,7 +1367,7 @@ func TestWorkspaceTokenRotate(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "rotate", "token1"}
+		cmdArgs := []string{"token", "rotate", "--name", tokenName1}
 		_, err = execWorkspaceCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})
@@ -1386,7 +1389,7 @@ func TestWorkspaceTokenDelete(t *testing.T) {
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseError, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "delete", "token1", "--force"}
+		cmdArgs := []string{"token", "delete", "--name", tokenName1, "--force"}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "failed to delete token")
 	})
@@ -1396,7 +1399,7 @@ func TestWorkspaceTokenDelete(t *testing.T) {
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "delete", "token1"}
+		cmdArgs := []string{"token", "delete", "--name", tokenName1}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
@@ -1406,7 +1409,7 @@ func TestWorkspaceTokenDelete(t *testing.T) {
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "delete", "token1", "--force"}
+		cmdArgs := []string{"token", "delete", "--name", tokenName1, "--force"}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})
@@ -1448,17 +1451,18 @@ func TestWorkspaceTokenDelete(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "delete", "token1"}
+		cmdArgs := []string{"token", "delete", "--name", tokenName1}
 		_, err = execWorkspaceCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})
 }
 
 var (
-	apiToken2  = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityId: "WORKSPACE", Role: "WORKSPACE_MEMBER"}, {EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
+	tokenName2 = "Token 2"
+	apiToken2  = astrocore.ApiToken{Id: "token1", Name: "Token 1", Token: &token, Description: description1, Type: "Type 1", Roles: []astrocore.ApiTokenRole{{EntityId: mockWorkspaceID, EntityType: "WORKSPACE", Role: "WORKSPACE_MEMBER"}, {EntityId: mockOrganizationID, EntityType: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName1}}
 	apiTokens2 = []astrocore.ApiToken{
 		apiToken2,
-		{Id: "token2", Name: "Token 2", Description: description2, Type: "Type 2", Roles: []astrocore.ApiTokenRole{{EntityId: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
+		{Id: "token2", Name: tokenName2, Description: description2, Type: "Type 2", Roles: []astrocore.ApiTokenRole{{EntityId: mockOrganizationID, EntityType: "ORGANIZATION", Role: "ORGANIZATION_MEMBER"}}, CreatedAt: time.Now(), CreatedBy: &astrocore.BasicSubjectProfile{FullName: &fullName2}},
 	}
 	ListOrganizationAPITokensResponseOK = astrocore.ListOrganizationApiTokensResponse{
 		HTTPResponse: &http.Response{
@@ -1513,7 +1517,7 @@ func TestWorkspaceTokenAdd(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "add", "token1", "--role", "WORKSPACE_MEMBER"}
+		cmdArgs := []string{"token", "add", "--org-token-name", tokenName1, "--role", "WORKSPACE_MEMBER"}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "failed to list tokens")
 	})
@@ -1523,7 +1527,7 @@ func TestWorkspaceTokenAdd(t *testing.T) {
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "update", "token1", "--role", "WORKSPACE_MEMBER"}
+		cmdArgs := []string{"token", "add", "--org-token-name", tokenName1, "--role", "WORKSPACE_MEMBER"}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
@@ -1533,7 +1537,7 @@ func TestWorkspaceTokenAdd(t *testing.T) {
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "add", "token2", "--role", "WORKSPACE_MEMBER"}
+		cmdArgs := []string{"token", "add", "--org-token-name", tokenName2, "--role", "WORKSPACE_MEMBER"}
 		_, err := execWorkspaceCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})
@@ -1575,7 +1579,7 @@ func TestWorkspaceTokenAdd(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 		astroCoreClient = mockClient
-		cmdArgs := []string{"token", "add", "token2"}
+		cmdArgs := []string{"token", "add", "--org-token-name", tokenName2}
 		_, err = execWorkspaceCmd(cmdArgs...)
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
## Description

- Adds org token command to astro cli
    - list
    - list roles
    - delete
    - update
    - create
    - rotate
- Fixes some bugs found in workspace token cli commands
- Does a refactor on workspace token command when id is passed in (It grabs the token by id rather than doing a full token list api call)

## 🎟 Issue(s)

Related astronomer/astro#13273

## 🧪 Functional Testing

I ran all the commands locally to verify they work as expected


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
