### PR TITLE
FIx astro deploy <deployment-id> --image

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -564,11 +564,28 @@ func getImageName(cloudDomain, deploymentID, organizationID string, coreClient a
 	workspaceID := resp.JSON200.WorkspaceId
 	webserverURL := resp.JSON200.WebServerUrl
 	dagDeployEnabled := resp.JSON200.IsDagDeployEnabled
+	cicdEnforcement := resp.JSON200.ApiKeyOnlyDeployments
+	var desiredDagTarballVersion string
+	if resp.JSON200.DesiredDagTarballVersion != nil {
+		desiredDagTarballVersion = *resp.JSON200.DesiredDagTarballVersion
+	} else {
+		desiredDagTarballVersion = ""
+	}
 
 	// We use latest and keep this tag around after deployments to keep subsequent deploys quick
 	deployImage := airflow.ImageName(namespace, "latest")
 
-	return deploymentInfo{namespace: namespace, deployImage: deployImage, currentVersion: currentVersion, organizationID: organizationID, workspaceID: workspaceID, webserverURL: webserverURL, dagDeployEnabled: dagDeployEnabled}, nil
+	return deploymentInfo{
+		namespace:                namespace,
+		deployImage:              deployImage,
+		currentVersion:           currentVersion,
+		organizationID:           organizationID,
+		workspaceID:              workspaceID,
+		webserverURL:             webserverURL,
+		dagDeployEnabled:         dagDeployEnabled,
+		desiredDagTarballVersion: desiredDagTarballVersion,
+		cicdEnforcement:          cicdEnforcement,
+	}, nil
 }
 
 func buildImageWithoutDags(path string, imageHandler airflow.ImageHandler) error {

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -63,16 +63,18 @@ var (
 			},
 		},
 	}
-	deploymentResponse = astrocore.GetDeploymentResponse{
+	DesiredDagTarballVersion = "desired-dag-tar-ball-version"
+	deploymentResponse       = astrocore.GetDeploymentResponse{
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
 		},
 		JSON200: &astrocore.Deployment{
-			RuntimeVersion:     "4.2.5",
-			ReleaseName:        "test-name",
-			WorkspaceId:        ws,
-			WebServerUrl:       "test-url",
-			IsDagDeployEnabled: false,
+			RuntimeVersion:           "4.2.5",
+			ReleaseName:              "test-name",
+			WorkspaceId:              ws,
+			WebServerUrl:             "test-url",
+			IsDagDeployEnabled:       false,
+			DesiredDagTarballVersion: &DesiredDagTarballVersion,
 		},
 	}
 	mockCoreDeploymentResponse = []astrocore.Deployment{

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -77,6 +77,18 @@ var (
 			DesiredDagTarballVersion: &DesiredDagTarballVersion,
 		},
 	}
+	deploymentResponse2 = astrocore.GetDeploymentResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &astrocore.Deployment{
+			RuntimeVersion:     "4.2.5",
+			ReleaseName:        "test-name",
+			WorkspaceId:        ws,
+			WebServerUrl:       "test-url",
+			IsDagDeployEnabled: false,
+		},
+	}
 	mockCoreDeploymentResponse = []astrocore.Deployment{
 		{
 			Id:     deploymentID,
@@ -111,7 +123,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
 
-	mockCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(4)
+	mockCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse2, nil).Times(4)
 	mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 	mockClient.On("ListDeployments", org, ws).Return([]astro.Deployment{{ID: "test-id", Workspace: astro.Workspace{ID: ws}}}, nil).Once()
 	mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentOptionsResponse, nil).Times(5)


### PR DESCRIPTION
## Description

astro deploy <deployment-id> --image does not work because disiredTarBallVersion is only being pulled when the id is not used. This PR ensures that disiredTarBallVersion is always pulled for image deploys

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1462

## 🧪 Functional Testing

manually tested:

astro deploy --image
astro deploy <deployment id> --image

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
