### PR TITLE
Add timeout on github client

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/astronomer/astro-cli/cmd/registry"
 
@@ -70,8 +72,8 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Check for latest version
 			if config.CFG.UpgradeMessage.GetBool() {
-				// create github client
-				githubClient := github.NewClient(nil)
+				// create github client with 3 second timeout, setting an aggresive timeout since its not mandatory to get a response in each command execution
+				githubClient := github.NewClient(&http.Client{Timeout: 3 * time.Second})
 				// compare current version to latest
 				err = version.CompareVersions(githubClient, "astronomer", "astro-cli")
 				if err != nil {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v48/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGithubAPITimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second) // sleeping and doing nothing
+	}))
+	defer ts.Close()
+	url, err := url.Parse(fmt.Sprintf("%s/", ts.URL))
+	assert.NoError(t, err)
+
+	githubClient := github.NewClient(&http.Client{Timeout: 1 * time.Second}) // client side timeout should be less than server side sleep defined above
+	githubClient.BaseURL = url
+
+	start := time.Now()
+	release, err := getLatestRelease(githubClient, "test", "test")
+	elapsed := time.Since(start)
+	// assert time to get a response from the function is only slightly greater than client timeout
+	assert.GreaterOrEqual(t, elapsed, 1*time.Second)
+	assert.Less(t, elapsed, 2*time.Second)
+	// assert error returned is related to client timeout
+	assert.Nil(t, release)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+}


### PR DESCRIPTION
## Description
As of now GitHub client does not have timeouts in any form, as a result whenever there is an issue on the GitHub end, Astro CLI ends up in a hang state. This PR introduces an aggressive timeout to the GitHub client because the use case for the API calls is not a blocker for any command execution, and it will ensure seamless UX even in case GitHub is experiencing an outage.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
