### PR TITLE
Catch Get Deployment API Error during Deploy

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -525,6 +525,11 @@ func getImageName(cloudDomain, deploymentID, organizationID string, coreClient a
 		return deploymentInfo{}, err
 	}
 
+	err = astrocore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+	if err != nil {
+		return deploymentInfo{}, err
+	}
+
 	currentVersion := resp.JSON200.RuntimeVersion
 	namespace := resp.JSON200.ReleaseName
 	workspaceID := resp.JSON200.WorkspaceId


### PR DESCRIPTION
## Description

The error from a get Deployment call is not being caught. This PR will catch that error and print the error to the user. We are seeing users get a panic error from this call. This means that they are getting an error from CORE API but it is not being caught.

## 🎟 Issue(s)

- https://github.com/astronomer/astro/issues/17574

## 🧪 Functional Testing

- Unable to find a way to test this change. The deployment get call from the API would need to return an error for this change.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
