### PR TITLE
Add team org role crud

### DIFF
--- a/astro-client-core/mocks/client.go
+++ b/astro-client-core/mocks/client.go
@@ -2267,6 +2267,66 @@ func (_m *ClientWithResponsesInterface) ListWorkspacesWithResponse(ctx context.C
 	return r0, r1
 }
 
+// MutateOrgTeamRoleWithBodyWithResponse provides a mock function with given fields: ctx, organizationId, teamId, contentType, body, reqEditors
+func (_m *ClientWithResponsesInterface) MutateOrgTeamRoleWithBodyWithResponse(ctx context.Context, organizationId string, teamId string, contentType string, body io.Reader, reqEditors ...astrocore.RequestEditorFn) (*astrocore.MutateOrgTeamRoleResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, organizationId, teamId, contentType, body)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *astrocore.MutateOrgTeamRoleResponse
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, io.Reader, ...astrocore.RequestEditorFn) *astrocore.MutateOrgTeamRoleResponse); ok {
+		r0 = rf(ctx, organizationId, teamId, contentType, body, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*astrocore.MutateOrgTeamRoleResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, io.Reader, ...astrocore.RequestEditorFn) error); ok {
+		r1 = rf(ctx, organizationId, teamId, contentType, body, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MutateOrgTeamRoleWithResponse provides a mock function with given fields: ctx, organizationId, teamId, body, reqEditors
+func (_m *ClientWithResponsesInterface) MutateOrgTeamRoleWithResponse(ctx context.Context, organizationId string, teamId string, body astrocore.MutateOrgTeamRoleRequest, reqEditors ...astrocore.RequestEditorFn) (*astrocore.MutateOrgTeamRoleResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, organizationId, teamId, body)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *astrocore.MutateOrgTeamRoleResponse
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, astrocore.MutateOrgTeamRoleRequest, ...astrocore.RequestEditorFn) *astrocore.MutateOrgTeamRoleResponse); ok {
+		r0 = rf(ctx, organizationId, teamId, body, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*astrocore.MutateOrgTeamRoleResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, astrocore.MutateOrgTeamRoleRequest, ...astrocore.RequestEditorFn) error); ok {
+		r1 = rf(ctx, organizationId, teamId, body, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // MutateOrgUserRoleWithBodyWithResponse provides a mock function with given fields: ctx, organizationId, userId, contentType, body, reqEditors
 func (_m *ClientWithResponsesInterface) MutateOrgUserRoleWithBodyWithResponse(ctx context.Context, organizationId string, userId string, contentType string, body io.Reader, reqEditors ...astrocore.RequestEditorFn) (*astrocore.MutateOrgUserRoleResponse, error) {
 	_va := make([]interface{}, len(reqEditors))

--- a/cloud/team/team_test.go
+++ b/cloud/team/team_test.go
@@ -193,6 +193,9 @@ var (
 			Role: "WORKSPACE_MEMBER",
 		},
 	}
+	errorBodyUpdateRole, _ = json.Marshal(astrocore.Error{
+		Message: "failed to update team role",
+	})
 	errorBodyUpdate, _ = json.Marshal(astrocore.Error{
 		Message: "failed to update team",
 	})
@@ -245,7 +248,7 @@ var (
 		HTTPResponse: &http.Response{
 			StatusCode: 500,
 		},
-		Body: errorBodyUpdate,
+		Body: errorBodyUpdateRole,
 	}
 	CreateTeamResponseOK = astrocore.CreateTeamResponse{
 		HTTPResponse: &http.Response{
@@ -827,9 +830,54 @@ func TestUpdate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
 		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
-		err := UpdateTeam(team1.Id, "name", "description", out, mockClient)
+		err := UpdateTeam(team1.Id, "name", "description", "", out, mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
+	t.Run("happy path Update - with role", func(t *testing.T) {
+		role := "ORGANIZATION_OWNER"
+		expectedOutMessage := fmt.Sprintf("Astro Team %s was successfully updated\nAstro Team role %s was successfully updated to %s\n", team1.Name, team1.Name, role)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
+		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
+		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseOK, nil).Once()
+		err := UpdateTeam(team1.Id, "name", "description", role, out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
+	t.Run("unhappy path Update - with invalid role", func(t *testing.T) {
+		role := "WORKSPACE_VIEWER"
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
+		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
+		err := UpdateTeam(team1.Id, "name", "description", role, out, mockClient)
+		assert.EqualError(t, err, "requested role is invalid. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")
+	})
+
+	t.Run("unhappy path Update - with role MutateOrgTeamRoleWithResponse error", func(t *testing.T) {
+		role := "ORGANIZATION_OWNER"
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
+		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
+		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseError, nil).Once()
+		err := UpdateTeam(team1.Id, "name", "description", role, out, mockClient)
+		assert.EqualError(t, err, "failed to update team role")
+	})
+
+	t.Run("unhappy path Update - with role MutateOrgTeamRoleWithResponse network error", func(t *testing.T) {
+		role := "ORGANIZATION_OWNER"
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
+		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
+		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errorNetwork).Once()
+		err := UpdateTeam(team1.Id, "name", "description", role, out, mockClient)
+		assert.EqualError(t, err, "network error")
 	})
 
 	t.Run("happy path Update with idp managed team", func(t *testing.T) {
@@ -839,7 +887,7 @@ func TestUpdate(t *testing.T) {
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
 		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
 		defer testUtil.MockUserInput(t, "y")()
-		err := UpdateTeam(team2.Id, "name", "description", out, mockClient)
+		err := UpdateTeam(team2.Id, "name", "description", "", out, mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
@@ -850,7 +898,7 @@ func TestUpdate(t *testing.T) {
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetIDPManagedTeamWithResponseOK, nil).Twice()
 		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
 		defer testUtil.MockUserInput(t, "n")()
-		err := UpdateTeam(team2.Id, "name", "description", out, mockClient)
+		err := UpdateTeam(team2.Id, "name", "description", "", out, mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, "", out.String())
 	})
@@ -861,7 +909,7 @@ func TestUpdate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
 		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
-		err := UpdateTeam(team1.Id, "name", "", out, mockClient)
+		err := UpdateTeam(team1.Id, "name", "", "", out, mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
@@ -872,7 +920,7 @@ func TestUpdate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
 		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
-		err := UpdateTeam(team1.Id, "", "description", out, mockClient)
+		err := UpdateTeam(team1.Id, "", "description", "", out, mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
@@ -881,7 +929,7 @@ func TestUpdate(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationTeamsResponseEmpty, nil).Twice()
-		err := UpdateTeam("", "name", "description", out, mockClient)
+		err := UpdateTeam("", "name", "description", "", out, mockClient)
 		assert.EqualError(t, err, "no teams found in your organization")
 	})
 
@@ -889,7 +937,7 @@ func TestUpdate(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errorNetwork).Twice()
-		err := UpdateTeam(team1.Id, "name", "description", out, mockClient)
+		err := UpdateTeam(team1.Id, "name", "description", "", out, mockClient)
 		assert.EqualError(t, err, "network error")
 	})
 
@@ -898,7 +946,7 @@ func TestUpdate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
 		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errorNetwork).Once()
-		err := UpdateTeam(team1.Id, "name", "description", out, mockClient)
+		err := UpdateTeam(team1.Id, "name", "description", "", out, mockClient)
 		assert.EqualError(t, err, "network error")
 	})
 
@@ -907,7 +955,7 @@ func TestUpdate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
 		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseError, nil).Once()
-		err := UpdateTeam(team1.Id, "name", "description", out, mockClient)
+		err := UpdateTeam(team1.Id, "name", "description", "", out, mockClient)
 		assert.EqualError(t, err, "failed to update team")
 	})
 
