### PR TITLE
Move houston version API call to only when context is not Astro

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,10 +39,6 @@ func NewRootCmd() *cobra.Command {
 	var err error
 	httpClient := houston.NewHTTPClient()
 	houstonClient = houston.NewClient(httpClient)
-	houstonVersion, err = houstonClient.GetPlatformVersion(nil)
-	if err != nil {
-		softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, fmt.Sprintf("Unable to get Houston version: %s", err.Error()))
-	}
 
 	airflowClient := airflowclient.NewAirflowClient(httputil.NewHTTPClient())
 	astroClient := astro.NewAstroClient(httputil.NewHTTPClient())
@@ -52,6 +48,10 @@ func NewRootCmd() *cobra.Command {
 	isCloudCtx := context.IsCloudContext()
 	if !isCloudCtx {
 		ctx = softwarePlatform
+		houstonVersion, err = houstonClient.GetPlatformVersion(nil)
+		if err != nil {
+			softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, fmt.Sprintf("Unable to get Houston version: %s", err.Error()))
+		}
 	}
 
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
## Description
Changes:
Move the Houston version API call in the root function of CLI to only when the current context is not Astro, this avoids cases when someone is logged into Astro, and CLI would end up calling `houston.<astro_domain>` to get the version, and the CLI execution could halt for 10 seconds in case the call fails by i/o timeout instead of no such host.

## 🎟 Issue(s)

Related #1294

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
