### PR TITLE
fix nil pointer deref on orgUserRelationIsIdpManaged

### DIFF
--- a/cloud/user/user.go
+++ b/cloud/user/user.go
@@ -228,7 +228,7 @@ func ListOrgUsers(out io.Writer, client astrocore.CoreClient) error {
 	}
 
 	for i := range users {
-		orgUserRelationIsIdpManaged := "false"
+		orgUserRelationIsIdpManaged := ""
 		orgUserRelationIsIdpManagedPointer := users[i].OrgUserRelationIsIdpManaged
 		if orgUserRelationIsIdpManagedPointer != nil {
 			orgUserRelationIsIdpManaged = strconv.FormatBool(*users[i].OrgUserRelationIsIdpManaged)
@@ -406,7 +406,7 @@ func ListWorkspaceUsers(out io.Writer, client astrocore.CoreClient, workspace st
 	}
 
 	for i := range users {
-		orgUserRelationIsIdpManaged := "false"
+		orgUserRelationIsIdpManaged := ""
 		orgUserRelationIsIdpManagedPointer := users[i].OrgUserRelationIsIdpManaged
 		if orgUserRelationIsIdpManagedPointer != nil {
 			orgUserRelationIsIdpManaged = strconv.FormatBool(*users[i].OrgUserRelationIsIdpManaged)

--- a/cloud/user/user.go
+++ b/cloud/user/user.go
@@ -228,12 +228,17 @@ func ListOrgUsers(out io.Writer, client astrocore.CoreClient) error {
 	}
 
 	for i := range users {
+		orgUserRelationIsIdpManaged := "false"
+		orgUserRelationIsIdpManagedPointer := users[i].OrgUserRelationIsIdpManaged
+		if orgUserRelationIsIdpManagedPointer != nil {
+			orgUserRelationIsIdpManaged = strconv.FormatBool(*users[i].OrgUserRelationIsIdpManaged)
+		}
 		table.AddRow([]string{
 			users[i].FullName,
 			users[i].Username,
 			users[i].Id,
 			*users[i].OrgRole,
-			strconv.FormatBool(*users[i].OrgUserRelationIsIdpManaged),
+			orgUserRelationIsIdpManaged,
 			users[i].CreatedAt.Format(time.RFC3339),
 		}, false)
 	}
@@ -401,12 +406,17 @@ func ListWorkspaceUsers(out io.Writer, client astrocore.CoreClient, workspace st
 	}
 
 	for i := range users {
+		orgUserRelationIsIdpManaged := "false"
+		orgUserRelationIsIdpManagedPointer := users[i].OrgUserRelationIsIdpManaged
+		if orgUserRelationIsIdpManagedPointer != nil {
+			orgUserRelationIsIdpManaged = strconv.FormatBool(*users[i].OrgUserRelationIsIdpManaged)
+		}
 		table.AddRow([]string{
 			users[i].FullName,
 			users[i].Username,
 			users[i].Id,
 			*users[i].WorkspaceRole,
-			strconv.FormatBool(*users[i].OrgUserRelationIsIdpManaged),
+			orgUserRelationIsIdpManaged,
 			users[i].CreatedAt.Format(time.RFC3339),
 		}, false)
 	}


### PR DESCRIPTION
## Description

Fixes a nil pointer deref when isIdpManaged is not returned for a given user

## 🧪 Functional Testing

tested against prod that the workspace that was breaking the command now returns the users list

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