@@ -919,7 +967,7 @@ func TestUpdate(t *testing.T) {
 		assert.NoError(t, err)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = UpdateTeam(team1.Id, "name", "description", out, mockClient)
+		err = UpdateTeam(team1.Id, "name", "description", "", out, mockClient)
 		assert.EqualError(t, err, "cannot retrieve organization short name from context")
 	})
 
@@ -928,7 +976,7 @@ func TestUpdate(t *testing.T) {
 		expectedOutMessage := ""
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err := UpdateTeam(team1.Id, "name", "description", out, mockClient)
+		err := UpdateTeam(team1.Id, "name", "description", "", out, mockClient)
 		assert.Error(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
@@ -953,7 +1001,7 @@ func TestUpdate(t *testing.T) {
 		expectedOutMessage := fmt.Sprintf("Astro Team %s was successfully updated\n", team1.Name)
 		mockClient.On("UpdateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateTeamResponseOK, nil).Once()
 
-		err = UpdateTeam("", "name", "description", out, mockClient)
+		err = UpdateTeam("", "name", "description", "", out, mockClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
@@ -1504,108 +1552,6 @@ func TestGetWorkspaceTeams(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		_, err := GetWorkspaceTeams(mockClient, "", 10)
 		assert.Error(t, err)
-		assert.Equal(t, expectedOutMessage, out.String())
-	})
-}
-
-func TestUpdateOrgTeamRole(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	t.Run("happy path Mutate org team role", func(t *testing.T) {
-		expectedOutMessage := fmt.Sprintf("The organizations team %s role was successfully updated to ORGANIZATION_MEMBER\n", team1.Id)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
-		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseOK, nil).Once()
-		err := UpdateOrgTeamRole(team1.Id, "ORGANIZATION_MEMBER", out, mockClient)
-		assert.NoError(t, err)
-		assert.Equal(t, expectedOutMessage, out.String())
-	})
-
-	t.Run("error path invalid org role", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err := UpdateOrgTeamRole("", "WORKSPACE_OWNER", out, mockClient)
-		assert.EqualError(t, err, "requested role is invalid. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")
-	})
-
-	t.Run("error path no org teams found", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationTeamsResponseEmpty, nil).Twice()
-		err := UpdateOrgTeamRole("", "ORGANIZATION_MEMBER", out, mockClient)
-		assert.EqualError(t, err, "no teams found in your organization")
-	})
-
-	t.Run("error path when GetTeamWithResponse return network error", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errorNetwork).Twice()
-		err := UpdateOrgTeamRole(team1.Id, "ORGANIZATION_MEMBER", out, mockClient)
-		assert.EqualError(t, err, "network error")
-	})
-
-	t.Run("error path when MutateOrgTeamRoleWithResponse return network error", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
-		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errorNetwork).Once()
-		err := UpdateOrgTeamRole(team1.Id, "ORGANIZATION_MEMBER", out, mockClient)
-		assert.EqualError(t, err, "network error")
-	})
-
-	t.Run("error path when MutateOrgTeamRoleWithResponse returns an error", func(t *testing.T) {
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
-		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseError, nil).Once()
-		err := UpdateOrgTeamRole(team1.Id, "ORGANIZATION_MEMBER", out, mockClient)
-		assert.EqualError(t, err, "failed to update team")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = UpdateOrgTeamRole(team1.Id, "ORGANIZATION_MEMBER", out, mockClient)
-		assert.EqualError(t, err, "cannot retrieve organization short name from context")
-	})
-
-	t.Run("error path when getting current context returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.Initial)
-		expectedOutMessage := ""
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err := UpdateOrgTeamRole(team1.Id, "ORGANIZATION_MEMBER", out, mockClient)
-		assert.Error(t, err)
-		assert.Equal(t, expectedOutMessage, out.String())
-	})
-	t.Run("UpdateOrgTeamRole no id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
-		out := new(bytes.Buffer)
-
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationTeamsResponseOK, nil).Twice()
-		// mock os.Stdin
-		expectedInput := []byte("1")
-		r, w, err := os.Pipe()
-		assert.NoError(t, err)
-		_, err = w.Write(expectedInput)
-		assert.NoError(t, err)
-		w.Close()
-		stdin := os.Stdin
-		// Restore stdin right after the test.
-		defer func() { os.Stdin = stdin }()
-		os.Stdin = r
-
-		expectedOutMessage := fmt.Sprintf("The organizations team %s role was successfully updated to ORGANIZATION_MEMBER\n", team1.Id)
-		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseOK, nil).Once()
-
-		err = UpdateOrgTeamRole("", "ORGANIZATION_MEMBER", out, mockClient)
-		assert.NoError(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 }

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -277,7 +277,6 @@ func newOrganizationTeamRootCmd(out io.Writer) *cobra.Command {
 		newTeamCreateCmd(out),
 		newOrganizationTeamListCmd(out),
 		newTeamUpdateCmd(out),
-		newOrganizationTeamUpdateRoleCmd(out),
 		newTeamDeleteCmd(out),
 		newOrganizationTeamUserRootCmd(out),
 	)
