### PR TITLE
Add more paths to dockerignore & gitignore

### DIFF
--- a/airflow/include/dockerignore
+++ b/airflow/include/dockerignore
@@ -3,3 +3,7 @@ astro
 .env
 airflow_settings.yaml
 logs/
+.venv
+airflow.db
+airflow.cfg
+

--- a/airflow/include/dockerignore
+++ b/airflow/include/dockerignore
@@ -6,4 +6,3 @@ logs/
 .venv
 airflow.db
 airflow.cfg
-

--- a/airflow/include/gitignore
+++ b/airflow/include/gitignore
@@ -4,3 +4,8 @@
 airflow_settings.yaml
 __pycache__/
 astro
+.venv
+airflow-webserver.pid
+webserver_config.py
+airflow.cfg
+airflow.db


### PR DESCRIPTION
These dirs aren't needed and will allow users to run astro-cli along with airflow from the same dir
