### PR TITLE
Prompt User For Team Name

### DIFF
--- a/cloud/team/team.go
+++ b/cloud/team/team.go
@@ -29,6 +29,7 @@ var (
 	ErrNoTeamsFoundInWorkspace  = errors.New("no teams found in your workspace")
 	ErrNoTeamMembersFoundInTeam = errors.New("no team members found in team")
 	ErrNoUsersFoundInOrg        = errors.New("no users found in your organization")
+	ErrNoTeamNameProvided       = errors.New("you must give your Team a name")
 	teamPagnationLimit          = 100
 )
 
@@ -46,7 +47,7 @@ func CreateTeam(name, description, role string, out io.Writer, client astrocore.
 		fmt.Println("Please specify a name for your Team")
 		name = input.Text(ansi.Bold("\nTeam name: "))
 		if name == "" {
-			return errors.New("you must give your Team a name")
+			return ErrNoTeamNameProvided
 		}
 	}
 	ctx, err := context.GetCurrentContext()

--- a/cloud/team/team.go
+++ b/cloud/team/team.go
@@ -4,7 +4,6 @@ import (
 	httpContext "context"
 	"errors"
 	"fmt"
-	"github.com/astronomer/astro-cli/pkg/ansi"
 	"io"
 	"os"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
 )

--- a/cloud/team/team.go
+++ b/cloud/team/team.go
@@ -4,6 +4,7 @@ import (
 	httpContext "context"
 	"errors"
 	"fmt"
+	"github.com/astronomer/astro-cli/pkg/ansi"
 	"io"
 	"os"
 	"strconv"
@@ -42,7 +43,11 @@ func CreateTeam(name, description, role string, out io.Writer, client astrocore.
 		return err
 	}
 	if name == "" {
-		return ErrInvalidName
+		fmt.Println("Please specify a name for your Team")
+		name = input.Text(ansi.Bold("\nTeam name: "))
+		if name == "" {
+			return errors.New("you must give your Team a name")
+		}
 	}
 	ctx, err := context.GetCurrentContext()
 	if err != nil {

--- a/cloud/team/team_test.go
+++ b/cloud/team/team_test.go
@@ -1019,6 +1019,18 @@ func TestCreate(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
+	t.Run("happy path no name passed so user types one in when prompted", func(t *testing.T) {
+		teamName := "Test Team Name"
+		expectedOutMessage := fmt.Sprintf("Astro Team %s was successfully created\n", teamName)
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("CreateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateTeamResponseOK, nil).Once()
+		defer testUtil.MockUserInput(t, teamName)()
+		err := CreateTeam("", *team1.Description, "ORGANIZATION_MEMBER", out, mockClient)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedOutMessage, out.String())
+	})
+
 	t.Run("error path when CreateTeamWithResponse return network error", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1056,12 +1068,12 @@ func TestCreate(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
-	t.Run("error path no name passed in", func(t *testing.T) {
+	t.Run("error path no name passed in and user doesn't type one in when prompted", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		err := CreateTeam("", *team1.Description, "ORGANIZATION_MEMBER", out, mockClient)
-		assert.EqualError(t, err, "no name provided for the team. Retry with a valid name")
+		assert.EqualError(t, err, "you must give your Team a name")
 	})
 
 	t.Run("error path invalid org role", func(t *testing.T) {

--- a/cloud/user/user.go
+++ b/cloud/user/user.go
@@ -142,7 +142,7 @@ func SelectUser(users []astrocore.User, workspace bool) (astrocore.User, error) 
 		Header:         []string{"#", "FULLNAME", "EMAIL", "ID", roleColumn, "CREATE DATE"},
 	}
 
-	fmt.Println("\nPlease select the user who's role you would like to update:")
+	fmt.Println("\nPlease select the user:")
 
 	userMap := map[string]astrocore.User{}
 	for i := range users {


### PR DESCRIPTION
## Description

- adds a prompt when user creates a team but does not pass in a team name
- makes the select user text more generic so it can be used in more flows

## 🎟 Issue(s)

https://github.com/astronomer/astro-cli/issues/1322
https://github.com/astronomer/astro-cli/issues/1255

## 🧪 Functional Testing

built the cli and ran it locally to verify it works as expected for team creation with and without the name passed in.

<img width="943" alt="Screenshot 2023-07-31 at 4 21 21 PM" src="https://github.com/astronomer/astro-cli/assets/8050013/36af5092-b2ac-474d-ac64-b5e4555938a3">


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
