### PR TITLE
upgrade golang version from 1.19.3 to 1.91.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - commit-next-tag
   release:
     docker:
-      - image: golang:1.19.3
+      - image: golang:1.19.12
     working_directory: /go/src/github.com/astronomer/astro-cli
     steps:
       - checkout


### PR DESCRIPTION
## Description
Changes:
- Upgrade Golang version from `1.19.3` to `1.19.12`, in the release workflow which is used to create binaries

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing
Have been using 1.19.12 locally since last month for CLI development, and haven't faced any issues which might be tied up to this upgrade


## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
