### PR TITLE
Remove volume mounting logic from pytest

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -101,16 +101,6 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 		"-i",
 		"--name",
 		"astro-pytest",
-		"-v",
-		airflowHome + "/dags:/usr/local/airflow/dags:rw",
-		"-v",
-		airflowHome + "/plugins:/usr/local/airflow/plugins:rw",
-		"-v",
-		airflowHome + "/include:/usr/local/airflow/include:rw",
-		"-v",
-		airflowHome + "/.astro:/usr/local/airflow/.astro:rw",
-		"-v",
-		airflowHome + "/tests:/usr/local/airflow/tests:rw",
 	}
 	fileExist, err := util.Exists(airflowHome + "/" + envFile)
 	if err != nil {


### PR DESCRIPTION
## Description
Changes:
- Removed volume mounting logic to add test files into the container for pytest & parse, since these files are already present on the image, and volume mounting is not supported for the container when running CLI on CICD platforms, which means these tests seem to fail for users during `astro deploy` process.

## 🎟 Issue(s)

Related #870

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

Screenshots of result from running these commands on Circle CI platform
<img width="826" alt="Screenshot 2023-08-10 at 1 59 08 PM" src="https://github.com/astronomer/astro-cli/assets/92356010/74761ad0-caa7-4c6b-a723-7cdf0c964793">
<img width="950" alt="Screenshot 2023-08-10 at 1 58 48 PM" src="https://github.com/astronomer/astro-cli/assets/92356010/dd80e9a3-6d6f-4f86-aaa2-4d29a2549834">
<img width="1038" alt="Screenshot 2023-08-10 at 1 58 36 PM" src="https://github.com/astronomer/astro-cli/assets/92356010/59c2a990-3f87-441e-827f-f9588b583b24">


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
