### PR TITLE
allow ASTRO_DOMAIN env var to override context

### DIFF
--- a/config/context.go
+++ b/config/context.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 )
@@ -39,14 +40,13 @@ type Context struct {
 // GetCurrentContext looks up current context and gets corresponding Context struct
 func GetCurrentContext() (Context, error) {
 	c := Context{}
-
-	domain := CFG.Context.GetHomeString()
-	if domain == "" {
-		return Context{}, ErrGetHomeString
+	var domain string
+	if domain = os.Getenv("ASTRO_DOMAIN"); domain == "" {
+		if domain = CFG.Context.GetHomeString(); domain == "" {
+			return Context{}, ErrGetHomeString
+		}
 	}
-
 	c.Domain = domain
-
 	return c.GetContext()
 }
 

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -123,6 +123,39 @@ contexts:
 	assert.Equal(t, "ck05r3bor07h40d02y2hw4n4v", ctx.Workspace)
 }
 
+func TestGetCurrentContext_WithDomainOverride(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configRaw := []byte(`cloud:
+  api:
+    port: "443"
+    protocol: https
+    ws_protocol: wss
+local:
+  enabled: true
+  host: http://example.com:8871/v1
+context: example_com
+contexts:
+  example_com:
+    domain: example.com
+    token: token
+    last_used_workspace: ck05r3bor07h40d02y2hw4n4v
+    workspace: ck05r3bor07h40d02y2hw4n4v
+  stage_example_com:
+    domain: stage.example.com
+    token: token
+    last_used_workspace: ck05r3bor07h40d02y2hw4n4w
+    workspace: ck05r3bor07h40d02y2hw4n4w
+`)
+	err = afero.WriteFile(fs, HomeConfigFile, configRaw, 0o777)
+	InitConfig(fs)
+	t.Setenv("ASTRO_DOMAIN", "stage.example.com")
+	ctx, err := GetCurrentContext()
+	assert.NoError(t, err)
+	assert.Equal(t, "stage.example.com", ctx.Domain)
+	assert.Equal(t, "token", ctx.Token)
+	assert.Equal(t, "ck05r3bor07h40d02y2hw4n4w", ctx.Workspace)
+}
+
 func TestDeleteContext(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	configRaw := []byte(`


### PR DESCRIPTION
## Description

adds the ability to override the current context via the `ASTRO_DOMAIN` env var

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

```
✗ astro context switch astronomer.io
 CONTEXT DOMAIN                      WORKSPACE
 astronomer.io                       <redacted>

 Switched context
✗ ASTRO_DOMAIN=astronomer-stage.io ./main deployment list
 NAME                                NAMESPACE     CLUSTER         DEPLOYMENT ID                    RUNTIME VERSION                    DAG 
<list redacted, but got back deployments in stage>
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
