### PR TITLE
remove conflict test

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -536,8 +536,7 @@ func (d *DockerCompose) Pytest(pytestFile, customImageName, deployImageName, pyt
 
 func (d *DockerCompose) UpgradeTest(newAirflowVersion, deploymentID, newImageName, customImage string, conflictTest, versionTest, dagTest bool, client astro.Client) error {
 	// figure out which tests to run
-	if !conflictTest && !versionTest && !dagTest {
-		conflictTest = true
+	if !versionTest && !dagTest {
 		versionTest = true
 		dagTest = true
 	}

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1109,7 +1109,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 
 		assert.NoError(t, err)
 		imageHandler.AssertExpectations(t)
@@ -1129,7 +1129,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, mockClient)
+		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", true, false, false, mockClient)
 
 		assert.NoError(t, err)
 		imageHandler.AssertExpectations(t)
@@ -1141,7 +1141,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1153,7 +1153,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1165,7 +1165,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1178,7 +1178,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1192,7 +1192,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1207,7 +1207,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1223,7 +1223,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1239,7 +1239,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1251,7 +1251,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, mockClient)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", true, false, false, mockClient)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1264,7 +1264,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, mockClient)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", true, false, false, mockClient)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1279,7 +1279,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -182,7 +182,6 @@ func newAirflowUpgradeTestCmd(astroClient astro.Client) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&airflowVersion, "airflow-version", "a", "", "The version of Airflow you want to upgrade to. The default is the latest available version. Tests are run against the equivalent Astro Runtime version. ")
-	cmd.Flags().BoolVarP(&conflictTest, "conflict-test", "c", false, "Only run conflict tests. These tests check whether you will have dependency conflicts after you upgrade.")
 	cmd.Flags().BoolVarP(&versionTest, "version-test", "", false, "Only run version tests. These tests show you how the versions of your dependencies will change after you upgrade.")
 	cmd.Flags().BoolVarP(&dagTest, "dag-test", "d", false, "Only run DAG tests. These tests check whether your DAGs will generate import errors after you upgrade.")
 	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "i", "", "ID of the Deployment you want run dependency tests against.")


### PR DESCRIPTION
## Description

Remove conflict test. Test currently finds a conflict with the latest version of runtime. This would be too confusing to users as there tests would fail and they would have no way to fix it

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
