### PR TITLE
fix run dag

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -484,7 +484,6 @@ func (d *DockerImage) Run(dagID, envFile, settingsFile, containerName, dagFile, 
 	if settingsFileExist {
 		cmdArgs = append(cmdArgs, []string{"./" + settingsFile}...)
 	}
-	args = append(args, cmdArgs...)
 
 	if executionDate != "" {
 		cmdArgs = append(cmdArgs, []string{"--execution-date", executionDate}...)
@@ -498,6 +497,8 @@ func (d *DockerImage) Run(dagID, envFile, settingsFile, containerName, dagFile, 
 
 	fmt.Println("\nStarting a DAG run for " + dagID + "...")
 	fmt.Println("\nLoading DAGs...")
+	log.Debug("args passed to docker command:")
+	log.Debug(args)
 
 	cmdErr := cmdExec(dockerCommand, stdout, stderr, args...)
 	// add back later fmt.Println("\nSee the output of this command for errors. To view task logs, use the '--task-logs' flag.")

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -3,6 +3,7 @@ package airflow
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -547,6 +548,7 @@ func TestUseBash(t *testing.T) {
 }
 
 func TestDockerImageRun(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	handler := DockerImage{
 		imageName: "testing",
 	}
@@ -562,6 +564,21 @@ func TestDockerImageRun(t *testing.T) {
 
 	t.Run("run success without container", func(t *testing.T) {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			if args[0] == "run" {
+				expectedArgs := []string{
+					"run_dag",
+					"./dags/", "",
+					"./", "--verbose",
+				}
+				for i := 0; i < 5; i++ {
+					if expectedArgs[i] != args[i+15] {
+						fmt.Println(args[i+15])
+						fmt.Println(expectedArgs[i])
+						return errors.New("args error") // Elements from index 0 to 4 in slice1 are not equal to elements from index 5 to 9 in slice2
+					}
+				}
+			}
+
 			return nil
 		}
 

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -574,7 +574,7 @@ func TestDockerImageRun(t *testing.T) {
 					if expectedArgs[i] != args[i+15] {
 						fmt.Println(args[i+15])
 						fmt.Println(expectedArgs[i])
-						return errors.New("args error") // Elements from index 0 to 4 in slice1 are not equal to elements from index 5 to 9 in slice2
+						return errMock // Elements from index 0 to 4 in slice1 are not equal to elements from index 5 to 9 in slice2
 					}
 				}
 			}


### PR DESCRIPTION
## Description

fix run dag error in 1.18

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