@@ -315,6 +314,8 @@ func newTeamUpdateCmd(out io.Writer) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&teamName, "name", "n", "", "The Team's name. If the name contains a space, specify the entire name within quotes \"\" ")
 	cmd.Flags().StringVarP(&teamDescription, "description", "d", "", "Description of the Team. If the description contains a space, specify the entire team description in quotes \"\"")
+	cmd.Flags().StringVarP(&updateOrganizationRole, "role", "r", "", "The new role for the "+
+		"team. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN, ORGANIZATION_OWNER ")
 	return cmd
 }
 
@@ -327,42 +328,7 @@ func teamUpdate(cmd *cobra.Command, out io.Writer, args []string) error {
 		id = args[0]
 	}
 
-	return team.UpdateTeam(id, teamName, teamDescription, out, astroCoreClient)
-}
-
-func newOrganizationTeamUpdateRoleCmd(out io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "update-org-role [team-id]",
-		Short: "Update a the role of a team in an Astro Organization",
-		Long: "Update the role of a team in an Astro Organization\n$astro workspace team update [team-id] --role [ORGANIZATION_MEMBER, " +
-			"ORGANIZATION_BILLING_ADMIN, ORGANIZATION_OWNER].",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return updateOrganizationTeamRole(cmd, args, out)
-		},
-	}
-	cmd.Flags().StringVarP(&updateOrganizationRole, "role", "r", "", "The new role for the "+
-		"team. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN, ORGANIZATION_OWNER ")
-	return cmd
-}
-
-func updateOrganizationTeamRole(cmd *cobra.Command, args []string, out io.Writer) error {
-	var id string
-
-	// if an id was provided in the args we use it
-	if len(args) > 0 {
-		id = args[0]
-	}
-	var err error
-	if updateOrganizationRole == "" {
-		// no role was provided so ask the user for it
-		updateOrganizationRole, err = selectOrganizationRole()
-		if err != nil {
-			return err
-		}
-	}
-
-	cmd.SilenceUsage = true
-	return team.UpdateOrgTeamRole(id, updateOrganizationRole, out, astroCoreClient)
+	return team.UpdateTeam(id, teamName, teamDescription, updateOrganizationRole, out, astroCoreClient)
 }
 
 func newTeamCreateCmd(out io.Writer) *cobra.Command {

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -332,7 +332,7 @@ func teamUpdate(cmd *cobra.Command, out io.Writer, args []string) error {
 
 func newOrganizationTeamUpdateRoleCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-role [team-id]",
+		Use:   "update-org-role [team-id]",
 		Short: "Update a the role of a team in an Astro Organization",
 		Long: "Update the role of a team in an Astro Organization\n$astro workspace team update [team-id] --role [ORGANIZATION_MEMBER, " +
 			"ORGANIZATION_BILLING_ADMIN, ORGANIZATION_OWNER].",
@@ -362,9 +362,6 @@ func updateOrganizationTeamRole(cmd *cobra.Command, args []string, out io.Writer
 	}
 
 	cmd.SilenceUsage = true
-	fmt.Println("AAAAA")
-	fmt.Println(id)
-	fmt.Println(updateOrganizationRole)
 	return team.UpdateOrgTeamRole(id, updateOrganizationRole, out, astroCoreClient)
 }
 

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -248,6 +248,17 @@ var (
 		Body:    errorBodyUpdate,
 		JSON200: nil,
 	}
+	MutateOrgTeamRoleResponseOK = astrocore.MutateOrgTeamRoleResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+	}
+	MutateOrgTeamRoleResponseError = astrocore.MutateOrgTeamRoleResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 500,
+		},
+		Body: teamRequestErrorBodyUpdate,
+	}
 	UpdateTeamResponseError = astrocore.UpdateTeamResponse{
 		HTTPResponse: &http.Response{
 			StatusCode: 500,
@@ -636,6 +647,101 @@ func TestTeamUpdate(t *testing.T) {
 	})
 }
 
