### PR TITLE
override the domain in more places

### DIFF
--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -254,7 +254,10 @@ func checkAPIKeys(astroClient astro.Client, coreClient astrocore.CoreClient, isD
 	c, err := context.GetCurrentContext() // get current context
 	if err != nil {
 		// set context
-		domain := defaultDomain
+		var domain string
+		if domain = os.Getenv("ASTRO_DOMAIN"); domain == "" {
+			domain = defaultDomain
+		}
 		if !context.Exists(domain) {
 			err := context.SetContext(domain)
 			if err != nil {
@@ -369,7 +372,10 @@ func checkAPIToken(isDeploymentFile bool, coreClient astrocore.CoreClient) (bool
 	c, err := context.GetCurrentContext() // get current context
 	if err != nil {
 		// set context
-		domain := defaultDomain
+		var domain string
+		if domain = os.Getenv("ASTRO_DOMAIN"); domain == "" {
+			domain = defaultDomain
+		}
 		if !context.Exists(domain) {
 			err := context.SetContext(domain)
 			if err != nil {


### PR DESCRIPTION
## Description

follow-up to https://github.com/astronomer/astro-cli/pull/1451, have to read `ASTRO_DOMAIN` when using API keys and API tokens as well

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

tested locally with a non-existent ~/.astro/config.yaml, ASTRO_DOMAIN=astronomer-stage.io, ASTRO_API_TOKEN=<stage-token>

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
