### PR TITLE
warn user of updating idp managed teams

### DIFF
--- a/cloud/team/team.go
+++ b/cloud/team/team.go
@@ -12,7 +12,6 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/context"
-	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
 )
@@ -32,9 +31,9 @@ var (
 	teamPagnationLimit          = 100
 )
 
-func confirmOperation() {
-	fmt.Printf("This is an IDP-managed team. Please avoid making changes in Astro whenever possible. \n%s to continue the operation or %s to abort", ansi.Green("Press Enter"), ansi.Red("^C"))
-	fmt.Scanln()
+func confirmOperation() bool {
+	y, _ := input.Confirm("This is an IDP-managed team. Are you sure you want to continue the operation?")
+	return y
 }
 
 func CreateTeam(name, description string, out io.Writer, client astrocore.CoreClient) error {
@@ -174,7 +173,10 @@ func UpdateTeam(id, name, description string, out io.Writer, client astrocore.Co
 		}
 	}
 	if team.IsIdpManaged {
-		confirmOperation()
+		y := confirmOperation()
+		if !y {
+			return nil
+		}
 	}
 	teamID := team.Id
 	teamUpdateRequest := astrocore.UpdateTeamJSONRequestBody{}
@@ -506,7 +508,10 @@ func Delete(id string, out io.Writer, client astrocore.CoreClient) error {
 		}
 	}
 	if team.IsIdpManaged {
-		confirmOperation()
+		y := confirmOperation()
+		if !y {
+			return nil
+		}
 	}
 	teamID := team.Id
 	resp, err := client.DeleteTeamWithResponse(httpContext.Background(), ctx.OrganizationShortName, teamID)
@@ -554,7 +559,10 @@ func RemoveUser(teamID, teamMemberID string, out io.Writer, client astrocore.Cor
 		}
 	}
 	if team.IsIdpManaged {
-		confirmOperation()
+		y := confirmOperation()
+		if !y {
+			return nil
+		}
 	}
 	teamID = team.Id
 	if team.Members == nil {
@@ -626,7 +634,10 @@ func AddUser(teamID, userID string, out io.Writer, client astrocore.CoreClient) 
 		}
 	}
 	if team.IsIdpManaged {
-		confirmOperation()
+		y := confirmOperation()
+		if !y {
+			return nil
+		}
 	}
 	teamID = team.Id
 

--- a/cloud/team/team_test.go
+++ b/cloud/team/team_test.go
@@ -703,6 +703,29 @@ func TestDelete(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
+	t.Run("happy path Delete with idp managed team", func(t *testing.T) {
+		expectedOutMessage := fmt.Sprintf("Astro Team %s was successfully deleted\n", team2.Name)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
+		mockClient.On("DeleteTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationTeamResponseOK, nil).Once()
+		defer testUtil.MockUserInput(t, "y")()
+		err := Delete(team2.Id, out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
+	t.Run("error path user reject delete", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
+		mockClient.On("DeleteTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationTeamResponseOK, nil).Once()
+		defer testUtil.MockUserInput(t, "n")()
+		err := Delete(team2.Id, out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, "", out.String())
+	})
+
 	t.Run("error path no org teams found", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -796,6 +819,29 @@ func TestUpdate(t *testing.T) {
 		err := UpdateTeam(team1.Id, "name", "description", out, mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
+	t.Run("happy path Update with idp managed team", func(t *testing.T) {
+		expectedOutMessage := fmt.Sprintf("Astro Team %s was successfully updated\n", team2.Name)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
+		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
+		defer testUtil.MockUserInput(t, "y")()
+		err := UpdateTeam(team2.Id, "name", "description", out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
+	t.Run("happy path user reject Update", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
+		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
+		defer testUtil.MockUserInput(t, "n")()
+		err := UpdateTeam(team2.Id, "name", "description", out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, "", out.String())
 	})
 
 	t.Run("happy path Update no description passed in", func(t *testing.T) {
@@ -974,6 +1020,31 @@ func TestAddUser(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
+	t.Run("happy path AddUser with idp managed team", func(t *testing.T) {
+		expectedOutMessage := fmt.Sprintf("Astro User %s was successfully added to team %s \n", user1.Id, team2.Name)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
+		mockClient.On("GetUserWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetUserWithResponseOK, nil).Twice()
+		mockClient.On("AddTeamMembersWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&AddTeamMemberResponseOK, nil).Once()
+		defer testUtil.MockUserInput(t, "y")()
+		err := AddUser(team2.Id, user1.Id, out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
+	t.Run("user reject AddUser", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
+		mockClient.On("GetUserWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetUserWithResponseOK, nil).Twice()
+		mockClient.On("AddTeamMembersWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&AddTeamMemberResponseOK, nil).Once()
+		defer testUtil.MockUserInput(t, "n")()
+		err := AddUser(team2.Id, user1.Id, out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, "", out.String())
+	})
+
 	t.Run("error path no org teams found", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1124,6 +1195,31 @@ func TestRemoveUser(t *testing.T) {
 		err := RemoveUser(team1.Id, user1.Id, out, mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
+	t.Run("happy path RemoveUser with idp managed team", func(t *testing.T) {
+		expectedOutMessage := fmt.Sprintf("Astro User %s was successfully removed from team %s \n", user1.Id, team2.Name)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
+		mockClient.On("ListOrgUsersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgUsersResponseOK, nil).Twice()
+		mockClient.On("RemoveTeamMemberWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RemoveTeamMemberResponseOK, nil).Once()
+		defer testUtil.MockUserInput(t, "y")()
+		err := RemoveUser(team2.Id, user1.Id, out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
+	t.Run("user reject RemoveUser with idp managed team", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
+		mockClient.On("ListOrgUsersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgUsersResponseOK, nil).Twice()
+		mockClient.On("RemoveTeamMemberWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RemoveTeamMemberResponseOK, nil).Once()
+		defer testUtil.MockUserInput(t, "n")()
+		err := RemoveUser(team2.Id, user1.Id, out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, "", out.String())
 	})
 
 	t.Run("error path no org teams found", func(t *testing.T) {

--- a/cloud/team/team_test.go
+++ b/cloud/team/team_test.go
@@ -45,8 +45,17 @@ var (
 		Id:          "team1-id",
 		Members:     &teamMembers,
 	}
+	team2 = astrocore.Team{
+		CreatedAt:    time.Now(),
+		Name:         "team 2",
+		Description:  &description,
+		Id:           "team2-id",
+		Members:      &teamMembers,
+		IsIdpManaged: true,
+	}
 	teams = []astrocore.Team{
 		team1,
+		team2,
 	}
 	GetUserWithResponseOK = astrocore.GetUserResponse{
 		HTTPResponse: &http.Response{
@@ -59,6 +68,12 @@ var (
 			StatusCode: 200,
 		},
 		JSON200: &team1,
+	}
+	GetIDPManagedTeamWithResponseOK = astrocore.GetTeamResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &team2,
 	}
 	errorBodyGet, _ = json.Marshal(astrocore.Error{
 		Message: "failed to get team",


### PR DESCRIPTION
## Description

warn user of updating idp managed teams

## 🎟 Issue(s)

https://github.com/astronomer/astro/issues/14251

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
