### PR TITLE
fix for updating deployments with larger scheduler

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -676,10 +676,13 @@ func Update(deploymentID, label, ws, description, deploymentName, dagDeploy, exe
 		queueCreateUpdate = true
 		deploymentUpdate.WorkerQueues = wQueueList
 	}
-	// validate resources requests
-	resourcesValid := validateResources(schedulerAU, schedulerReplicas, configOption)
-	if !resourcesValid {
-		return nil
+
+	if !(IsDeploymentHosted(currentDeployment.Type) || IsDeploymentDedicated(currentDeployment.Type)) {
+		// validate au resources requests
+		resourcesValid := validateResources(schedulerAU, schedulerReplicas, configOption)
+		if !resourcesValid {
+			return nil
+		}
 	}
 
 	// confirm changes with user only if force=false


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Fix for updating deployments with larger scheduler

## 🎟 Issue(s)

Related #1310 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

**Error before Bug Fix**
![Screenshot 2023-07-11 at 11 23 05](https://github.com/astronomer/astro-cli/assets/65428224/628026fe-1fd1-4412-b86c-2c4b59363eab)

**Successful Update after fix**
![Screenshot 2023-07-11 at 11 23 21](https://github.com/astronomer/astro-cli/assets/65428224/0c0203c2-1ecd-4677-a422-7be8abf85cc0)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
