### PR TITLE
add warning message

### DIFF
--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -245,6 +245,7 @@ func checkAPIKeys(astroClient astro.Client, coreClient astrocore.CoreClient, isD
 	}
 	if !isDeploymentFile {
 		fmt.Println("Using an Astro API key")
+		fmt.Println("\nWarning: Starting November 1st, 2023, you will no longer be able to create new Deployment API keys. To ensure uninterrupted access to our services, we strongly recommend transitioning to Deployment API tokens. See https://docs.astronomer.io/astro/deployment-api-tokens.")
 	}
 
 	// get authConfig


### PR DESCRIPTION
## Description

Adding a warning to tell users when they will not be able to create deployment api keys anymore 

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
