### PR TITLE
fix: #1387 persist include dir after running pytest

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -120,11 +120,13 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 		stdout = nil
 		stderr = nil
 	}
+
 	// create pytest container
 	docErr := cmdExec(dockerCommand, stdout, stderr, args...)
 	if docErr != nil {
 		return "", docErr
 	}
+
 	// cp DAGs folder
 	args = []string{
 		"cp",
@@ -135,6 +137,7 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 	if docErr != nil {
 		return "", docErr
 	}
+
 	// cp .astro folder
 	// on some machine .astro is being docker ignored, but not
 	// on every machine, hence to keep behavior consistent
@@ -148,11 +151,13 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 	if docErr != nil {
 		return "", docErr
 	}
+
 	// start pytest container
 	docErr = cmdExec(dockerCommand, stdout, stderr, []string{"start", "astro-pytest", "-a"}...)
 	if docErr != nil {
 		log.Debugf("Error starting pytest container: %s", docErr.Error())
 	}
+
 	// get exit code
 	args = []string{
 		"inspect",
@@ -160,26 +165,29 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 		"--format='{{.State.ExitCode}}'",
 	}
 	var outb bytes.Buffer
-	err = cmdExec(dockerCommand, &outb, stderr, args...)
-	if err != nil {
-		log.Debug(err)
+	docErr = cmdExec(dockerCommand, &outb, stderr, args...)
+	if docErr != nil {
+		log.Debug(docErr)
 	}
+
 	if htmlReport {
 		// Copy the dag-test-report.html file from the container to the destination folder
-		err = cmdExec(dockerCommand, nil, stderr, "cp", "astro-pytest:/usr/local/airflow/dag-test-report.html", "./"+testHomeDirectory)
-		if err != nil {
-			// Remove the temporary container
-			err2 := cmdExec(dockerCommand, nil, stderr, "rm", "astro-pytest")
-			if err2 != nil {
-				return outb.String(), err2
-			}
-			return outb.String(), err
+		docErr = cmdExec(dockerCommand, nil, stderr, "cp", "astro-pytest:/usr/local/airflow/dag-test-report.html", "./"+testHomeDirectory)
+		if docErr != nil {
+			log.Debugf("Error copying dag-test-report.html file from the pytest container: %s", docErr.Error())
 		}
 	}
+
+	// Persist the include folder from the Docker container to local include folder
+	docErr = cmdExec(dockerCommand, nil, stderr, "cp", "astro-pytest:/usr/local/airflow/include/", ".")
+	if docErr != nil {
+		log.Debugf("Error copying include folder from the pytest container: %s", docErr.Error())
+	}
+
 	// delete container
-	err = cmdExec(dockerCommand, nil, stderr, "rm", "astro-pytest")
-	if err != nil {
-		log.Debug(err)
+	docErr = cmdExec(dockerCommand, nil, stderr, "rm", "astro-pytest")
+	if docErr != nil {
+		log.Debugf("Error removing the astro-pytest container: %s", docErr.Error())
 	}
 
 	return outb.String(), docErr


### PR DESCRIPTION
## Description

After running `astro dev pytest`, the coverage reports created with the `include` dir are not being persisted outside of the test container.

This is a problem, because the coverage reports cannot then be used to update PR comments etc. with the report results. Essentially, coverage reports are useless.

In the current state, [this statement is false](https://docs.astronomer.io/astro/cli/astro-dev-pytest):

> If your test generates artifacts, such as code coverage reports, you can output the artifacts to the include folder of your Astro project so they can be accessed after the test has finished.

This PR makes the above statement true, copying the include folder on the host machine after the Pytest run completes.

## 🎟 Issue(s)

https://github.com/astronomer/astro-cli/issues/1387

## 🧪 Functional Testing

1. `astro dev init`
2. Add `pytest-cov==4.1.0` to `requirements.txt` (or any other pytest-cov version)
3. `astro dev pytest --args "--cov --cov-report=xml:include/coverage.xml --cov-report=html:include/html"`
4. Observe that the `include` dir is populated once the tests succeed

## 📸 Screenshots

![1387](https://github.com/astronomer/astro-cli/assets/151692348/0fd44c5f-d40b-4c40-b09c-32f5f1e95d6b)

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
