### PR TITLE
Throw correct error on updating worker queue config for kubernetes executor

### DIFF
--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2801,10 +2801,12 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+				minCount := -1
 				qList = []inspect.Workerq{
 					{
 						Name:           "default",
 						WorkerType:     "test-worker-1",
+						MinWorkerCount: &minCount,
 						MaxWorkerCount: 10,
 					},
 				}
@@ -2838,10 +2840,12 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+				minCount := -1
 				qList = []inspect.Workerq{
 					{
 						Name:              "default",
 						WorkerType:        "test-worker-1",
+						MinWorkerCount:    &minCount,
 						WorkerConcurrency: 10,
 					},
 				}
@@ -2948,18 +2952,21 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+			minCount := -1
 			qList = []inspect.Workerq{
 				{
-					Name:       "default",
-					WorkerType: "test-worker-1",
+					Name:           "default",
+					WorkerType:     "test-worker-1",
+					MinWorkerCount: &minCount,
 				},
 			}
 			deploymentFromFile.Deployment.WorkerQs = qList
 			expectedQList = []astro.WorkerQueue{
 				{
-					Name:       "default",
-					IsDefault:  true,
-					NodePoolID: "test-pool-id",
+					Name:           "default",
+					IsDefault:      true,
+					NodePoolID:     "test-pool-id",
+					MinWorkerCount: minCount,
 				},
 			}
 			existingPools = []astrocore.NodePool{
@@ -3233,18 +3240,21 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+			minCount := -1
 			qList = []inspect.Workerq{
 				{
-					Name:       "default",
-					WorkerType: "test-worker-1",
+					Name:           "default",
+					WorkerType:     "test-worker-1",
+					MinWorkerCount: &minCount,
 				},
 			}
 			deploymentFromFile.Deployment.WorkerQs = qList
 			expectedQList = []astro.WorkerQueue{
 				{
-					Name:       "default",
-					IsDefault:  true,
-					NodePoolID: "test-pool-id",
+					Name:           "default",
+					IsDefault:      true,
+					NodePoolID:     "test-pool-id",
+					MinWorkerCount: minCount,
 				},
 			}
 			existingPools = []astrocore.NodePool{

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -284,7 +284,7 @@ func IsKubernetesWorkerQueueInputValid(requestedWorkerQueue *astro.WorkerQueue) 
 		errorMessage = "pod ram in the request. It will be calculated based on the requested worker type"
 		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}
-	if requestedWorkerQueue.MinWorkerCount != 0 {
+	if requestedWorkerQueue.MinWorkerCount != -1 {
 		errorMessage = "minimum worker count in the request. It can only be used with CeleryExecutor"
 		return fmt.Errorf("%s %w %s", deployment.KubeExecutor, ErrNotSupported, errorMessage)
 	}

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -481,7 +481,7 @@ func TestCreate(t *testing.T) {
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(keDeployment, nil).Once()
-			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "default", createAction, "test-instance-type-1", 0, 0, 0, false, mockClient, mockCoreClient, out)
+			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "default", createAction, "test-instance-type-1", -1, 0, 0, false, mockClient, mockCoreClient, out)
 			assert.ErrorIs(t, err, errCannotUpdateExistingQueue)
 			mockClient.AssertExpectations(t)
 		})
@@ -1091,7 +1091,7 @@ func TestUpdate(t *testing.T) {
 			}, nil).Once()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(keDeployment, nil).Twice()
 			mockClient.On("UpdateDeployment", &updateKEDeploymentInput).Return(keDeployment[0], nil).Once()
-			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "default", updateAction, "test-instance-type", 0, 0, 0, true, mockClient, mockCoreClient, out)
+			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "default", updateAction, "test-instance-type", -1, 0, 0, true, mockClient, mockCoreClient, out)
 			assert.NoError(t, err)
 			assert.Contains(t, out.String(), expectedOutMessage)
 			mockClient.AssertExpectations(t)
@@ -1120,7 +1120,7 @@ func TestUpdate(t *testing.T) {
 			defer func() { updateKEDeploymentInput.WorkerQueues[0].NodePoolID = origNodePoolID }()
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(keDeployment, nil).Twice()
 			mockClient.On("UpdateDeployment", &updateKEDeploymentInput).Return(keDeployment[0], nil).Once()
-			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "default", updateAction, "test-instance-type-1", 0, 0, 0, true, mockClient, mockCoreClient, out)
+			err := CreateOrUpdate("test-ws-id", "", "test-deployment-label", "default", updateAction, "test-instance-type-1", -1, 0, 0, true, mockClient, mockCoreClient, out)
 			assert.NoError(t, err)
 			assert.Contains(t, out.String(), expectedOutMessage)
 			mockClient.AssertExpectations(t)
