### PR TITLE
Fix concurrency check for hosted deployments

### DIFF
--- a/astro-client/queries.go
+++ b/astro-client/queries.go
@@ -178,6 +178,7 @@ var (
 		}
 		astroMachines {
 			concurrentTasks
+			concurrentTasksMax
 			cpu
 			memory
 			nodePoolType
@@ -186,6 +187,7 @@ var (
 		}
 		defaultAstroMachine {
 			concurrentTasks
+			concurrentTasksMax
 			cpu
 			memory
 			nodePoolType

--- a/astro-client/types.go
+++ b/astro-client/types.go
@@ -269,12 +269,13 @@ type DeploymentConfig struct {
 }
 
 type Machine struct {
-	Type            string `json:"type"`
-	CPU             string `json:"cpu"`
-	Memory          string `json:"memory"`
-	StorageSize     string `json:"storageSize"`
-	ConcurrentTasks int    `json:"concurrentTasks"`
-	NodePoolType    string `json:"nodePoolType"`
+	Type               string `json:"type"`
+	CPU                string `json:"cpu"`
+	Memory             string `json:"memory"`
+	StorageSize        string `json:"storageSize"`
+	ConcurrentTasks    int    `json:"concurrentTasks"`
+	ConcurrentTasksMax int    `json:"concurrentTasksMax"`
+	NodePoolType       string `json:"nodePoolType"`
 }
 
 type MachineUnit struct {

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -981,13 +981,13 @@ deployment:
       is_default: true
       max_worker_count: 130
       min_worker_count: 12
-      worker_concurrency: 180
+      worker_concurrency: 10
       worker_type: a5
     - name: test-queue-1
       is_default: false
       max_worker_count: 175
       min_worker_count: 8
-      worker_concurrency: 176
+      worker_concurrency: 10
       worker_type: a5
   metadata:
     deployment_id: test-deployment-id
@@ -1045,6 +1045,38 @@ deployment:
 			}
 			fileutil.WriteStringToFile(filePath, data)
 			defer afero.NewOsFs().Remove(filePath)
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				AstroMachines: []astro.Machine{
+					{
+						Type:               "a5",
+						ConcurrentTasks:    5,
+						ConcurrentTasksMax: 15,
+					},
+					{
+						Type:               "a10",
+						ConcurrentTasks:    10,
+						ConcurrentTasksMax: 30,
+					},
+					{
+						Type:               "a20",
+						ConcurrentTasks:    20,
+						ConcurrentTasksMax: 60,
+					},
+				},
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
 			mockCoreClient.On("ListClustersWithResponse", mock.Anything, mockOrgShortName, clusterListParams).Return(&mockListClustersResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil).Once()
@@ -1225,7 +1257,7 @@ deployment:
                 "is_default": true,
                 "max_worker_count": 130,
                 "min_worker_count": 12,
-                "worker_concurrency": 180,
+                "worker_concurrency": 10,
                 "worker_type": "a5"
             },
             {
@@ -1233,7 +1265,7 @@ deployment:
                 "is_default": false,
                 "max_worker_count": 175,
                 "min_worker_count": 8,
-                "worker_concurrency": 176,
+                "worker_concurrency": 10,
                 "worker_type": "a5"
             }
         ],
@@ -1303,6 +1335,38 @@ deployment:
 				},
 				JSON200: &astrocore.SharedCluster{Id: "test-cluster-id"},
 			}
