### PR TITLE
Bug fix when team has no members and list team users is called

### DIFF
--- a/cloud/team/team.go
+++ b/cloud/team/team.go
@@ -714,19 +714,23 @@ func ListTeamUsers(teamID string, out io.Writer, client astrocore.CoreClient) (e
 		DynamicPadding: true,
 		Header:         []string{"ID", "FullName", "Email"},
 	}
-	members := *team.Members
-	for i := range members {
-		var fullName string
-		if members[i].FullName != nil {
-			fullName = *members[i].FullName
+	if team.Members != nil {
+		members := *team.Members
+		for i := range members {
+			var fullName string
+			if members[i].FullName != nil {
+				fullName = *members[i].FullName
+			}
+			table.AddRow([]string{
+				members[i].UserId,
+				fullName,
+				members[i].Username,
+			}, false)
 		}
-		table.AddRow([]string{
-			members[i].UserId,
-			fullName,
-			members[i].Username,
-		}, false)
-	}
 
-	table.Print(out)
+		table.Print(out)
+		return nil
+	}
+	fmt.Println("The selected team has no members")
 	return nil
 }

--- a/cloud/team/team_test.go
+++ b/cloud/team/team_test.go
@@ -1241,6 +1241,15 @@ func TestListTeamUsers(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("happy path ListTeamUsers team with no membership", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseEmptyMembership, nil).Twice()
+		err := ListTeamUsers(team1.Id, out, mockClient)
+		assert.NoError(t, err)
+	})
+
 	t.Run("error path when GetTeamWithResponse returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)


### PR DESCRIPTION
## Description

Bug fix when team has no members and list team users is called

## 🎟 Issue(s)

Related #1269

## 🧪 Functional Testing

created an team without membership and called the cli method

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
