### PR TITLE
Default dag deploy for hosted

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -33,6 +33,7 @@ var (
 	errInvalidValue                   = errors.New("is not valid")
 	errNotPermitted                   = errors.New("is not permitted")
 	canCiCdDeploy                     = deployment.CanCiCdDeploy
+	dagDeploy                         bool
 )
 
 const (
@@ -117,6 +118,11 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, coreClient as
 		workspaceID, err = getWorkspaceIDFromName(formattedDeployment.Deployment.Configuration.WorkspaceName, c.Organization, coreClient)
 		if err != nil {
 			return err
+		}
+		// get correct value for dag deploy
+		dagDeploy = formattedDeployment.Deployment.Configuration.DagDeployEnabled
+		if organization.IsOrgHosted() {
+			dagDeploy = true
 		}
 		// check if deployment exists
 		if deploymentExists(existingDeployments, formattedDeployment.Deployment.Configuration.Name) {
@@ -279,7 +285,7 @@ func getCreateOrUpdateInput(deploymentFromFile *inspect.FormattedDeployment, clu
 			Label:                 deploymentFromFile.Deployment.Configuration.Name,
 			Description:           deploymentFromFile.Deployment.Configuration.Description,
 			RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
-			DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+			DagDeployEnabled:      dagDeploy,
 			SchedulerSize:         deploymentFromFile.Deployment.Configuration.SchedulerSize,
 			APIKeyOnlyDeployments: deploymentFromFile.Deployment.Configuration.APIKeyOnlyDeployments,
 			IsHighAvailability:    deploymentFromFile.Deployment.Configuration.IsHighAvailability,

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -33,7 +33,6 @@ var (
 	errInvalidValue                   = errors.New("is not valid")
 	errNotPermitted                   = errors.New("is not permitted")
 	canCiCdDeploy                     = deployment.CanCiCdDeploy
-	dagDeploy                         bool
 )
 
 const (
@@ -58,6 +57,7 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, coreClient as
 		existingDeployments                            []astro.Deployment
 		nodePools                                      []astrocore.NodePool
 		jsonOutput                                     bool
+		dagDeploy                                      bool
 	)
 
 	// get file contents as []byte
@@ -138,7 +138,7 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, coreClient as
 		}
 		// this deployment does not exist so create it
 		// transform formattedDeployment to DeploymentCreateInput
-		createInput, _, err = getCreateOrUpdateInput(&formattedDeployment, clusterID, workspaceID, createAction, &astro.Deployment{}, nodePools, client)
+		createInput, _, err = getCreateOrUpdateInput(&formattedDeployment, clusterID, workspaceID, createAction, &astro.Deployment{}, nodePools, dagDeploy, client)
 		if err != nil {
 			return err
 		}
@@ -167,7 +167,7 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, coreClient as
 		}
 
 		// transform formattedDeployment to DeploymentUpdateInput
-		_, updateInput, err = getCreateOrUpdateInput(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, client)
+		_, updateInput, err = getCreateOrUpdateInput(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, dagDeploy, client)
 		if err != nil {
 			return err
 		}
@@ -218,7 +218,7 @@ func CreateOrUpdate(inputFile, action string, client astro.Client, coreClient as
 // It returns an error if getting default options fail.
 // It returns an error if worker-queue options are not valid.
 // It returns an error if node pool id could not be found for the worker type.
-func getCreateOrUpdateInput(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astro.Deployment, nodePools []astrocore.NodePool, client astro.Client) (astro.CreateDeploymentInput, astro.UpdateDeploymentInput, error) { //nolint
+func getCreateOrUpdateInput(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astro.Deployment, nodePools []astrocore.NodePool, dagDeploy bool, client astro.Client) (astro.CreateDeploymentInput, astro.UpdateDeploymentInput, error) { //nolint
 	var (
 		defaultOptions astro.WorkerQueueDefaultOptions
 		configOptions  astro.DeploymentConfig

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2735,7 +2735,6 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				mockClient.AssertExpectations(t)
 			})
 			t.Run("sets default queue options if none were requested", func(t *testing.T) {
-				dagDeploy := true
 				deploymentFromFile = inspect.FormattedDeployment{}
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				deploymentFromFile.Deployment.Configuration.ClusterName = "test-cluster"
@@ -2744,6 +2743,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+				dagDeploy = true
 				deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
 
@@ -3040,6 +3040,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+			dagDeploy = true
+			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 
 			expectedDeploymentInput = astro.CreateDeploymentInput{
 				WorkspaceID:           workspaceID,
@@ -3073,6 +3075,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+			dagDeploy = true
+			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 			minCount := -1
 			qList = []inspect.Workerq{
 				{
@@ -3134,6 +3138,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+			dagDeploy = true
+			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 			minCount := 3
 			qList = []inspect.Workerq{
 				{
@@ -3236,6 +3242,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
+			dagDeploy = true
 			existingDeployment := astro.Deployment{
 				ID:    deploymentID,
 				Label: "test-deployment",
@@ -3303,6 +3311,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+			dagDeploy = true
+			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 
 			existingPools := []astro.NodePool{
 				{
@@ -3361,6 +3371,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+			dagDeploy = true
+			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 			minCount := -1
 			qList = []inspect.Workerq{
 				{
@@ -3448,6 +3460,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+			dagDeploy = true
+			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 			minCount := 3
 			qList = []inspect.Workerq{
 				{

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2735,7 +2735,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				mockClient.AssertExpectations(t)
 			})
 			t.Run("sets default queue options if none were requested", func(t *testing.T) {
-				dagDeploy := false
+				dagDeploy := true
 				deploymentFromFile = inspect.FormattedDeployment{}
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				deploymentFromFile.Deployment.Configuration.ClusterName = "test-cluster"

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2735,6 +2735,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				mockClient.AssertExpectations(t)
 			})
 			t.Run("sets default queue options if none were requested", func(t *testing.T) {
+				dagDeploy := false
 				deploymentFromFile = inspect.FormattedDeployment{}
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				deploymentFromFile.Deployment.Configuration.ClusterName = "test-cluster"
@@ -2743,7 +2744,9 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+				deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+
 				minCount := -1
 				qList = []inspect.Workerq{
 					{

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2812,7 +2812,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 					Label:                 deploymentFromFile.Deployment.Configuration.Name,
 					Description:           deploymentFromFile.Deployment.Configuration.Description,
 					RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
-					DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+					DagDeployEnabled:      *deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 					DeploymentSpec: astro.DeploymentCreateSpec{
 						Executor: deployment.CeleryExecutor,
 						Scheduler: astro.Scheduler{
@@ -3044,7 +3044,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				Label:                 deploymentFromFile.Deployment.Configuration.Name,
 				Description:           deploymentFromFile.Deployment.Configuration.Description,
 				RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
-				DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+				DagDeployEnabled:      *deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
 					Executor: deployment.CeleryExecutor,
 					Scheduler: astro.Scheduler{
@@ -3105,7 +3105,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				Label:                 deploymentFromFile.Deployment.Configuration.Name,
 				Description:           deploymentFromFile.Deployment.Configuration.Description,
 				RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
-				DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+				DagDeployEnabled:      *deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
 					Executor: deployment.KubeExecutor,
 					Scheduler: astro.Scheduler{
@@ -3203,7 +3203,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				Label:                 deploymentFromFile.Deployment.Configuration.Name,
 				Description:           deploymentFromFile.Deployment.Configuration.Description,
 				RuntimeReleaseVersion: deploymentFromFile.Deployment.Configuration.RunTimeVersion,
-				DagDeployEnabled:      deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+				DagDeployEnabled:      *deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
 					Executor: deployment.CeleryExecutor,
 					Scheduler: astro.Scheduler{
@@ -3246,7 +3246,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				ClusterID:        clusterID,
 				Label:            deploymentFromFile.Deployment.Configuration.Name,
 				Description:      deploymentFromFile.Deployment.Configuration.Description,
-				DagDeployEnabled: deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+				DagDeployEnabled: *deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
 					Executor: "CeleryExecutor",
 					Scheduler: astro.Scheduler{
@@ -3331,7 +3331,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				ClusterID:        clusterID,
 				Label:            deploymentFromFile.Deployment.Configuration.Name,
 				Description:      deploymentFromFile.Deployment.Configuration.Description,
-				DagDeployEnabled: deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+				DagDeployEnabled: *deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
 					Executor: deploymentFromFile.Deployment.Configuration.Executor,
 					Scheduler: astro.Scheduler{
@@ -3418,7 +3418,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				ClusterID:        clusterID,
 				Label:            deploymentFromFile.Deployment.Configuration.Name,
 				Description:      deploymentFromFile.Deployment.Configuration.Description,
-				DagDeployEnabled: deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+				DagDeployEnabled: *deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
 					Executor: deploymentFromFile.Deployment.Configuration.Executor,
 					Scheduler: astro.Scheduler{
@@ -3524,7 +3524,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				ClusterID:        clusterID,
 				Label:            deploymentFromFile.Deployment.Configuration.Name,
 				Description:      deploymentFromFile.Deployment.Configuration.Description,
-				DagDeployEnabled: deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
+				DagDeployEnabled: *deploymentFromFile.Deployment.Configuration.DagDeployEnabled,
 				DeploymentSpec: astro.DeploymentCreateSpec{
 					Executor: "CeleryExecutor",
 					Scheduler: astro.Scheduler{

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -882,7 +882,6 @@ deployment:
     name: test-deployment-label
     description: description
     runtime_version: 6.0.0
-    dag_deploy_enabled: true
     executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3
@@ -1859,7 +1858,6 @@ deployment:
     name: test-deployment-label
     description: description 1
     runtime_version: 6.0.0
-    dag_deploy_enabled: true
     executor: CeleryExecutor
     scheduler_au: 5
     scheduler_count: 3

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2562,6 +2562,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+			dagDeploy := true
 			minCount := 3
 			qList = []inspect.Workerq{
 				{
@@ -2612,7 +2613,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 
 			expectedDeploymentInput = astro.CreateDeploymentInput{}
 			mockClient := new(astro_mocks.Client)
-			actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+			actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 			assert.ErrorContains(t, err, "worker_type: test-worker-8 does not exist in cluster: test-cluster")
 			assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 			mockClient.AssertExpectations(t)
@@ -2628,6 +2629,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+				dagDeploy := true
 				minCountThirty := 30
 				minCountThree := 3
 				qList = []inspect.Workerq{
@@ -2680,7 +2682,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
 				mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 				assert.ErrorContains(t, err, "worker queue option is invalid: min worker count")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
@@ -2695,6 +2697,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+				dagDeploy := true
 				minCountThirty := 30
 				minCountThree := 3
 				qList = []inspect.Workerq{
@@ -2729,7 +2732,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
 				mockClient.On("GetWorkerQueueOptions").Return(astro.WorkerQueueDefaultOptions{}, errTest).Once()
-				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 				assert.ErrorContains(t, err, "failed to get worker queue default options")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
@@ -2743,7 +2746,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
-				dagDeploy = true
+				dagDeploy := true
 				deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
 
@@ -2827,7 +2830,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				}
 				mockClient := new(astro_mocks.Client)
 				mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 				assert.NoError(t, err)
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
@@ -2844,6 +2847,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+				dagDeploy := true
 				qList = []inspect.Workerq{
 					{
 						Name:       "default",
@@ -2869,7 +2873,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				}
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
-				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 				assert.ErrorContains(t, err, "KubernetesExecutor does not support more than one worker queue. (2) were requested")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
@@ -2884,6 +2888,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+				dagDeploy := true
 				minCount := 10
 				qList = []inspect.Workerq{
 					{
@@ -2907,7 +2912,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				}
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
-				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 				assert.ErrorContains(t, err, "KubernetesExecutor does not support minimum worker count in the request. It can only be used with CeleryExecutor")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
@@ -2922,6 +2927,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+				dagDeploy := true
 				minCount := -1
 				qList = []inspect.Workerq{
 					{
@@ -2946,7 +2952,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				}
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
-				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 				assert.ErrorContains(t, err, "KubernetesExecutor does not support maximum worker count in the request. It can only be used with CeleryExecutor")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
@@ -2961,6 +2967,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+				dagDeploy := true
 				minCount := -1
 				qList = []inspect.Workerq{
 					{
@@ -2985,7 +2992,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				}
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
-				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 				assert.ErrorContains(t, err, "KubernetesExecutor does not support worker concurrency in the request. It can only be used with CeleryExecutor")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
@@ -3000,6 +3007,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 				deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 				deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+				dagDeploy := true
 				qList = []inspect.Workerq{
 					{
 						Name:       "default",
@@ -3022,7 +3030,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				}
 				expectedDeploymentInput = astro.CreateDeploymentInput{}
 				mockClient := new(astro_mocks.Client)
-				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+				actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 				assert.ErrorContains(t, err, "KubernetesExecutor does not support pod ram in the request. It will be calculated based on the requested worker type")
 				assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 				mockClient.AssertExpectations(t)
@@ -3040,7 +3048,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
-			dagDeploy = true
+			dagDeploy := true
 			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 
 			expectedDeploymentInput = astro.CreateDeploymentInput{
@@ -3060,7 +3068,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				WorkerQueues: nil,
 			}
 			mockClient := new(astro_mocks.Client)
-			actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, nil, mockClient)
+			actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, nil, dagDeploy, mockClient)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 			mockClient.AssertExpectations(t)
@@ -3075,7 +3083,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
-			dagDeploy = true
+			dagDeploy := true
 			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 			minCount := -1
 			qList = []inspect.Workerq{
@@ -3123,7 +3131,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				WorkerQueues: expectedQList,
 			}
 			mockClient := new(astro_mocks.Client)
-			actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+			actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 			mockClient.AssertExpectations(t)
@@ -3138,7 +3146,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
-			dagDeploy = true
+			dagDeploy := true
 			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 			minCount := 3
 			qList = []inspect.Workerq{
@@ -3224,7 +3232,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			}
 			mockClient := new(astro_mocks.Client)
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-			actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, mockClient)
+			actualCreateInput, _, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "create", &astro.Deployment{}, existingPools, dagDeploy, mockClient)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedDeploymentInput, actualCreateInput)
 			mockClient.AssertExpectations(t)
@@ -3242,8 +3250,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+			dagDeploy := true
 			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
-			dagDeploy = true
 			existingDeployment := astro.Deployment{
 				ID:    deploymentID,
 				Label: "test-deployment",
@@ -3268,7 +3276,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				WorkerQueues: nil,
 			}
 			mockClient := new(astro_mocks.Client)
-			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, nil, mockClient)
+			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, nil, dagDeploy, mockClient)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedUpdateDeploymentInput, actualUpdateInput)
 			mockClient.AssertExpectations(t)
@@ -3284,6 +3292,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
+			dagDeploy := true
 			existingDeployment := astro.Deployment{
 				ID:    deploymentID,
 				Label: "test-deployment",
@@ -3294,7 +3303,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 
 			expectedUpdateDeploymentInput = astro.UpdateDeploymentInput{}
 			mockClient := new(astro_mocks.Client)
-			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, "diff-cluster", workspaceID, "update", &existingDeployment, nil, mockClient)
+			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, "diff-cluster", workspaceID, "update", &existingDeployment, nil, dagDeploy, mockClient)
 			assert.ErrorIs(t, err, errNotPermitted)
 			assert.ErrorContains(t, err, "changing an existing deployment's cluster is not permitted")
 			assert.Equal(t, expectedUpdateDeploymentInput, actualUpdateInput)
@@ -3311,7 +3320,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
-			dagDeploy = true
+			dagDeploy := true
 			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 
 			existingPools := []astro.NodePool{
@@ -3355,7 +3364,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				WorkerQueues: nil, // a default queue is created by the api
 			}
 			mockClient := new(astro_mocks.Client)
-			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, nil, mockClient)
+			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, nil, dagDeploy, mockClient)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedUpdateDeploymentInput, actualUpdateInput)
 			mockClient.AssertExpectations(t)
@@ -3371,7 +3380,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
-			dagDeploy = true
+			dagDeploy := true
 			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 			minCount := -1
 			qList = []inspect.Workerq{
@@ -3444,7 +3453,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 				WorkerQueues: expectedQList,
 			}
 			mockClient := new(astro_mocks.Client)
-			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, mockClient)
+			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, mockClient)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedUpdateDeploymentInput, actualUpdateInput)
 			mockClient.AssertExpectations(t)
@@ -3460,7 +3469,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
 			deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
 			deploymentFromFile.Deployment.Configuration.Executor = deployment.CeleryExecutor
-			dagDeploy = true
+			dagDeploy := true
 			deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 			minCount := 3
 			qList = []inspect.Workerq{
@@ -3553,7 +3562,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			}
 			mockClient := new(astro_mocks.Client)
 			mockClient.On("GetWorkerQueueOptions").Return(mockWorkerQueueDefaultOptions, nil).Once()
-			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, mockClient)
+			_, actualUpdateInput, err = getCreateOrUpdateInput(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, mockClient)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedUpdateDeploymentInput, actualUpdateInput)
 			mockClient.AssertExpectations(t)

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -37,7 +37,7 @@ type deploymentConfig struct {
 	Name                  string `mapstructure:"name" yaml:"name" json:"name"`
 	Description           string `mapstructure:"description" yaml:"description" json:"description"`
 	RunTimeVersion        string `mapstructure:"runtime_version" yaml:"runtime_version" json:"runtime_version"`
-	DagDeployEnabled      bool   `mapstructure:"dag_deploy_enabled" yaml:"dag_deploy_enabled" json:"dag_deploy_enabled"`
+	DagDeployEnabled      *bool  `mapstructure:"dag_deploy_enabled" yaml:"dag_deploy_enabled" json:"dag_deploy_enabled"`
 	APIKeyOnlyDeployments bool   `mapstructure:"ci_cd_enforcement" yaml:"ci_cd_enforcement" json:"ci_cd_enforcement"`
 	SchedulerSize         string `mapstructure:"scheduler_size" yaml:"scheduler_size" json:"scheduler_size"`
 	IsHighAvailability    bool   `mapstructure:"is_high_availability" yaml:"is_high_availability" json:"is_high_availability"`

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -562,7 +562,7 @@ func TestGetDeploymentConfig(t *testing.T) {
 			RunTimeVersion:   sourceDeployment.RuntimeRelease.Version,
 			SchedulerAU:      sourceDeployment.DeploymentSpec.Scheduler.AU,
 			SchedulerCount:   sourceDeployment.DeploymentSpec.Scheduler.Replicas,
-			DagDeployEnabled: sourceDeployment.DagDeployEnabled,
+			DagDeployEnabled: &sourceDeployment.DagDeployEnabled,
 			Executor:         sourceDeployment.DeploymentSpec.Executor,
 		}
 		rawDeploymentConfig := getDeploymentConfig(&sourceDeployment)

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -324,7 +324,7 @@ func deploymentLogs(cmd *cobra.Command, args []string) error {
 	return deployment.Logs(deploymentID, ws, deploymentName, warnLogs, errorLogs, infoLogs, logCount, astroClient)
 }
 
-func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error {
+func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //nolint:gocognit
 	// Find Workspace ID
 	ws, err := coalesceWorkspace()
 	if err != nil {

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -147,7 +147,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&workspaceID, "workspace-id", "w", "", "Workspace to create the Deployment in")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Description of the Deployment. If the description contains a space, specify the entire description in quotes \"\"")
 	cmd.Flags().StringVarP(&runtimeVersion, "runtime-version", "v", "", "Runtime version for the Deployment")
-	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "disable", "Enables DAG-only deploys for the Deployment")
+	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "", "Enables DAG-only deploys for the Deployment")
 	cmd.Flags().StringVarP(&executor, "executor", "e", "", "The executor to use for the Deployment. Possible values can be CeleryExecutor or KubernetesExecutor.")
 	cmd.Flags().StringVarP(&inputFile, "deployment-file", "", "", "Location of file containing the Deployment to create. File can be in either JSON or YAML format.")
 	cmd.Flags().BoolVarP(&waitForStatus, "wait", "i", false, "Wait for the Deployment to become healthy before ending the command")
@@ -364,6 +364,13 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error {
 	}
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {
 		return errors.New("Invalid --dag-deploy value)")
+	}
+	if dagDeploy == "" {
+		if organization.IsOrgHosted() {
+			dagDeploy = enable
+		} else {
+			dagDeploy = disable
+		}
 	}
 
 	// Get latest runtime version


### PR DESCRIPTION
## Description

dag deploy enabled by default for hosted

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1344

## 🧪 Functional Testing

manual testing in dev in a both a hybrid and hosted org
- created a deployment with deployment create command
- created a deployment with deployment file

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
