### PR TITLE
Specify aws in region request when creating a deployment

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -47,6 +47,7 @@ const (
 	CeleryExecutor = "CeleryExecutor"
 	notApplicable  = "N/A"
 	gcpCloud       = "gcp"
+	awsCloud       = "aws"
 	standard       = "standard"
 )
 
@@ -413,6 +414,9 @@ func ListClusterOptions(cloudProvider string, coreClient astrocore.CoreClient) (
 	var provider astrocore.GetClusterOptionsParamsProvider
 	if cloudProvider == gcpCloud {
 		provider = astrocore.GetClusterOptionsParamsProvider(astrocore.GetClusterOptionsParamsProviderGcp) //nolint
+	}
+	if cloudProvider == awsCloud {
+		provider = astrocore.GetClusterOptionsParamsProvider(astrocore.GetClusterOptionsParamsProviderAws) //nolint
 	}
 	optionsParams := &astrocore.GetClusterOptionsParams{
 		Provider: &provider,


### PR DESCRIPTION
## Description

before fix
<img width="340" alt="Screenshot 2023-09-27 at 3 18 34 PM" src="https://github.com/astronomer/astro-cli/assets/63181127/cc9eb068-02b6-437b-a6ca-ebe394743275">

after fix
<img width="346" alt="Screenshot 2023-09-27 at 3 17 08 PM" src="https://github.com/astronomer/astro-cli/assets/63181127/061e1a6f-bb7a-4d61-aa1b-fe4063ae4989">


## 🎟 Issue(s)



## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
