### PR TITLE
consume workload identity from core api

### DIFF
--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -24,9 +24,11 @@ import (
 var (
 	errGetDeployment           = errors.New("test get deployment error")
 	errMarshal                 = errors.New("test error")
+	workloadIdentity           = "astro-great-release-name@provider-account.iam.gserviceaccount.com"
 	mockCoreDeploymentResponse = []astrocore.Deployment{
 		{
-			Status: "HEALTHY",
+			Status:           "HEALTHY",
+			WorkloadIdentity: &workloadIdentity,
 		},
 	}
 	mockListDeploymentsResponse = astrocore.ListDeploymentsResponse{
@@ -410,8 +412,6 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 	deploymentListParams := &astrocore.ListDeploymentsParams{
 		DeploymentIds: &depIds,
 	}
-
-	workloadIdentity := "astro-great-release-name@provider-account.iam.gserviceaccount.com"
 
 	t.Run("returns deployment metadata for the requested cloud deployment", func(t *testing.T) {
 		var actualDeploymentMeta deploymentMetadata


### PR DESCRIPTION
## Description

removes the hardcoded CLI logic for this and consumes the correct value from core API.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

tested locally using `./astro deployment inspect`

## 📸 Screenshots

<img width="865" alt="image" src="https://github.com/astronomer/astro-cli/assets/4218638/ac152670-9acf-40dc-ad85-48947e12325d">


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
