### PR TITLE
Fix zero worker concurrency error

### DIFF
--- a/cmd/cloud/deployment_workerqueue.go
+++ b/cmd/cloud/deployment_workerqueue.go
@@ -3,18 +3,20 @@ package cloud
 import (
 	"io"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/astronomer/astro-cli/cloud/deployment/workerqueue"
 )
 
 var (
-	concurrency    int
-	minWorkerCount int
-	maxWorkerCount int
-	workerType     string
-	name           string
-	force          bool
+	concurrency        int
+	minWorkerCount     int
+	maxWorkerCount     int
+	workerType         string
+	name               string
+	force              bool
+	errZeroConcurrency = errors.New("Worker concurrency cannot be 0. Min value starts from 1")
 )
 
 func newDeploymentWorkerQueueRootCmd(out io.Writer) *cobra.Command {
@@ -98,6 +100,10 @@ func deploymentWorkerQueueCreateOrUpdate(cmd *cobra.Command, _ []string, out io.
 	ws, err := coalesceWorkspace()
 	if err != nil {
 		return err
+	}
+
+	if cmd.Flags().Changed("concurrency") && concurrency == 0 {
+		return errZeroConcurrency
 	}
 
 	return workerqueue.CreateOrUpdate(ws, deploymentID, deploymentName, name, cmd.Name(), workerType, minWorkerCount, maxWorkerCount, concurrency, force, astroClient, out)

--- a/cmd/cloud/deployment_workerqueue.go
+++ b/cmd/cloud/deployment_workerqueue.go
@@ -16,7 +16,7 @@ var (
 	workerType         string
 	name               string
 	force              bool
-	errZeroConcurrency = errors.New("Worker concurrency cannot be 0. Min value starts from 1")
+	errZeroConcurrency = errors.New("Worker concurrency cannot be 0. Minimum value starts from 1")
 )
 
 func newDeploymentWorkerQueueRootCmd(out io.Writer) *cobra.Command {

--- a/cmd/cloud/deployment_workerqueue_test.go
+++ b/cmd/cloud/deployment_workerqueue_test.go
@@ -460,6 +460,11 @@ func TestNewDeploymentWorkerQueueUpdateCmd(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Contains(t, resp, expectedHelp)
 	})
+	t.Run("throw error if worker concurrency is set as 0", func(t *testing.T) {
+		cmdArgs := []string{"worker-queue", "update", "--concurrency", "0"}
+		_, err := execDeploymentCmd(cmdArgs...)
+		assert.ErrorIs(t, err, errZeroConcurrency)
+	})
 	t.Run("happy path update worker queue", func(t *testing.T) {
 		deploymentRespWithQueues := []astro.Deployment{
 			{


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

throw error is worker concurrency is set to 0 by user

## 🎟 Issue(s)

Related #1267 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
