### PR TITLE
Pick workspace by default if only one exists

### DIFF
--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -13,6 +13,7 @@ import (
 	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
 )
@@ -314,6 +315,18 @@ func Delete(id string, out io.Writer, client astrocore.CoreClient) error {
 }
 
 func selectWorkspace(workspaces []astrocore.Workspace) (astrocore.Workspace, error) {
+	if len(workspaces) == 0 {
+		return astrocore.Workspace{}, nil
+	}
+
+	if len(workspaces) == 1 {
+		fmt.Println("Only one Workspace was found. Using the following Workspace by default: \n" +
+			fmt.Sprintf("\n Workspace Name: %s", ansi.Bold(workspaces[0].Name)) +
+			fmt.Sprintf("\n Workspace ID: %s\n", ansi.Bold(workspaces[0].Id)))
+
+		return workspaces[0], nil
+	}
+
 	table := printutil.Table{
 		Padding:        []int{30, 50, 10, 50, 10, 10, 10},
 		DynamicPadding: true,

--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -23,6 +23,7 @@ var (
 	ErrInvalidName         = errors.New("no name provided for the workspace. Retry with a valid name")
 	ErrInvalidTokenName    = errors.New("no name provided for the workspace token. Retry with a valid name")
 	ErrWorkspaceNotFound   = errors.New("no workspace was found for the ID you provided")
+	ErrNoWorkspaceExists   = errors.New("no workspace was found in your organization")
 	ErrWrongEnforceInput   = errors.New("the input to the `--enforce-cicd` flag")
 )
 
@@ -224,6 +225,9 @@ func Update(id, name, description, enforceCD string, out io.Writer, client astro
 	var workspace astrocore.Workspace
 	if id == "" {
 		workspace, err = selectWorkspace(workspaces)
+		if workspace.Id == "" {
+			return ErrNoWorkspaceExists
+		}
 		if err != nil {
 			return err
 		}
@@ -288,6 +292,9 @@ func Delete(id string, out io.Writer, client astrocore.CoreClient) error {
 	var workspace astrocore.Workspace
 	if id == "" {
 		workspace, err = selectWorkspace(workspaces)
+		if workspace.Id == "" {
+			return ErrNoWorkspaceExists
+		}
 		if err != nil {
 			return err
 		}

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -467,6 +467,40 @@ func TestUpdate(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
+	t.Run("ask to select the workspace if more than 1 exists", func(t *testing.T) {
+		workspace2 := astrocore.Workspace{
+			Name:                         "test-workspace-2",
+			Description:                  &description,
+			ApiKeyOnlyDeploymentsDefault: false,
+			Id:                           "workspace-id-2",
+		}
+
+		workspaces = []astrocore.Workspace{
+			workspace1,
+			workspace2,
+		}
+
+		ListWorkspacesResponseOK = astrocore.ListWorkspacesResponse{
+			HTTPResponse: &http.Response{
+				StatusCode: 200,
+			},
+			JSON200: &astrocore.WorkspacesPaginated{
+				Limit:      2,
+				Offset:     0,
+				TotalCount: 2,
+				Workspaces: workspaces,
+			},
+		}
+		expectedOutMessage := "Astro Workspace test-workspace was successfully updated\n"
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("UpdateWorkspaceWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceResponseOK, nil).Once()
+		mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
+		err := Update("workspace-id", "update-workspace-test", "updated workspace", "ON", out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
 	t.Run("error path when UpdateWorkspaceWithResponse return network error", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -364,6 +364,27 @@ func TestDelete(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
+	t.Run("print message if no workpaces found", func(t *testing.T) {
+		ws := []astrocore.Workspace{}
+
+		listWorkspacesResponseOK := astrocore.ListWorkspacesResponse{
+			HTTPResponse: &http.Response{
+				StatusCode: 200,
+			},
+			JSON200: &astrocore.WorkspacesPaginated{
+				Limit:      2,
+				Offset:     0,
+				TotalCount: 0,
+				Workspaces: ws,
+			},
+		}
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&listWorkspacesResponseOK, nil).Once()
+		err := Delete("", out, mockClient)
+		assert.ErrorIs(t, err, ErrNoWorkspaceExists)
+	})
+
 	t.Run("error path when DeleteWorkspaceWithResponse return network error", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -465,6 +486,28 @@ func TestUpdate(t *testing.T) {
 		err := Update("workspace-id", "update-workspace-test", "updated workspace", "ON", out, mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
+	t.Run("print message if no workpaces found", func(t *testing.T) {
+		ws := []astrocore.Workspace{}
+
+		listWorkspacesResponseOK := astrocore.ListWorkspacesResponse{
+			HTTPResponse: &http.Response{
+				StatusCode: 200,
+			},
+			JSON200: &astrocore.WorkspacesPaginated{
+				Limit:      2,
+				Offset:     0,
+				TotalCount: 0,
+				Workspaces: ws,
+			},
+		}
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("UpdateWorkspaceWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceResponseOK, nil).Once()
+		mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&listWorkspacesResponseOK, nil).Once()
+		err := Update("", "update-workspace-test", "updated workspace", "ON", out, mockClient)
+		assert.ErrorIs(t, err, ErrNoWorkspaceExists)
 	})
 
 	t.Run("ask to select the workspace if more than 1 exists", func(t *testing.T) {


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Pick workspace by default if only one exists

## 🎟 Issue(s)

Related #1244 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screenshot 2023-06-23 at 09 02 06](https://github.com/astronomer/astro-cli/assets/65428224/747bf51b-2638-446f-828e-aceb4d67245d)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