+func TestTeamUpdateOrgRole(t *testing.T) {
+	expectedHelp := "organization team update-org-role [team-id]"
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+
+	t.Run("-h prints update help", func(t *testing.T) {
+		cmdArgs := []string{"team", "update-org-role", "-h"}
+		resp, err := execOrganizationCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, expectedHelp)
+	})
+
+	t.Run("valid id with valid role", func(t *testing.T) {
+		expectedOut := fmt.Sprintf("The organizations team %s role was successfully updated to ORGANIZATION_MEMBER\n", team1.Id)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
+		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseOK, nil).Once()
+		astroCoreClient = mockClient
+		cmdArgs := []string{"team", "update-org-role", team1.Id, "--role", "ORGANIZATION_MEMBER"}
+		resp, err := execOrganizationCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, expectedOut)
+	})
+
+	t.Run("any errors from api are returned and role is not updated", func(t *testing.T) {
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
+		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseError, nil).Once()
+		astroCoreClient = mockClient
+		cmdArgs := []string{"team", "update-org-role", team1.Id, "--role", "ORGANIZATION_MEMBER"}
+		_, err := execOrganizationCmd(cmdArgs...)
+		assert.EqualError(t, err, "failed to update team")
+	})
+
+	t.Run("any context errors from api are returned and role is not updated", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.Initial)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
+		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseOK, nil).Once()
+		astroCoreClient = mockClient
+		cmdArgs := []string{"team", "update-org-role", team1.Id, "--role", "ORGANIZATION_MEMBER"}
+		_, err := execOrganizationCmd(cmdArgs...)
+		assert.Error(t, err)
+	})
+	t.Run("command asks for input when no id is passed in as an arg", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
+
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgTeamsResponseOK, nil).Twice()
+		// mock os.Stdin
+		expectedInput := []byte("1")
+		r, w, err := os.Pipe()
+		assert.NoError(t, err)
+		_, err = w.Write(expectedInput)
+		assert.NoError(t, err)
+		w.Close()
+		stdin := os.Stdin
+		// Restore stdin right after the test.
+		defer func() { os.Stdin = stdin }()
+		os.Stdin = r
+
+		expectedOut := fmt.Sprintf("The organizations team %s role was successfully updated to ORGANIZATION_MEMBER\n", team1.Id)
+		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseOK, nil).Once()
+		astroCoreClient = mockClient
+
+		cmdArgs := []string{"team", "update-org-role", "--role", "ORGANIZATION_MEMBER"}
+		resp, err := execOrganizationCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, expectedOut)
+	})
+
+	t.Run("command asks for input when no role is passed in", func(t *testing.T) {
+		expectedOut := fmt.Sprintf("The organizations team %s role was successfully updated to ORGANIZATION_MEMBER\n", team1.Id)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
+		mockClient.On("MutateOrgTeamRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateOrgTeamRoleResponseOK, nil).Once()
+		astroCoreClient = mockClient
+
+		cmdArgs := []string{"team", "update-org-role", team1.Id}
+		expectedInput := []byte("1")
+		r, w, err := os.Pipe()
+		assert.NoError(t, err)
+		_, err = w.Write(expectedInput)
+		assert.NoError(t, err)
+		w.Close()
+		stdin := os.Stdin
+		// Restore stdin right after the test.
+		defer func() { os.Stdin = stdin }()
+		os.Stdin = r
+
+		resp, err := execOrganizationCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, expectedOut)
+	})
+}
+
 func TestTeamCreate(t *testing.T) {
 	expectedHelp := "organization team create"
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
@@ -651,7 +757,7 @@ func TestTeamCreate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateTeamResponseOK, nil).Once()
 		astroCoreClient = mockClient
