### PR TITLE
fix case of html report not generating in pytest with failing tests

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -151,7 +151,7 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 	// start pytest container
 	docErr = cmdExec(dockerCommand, stdout, stderr, []string{"start", "astro-pytest", "-a"}...)
 	if docErr != nil {
-		return "", docErr
+		log.Debugf("Error starting pytest container: %s", docErr.Error())
 	}
 	// get exit code
 	args = []string{

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -131,12 +131,16 @@ func TestDockerImagePytest(t *testing.T) {
 			switch {
 			case args[0] == "start":
 				return errMock
+			case args[0] == "inspect":
+				stdout.Write([]byte(`exit code 1`)) // making sure exit code is captured properly
+				return nil
 			default:
 				return nil
 			}
 		}
-		_, err = handler.Pytest("", "", "", "", []string{}, true, options)
+		out, err := handler.Pytest("", "", "", "", []string{}, true, options)
 		assert.Error(t, err)
+		assert.Equal(t, out, "exit code 1")
 	})
 
 	t.Run("copy error", func(t *testing.T) {


### PR DESCRIPTION
## Description
Changes:
- Fix a case in the `pytest` function logic in which we were not generating HTML reports if any test fails as part of pytest logic.

## 🎟 Issue(s)

Related #1382 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.
<img width="1675" alt="Screenshot 2023-09-11 at 11 41 25 AM" src="https://github.com/astronomer/astro-cli/assets/92356010/5817d1f9-3ac4-4c5e-aa91-c6010bff8a27">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
