### PR TITLE
throw message when user tries to switch to the current org

### DIFF
--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -169,6 +169,11 @@ func Switch(orgNameOrID string, astroClient astro.Client, coreClient astrocore.C
 	if targetOrg == nil {
 		return errInvalidOrganizationName
 	}
+
+	if targetOrg.Id == c.Organization {
+		fmt.Fprintln(out, "You selected the same organization as the current one. No switch was made")
+		return nil
+	}
 	return SwitchWithContext(c.Domain, targetOrg, astroClient, coreClient, out)
 }
 

--- a/cloud/organization/organization_test.go
+++ b/cloud/organization/organization_test.go
@@ -169,6 +169,18 @@ func TestSwitch(t *testing.T) {
 		mockCoreClient.AssertExpectations(t)
 	})
 
+	t.Run("switching to a current organization", func(t *testing.T) {
+		mockGQLClient := new(astro_mocks.Client)
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astrocore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+
+		buf := new(bytes.Buffer)
+		err := Switch("org1", mockGQLClient, mockCoreClient, buf, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "You selected the same organization as the current one. No switch was made\n", buf.String())
+		mockCoreClient.AssertExpectations(t)
+	})
+
 	t.Run("successful switch without name", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -177,7 +189,7 @@ func TestSwitch(t *testing.T) {
 			return nil
 		}
 		// mock os.Stdin
-		input := []byte("1")
+		input := []byte("2")
 		r, w, err := os.Pipe()
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

throw message when user tries to switch to the current org

## 🎟 Issue(s)

Related #1280 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screenshot 2023-07-07 at 16 42 10](https://github.com/astronomer/astro-cli/assets/65428224/1de64bb4-0bc0-4e08-9f6e-b46102661e86)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