@@ -1129,7 +1129,7 @@ func TestUpdate(t *testing.T) {
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return(keDeployment, nil).Once()
-			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "test-KE-q", updateAction, "test-instance-type-1", 0, 0, 0, false, mockClient, mockCoreClient, out)
+			err := CreateOrUpdate("test-ws-id", "test-deployment-id", "", "test-KE-q", updateAction, "test-instance-type-1", -1, 0, 0, false, mockClient, mockCoreClient, out)
 			assert.ErrorIs(t, err, ErrNotSupported)
 			assert.ErrorContains(t, err, "KubernetesExecutor does not support a non default worker queue in the request. Rename the queue to default")
 			mockClient.AssertExpectations(t)
@@ -1618,8 +1618,11 @@ func TestIsHostedCeleryWorkerQueueInputValid(t *testing.T) {
 func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	requestedWorkerQueue := &astro.WorkerQueue{
-		Name:       "default",
-		NodePoolID: "test-pool-id",
+		Name:              "default",
+		NodePoolID:        "test-pool-id",
+		MinWorkerCount:    -1,
+		MaxWorkerCount:    0,
+		WorkerConcurrency: 0,
 	}
 
 	t.Run("returns nil when queue input is valid", func(t *testing.T) {
@@ -1630,8 +1633,11 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		requestedWorkerQueue.Name = "test-queue"
 		defer func() {
 			requestedWorkerQueue = &astro.WorkerQueue{
-				Name:       "default",
-				NodePoolID: "test-pool-id",
+				Name:              "default",
+				NodePoolID:        "test-pool-id",
+				MinWorkerCount:    -1,
+				MaxWorkerCount:    0,
+				WorkerConcurrency: 0,
 			}
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
@@ -1642,8 +1648,11 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		requestedWorkerQueue.PodCPU = "1.0"
 		defer func() {
 			requestedWorkerQueue = &astro.WorkerQueue{
-				Name:       "default",
-				NodePoolID: "test-pool-id",
+				Name:              "default",
+				NodePoolID:        "test-pool-id",
+				MinWorkerCount:    -1,
+				MaxWorkerCount:    0,
+				WorkerConcurrency: 0,
 			}
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
@@ -1654,8 +1663,11 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		requestedWorkerQueue.PodRAM = "1.0"
 		defer func() {
 			requestedWorkerQueue = &astro.WorkerQueue{
-				Name:       "default",
-				NodePoolID: "test-pool-id",
+				Name:              "default",
+				NodePoolID:        "test-pool-id",
+				MinWorkerCount:    -1,
+				MaxWorkerCount:    0,
+				WorkerConcurrency: 0,
 			}
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
@@ -1666,8 +1678,11 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		requestedWorkerQueue.MinWorkerCount = 8
 		defer func() {
 			requestedWorkerQueue = &astro.WorkerQueue{
-				Name:       "default",
-				NodePoolID: "test-pool-id",
+				Name:              "default",
+				NodePoolID:        "test-pool-id",
+				MinWorkerCount:    -1,
+				MaxWorkerCount:    0,
+				WorkerConcurrency: 0,
 			}
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
@@ -1678,8 +1693,11 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		requestedWorkerQueue.MaxWorkerCount = 25
 		defer func() {
 			requestedWorkerQueue = &astro.WorkerQueue{
-				Name:       "default",
-				NodePoolID: "test-pool-id",
+				Name:              "default",
+				NodePoolID:        "test-pool-id",
+				MinWorkerCount:    -1,
+				MaxWorkerCount:    0,
+				WorkerConcurrency: 0,
 			}
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)
@@ -1690,8 +1708,11 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 		requestedWorkerQueue.WorkerConcurrency = 350
 		defer func() {
 			requestedWorkerQueue = &astro.WorkerQueue{
-				Name:       "default",
-				NodePoolID: "test-pool-id",
+				Name:              "default",
+				NodePoolID:        "test-pool-id",
+				MinWorkerCount:    -1,
+				MaxWorkerCount:    0,
+				WorkerConcurrency: 0,
 			}
 		}()
 		err := IsKubernetesWorkerQueueInputValid(requestedWorkerQueue)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Throw correct error on updating worker queue config for kubernetes executor

## 🎟 Issue(s)

Related #1287 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

![Screenshot 2023-07-07 at 19 34 16](https://github.com/astronomer/astro-cli/assets/65428224/5f53501d-1c0a-49b5-a938-23e9aa19007f)
![Screenshot 2023-07-07 at 19 34 23](https://github.com/astronomer/astro-cli/assets/65428224/b7aac059-abb1-4156-87a3-9d265e4c077e)
![Screenshot 2023-07-07 at 19 34 45](https://github.com/astronomer/astro-cli/assets/65428224/a04ca522-800b-4f57-ac3a-f8eb22105ac7)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
