### PR TITLE
Fix typo in parse skipping log message

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -483,7 +483,7 @@ func parseDAGs(deployImage string, containerHandler airflow.ContainerHandler) er
 			return errDagsParseFailed
 		}
 	} else {
-		fmt.Println("Skiping parsing dags due to skip parse being set to true in either the config.yaml or local environment variables")
+		fmt.Println("Skipping parsing dags due to skip parse being set to true in either the config.yaml or local environment variables")
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Fixes a small typo in the log message when skipping parsing on deploy.
