### PR TITLE
Fix .astro folder not present in few images causing failure for parse command

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -135,6 +135,19 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 	if docErr != nil {
 		return "", docErr
 	}
+	// cp .astro folder
+	// on some machine .astro is being docker ignored, but not
+	// on every machine, hence to keep behaviour consistent
+	// copying the .astro folder explicitly
+	args = []string{
+		"cp",
+		airflowHome + "/.astro",
+		"astro-pytest:/usr/local/airflow/",
+	}
+	docErr = cmdExec(dockerCommand, stdout, stderr, args...)
+	if docErr != nil {
+		return "", docErr
+	}
 	// start pytest container
 	docErr = cmdExec(dockerCommand, stdout, stderr, []string{"start", "astro-pytest", "-a"}...)
 	if docErr != nil {

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -137,7 +137,7 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 	}
 	// cp .astro folder
 	// on some machine .astro is being docker ignored, but not
-	// on every machine, hence to keep behaviour consistent
+	// on every machine, hence to keep behavior consistent
 	// copying the .astro folder explicitly
 	args = []string{
 		"cp",


### PR DESCRIPTION
## Description
Changes:
- Add an explicit copy of `.astro` folder for pytest. The `.astro` is getting docker ignored on a few machines, but not on all machines. So in order to have consistent behavior, since parse logic requires files from `.astro`, this PR adds changes to explicitly copy `.astro` folder to the container running pytest & parse command.

## 🎟 Issue(s)

Related #1374 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
