### PR TITLE
add workspace id as flag to workspace team add cmd

### DIFF
--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -407,6 +407,7 @@ func newWorkspaceTeamAddCmd(out io.Writer) *cobra.Command {
 			return addWorkspaceTeam(cmd, args, out)
 		},
 	}
+	cmd.Flags().StringVarP(&workspaceID, "workspace-id", "w", "", "The Workspace's unique identifier")
 	cmd.Flags().StringVarP(&addWorkspaceRole, "role", "r", "WORKSPACE_MEMBER", "The role for the "+
 		"new team. Possible values are WORKSPACE_MEMBER, WORKSPACE_AUTHOR, WORKSPACE_OPERATOR and WORKSPACE_OWNER ")
 	return cmd
@@ -421,7 +422,7 @@ func addWorkspaceTeam(cmd *cobra.Command, args []string, out io.Writer) error {
 		id = args[0]
 	}
 	cmd.SilenceUsage = true
-	return team.AddWorkspaceTeam(id, addWorkspaceRole, "", out, astroCoreClient)
+	return team.AddWorkspaceTeam(id, addWorkspaceRole, workspaceID, out, astroCoreClient)
 }
 
 func newWorkspaceTeamUpdateCmd(out io.Writer) *cobra.Command {

--- a/cmd/cloud/workspace_test.go
+++ b/cmd/cloud/workspace_test.go
@@ -874,6 +874,20 @@ func TestWorkspaceTeamAdd(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Contains(t, resp, expectedOut)
 	})
+
+	t.Run("can add team with workspace-id flag", func(t *testing.T) {
+		workspaceIdFromFlag := "mock-workspace-id"
+		expectedOut := fmt.Sprintf("The team %s was successfully added to the workspace with the role WORKSPACE_MEMBER\n", team1.Id)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
+		mockClient.On("MutateWorkspaceTeamRoleWithResponse", mock.Anything, mock.Anything, workspaceIdFromFlag, mock.Anything, mock.Anything).Return(&MutateWorkspaceTeamRoleResponseOK, nil).Once()
+		astroCoreClient = mockClient
+		cmdArgs := []string{"team", "add", team1.Id, "--role", "WORKSPACE_MEMBER", "--workspace-id", workspaceIdFromFlag}
+		resp, err := execWorkspaceCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, expectedOut)
+	})
+
 	t.Run("valid email with invalid role returns an error and team is not added", func(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()

--- a/cmd/cloud/workspace_test.go
+++ b/cmd/cloud/workspace_test.go
@@ -876,13 +876,13 @@ func TestWorkspaceTeamAdd(t *testing.T) {
 	})
 
 	t.Run("can add team with workspace-id flag", func(t *testing.T) {
-		workspaceIdFromFlag := "mock-workspace-id"
+		workspaceIDFromFlag := "mock-workspace-id"
 		expectedOut := fmt.Sprintf("The team %s was successfully added to the workspace with the role WORKSPACE_MEMBER\n", team1.Id)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
-		mockClient.On("MutateWorkspaceTeamRoleWithResponse", mock.Anything, mock.Anything, workspaceIdFromFlag, mock.Anything, mock.Anything).Return(&MutateWorkspaceTeamRoleResponseOK, nil).Once()
+		mockClient.On("MutateWorkspaceTeamRoleWithResponse", mock.Anything, mock.Anything, workspaceIDFromFlag, mock.Anything, mock.Anything).Return(&MutateWorkspaceTeamRoleResponseOK, nil).Once()
 		astroCoreClient = mockClient
-		cmdArgs := []string{"team", "add", team1.Id, "--role", "WORKSPACE_MEMBER", "--workspace-id", workspaceIdFromFlag}
+		cmdArgs := []string{"team", "add", team1.Id, "--role", "WORKSPACE_MEMBER", "--workspace-id", workspaceIDFromFlag}
 		resp, err := execWorkspaceCmd(cmdArgs...)
 		assert.NoError(t, err)
 		assert.Contains(t, resp, expectedOut)


### PR DESCRIPTION
## Description

Adds workspace id as optional param to workspace team add cmd.

Motivation: the docs team was asked to provide a script that would allow an org to add a team to multiple workspaces. This is difficult without this command.

## 🧪 Functional Testing

Tested locally against dev with and without flag passed in. All worked as expected.
## 📸 Screenshots

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
