### PR TITLE
Copy DAGs folder before running pytest command

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -97,7 +97,7 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 		return "", err
 	}
 	args := []string{
-		"run",
+		"create",
 		"-i",
 		"--name",
 		"astro-pytest",
@@ -120,12 +120,26 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 		stdout = nil
 		stderr = nil
 	}
-	// run pytest
+	// create pytest container
 	docErr := cmdExec(dockerCommand, stdout, stderr, args...)
 	if docErr != nil {
-		log.Debug(docErr)
+		return "", docErr
 	}
-
+	// cp DAGs folder
+	args = []string{
+		"cp",
+		airflowHome + "/dags",
+		"astro-pytest:/usr/local/airflow/",
+	}
+	docErr = cmdExec(dockerCommand, stdout, stderr, args...)
+	if docErr != nil {
+		return "", docErr
+	}
+	// start pytest container
+	docErr = cmdExec(dockerCommand, stdout, stderr, []string{"start", "astro-pytest", "-a"}...)
+	if docErr != nil {
+		return "", docErr
+	}
 	// get exit code
 	args = []string{
 		"inspect",

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -113,6 +113,32 @@ func TestDockerImagePytest(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("create error", func(t *testing.T) {
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			switch {
+			case args[0] == "create":
+				return errMock
+			default:
+				return nil
+			}
+		}
+		_, err = handler.Pytest("", "", "", "", []string{}, true, options)
+		assert.Error(t, err)
+	})
+
+	t.Run("start error", func(t *testing.T) {
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			switch {
+			case args[0] == "start":
+				return errMock
+			default:
+				return nil
+			}
+		}
+		_, err = handler.Pytest("", "", "", "", []string{}, true, options)
+		assert.Error(t, err)
+	})
+
 	t.Run("copy error", func(t *testing.T) {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 			switch {


### PR DESCRIPTION
## Description
Changes:
- Fix potentially missing DAGs folder when pytest is run during `astro deploy` with dags only deploy. This change would explicitly copy the DAGs folder before running the pytest container.

## 🎟 Issue(s)
Original change: https://github.com/astronomer/astro-cli/pull/1351
Slack thread conversation: https://astronomer.slack.com/archives/CL44PA4DB/p1692987720142969

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots
All tests passing, on a Linux CI machine
<img width="779" alt="Screenshot 2023-08-28 at 5 17 45 PM" src="https://github.com/astronomer/astro-cli/assets/92356010/4a0b016a-ba92-4f63-bacd-4b855f2382cc">

Copied advanced DAG file to `dags/test-dags`, so that pytest would fail because of duplicate DAGs, and it would also show that the DAGs folder is being picked up for pytest when running dags deploy
<img width="2087" alt="Screenshot 2023-08-28 at 5 24 02 PM" src="https://github.com/astronomer/astro-cli/assets/92356010/80c19011-9d3d-41d5-94ff-c964afd42f83">


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
