### PR TITLE
Update default deployment url

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -1009,10 +1009,10 @@ func GetDeploymentURL(deploymentID, workspaceID string) (string, error) {
 	}
 	switch ctx.Domain {
 	case domainutil.LocalDomain:
-		deploymentURL = ctx.Domain + ":5000/" + workspaceID + "/deployments/" + deploymentID + "/analytics"
+		deploymentURL = ctx.Domain + ":5000/" + workspaceID + "/deployments/" + deploymentID + "/overview"
 	default:
 		_, domain := domainutil.GetPRSubDomain(ctx.Domain)
-		deploymentURL = "cloud." + domain + "/" + workspaceID + "/deployments/" + deploymentID + "/analytics"
+		deploymentURL = "cloud." + domain + "/" + workspaceID + "/deployments/" + deploymentID + "/overview"
 	}
 	return deploymentURL, nil
 }

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -2651,42 +2651,42 @@ func TestGetDeploymentURL(t *testing.T) {
 
 	t.Run("returns deploymentURL for dev environment", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudDevPlatform)
-		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id/analytics"
+		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id/overview"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)
 	})
 	t.Run("returns deploymentURL for stage environment", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudStagePlatform)
-		expectedURL := "cloud.astronomer-stage.io/workspace-id/deployments/deployment-id/analytics"
+		expectedURL := "cloud.astronomer-stage.io/workspace-id/deployments/deployment-id/overview"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)
 	})
 	t.Run("returns deploymentURL for perf environment", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPerfPlatform)
-		expectedURL := "cloud.astronomer-perf.io/workspace-id/deployments/deployment-id/analytics"
+		expectedURL := "cloud.astronomer-perf.io/workspace-id/deployments/deployment-id/overview"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)
 	})
 	t.Run("returns deploymentURL for cloud (prod) environment", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
-		expectedURL := "cloud.astronomer.io/workspace-id/deployments/deployment-id/analytics"
+		expectedURL := "cloud.astronomer.io/workspace-id/deployments/deployment-id/overview"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)
 	})
 	t.Run("returns deploymentURL for pr preview environment", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPrPreview)
-		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id/analytics"
+		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id/overview"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)
 	})
 	t.Run("returns deploymentURL for local environment", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		expectedURL := "localhost:5000/workspace-id/deployments/deployment-id/analytics"
+		expectedURL := "localhost:5000/workspace-id/deployments/deployment-id/overview"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -202,7 +202,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
 `
 			fileutil.WriteStringToFile(filePath, data)
@@ -260,7 +260,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -323,7 +323,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -388,7 +388,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -453,7 +453,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -518,7 +518,7 @@ deployment:
             "workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -620,7 +620,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails: []
 `
@@ -727,7 +727,7 @@ deployment:
             "workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -829,7 +829,7 @@ deployment:
             "workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -921,7 +921,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1039,7 +1039,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1201,7 +1201,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -1331,7 +1331,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -1488,7 +1488,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1554,7 +1554,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1630,7 +1630,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1707,7 +1707,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -1806,7 +1806,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -1897,7 +1897,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -2035,7 +2035,7 @@ deployment:
     status: HEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -2205,7 +2205,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -2333,7 +2333,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -2473,7 +2473,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -2549,7 +2549,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -2652,7 +2652,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -418,7 +418,7 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, deploymentListParams).Return(mockCoreDeploymentResponse, nil).Once()
 		expectedCloudDomainURL := "cloud.astronomer.io/" + sourceDeployment.Workspace.ID +
-			"/deployments/" + sourceDeployment.ID + "/analytics"
+			"/deployments/" + sourceDeployment.ID + "/overview"
 		expectedDeploymentMetadata := deploymentMetadata{
 			DeploymentID:     &sourceDeployment.ID,
 			WorkspaceID:      &sourceDeployment.Workspace.ID,
@@ -443,7 +443,7 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 		var actualDeploymentMeta deploymentMetadata
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		expectedCloudDomainURL := "localhost:5000/" + sourceDeployment.Workspace.ID +
-			"/deployments/" + sourceDeployment.ID + "/analytics"
+			"/deployments/" + sourceDeployment.ID + "/overview"
 		expectedDeploymentMetadata := deploymentMetadata{
 			DeploymentID:     &sourceDeployment.ID,
 			WorkspaceID:      &sourceDeployment.Workspace.ID,
@@ -942,7 +942,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
         status: UNHEALTHY
         created_at: 2022-11-17T13:25:55.275697-08:00
         updated_at: 2022-11-17T13:25:55.275697-08:00
-        deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+        deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
         webserver_url: some-url
     alert_emails:
         - email1
@@ -1093,7 +1093,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url"
         },
         "alert_emails": [

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -293,7 +293,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -592,7 +592,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/analytics
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
     webserver_url: some-url
   alert_emails:
     - test1@test.com


### PR DESCRIPTION
## Description

We recently updated the default URL of a Deployment without modifying the links to the old page in the CLI. We've added a [redirect for the old links in the UI](https://github.com/astronomer/astro/pull/16130) that we'll keep around until we no longer support the CLI version with the old links.

## 🎟 Issue(s)

Related #1377

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