+			mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
+				AstroMachines: []astro.Machine{
+					{
+						Type:               "a5",
+						ConcurrentTasks:    5,
+						ConcurrentTasksMax: 15,
+					},
+					{
+						Type:               "a10",
+						ConcurrentTasks:    10,
+						ConcurrentTasksMax: 30,
+					},
+					{
+						Type:               "a20",
+						ConcurrentTasks:    20,
+						ConcurrentTasksMax: 60,
+					},
+				},
+				Components: astro.Components{
+					Scheduler: astro.SchedulerConfig{
+						AU: astro.AuConfig{
+							Default: 5,
+							Limit:   24,
+						},
+						Replicas: astro.ReplicasConfig{
+							Default: 1,
+							Minimum: 1,
+							Limit:   4,
+						},
+					},
+				},
+			}, nil).Once()
 			mockCoreClient.On("GetSharedClusterWithResponse", mock.Anything, mock.Anything).Return(mockOKResponse, nil).Once()
 			mockClient.On("ListDeployments", orgID, "").Return([]astro.Deployment{}, nil).Once()
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -605,16 +605,19 @@ func TestCreateHostedShared(t *testing.T) {
 	mockClient.On("GetDeploymentConfig").Return(astro.DeploymentConfig{
 		AstroMachines: []astro.Machine{
 			{
-				Type:            "a5",
-				ConcurrentTasks: 5,
+				Type:               "a5",
+				ConcurrentTasks:    5,
+				ConcurrentTasksMax: 15,
 			},
 			{
-				Type:            "a10",
-				ConcurrentTasks: 10,
+				Type:               "a10",
+				ConcurrentTasks:    10,
+				ConcurrentTasksMax: 30,
 			},
 			{
-				Type:            "a20",
-				ConcurrentTasks: 20,
+				Type:               "a20",
+				ConcurrentTasks:    20,
+				ConcurrentTasksMax: 60,
 			},
 		},
 		Components: astro.Components{

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -1511,6 +1511,89 @@ func TestIsCeleryWorkerQueueInputValid(t *testing.T) {
 	})
 }
 
+func TestIsHostedCeleryWorkerQueueInputValid(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
+		MinWorkerCount: astro.WorkerQueueOption{
+			Floor:   0,
+			Ceiling: 20,
+			Default: 5,
+		},
+		MaxWorkerCount: astro.WorkerQueueOption{
+			Floor:   20,
+			Ceiling: 200,
+			Default: 125,
+		},
+		WorkerConcurrency: astro.WorkerQueueOption{
+			Floor:   175,
+			Ceiling: 275,
+			Default: 180,
+		},
+	}
+
+	mockMachineOptions := &astro.Machine{
+		Type:               "a5",
+		ConcurrentTasks:    5,
+		ConcurrentTasksMax: 15,
+	}
+	requestedWorkerQueue := &astro.WorkerQueue{
+		Name:              "test-worker-queue",
+		IsDefault:         false,
+		MaxWorkerCount:    0,
+		MinWorkerCount:    0,
+		WorkerConcurrency: 0,
+		NodePoolID:        "",
+	}
+
+	t.Run("happy path when min or max worker count and worker concurrency are within default floor and ceiling", func(t *testing.T) {
+		requestedWorkerQueue.MinWorkerCount = 0
+		requestedWorkerQueue.MaxWorkerCount = 25
+		requestedWorkerQueue.WorkerConcurrency = 10
+		err := IsHostedCeleryWorkerQueueInputValid(requestedWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
+		assert.NoError(t, err)
+	})
+	t.Run("returns an error when min worker count is not between default floor and ceiling values", func(t *testing.T) {
+		requestedWorkerQueue.MinWorkerCount = 35
+		err := IsHostedCeleryWorkerQueueInputValid(requestedWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
+		assert.ErrorIs(t, err, errInvalidWorkerQueueOption)
+		assert.Contains(t, err.Error(), "worker queue option is invalid: min worker count must be between 0 and 20")
+	})
+	t.Run("returns an error when max worker count is not between default floor and ceiling values", func(t *testing.T) {
+		requestedWorkerQueue.MinWorkerCount = 8
+		requestedWorkerQueue.MaxWorkerCount = 19
+		err := IsHostedCeleryWorkerQueueInputValid(requestedWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
+		assert.ErrorIs(t, err, errInvalidWorkerQueueOption)
+		assert.Contains(t, err.Error(), "worker queue option is invalid: max worker count must be between 20 and 200")
+	})
+	t.Run("returns an error when worker concurrency is not between default floor and ceiling values", func(t *testing.T) {
+		requestedWorkerQueue.MinWorkerCount = 8
+		requestedWorkerQueue.MaxWorkerCount = 25
+		requestedWorkerQueue.WorkerConcurrency = 20
+		err := IsHostedCeleryWorkerQueueInputValid(requestedWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
+		assert.ErrorIs(t, err, errInvalidWorkerQueueOption)
+		assert.Contains(t, err.Error(), "worker queue option is invalid: worker concurrency must be between 5 and 15")
+	})
+	t.Run("returns an error when podCPU is present in input", func(t *testing.T) {
+		requestedWorkerQueue.MinWorkerCount = 8
+		requestedWorkerQueue.MaxWorkerCount = 25
+		requestedWorkerQueue.WorkerConcurrency = 10
+		requestedWorkerQueue.PodCPU = "lots"
+		err := IsHostedCeleryWorkerQueueInputValid(requestedWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
+		assert.ErrorIs(t, err, ErrNotSupported)
+		assert.Contains(t, err.Error(), "CeleryExecutor does not support pod_cpu in the request. It can only be used with KubernetesExecutor")
+	})
+	t.Run("returns an error when podRAM is present in input", func(t *testing.T) {
+		requestedWorkerQueue.MinWorkerCount = 8
+		requestedWorkerQueue.MaxWorkerCount = 25
+		requestedWorkerQueue.WorkerConcurrency = 10
+		requestedWorkerQueue.PodCPU = ""
+		requestedWorkerQueue.PodRAM = "huge"
+		err := IsHostedCeleryWorkerQueueInputValid(requestedWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
+		assert.ErrorIs(t, err, ErrNotSupported)
+		assert.Contains(t, err.Error(), "CeleryExecutor does not support pod_ram in the request. It can only be used with KubernetesExecutor")
+	})
+}
+
 func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	requestedWorkerQueue := &astro.WorkerQueue{


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Fix concurrency check for hosted deployments

## 🎟 Issue(s)

Related #1267 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

<img width="959" alt="Screenshot 2023-06-22 at 20 08 29" src="https://github.com/astronomer/astro-cli/assets/65428224/8a2e815e-8223-4e7b-ae01-21fce985fd2c">
<img width="946" alt="Screenshot 2023-06-22 at 20 08 48" src="https://github.com/astronomer/astro-cli/assets/65428224/37c37e60-a396-4d92-8a30-73aa78e9761a">


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
