### PR TITLE
removeIsIdpManagedFromListWorkspaceUsers

### DIFF
--- a/cloud/user/user.go
+++ b/cloud/user/user.go
@@ -398,7 +398,7 @@ func ListWorkspaceUsers(out io.Writer, client astrocore.CoreClient, workspace st
 	table := printutil.Table{
 		Padding:        []int{30, 50, 10, 50, 10, 10, 10},
 		DynamicPadding: true,
-		Header:         []string{"FULLNAME", "EMAIL", "ID", "WORKSPACE ROLE", "IDP MANAGED", "CREATE DATE"},
+		Header:         []string{"FULLNAME", "EMAIL", "ID", "WORKSPACE ROLE", "CREATE DATE"},
 	}
 	users, err := GetWorkspaceUsers(client, workspace, userPagnationLimit)
 	if err != nil {
@@ -406,17 +406,11 @@ func ListWorkspaceUsers(out io.Writer, client astrocore.CoreClient, workspace st
 	}
 
 	for i := range users {
-		orgUserRelationIsIdpManaged := ""
-		orgUserRelationIsIdpManagedPointer := users[i].OrgUserRelationIsIdpManaged
-		if orgUserRelationIsIdpManagedPointer != nil {
-			orgUserRelationIsIdpManaged = strconv.FormatBool(*users[i].OrgUserRelationIsIdpManaged)
-		}
 		table.AddRow([]string{
 			users[i].FullName,
 			users[i].Username,
 			users[i].Id,
 			*users[i].WorkspaceRole,
-			orgUserRelationIsIdpManaged,
 			users[i].CreatedAt.Format(time.RFC3339),
 		}, false)
 	}


### PR DESCRIPTION
## Description

Remove is idp managed from the list workspace user table as the list workspace user endpoint does not return this data.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
