### PR TITLE
Fixing workload identity on inspect

### DIFF
--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -28,9 +28,11 @@ const (
 var (
 	errTest                    = errors.New("test error")
 	limit                      = 1000
+	workloadIdentity           = "astro-great-release-name@provider-account.iam.gserviceaccount.com"
 	mockCoreDeploymentResponse = []astrocore.Deployment{
 		{
-			Status: "HEALTHY",
+			Status:           "HEALTHY",
+			WorkloadIdentity: &workloadIdentity,
 		},
 	}
 	mockListDeploymentsResponse = astrocore.ListDeploymentsResponse{
@@ -197,6 +199,7 @@ deployment:
     release_name: great-release-name
     airflow_version: 2.4.0
     status: UNHEALTHY
+    workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
     deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
@@ -254,6 +257,7 @@ deployment:
     release_name: great-release-name
     airflow_version: 2.4.0
     status: UNHEALTHY
+    workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
     deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
@@ -316,6 +320,7 @@ deployment:
     release_name: great-release-name
     airflow_version: 2.4.0
     status: UNHEALTHY
+    workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
     deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
@@ -380,6 +385,7 @@ deployment:
     release_name: great-release-name
     airflow_version: 2.4.0
     status: UNHEALTHY
+    workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
     deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
@@ -444,6 +450,7 @@ deployment:
     release_name: great-release-name
     airflow_version: 2.4.0
     status: UNHEALTHY
+    workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
     deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
@@ -508,6 +515,7 @@ deployment:
             "release_name": "great-release-name",
             "airflow_version": "2.4.0",
             "status": "UNHEALTHY",
+            "workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
             "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
@@ -609,6 +617,7 @@ deployment:
     release_name: great-release-name
     airflow_version: 2.4.0
     status: UNHEALTHY
+    workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
     deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
@@ -715,6 +724,7 @@ deployment:
             "release_name": "great-release-name",
             "airflow_version": "2.4.0",
             "status": "UNHEALTHY",
+            "workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
             "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
@@ -816,6 +826,7 @@ deployment:
             "release_name": "great-release-name",
             "airflow_version": "2.4.0",
             "status": "UNHEALTHY",
+			"workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
             "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -826,7 +826,7 @@ deployment:
             "release_name": "great-release-name",
             "airflow_version": "2.4.0",
             "status": "UNHEALTHY",
-			"workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
+            "workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
             "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -147,8 +147,9 @@ func Inspect(wsID, deploymentName, deploymentID, outputFormat string, client ast
 
 func getDeploymentInfo(sourceDeployment *astro.Deployment, coreDeployment astrocore.Deployment) (map[string]interface{}, error) { //nolint
 	var (
-		deploymentURL string
-		err           error
+		deploymentURL    string
+		workloadIdentity string
+		err              error
 	)
 
 	deploymentURL, err = deployment.GetDeploymentURL(sourceDeployment.ID, sourceDeployment.Workspace.ID)
@@ -163,6 +164,9 @@ func getDeploymentInfo(sourceDeployment *astro.Deployment, coreDeployment astroc
 		}
 		releaseName = notApplicable
 	}
+	if coreDeployment.WorkloadIdentity != nil {
+		workloadIdentity = *coreDeployment.WorkloadIdentity
+	}
 	return map[string]interface{}{
 		"deployment_id":     sourceDeployment.ID,
 		"workspace_id":      sourceDeployment.Workspace.ID,
@@ -174,7 +178,7 @@ func getDeploymentInfo(sourceDeployment *astro.Deployment, coreDeployment astroc
 		"webserver_url":     sourceDeployment.DeploymentSpec.Webserver.URL,
 		"created_at":        sourceDeployment.CreatedAt,
 		"updated_at":        sourceDeployment.UpdatedAt,
-		"workload_identity": *coreDeployment.WorkloadIdentity,
+		"workload_identity": workloadIdentity,
 		"status":            coreDeployment.Status,
 	}, nil
 }

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -174,7 +174,7 @@ func getDeploymentInfo(sourceDeployment *astro.Deployment, coreDeployment astroc
 		"webserver_url":     sourceDeployment.DeploymentSpec.Webserver.URL,
 		"created_at":        sourceDeployment.CreatedAt,
 		"updated_at":        sourceDeployment.UpdatedAt,
-		"workload_identity": coreDeployment.WorkloadIdentity,
+		"workload_identity": *coreDeployment.WorkloadIdentity,
 		"status":            coreDeployment.Status,
 	}, nil
 }

--- a/cmd/cloud/deployment_inspect_test.go
+++ b/cmd/cloud/deployment_inspect_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	workloadIdentity   = "astro-great-release-name@provider-account.iam.gserviceaccount.com"
 	deploymentResponse = []astro.Deployment{
 		{
 			ID:          "test-deployment-id",
@@ -105,7 +106,8 @@ var (
 	}
 	mockCoreDeploymentResponse = []astrocore.Deployment{
 		{
-			Status: "HEALTHY",
+			Status:           "HEALTHY",
+			WorkloadIdentity: &workloadIdentity,
 		},
 	}
 	mockListDeploymentsResponse = astrocore.ListDeploymentsResponse{

--- a/cmd/cloud/deployment_inspect_test.go
+++ b/cmd/cloud/deployment_inspect_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 var (
-	workloadIdentity   = "astro-great-release-name@provider-account.iam.gserviceaccount.com"
 	deploymentResponse = []astro.Deployment{
 		{
 			ID:          "test-deployment-id",
@@ -106,8 +105,7 @@ var (
 	}
 	mockCoreDeploymentResponse = []astrocore.Deployment{
 		{
-			Status:           "HEALTHY",
-			WorkloadIdentity: &workloadIdentity,
+			Status: "HEALTHY",
 		},
 	}
 	mockListDeploymentsResponse = astrocore.ListDeploymentsResponse{


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Fixing workload identity on inspect

## 🎟 Issue(s)

Related #1362 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
