### PR TITLE
make it so you can create a kuberenetes deployment with a file created from --template

### DIFF
--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -400,6 +400,9 @@ func getTemplate(formattedDeployment *FormattedDeployment) FormattedDeployment {
 		}
 	}
 	template.Deployment.EnvVars = newEnvVars
+	if template.Deployment.Configuration.Executor == deployment.KubeExecutor {
+		template.Deployment.WorkerQs = nil
+	}
 
 	return template
 }

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -1161,20 +1161,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
             "cloud_provider": "",
             "region": ""
         },
-        "worker_queues": [
-            {
-                "name": "default",
-                "worker_type": "test-instance-type",
-                "pod_cpu": "smallCPU",
-                "pod_ram": "megsOfRam"
-            },
-            {
-                "name": "test-queue-1",
-                "worker_type": "test-instance-type-1",
-                "pod_cpu": "LotsOfCPU",
-                "pod_ram": "gigsOfRam"
-            }
-        ],
+        "worker_queues": null,
         "alert_emails": [
             "email1",
             "email2"


### PR DESCRIPTION
## Description

make it so users can use inspect --template to create a kuberenetes deployment

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1315

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