-		cmdArgs := []string{"team", "create", team1.Id, "--name", team1.Name, "--description", *team1.Description}
+		cmdArgs := []string{"team", "create", team1.Id, "--role", "ORGANIZATION_MEMBER", "--name", team1.Name, "--description", *team1.Description}
 		resp, err := execOrganizationCmd(cmdArgs...)
 		assert.NoError(t, err)
 		assert.Contains(t, resp, expectedOut)
@@ -661,7 +767,7 @@ func TestTeamCreate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateTeamResponseError, nil).Once()
 		astroCoreClient = mockClient
-		cmdArgs := []string{"team", "create", team1.Id, "--name", team1.Name}
+		cmdArgs := []string{"team", "create", team1.Id, "--role", "ORGANIZATION_MEMBER", "--name", team1.Name}
 		_, err := execOrganizationCmd(cmdArgs...)
 		assert.EqualError(t, err, "failed to create team")
 	})
@@ -671,7 +777,7 @@ func TestTeamCreate(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateTeamResponseOK, nil).Once()
 		astroCoreClient = mockClient
-		cmdArgs := []string{"create", team1.Id, "--name", team1.Name}
+		cmdArgs := []string{"create", team1.Id, "--role", "ORGANIZATION_MEMBER", "--name", team1.Name}
 		_, err := execOrganizationCmd(cmdArgs...)
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
## Description

- modifies create team cmd to take in org role
- adds a mutate org role cmd
- modifies team list and get to return the org role

## 🎟 Issue(s)

Related #14652

## 🧪 Functional Testing

Tested against the pr preview of https://github.com/astronomer/astro/pull/14609

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
