### PR TITLE
Fixing unit tests to use LocalPlatform Config

### DIFF
--- a/airflow-client/airflow-client_test.go
+++ b/airflow-client/airflow-client_test.go
@@ -19,7 +19,7 @@ func TestNewAirflowClient(t *testing.T) {
 }
 
 func TestDoAirflowClient(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := "{\"connections\":[{\"connection_id\":\"\"}]}"
 	client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
@@ -76,7 +76,7 @@ var mockVar = &Variable{
 }
 
 func TestGetConnections(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	jsonResponse, err := json.Marshal(mockConnResponse)
 	assert.NoError(t, err)
 
@@ -130,7 +130,7 @@ func TestGetConnections(t *testing.T) {
 }
 
 func TestUpdateConnection(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	connJSON, err := json.Marshal(mockConn)
 	assert.NoError(t, err)
 	jsonResponse, err := json.Marshal(mockConnResponse)
@@ -208,7 +208,7 @@ func TestUpdateConnection(t *testing.T) {
 }
 
 func TestCreateConnection(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	connJSON, err := json.Marshal(mockConn)
 	assert.NoError(t, err)
 	jsonResponse, err := json.Marshal(mockConnResponse)
@@ -286,7 +286,7 @@ func TestCreateConnection(t *testing.T) {
 }
 
 func TestCreateVariable(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedURL := "https://test-airflow-url/api/v1/variables"
 
 	t.Run("success", func(t *testing.T) {
@@ -348,7 +348,7 @@ func TestCreateVariable(t *testing.T) {
 }
 
 func TestGetVariables(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedURL := "https://test-airflow-url/api/v1/variables"
 
 	t.Run("success", func(t *testing.T) {
@@ -390,7 +390,7 @@ func TestGetVariables(t *testing.T) {
 }
 
 func TestUpdateVariable(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedURL := "https://test-airflow-url/api/v1/variables/test-key"
 
 	t.Run("success", func(t *testing.T) {
@@ -468,7 +468,7 @@ var mockPool = &Pool{
 }
 
 func TestCreatePool(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	poolJSON, err := json.Marshal(mockPool)
 	assert.NoError(t, err)
@@ -547,7 +547,7 @@ func TestCreatePool(t *testing.T) {
 }
 
 func TestUpdatePool(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockPoolJSON, err := json.Marshal(mockPool)
 	assert.NoError(t, err)
 	jsonResponse, err := json.Marshal(mockPoolResponse)
@@ -625,7 +625,7 @@ func TestUpdatePool(t *testing.T) {
 }
 
 func TestGetPools(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockPoolResponseJSON, err := json.Marshal(mockPoolResponse)
 	assert.NoError(t, err)
 

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -291,7 +291,7 @@ func TestParseExitCode(t *testing.T) {
 }
 
 func TestDockerCreatePipFreeze(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	handler := DockerImage{
 		imageName: "testing",
 	}

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1072,7 +1072,7 @@ func TestDockerComposePytest(t *testing.T) {
 }
 
 func TestDockerComposedUpgradeTest(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 	mockDockerCompose := DockerCompose{projectName: "test", dockerfile: "Dockerfile", airflowHome: cwd}

--- a/astro-client/astro_test.go
+++ b/astro-client/astro_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCreateDeployment(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			CreateDeployment: Deployment{
@@ -58,7 +58,7 @@ func TestCreateDeployment(t *testing.T) {
 }
 
 func TestUpdateDeployment(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			UpdateDeployment: Deployment{
@@ -104,7 +104,7 @@ func TestUpdateDeployment(t *testing.T) {
 }
 
 func TestListDeployments(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	org := "test-org-id"
 	mockResponse := &Response{
 		Data: ResponseData{
@@ -153,7 +153,7 @@ func TestListDeployments(t *testing.T) {
 }
 
 func TestGetDeployment(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	deployment := "test-deployment-id"
 	mockResponse := &Response{
 		Data: ResponseData{
@@ -202,7 +202,7 @@ func TestGetDeployment(t *testing.T) {
 }
 
 func TestDeleteDeployment(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			DeleteDeployment: Deployment{
@@ -248,7 +248,7 @@ func TestDeleteDeployment(t *testing.T) {
 }
 
 func TestGetDeploymentHistory(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			GetDeploymentHistory: DeploymentHistory{
@@ -298,7 +298,7 @@ func TestGetDeploymentHistory(t *testing.T) {
 }
 
 func TestGetDeploymentConfig(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			GetDeploymentConfig: DeploymentConfig{
@@ -349,7 +349,7 @@ func TestGetDeploymentConfig(t *testing.T) {
 }
 
 func TestGetDeploymentConfigWithOrganization(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			GetDeploymentConfig: DeploymentConfig{
@@ -400,7 +400,7 @@ func TestGetDeploymentConfigWithOrganization(t *testing.T) {
 }
 
 func TestModifyDeploymentVariable(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			UpdateDeploymentVariables: []EnvironmentVariablesObject{
@@ -446,7 +446,7 @@ func TestModifyDeploymentVariable(t *testing.T) {
 }
 
 func TestInitiateDagDeployment(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			InitiateDagDeployment: InitiateDagDeployment{
@@ -489,7 +489,7 @@ func TestInitiateDagDeployment(t *testing.T) {
 }
 
 func TestReportDagDeploymentStatus(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			ReportDagDeploymentStatus: DagDeploymentStatus{
@@ -539,7 +539,7 @@ func TestReportDagDeploymentStatus(t *testing.T) {
 }
 
 func TestCreateImage(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			CreateImage: &Image{
@@ -586,7 +586,7 @@ func TestCreateImage(t *testing.T) {
 }
 
 func TestDeployImage(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := &Response{
 		Data: ResponseData{
 			DeployImage: &Image{
@@ -633,7 +633,7 @@ func TestDeployImage(t *testing.T) {
 }
 
 func TestWorkerQueueOptions(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := Response{
 		Data: ResponseData{
 			GetWorkerQueueOptions: WorkerQueueDefaultOptions{
@@ -689,7 +689,7 @@ func TestWorkerQueueOptions(t *testing.T) {
 }
 
 func TestGetOrganizationAuditLogs(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("Can export organization audit logs", func(t *testing.T) {
 		mockResponse := "A lot of audit logs entries"
@@ -745,7 +745,7 @@ func TestGetOrganizationAuditLogs(t *testing.T) {
 }
 
 func TestUpdateAlertEmails(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("updates a deployments alert emails", func(t *testing.T) {
 		emails := []string{"test1@email.com", "test2@meail.com"}

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -186,7 +186,7 @@ func Test_FetchDomainAuthConfig(t *testing.T) {
 }
 
 func TestRequestUserInfo(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockUserInfo := UserInfo{
 		Email:      "test@astronomer.test",
 		Name:       "astro.crush",
@@ -241,7 +241,7 @@ func TestRequestUserInfo(t *testing.T) {
 }
 
 func TestRequestToken(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockResponse := postTokenResponse{
 		RefreshToken: "test-refresh-token",
 		AccessToken:  "test-access-token",
@@ -342,7 +342,7 @@ func TestAuthorizeCallbackHandler(t *testing.T) {
 }
 
 func TestAuthDeviceLogin(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("success without login link", func(t *testing.T) {
 		mockResponse := Result{RefreshToken: "test-token", AccessToken: "test-token", ExpiresIn: 300}
 		callbackHandler := func() (string, error) {
@@ -425,7 +425,7 @@ func TestAuthDeviceLogin(t *testing.T) {
 
 func TestSwitchToLastUsedWorkspace(t *testing.T) {
 	t.Run("failure case", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		ctx := &config.Context{
 			LastUsedWorkspace: "test-id",
 		}
@@ -435,7 +435,7 @@ func TestSwitchToLastUsedWorkspace(t *testing.T) {
 		assert.Equal(t, astrocore.Workspace{}, resp)
 	})
 
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("success", func(t *testing.T) {
 		ctx := &config.Context{
 			LastUsedWorkspace: "test-id",
@@ -459,7 +459,7 @@ func TestSwitchToLastUsedWorkspace(t *testing.T) {
 }
 
 func TestCheckUserSession(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("success", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -661,7 +661,7 @@ func TestCheckUserSession(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("success", func(t *testing.T) {
 		mockResponse := Result{RefreshToken: "test-token", AccessToken: "test-token", ExpiresIn: 300}
 		mockUserInfo := UserInfo{Email: "test@astronomer.test"}
@@ -869,7 +869,7 @@ func TestLogin(t *testing.T) {
 }
 
 func TestLogout(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("success", func(t *testing.T) {
 		buf := new(bytes.Buffer)
 		Logout("astronomer.io", buf)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -119,7 +119,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 		WaitForStatus:  false,
 		Dags:           false,
 	}
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
 
@@ -224,7 +224,7 @@ func TestDeployOnCiCdEnforcedDeployment(t *testing.T) {
 		WaitForStatus:  false,
 		Dags:           false,
 	}
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
 
@@ -261,7 +261,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 		WaitForStatus:  false,
 		Dags:           false,
 	}
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
 	mockClient := new(astro_mocks.Client)
 
@@ -630,7 +630,7 @@ func TestDeployFailure(t *testing.T) {
 	defer os.RemoveAll("./testfiles/dags/")
 
 	// no context set failure
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	err := config.ResetCurrentContext()
 	assert.NoError(t, err)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -664,7 +664,7 @@ func TestDeployFailure(t *testing.T) {
 			},
 		},
 	}
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(astro_mocks.Client)
 	mockClient.On("ListDeployments", org, ws).Return(mockDeplyResp, nil).Times(2)
 	mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(3)
@@ -933,7 +933,7 @@ func TestDeployNoMonitoringDAGHosted(t *testing.T) {
 }
 
 func TestBuildImageFailure(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockImageHandler := new(mocks.ImageHandler)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -2968,7 +2968,7 @@ func TestGetDeploymentURL(t *testing.T) {
 		assert.Equal(t, expectedURL, actualURL)
 	})
 	t.Run("returns deploymentURL for cloud (prod) environment", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		expectedURL := "cloud.astronomer.io/workspace-id/deployments/deployment-id/overview"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		assert.NoError(t, err)

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -70,7 +70,7 @@ const (
 )
 
 func TestList(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("success", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
@@ -120,7 +120,7 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("success with hidden namespace information", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		ctx, err := context.GetCurrentContext()
 		assert.NoError(t, err)
 		ctx.SetContextKey("organization_product", "HOSTED")
@@ -160,7 +160,7 @@ func TestList(t *testing.T) {
 
 func TestGetDeployment(t *testing.T) {
 	deploymentID := "test-id-wrong"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(astro_mocks.Client)
 
 	t.Run("invalid deployment ID", func(t *testing.T) {
@@ -389,7 +389,7 @@ func TestGetDeployment(t *testing.T) {
 }
 
 func TestCoreGetDeployment(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	deploymentID := "test-deployment-id"
 	depIds := []string{deploymentID}
@@ -489,7 +489,7 @@ func TestIsDeploymentDedicated(t *testing.T) {
 }
 
 func TestSelectRegion(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
 	t.Run("list regions failure", func(t *testing.T) {
@@ -647,7 +647,7 @@ func TestSelectRegion(t *testing.T) {
 }
 
 func TestLogs(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	deploymentID := "test-id"
 	logCount := 1
 	logLevels := []string{"WARN", "ERROR", "INFO"}
@@ -707,7 +707,7 @@ func TestLogs(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	csID := "test-cluster-id"
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1465,7 +1465,7 @@ func TestCreate(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 	t.Run("success with hidden namespace information", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		ctx, err := context.GetCurrentContext()
 		assert.NoError(t, err)
 		ctx.SetContextKey("organization_product", "HOSTED")
@@ -1653,7 +1653,7 @@ func TestValidateResources(t *testing.T) {
 }
 
 func TestSelectCluster(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	csID := "test-cluster-id"
 	t.Run("list cluster failure", func(t *testing.T) {
@@ -1761,7 +1761,7 @@ func TestCanCiCdDeploy(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) { //nolint
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(astro_mocks.Client)
 
 	deploymentResp := astro.Deployment{
@@ -2826,7 +2826,7 @@ func TestUpdate(t *testing.T) { //nolint
 }
 
 func TestDelete(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	deploymentResp := astro.Deployment{
 		ID:             "test-id",
@@ -2968,7 +2968,7 @@ func TestGetDeploymentURL(t *testing.T) {
 		assert.Equal(t, expectedURL, actualURL)
 	})
 	t.Run("returns deploymentURL for cloud (prod) environment", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		expectedURL := "cloud.astronomer.io/workspace-id/deployments/deployment-id/overview"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		assert.NoError(t, err)
@@ -3071,7 +3071,7 @@ func TestPrintWarning(t *testing.T) {
 }
 
 func TestUseSharedCluster(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	csID := "test-cluster-id"
 	region := "us-central1"
 	getSharedClusterParams := &astrocore.GetSharedClusterParams{
@@ -3119,7 +3119,7 @@ func TestUseSharedCluster(t *testing.T) {
 }
 
 func TestUseSharedClusterOrSelectCluster(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	csID := "test-cluster-id"
 

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestVariableList(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockResponse := []astro.Deployment{
 		{
@@ -109,7 +109,7 @@ func TestVariableList(t *testing.T) {
 }
 
 func TestVariableModify(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockListResponse := []astro.Deployment{
 		{

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -274,7 +274,7 @@ deployment:
 			mockClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if cluster does not exist", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -339,7 +339,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if listing cluster fails", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -404,7 +404,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if listing deployment fails", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -470,7 +470,7 @@ deployment:
 			mockClient.AssertExpectations(t)
 		})
 		t.Run("does not update environment variables if input is empty", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			out := new(bytes.Buffer)
@@ -570,7 +570,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("does not update alert emails if input is empty", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			out := new(bytes.Buffer)
@@ -667,7 +667,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error from the api if creating environment variables fails", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -769,7 +769,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error from the api if creating alert emails fails", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -873,7 +873,7 @@ deployment:
 	})
 	t.Run("when action is create", func(t *testing.T) {
 		t.Run("reads the yaml file and creates a deployment", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -988,7 +988,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("reads the yaml file and creates a hosted dedicated deployment", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1141,7 +1141,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("reads the json file and creates a deployment", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1271,7 +1271,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("reads the json file and creates a hosted standard deployment", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1440,7 +1440,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if workspace does not exist", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -1506,7 +1506,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if listing workspace fails", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -1572,7 +1572,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if deployment already exists", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			existingDeployments := []astro.Deployment{
 				{
@@ -1648,7 +1648,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if creating deployment input fails", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -1747,7 +1747,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error from the api if create deployment fails", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -1849,7 +1849,7 @@ deployment:
 	})
 	t.Run("when action is update", func(t *testing.T) {
 		t.Run("reads the yaml file and updates an existing deployment", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1986,7 +1986,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("reads the yaml file and updates an existing hosted standard deployment", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -2155,7 +2155,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("return an error when enabling dag deploy for ci-cd enforced deployment", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -2273,7 +2273,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("reads the json file and updates an existing deployment", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			out := new(bytes.Buffer)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -2425,7 +2425,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if deployment does not exist", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -2490,7 +2490,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error if creating update deployment input fails", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -2593,7 +2593,7 @@ deployment:
 			mockCoreClient.AssertExpectations(t)
 		})
 		t.Run("returns an error from the api if update deployment fails", func(t *testing.T) {
-			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			testUtil.InitTestConfig(testUtil.LocalPlatform)
 			mockClient := new(astro_mocks.Client)
 			mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 			filePath = "./deployment.yaml"
@@ -3927,7 +3927,7 @@ func TestGetClusterFromName(t *testing.T) {
 		actualNodePools                                 []astrocore.NodePool
 		err                                             error
 	)
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedClusterID = "test-cluster-id"
 	clusterName = "test-cluster"
 	t.Run("returns a cluster id if cluster exists in organization", func(t *testing.T) {
@@ -3972,7 +3972,7 @@ func TestGetWorkspaceIDFromName(t *testing.T) {
 		workspaceName, expectedWorkspaceID, actualWorkspaceID, orgID string
 		err                                                          error
 	)
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedWorkspaceID = "test-ws-id"
 	workspaceName = "test-workspace"
 	orgID = "test-org-id"
@@ -4008,7 +4008,7 @@ func TestGetNodePoolIDFromName(t *testing.T) {
 		existingPools                                       []astrocore.NodePool
 		err                                                 error
 	)
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedPoolID = "test-pool-id"
 	workerType = "worker-1"
 	clusterID = "test-cluster-id"

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -417,7 +417,7 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 		var actualDeploymentMeta deploymentMetadata
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, deploymentListParams).Return(mockCoreDeploymentResponse, nil).Once()
-		expectedCloudDomainURL := "cloud.astronomer.io/" + sourceDeployment.Workspace.ID +
+		expectedCloudDomainURL := "localhost:5000/" + sourceDeployment.Workspace.ID +
 			"/deployments/" + sourceDeployment.ID + "/overview"
 		expectedDeploymentMetadata := deploymentMetadata{
 			DeploymentID:     &sourceDeployment.ID,

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -66,7 +66,7 @@ func restoreYAMLMarshal(replace func(v interface{}) ([]byte, error)) {
 }
 
 func TestInspect(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	workspaceID := "test-ws-id"
 	deploymentID := "test-deployment-id"
@@ -282,7 +282,7 @@ func TestInspect(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 	t.Run("Display Cluster Region and hide Release Name if an org is hosted", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		ctx, err := context.GetCurrentContext()
 		assert.NoError(t, err)
 		ctx.SetContextKey("organization_product", "HOSTED")
@@ -415,7 +415,7 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 
 	t.Run("returns deployment metadata for the requested cloud deployment", func(t *testing.T) {
 		var actualDeploymentMeta deploymentMetadata
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, deploymentListParams).Return(mockCoreDeploymentResponse, nil).Once()
 		expectedCloudDomainURL := "cloud.astronomer.io/" + sourceDeployment.Workspace.ID +
 			"/deployments/" + sourceDeployment.ID + "/overview"
@@ -553,7 +553,7 @@ func TestGetDeploymentConfig(t *testing.T) {
 
 	t.Run("returns deployment config for the requested cloud deployment", func(t *testing.T) {
 		var actualDeploymentConfig deploymentConfig
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		expectedDeploymentConfig := deploymentConfig{
 			Name:             sourceDeployment.Label,
 			Description:      sourceDeployment.Description,
@@ -573,7 +573,7 @@ func TestGetDeploymentConfig(t *testing.T) {
 }
 
 func TestGetPrintableDeployment(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	sourceDeployment := astro.Deployment{
 		ID:          "test-deployment-id",
 		Label:       "test-deployment-label",
@@ -758,7 +758,7 @@ func TestGetAdditional(t *testing.T) {
 				"worker_type":        "test-instance-type-1",
 			},
 		}
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		rawExpected := map[string]interface{}{
 			"alert_emails":          sourceDeployment.AlertEmails,
 			"worker_queues":         qList,
@@ -788,7 +788,7 @@ func TestGetAdditional(t *testing.T) {
 				"worker_type": "test-instance-type-1",
 			},
 		}
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		rawExpected := map[string]interface{}{
 			"alert_emails":          sourceDeployment.AlertEmails,
 			"worker_queues":         qList,
@@ -804,7 +804,7 @@ func TestGetAdditional(t *testing.T) {
 }
 
 func TestFormatPrintableDeployment(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	sourceDeployment := astro.Deployment{
 		ID:          "test-deployment-id",
 		Label:       "test-deployment-label",
@@ -1296,7 +1296,7 @@ func TestGetSpecificField(t *testing.T) {
 		UpdatedAt: time.Now(),
 		Status:    "UNHEALTHY",
 	}
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	info, _ := getDeploymentInfo(&sourceDeployment, mockCoreDeploymentResponse[0])
 	config := getDeploymentConfig(&sourceDeployment)
 	additional := getAdditional(&sourceDeployment)
@@ -1442,7 +1442,7 @@ func TestGetWorkerTypeFromNodePoolID(t *testing.T) {
 		expectedWorkerType, poolID, actualWorkerType string
 		existingPools                                []astro.NodePool
 	)
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedWorkerType = "worker-1"
 	poolID = "test-pool-id"
 	existingPools = []astro.NodePool{
@@ -1469,7 +1469,7 @@ func TestGetWorkerTypeFromNodePoolID(t *testing.T) {
 }
 
 func TestGetTemplate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	sourceDeployment := astro.Deployment{
 		ID:          "test-deployment-id",
 		Label:       "test-deployment-label",

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -23,7 +23,7 @@ var (
 )
 
 func TestCreate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedWorkerQueue := astro.WorkerQueue{
 		Name:              "test-worker-queue",
 		IsDefault:         false,
@@ -489,7 +489,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreateHostedShared(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedWorkerQueue := astro.WorkerQueue{
 		Name:              "test-worker-queue",
 		IsDefault:         false,
@@ -697,7 +697,7 @@ func TestCreateHostedShared(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	expectedWorkerQueue := astro.WorkerQueue{
 		Name:              "test-queue-1",
 		IsDefault:         false,
@@ -1138,7 +1138,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	deploymentRespWithQueues := []astro.Deployment{
 		{
@@ -1367,7 +1367,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestGetWorkerQueueDefaultOptions(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
 		MinWorkerCount: astro.WorkerQueueOption{
 			Floor:   1,
@@ -1403,7 +1403,7 @@ func TestGetWorkerQueueDefaultOptions(t *testing.T) {
 }
 
 func TestSetWorkerQueueValues(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
 		MinWorkerCount: astro.WorkerQueueOption{
 			Floor:   1,
@@ -1456,7 +1456,7 @@ func TestSetWorkerQueueValues(t *testing.T) {
 }
 
 func TestIsCeleryWorkerQueueInputValid(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
 		MinWorkerCount: astro.WorkerQueueOption{
 			Floor:   0,
@@ -1533,7 +1533,7 @@ func TestIsCeleryWorkerQueueInputValid(t *testing.T) {
 }
 
 func TestIsHostedCeleryWorkerQueueInputValid(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockWorkerQueueDefaultOptions := astro.WorkerQueueDefaultOptions{
 		MinWorkerCount: astro.WorkerQueueOption{
 			Floor:   0,
@@ -1616,7 +1616,7 @@ func TestIsHostedCeleryWorkerQueueInputValid(t *testing.T) {
 }
 
 func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	requestedWorkerQueue := &astro.WorkerQueue{
 		Name:              "default",
 		NodePoolID:        "test-pool-id",
@@ -1722,7 +1722,7 @@ func TestIsKubernetesWorkerQueueInputValid(t *testing.T) {
 }
 
 func TestQueueExists(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	existingQueues := []astro.WorkerQueue{
 		{
 			ID:                "test-wq-id",

--- a/cloud/environment/environment_test.go
+++ b/cloud/environment/environment_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestListConnections(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	context, _ := config.GetCurrentContext()
 	organization := context.Organization

--- a/cloud/organization/organization_test.go
+++ b/cloud/organization/organization_test.go
@@ -60,7 +60,7 @@ var (
 
 func TestList(t *testing.T) {
 	// initialize empty config
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("organization list success", func(t *testing.T) {
 		mockClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
@@ -93,7 +93,7 @@ func TestList(t *testing.T) {
 
 func TestGetOrganizationSelection(t *testing.T) {
 	// initialize empty config
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("get organiation selection success", func(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockPlatformClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)

--- a/cloud/organization/organization_token_test.go
+++ b/cloud/organization/organization_token_test.go
@@ -153,7 +153,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 	)
 
 	t.Run("return error for invalid workspace role", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		err := AddOrgTokenToWorkspace(selectedTokenID, selectedTokenName, "INVALID_ROLE", workspace, nil, nil)
 		assert.Error(t, err)
 		assert.Equal(t, user.ErrInvalidWorkspaceRole, err)
@@ -167,7 +167,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 	})
 
 	t.Run("return error for failed to list organization tokens", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
 
@@ -177,7 +177,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 	})
 
 	t.Run("return error for failed to select organization token", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
@@ -188,7 +188,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 	})
 
 	t.Run("return error for organization token already in workspace", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 
@@ -198,7 +198,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 	})
 
 	t.Run("successfully add organization token to workspace using id", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
@@ -209,7 +209,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 	})
 
 	t.Run("return error for failed to get organization token", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
 
@@ -219,7 +219,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 	})
 
 	t.Run("successfully add organization token to workspace", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -230,7 +230,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 	})
 
 	t.Run("successfully select and add organization token to workspace", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -251,7 +251,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 	})
 
 	t.Run("successfully select and add organization token to workspace 2", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponse2O0, nil)
@@ -274,7 +274,7 @@ func TestAddOrgTokenToWorkspace(t *testing.T) {
 
 func TestListTokens(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
@@ -283,7 +283,7 @@ func TestListTokens(t *testing.T) {
 	})
 
 	t.Run("error path when ListOrganizationApiTokensWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil).Twice()
@@ -303,7 +303,7 @@ func TestListTokens(t *testing.T) {
 
 func TestCreateToken(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateOrganizationAPITokenResponseOK, nil)
@@ -324,7 +324,7 @@ func TestCreateToken(t *testing.T) {
 	})
 
 	t.Run("invalid role", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
@@ -334,7 +334,7 @@ func TestCreateToken(t *testing.T) {
 	})
 
 	t.Run("empty name", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
@@ -346,7 +346,7 @@ func TestCreateToken(t *testing.T) {
 
 func TestUpdateToken(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
@@ -356,7 +356,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("happy path no id", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
@@ -377,7 +377,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("happy path multiple name", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponse2O0, nil).Twice()
@@ -398,7 +398,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("happy path", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
@@ -408,7 +408,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when listOrganizationTokens returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
@@ -417,7 +417,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when listOrganizationToken returns an not found error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -426,7 +426,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when getOrganizationToken returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
@@ -435,7 +435,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when UpdateOrganizationApiTokenWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
@@ -453,7 +453,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when workspace role is invalid returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
@@ -462,7 +462,7 @@ func TestUpdateToken(t *testing.T) {
 		assert.Equal(t, user.ErrInvalidOrganizationRole.Error(), err.Error())
 	})
 	t.Run("Happy path when applying workspace role", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -472,7 +472,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("Happy path when applying organization role using id", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
@@ -484,7 +484,7 @@ func TestUpdateToken(t *testing.T) {
 
 func TestRotateToken(t *testing.T) {
 	t.Run("happy path - id provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil)
@@ -494,7 +494,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("happy path name provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -504,7 +504,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("happy path with confirmation", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -522,7 +522,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("error path when listOrganizationTokens returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
@@ -531,7 +531,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("error path when listOrganizationToken returns an not found error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -540,7 +540,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("error path when getOrganizationToken returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
@@ -549,7 +549,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("error path when RotateOrganizationApiTokenWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -561,7 +561,7 @@ func TestRotateToken(t *testing.T) {
 
 func TestDeleteToken(t *testing.T) {
 	t.Run("happy path - delete workspace token - by name", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
@@ -571,7 +571,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("happy path - delete workspace token - by id", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
@@ -581,7 +581,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("happy path - remove organization token", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
@@ -599,7 +599,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("error path when getOrganizationToken returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
@@ -608,7 +608,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("error path when listOrganizationTokens returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
@@ -617,7 +617,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("error path when listOrganizationToken returns a not found error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -626,7 +626,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("error path when DeleteOrganizationApiTokenWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
@@ -638,7 +638,7 @@ func TestDeleteToken(t *testing.T) {
 
 func TestListTokenRoles(t *testing.T) {
 	t.Run("happy path - list token roles by id", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
@@ -647,7 +647,7 @@ func TestListTokenRoles(t *testing.T) {
 	})
 
 	t.Run("error path - list token roles by id - api error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil)
@@ -664,7 +664,7 @@ func TestListTokenRoles(t *testing.T) {
 	})
 
 	t.Run("happy path - list token roles no id", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
@@ -683,7 +683,7 @@ func TestListTokenRoles(t *testing.T) {
 	})
 
 	t.Run("error path - list token roles no id - list tokens api error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil).Twice()

--- a/cloud/team/team_test.go
+++ b/cloud/team/team_test.go
@@ -315,7 +315,7 @@ var (
 
 func TestListOrgTeam(t *testing.T) {
 	t.Run("happy path TestListOrgTeam", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationTeamsResponseOK, nil).Twice()
@@ -324,7 +324,7 @@ func TestListOrgTeam(t *testing.T) {
 	})
 
 	t.Run("error path when ListOrganizationTeamsWithResponse return network error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errorNetwork).Once()
@@ -333,7 +333,7 @@ func TestListOrgTeam(t *testing.T) {
 	})
 
 	t.Run("error path when ListOrganizationTeamsWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationTeamsResponseError, nil).Twice()
@@ -342,7 +342,7 @@ func TestListOrgTeam(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -365,9 +365,9 @@ func TestListOrgTeam(t *testing.T) {
 }
 
 func TestListWorkspaceTeam(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path TestListWorkspaceTeam", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceTeamsResponseOK, nil).Twice()
@@ -376,7 +376,7 @@ func TestListWorkspaceTeam(t *testing.T) {
 	})
 
 	t.Run("error path when ListWorkspaceTeamsWithResponse return network error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errorNetwork).Once()
@@ -385,7 +385,7 @@ func TestListWorkspaceTeam(t *testing.T) {
 	})
 
 	t.Run("error path when ListWorkspaceTeamsWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceTeamsResponseError, nil).Twice()
@@ -394,7 +394,7 @@ func TestListWorkspaceTeam(t *testing.T) {
 	})
 
 	t.Run("error path when no Workspaceanization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -417,7 +417,7 @@ func TestListWorkspaceTeam(t *testing.T) {
 }
 
 func TestUpdateWorkspaceTeamRole(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path UpdateWorkspaceTeamRole", func(t *testing.T) {
 		expectedOutMessage := "The workspace team team1-id role was successfully updated to WORKSPACE_MEMBER\n"
 		out := new(bytes.Buffer)
@@ -472,7 +472,7 @@ func TestUpdateWorkspaceTeamRole(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -494,7 +494,7 @@ func TestUpdateWorkspaceTeamRole(t *testing.T) {
 	})
 
 	t.Run("UpdateWorkspaceTeamRole no id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -521,7 +521,7 @@ func TestUpdateWorkspaceTeamRole(t *testing.T) {
 }
 
 func TestAddWorkspaceTeam(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path AddWorkspaceTeam", func(t *testing.T) {
 		expectedOutMessage := "The team team1-id was successfully added to the workspace with the role WORKSPACE_MEMBER\n"
 		out := new(bytes.Buffer)
@@ -568,7 +568,7 @@ func TestAddWorkspaceTeam(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -590,7 +590,7 @@ func TestAddWorkspaceTeam(t *testing.T) {
 	})
 
 	t.Run("AddWorkspaceTeam no id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -617,7 +617,7 @@ func TestAddWorkspaceTeam(t *testing.T) {
 }
 
 func TestRemoveWorkspaceTeam(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path DeleteWorkspaceTeam", func(t *testing.T) {
 		expectedOutMessage := fmt.Sprintf("Astro Team %s was successfully removed from workspace %s\n", team1.Name, workspaceID)
 		out := new(bytes.Buffer)
@@ -656,7 +656,7 @@ func TestRemoveWorkspaceTeam(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -678,7 +678,7 @@ func TestRemoveWorkspaceTeam(t *testing.T) {
 	})
 
 	t.Run("RemoveWorkspaceTeam no id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -705,7 +705,7 @@ func TestRemoveWorkspaceTeam(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path Delete", func(t *testing.T) {
 		expectedOutMessage := fmt.Sprintf("Astro Team %s was successfully deleted\n", team1.Name)
 		out := new(bytes.Buffer)
@@ -775,7 +775,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -796,7 +796,7 @@ func TestDelete(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 	t.Run("DeleteTeam no id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -823,7 +823,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path Update", func(t *testing.T) {
 		expectedOutMessage := fmt.Sprintf("Astro Team %s was successfully updated\n", team1.Name)
 		out := new(bytes.Buffer)
@@ -960,7 +960,7 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -981,7 +981,7 @@ func TestUpdate(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 	t.Run("UpdateTeam no id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1008,7 +1008,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path Update", func(t *testing.T) {
 		expectedOutMessage := fmt.Sprintf("Astro Team %s was successfully created\n", team1.Name)
 		out := new(bytes.Buffer)
@@ -1048,7 +1048,7 @@ func TestCreate(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -1069,7 +1069,7 @@ func TestCreate(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 	t.Run("error path no name passed in and user doesn't type one in when prompted", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		err := CreateTeam("", *team1.Description, "ORGANIZATION_MEMBER", out, mockClient)
@@ -1077,7 +1077,7 @@ func TestCreate(t *testing.T) {
 	})
 
 	t.Run("error path invalid org role", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		err := CreateTeam("", *team1.Description, "WORKSPACE_OWNER", out, mockClient)
@@ -1086,7 +1086,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestAddUser(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path AddUser", func(t *testing.T) {
 		expectedOutMessage := fmt.Sprintf("Astro User %s was successfully added to team %s \n", user1.Id, team1.Name)
 		out := new(bytes.Buffer)
@@ -1153,7 +1153,7 @@ func TestAddUser(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -1175,7 +1175,7 @@ func TestAddUser(t *testing.T) {
 	})
 
 	t.Run("AddUser no team-id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1205,7 +1205,7 @@ func TestAddUser(t *testing.T) {
 		assert.Equal(t, expectedOut, out.String())
 	})
 	t.Run("AddUser no user_id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1236,7 +1236,7 @@ func TestAddUser(t *testing.T) {
 	})
 
 	t.Run("AddUser no user_id passed no org users found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
@@ -1263,7 +1263,7 @@ func TestAddUser(t *testing.T) {
 }
 
 func TestRemoveUser(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path RemoveUser", func(t *testing.T) {
 		expectedOutMessage := fmt.Sprintf("Astro User %s was successfully removed from team %s \n", user1.Id, team1.Name)
 		out := new(bytes.Buffer)
@@ -1338,7 +1338,7 @@ func TestRemoveUser(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -1360,7 +1360,7 @@ func TestRemoveUser(t *testing.T) {
 	})
 
 	t.Run("RemoveUser no team-id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1390,7 +1390,7 @@ func TestRemoveUser(t *testing.T) {
 		assert.Equal(t, expectedOut, out.String())
 	})
 	t.Run("RemoveUser no user_id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1423,7 +1423,7 @@ func TestRemoveUser(t *testing.T) {
 
 func TestListTeamUsers(t *testing.T) {
 	t.Run("happy path ListTeamUsers", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
@@ -1432,7 +1432,7 @@ func TestListTeamUsers(t *testing.T) {
 	})
 
 	t.Run("happy path ListTeamUsers team with no membership", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseEmptyMembership, nil).Twice()
@@ -1441,7 +1441,7 @@ func TestListTeamUsers(t *testing.T) {
 	})
 
 	t.Run("error path when GetTeamWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseError, nil).Twice()
@@ -1451,7 +1451,7 @@ func TestListTeamUsers(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -1473,7 +1473,7 @@ func TestListTeamUsers(t *testing.T) {
 	})
 
 	t.Run("ListTeamUsers no team-id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1501,7 +1501,7 @@ func TestListTeamUsers(t *testing.T) {
 
 func TestGetTeam(t *testing.T) {
 	t.Run("happy path GetTeam", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
 		_, err := GetTeam(mockClient, team1.Id)
@@ -1509,7 +1509,7 @@ func TestGetTeam(t *testing.T) {
 	})
 
 	t.Run("error path when GetTeamWithResponse returns a network error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errorNetwork).Twice()
 
@@ -1518,7 +1518,7 @@ func TestGetTeam(t *testing.T) {
 	})
 
 	t.Run("error path when GetTeamWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseError, nil).Twice()
 
@@ -1527,7 +1527,7 @@ func TestGetTeam(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -1550,7 +1550,7 @@ func TestGetTeam(t *testing.T) {
 
 func TestGetWorkspaceTeams(t *testing.T) {
 	t.Run("happy path get WorkspaceTeams pulls workspace from context", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceTeamsResponseOK, nil).Twice()
 		_, err := GetWorkspaceTeams(mockClient, "", 10)

--- a/cloud/user/user_test.go
+++ b/cloud/user/user_test.go
@@ -161,7 +161,7 @@ func (t testWriter) Write(p []byte) (n int, err error) {
 }
 
 func TestCreateInvite(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	inviteUserID := "user_cuid"
 	createInviteResponseOK := astrocore.CreateUserInviteResponse{
 		HTTPResponse: &http.Response{
@@ -231,7 +231,7 @@ func TestCreateInvite(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -263,7 +263,7 @@ func TestCreateInvite(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 	t.Run("error path when writing output returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateUserInviteWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&createInviteResponseError, nil).Once()
 		err := CreateInvite("test-email@test.com", "ORGANIZATION_MEMBER", testWriter{Error: errorInvite}, mockClient)
@@ -330,7 +330,7 @@ func TestUpdateUserRole(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -352,7 +352,7 @@ func TestUpdateUserRole(t *testing.T) {
 	})
 
 	t.Run("UpdateUserRole no email passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -404,7 +404,7 @@ func TestListOrgUser(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -447,7 +447,7 @@ func TestIsWorkspaceRoleValid(t *testing.T) {
 }
 
 func TestListWorkspaceUser(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path TestListWorkspaceUser", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -473,7 +473,7 @@ func TestListWorkspaceUser(t *testing.T) {
 	})
 
 	t.Run("error path when no Workspaceanization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -496,7 +496,7 @@ func TestListWorkspaceUser(t *testing.T) {
 }
 
 func TestUpdateWorkspaceUserRole(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path UpdateWorkspaceUserRole", func(t *testing.T) {
 		expectedOutMessage := "The workspace user user@1.com role was successfully updated to WORKSPACE_MEMBER\n"
 		out := new(bytes.Buffer)
@@ -535,7 +535,7 @@ func TestUpdateWorkspaceUserRole(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -557,7 +557,7 @@ func TestUpdateWorkspaceUserRole(t *testing.T) {
 	})
 
 	t.Run("UpdateWorkspaceUserRole no email passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -584,7 +584,7 @@ func TestUpdateWorkspaceUserRole(t *testing.T) {
 }
 
 func TestAddWorkspaceUser(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path AddWorkspaceUser", func(t *testing.T) {
 		expectedOutMessage := "The user user@1.com was successfully added to the workspace with the role WORKSPACE_MEMBER\n"
 		out := new(bytes.Buffer)
@@ -623,7 +623,7 @@ func TestAddWorkspaceUser(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -645,7 +645,7 @@ func TestAddWorkspaceUser(t *testing.T) {
 	})
 
 	t.Run("AddWorkspaceUser no email passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -672,7 +672,7 @@ func TestAddWorkspaceUser(t *testing.T) {
 }
 
 func TestDeleteWorkspaceUser(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path DeleteWorkspaceUser", func(t *testing.T) {
 		expectedOutMessage := "The user user@1.com was successfully removed from the workspace\n"
 		out := new(bytes.Buffer)
@@ -703,7 +703,7 @@ func TestDeleteWorkspaceUser(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -725,7 +725,7 @@ func TestDeleteWorkspaceUser(t *testing.T) {
 	})
 
 	t.Run("DeleteWorkspaceUser no email passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -753,7 +753,7 @@ func TestDeleteWorkspaceUser(t *testing.T) {
 
 func TestGetUser(t *testing.T) {
 	t.Run("happy path GetUser", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetUserWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetUserWithResponseOK, nil).Twice()
 		_, err := GetUser(mockClient, user1.Id)
@@ -761,7 +761,7 @@ func TestGetUser(t *testing.T) {
 	})
 
 	t.Run("error path when GetUserWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetUserWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetUserWithResponseError, nil).Twice()
 
@@ -770,7 +770,7 @@ func TestGetUser(t *testing.T) {
 	})
 
 	t.Run("error path when GetUserWithResponse returns a network error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetUserWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errorNetwork).Twice()
 
@@ -779,7 +779,7 @@ func TestGetUser(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -70,7 +70,7 @@ func TestListError(t *testing.T) {
 }
 
 func TestGetWorkspaceSelection(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
 	t.Run("success", func(t *testing.T) {
@@ -144,7 +144,7 @@ func TestGetWorkspaceSelection(t *testing.T) {
 }
 
 func TestSwitch(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
 	t.Run("success", func(t *testing.T) {
@@ -229,7 +229,7 @@ func TestSwitch(t *testing.T) {
 }
 
 func TestGetCurrentWorkspace(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	resp, err := GetCurrentWorkspace()
 	assert.NoError(t, err)
@@ -274,7 +274,7 @@ var (
 )
 
 func TestCreate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path Create", func(t *testing.T) {
 		expectedOutMessage := "Astro Workspace workspace-test was successfully created\n"
 		out := new(bytes.Buffer)
@@ -310,7 +310,7 @@ func TestCreate(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -352,7 +352,7 @@ var (
 )
 
 func TestDelete(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path Delete", func(t *testing.T) {
 		expectedOutMessage := "Astro Workspace test-workspace was successfully deleted\n"
 		out := new(bytes.Buffer)
@@ -404,7 +404,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -426,7 +426,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("DeleteWorkspace no workspace id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -476,7 +476,7 @@ var (
 )
 
 func TestUpdate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("happy path Update", func(t *testing.T) {
 		expectedOutMessage := "Astro Workspace test-workspace was successfully updated\n"
 		out := new(bytes.Buffer)
@@ -563,7 +563,7 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		err = c.SetContextKey("organization_short_name", "")
@@ -585,7 +585,7 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("UpdateWorkspace no workspace id passed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)

--- a/cloud/workspace/workspace_token_test.go
+++ b/cloud/workspace/workspace_token_test.go
@@ -132,7 +132,7 @@ var (
 
 func TestListTokens(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
@@ -141,7 +141,7 @@ func TestListTokens(t *testing.T) {
 	})
 
 	t.Run("with specified workspace", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
@@ -152,7 +152,7 @@ func TestListTokens(t *testing.T) {
 	})
 
 	t.Run("error path when ListWorkspaceApiTokensWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseError, nil).Twice()
@@ -172,7 +172,7 @@ func TestListTokens(t *testing.T) {
 
 func TestCreateToken(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateWorkspaceAPITokenResponseOK, nil)
@@ -193,7 +193,7 @@ func TestCreateToken(t *testing.T) {
 	})
 
 	t.Run("invalid role", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
@@ -203,7 +203,7 @@ func TestCreateToken(t *testing.T) {
 	})
 
 	t.Run("empty name", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
@@ -215,7 +215,7 @@ func TestCreateToken(t *testing.T) {
 
 func TestUpdateToken(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil).Twice()
@@ -225,7 +225,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("happy path no id", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
@@ -246,7 +246,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("happy path multiple name", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponse2O0, nil).Twice()
@@ -267,7 +267,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("happy path", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil).Twice()
@@ -277,7 +277,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when listWorkspaceTokens returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseError, nil)
@@ -286,7 +286,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when listWorkspaceToken returns an not found error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
@@ -295,7 +295,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when getWorkspaceToken returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseError, nil)
@@ -304,7 +304,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when UpdateWorkspaceApiTokenWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil)
@@ -322,7 +322,7 @@ func TestUpdateToken(t *testing.T) {
 	})
 
 	t.Run("error path when workspace role is invalid returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil)
@@ -331,7 +331,7 @@ func TestUpdateToken(t *testing.T) {
 		assert.Equal(t, user.ErrInvalidWorkspaceRole.Error(), err.Error())
 	})
 	t.Run("Happy path when applying workspace role", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
@@ -343,7 +343,7 @@ func TestUpdateToken(t *testing.T) {
 
 func TestRotateToken(t *testing.T) {
 	t.Run("happy path - id provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil)
@@ -353,7 +353,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("happy path name provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
@@ -363,7 +363,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("happy path with confirmation", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
@@ -381,7 +381,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("error path when listWorkspaceTokens returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseError, nil)
@@ -390,7 +390,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("error path when listWorkspaceToken returns an not found error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
@@ -399,7 +399,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("error path when getWorkspaceToken returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseError, nil)
@@ -408,7 +408,7 @@ func TestRotateToken(t *testing.T) {
 	})
 
 	t.Run("error path when RotateWorkspaceApiTokenWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
@@ -420,7 +420,7 @@ func TestRotateToken(t *testing.T) {
 
 func TestDeleteToken(t *testing.T) {
 	t.Run("happy path - delete workspace token - by name", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
@@ -430,7 +430,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("happy path - delete workspace token - by id", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseOK, nil).Twice()
@@ -440,7 +440,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("happy path - remove organization token", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
@@ -458,7 +458,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("error path when getWorkspaceToken returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetWorkspaceAPITokenResponseError, nil)
@@ -467,7 +467,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("error path when listWorkspaceTokens returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseError, nil)
@@ -476,7 +476,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("error path when listWorkspaceToken returns a not found error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
@@ -485,7 +485,7 @@ func TestDeleteToken(t *testing.T) {
 	})
 
 	t.Run("error path when DeleteWorkspaceApiTokenWithResponse returns an error", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		out := new(bytes.Buffer)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -32,7 +32,7 @@ func TestDevRootCommand(t *testing.T) {
 }
 
 func TestDevInitCommand(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	output, err := executeCommand("dev", "init", "--help")
 	assert.NoError(t, err)
 	assert.Contains(t, output, "astro dev", output)
@@ -544,7 +544,7 @@ func TestAirflowStart(t *testing.T) {
 }
 
 func TestAirflowUpgradeTest(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("success", func(t *testing.T) {
 		cmd := newAirflowUpgradeTestCmd(nil)
 
@@ -890,7 +890,7 @@ func TestAirflowStop(t *testing.T) {
 }
 
 func TestAirflowRestart(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("success", func(t *testing.T) {
 		cmd := newAirflowRestartCmd(nil)
@@ -1028,7 +1028,7 @@ func TestAirflowRestart(t *testing.T) {
 
 func TestAirflowPytest(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		cmd := newAirflowPytestCmd()
 		args := []string{"test-pytest-file"}
@@ -1046,7 +1046,7 @@ func TestAirflowPytest(t *testing.T) {
 	})
 
 	t.Run("exit code 1", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		cmd := newAirflowPytestCmd()
 		args := []string{"test-pytest-file"}
@@ -1064,7 +1064,7 @@ func TestAirflowPytest(t *testing.T) {
 	})
 
 	t.Run("pytest file doesnot exists", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		cmd := newAirflowPytestCmd()
 		args := []string{"test-pytest-file"}
@@ -1082,7 +1082,7 @@ func TestAirflowPytest(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		cmd := newAirflowPytestCmd()
 		args := []string{"test-pytest-file"}
@@ -1100,7 +1100,7 @@ func TestAirflowPytest(t *testing.T) {
 	})
 
 	t.Run("containerHandlerInit failure", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		cmd := newAirflowPytestCmd()
 		args := []string{"test-pytest-file"}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -26,11 +26,11 @@ func TestAuthRootCommand(t *testing.T) {
 
 func TestLogin(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cloudDomain := "astronomer.io"
+	localDomain := "localhost"
 	softwareDomain := "astronomer_dev.com"
 
 	cloudLogin = func(domain, token string, client astro.Client, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
-		assert.Equal(t, cloudDomain, domain)
+		assert.Equal(t, localDomain, domain)
 		return nil
 	}
 
@@ -40,7 +40,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	// cloud login success
-	login(&cobra.Command{}, []string{cloudDomain}, nil, nil, nil, buf)
+	login(&cobra.Command{}, []string{localDomain}, nil, nil, nil, buf)
 
 	// software login success
 	testUtil.InitTestConfig(testUtil.Initial)
@@ -72,18 +72,18 @@ func TestLogin(t *testing.T) {
 }
 
 func TestLogout(t *testing.T) {
-	cloudDomain := "astronomer.io"
+	localDomain := "localhost"
 	softwareDomain := "astronomer_dev.com"
 
 	cloudLogout = func(domain string, out io.Writer) {
-		assert.Equal(t, cloudDomain, domain)
+		assert.Equal(t, localDomain, domain)
 	}
 	softwareLogout = func(domain string) {
 		assert.Equal(t, softwareDomain, domain)
 	}
 
 	// cloud logout success
-	err := logout(&cobra.Command{}, []string{cloudDomain}, os.Stdout)
+	err := logout(&cobra.Command{}, []string{localDomain}, os.Stdout)
 	assert.NoError(t, err)
 
 	// software logout success

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -27,10 +27,11 @@ func TestAuthRootCommand(t *testing.T) {
 func TestLogin(t *testing.T) {
 	buf := new(bytes.Buffer)
 	localDomain := "localhost"
+	cloudDomain := "astronomer.io"
 	softwareDomain := "astronomer_dev.com"
 
 	cloudLogin = func(domain, token string, client astro.Client, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
-		assert.Equal(t, localDomain, domain)
+		assert.Equal(t, cloudDomain, domain)
 		return nil
 	}
 
@@ -40,14 +41,14 @@ func TestLogin(t *testing.T) {
 	}
 
 	// cloud login success
-	login(&cobra.Command{}, []string{localDomain}, nil, nil, nil, buf)
+	login(&cobra.Command{}, []string{cloudDomain}, nil, nil, nil, buf)
 
 	// software login success
 	testUtil.InitTestConfig(testUtil.Initial)
 	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, nil, buf)
 
 	// no domain, cloud login
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	login(&cobra.Command{}, []string{}, nil, nil, nil, buf)
 
 	// no domain, software login

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -47,7 +47,7 @@ func TestLogin(t *testing.T) {
 	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, nil, buf)
 
 	// no domain, cloud login
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	login(&cobra.Command{}, []string{}, nil, nil, nil, buf)
 
 	// no domain, software login
@@ -58,12 +58,12 @@ func TestLogin(t *testing.T) {
 	config.ResetCurrentContext()
 	login(&cobra.Command{}, []string{}, nil, nil, nil, buf)
 
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	defer testUtil.MockUserInput(t, "n")()
 	login(&cobra.Command{}, []string{"fail.astronomer.io"}, nil, nil, nil, buf)
 	assert.Contains(t, buf.String(), "fail.astronomer.io is an invalid domain to login into Astro.\n")
 
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	softwareDomain = "software.astronomer.io"
 	buf = new(bytes.Buffer)
 	defer testUtil.MockUserInput(t, "y")()
@@ -91,7 +91,7 @@ func TestLogout(t *testing.T) {
 	assert.NoError(t, err)
 
 	// no domain, cloud logout
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	err = logout(&cobra.Command{}, []string{}, os.Stdout)
 	assert.NoError(t, err)
 

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -26,7 +26,6 @@ func TestAuthRootCommand(t *testing.T) {
 
 func TestLogin(t *testing.T) {
 	buf := new(bytes.Buffer)
-	localDomain := "localhost"
 	cloudDomain := "astronomer.io"
 	softwareDomain := "astronomer_dev.com"
 

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -20,7 +20,7 @@ func execDeployCmd(args ...string) error {
 }
 
 func TestDeployImage(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	EnsureProjectDir = func(cmd *cobra.Command, args []string) error {
 		return nil

--- a/cmd/cloud/deployment_inspect_test.go
+++ b/cmd/cloud/deployment_inspect_test.go
@@ -124,7 +124,7 @@ var (
 
 func TestNewDeploymentInspectCmd(t *testing.T) {
 	expectedHelp := "Inspect an Astro Deployment."
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(astro_mocks.Client)
 	astroClient = mockClient
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)

--- a/cmd/cloud/deployment_objects_test.go
+++ b/cmd/cloud/deployment_objects_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestDeploymentConnectionRootCommand(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
 	cmd := newDeploymentRootCmd(os.Stdout)
 	cmd.SetOut(buf)
@@ -38,7 +38,7 @@ func TestDeploymentConnectionRootCommand(t *testing.T) {
 
 func TestConnectionList(t *testing.T) {
 	expectedHelp := "list connections for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -73,7 +73,7 @@ func TestConnectionList(t *testing.T) {
 
 func TestConnectionCreate(t *testing.T) {
 	expectedHelp := "Create Airflow connections for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -104,7 +104,7 @@ func TestConnectionCreate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("successful airflow variable create", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, deploymentListParams).Return(&mockListDeploymentsResponse, nil).Once()
 		mockAstroClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Once()
 		mockClient.On("CreateConnection", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
@@ -116,7 +116,7 @@ func TestConnectionCreate(t *testing.T) {
 
 func TestConnectionUpdate(t *testing.T) {
 	expectedHelp := "Update existing Airflow connections for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -151,7 +151,7 @@ func TestConnectionUpdate(t *testing.T) {
 	})
 
 	t.Run("successful connection update", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockAstroClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Once()
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, deploymentListParams).Return(&mockListDeploymentsResponse, nil).Once()
 		mockClient.On("UpdateConnection", mock.AnythingOfType("string"), mock.AnythingOfType("*airflowclient.Connection")).Return(nil).Once()
@@ -163,7 +163,7 @@ func TestConnectionUpdate(t *testing.T) {
 
 func TestConnectionCopy(t *testing.T) {
 	expectedHelp := "Copy Airflow connections from one Astro Deployment to another"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -208,7 +208,7 @@ func TestConnectionCopy(t *testing.T) {
 	})
 
 	t.Run("successful connection copy", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient.On("GetConnections", mock.Anything).Return(mockResp, nil).Twice()
 		mockClient.On("UpdateConnection", mock.AnythingOfType("string"), mock.AnythingOfType("*airflowclient.Connection")).Return(nil).Twice()
 		mockAstroClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Twice()
@@ -222,7 +222,7 @@ func TestConnectionCopy(t *testing.T) {
 
 func TestVariableList(t *testing.T) {
 	expectedHelp := "list Airflow variables stored in an Astro Deployment's metadata database"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -253,7 +253,7 @@ func TestVariableList(t *testing.T) {
 
 func TestVariableUpdate(t *testing.T) {
 	expectedHelp := "Update Airflow variables for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -288,7 +288,7 @@ func TestVariableUpdate(t *testing.T) {
 	})
 
 	t.Run("successful airflow variable update", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockAstroClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Once()
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, deploymentListParams).Return(&mockListDeploymentsResponse, nil).Once()
 		mockClient.On("UpdateVariable", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
@@ -300,7 +300,7 @@ func TestVariableUpdate(t *testing.T) {
 
 func TestVaraibleCreate(t *testing.T) {
 	expectedHelp := "Create Airflow variables for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -333,7 +333,7 @@ func TestVaraibleCreate(t *testing.T) {
 	})
 
 	t.Run("successful airflow variable create", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, deploymentListParams).Return(&mockListDeploymentsResponse, nil).Once()
 		mockAstroClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Once()
 		mockClient.On("CreateVariable", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
@@ -345,7 +345,7 @@ func TestVaraibleCreate(t *testing.T) {
 
 func TestVariableCopy(t *testing.T) {
 	expectedHelp := "Copy Airflow variables from one Astro Deployment to another Astro Deployment."
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -390,7 +390,7 @@ func TestVariableCopy(t *testing.T) {
 	})
 
 	t.Run("successful variable copy", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient.On("GetVariables", mock.Anything).Return(mockResp, nil).Twice()
 		mockClient.On("UpdateVariable", mock.AnythingOfType("string"), mock.Anything).Return(nil).Twice()
 		mockAstroClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Twice()
@@ -404,7 +404,7 @@ func TestVariableCopy(t *testing.T) {
 
 func TestPoolList(t *testing.T) {
 	expectedHelp := "list Airflow pools for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -439,7 +439,7 @@ func TestPoolList(t *testing.T) {
 
 func TestPoolUpdate(t *testing.T) {
 	expectedHelp := "Update Airflow pools for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -474,7 +474,7 @@ func TestPoolUpdate(t *testing.T) {
 	})
 
 	t.Run("successful pool update", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockAstroClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Once()
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, deploymentListParams).Return(&mockListDeploymentsResponse, nil).Once()
 		mockClient.On("UpdatePool", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
@@ -486,7 +486,7 @@ func TestPoolUpdate(t *testing.T) {
 
 func TestPoolCreate(t *testing.T) {
 	expectedHelp := "Create Airflow pools for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -519,7 +519,7 @@ func TestPoolCreate(t *testing.T) {
 	})
 
 	t.Run("successful pool create", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockAstroClient.On("ListDeployments", mock.Anything, mock.Anything).Return(deploymentResponse, nil).Once()
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, deploymentListParams).Return(&mockListDeploymentsResponse, nil).Once()
 		mockClient.On("CreatePool", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
@@ -531,7 +531,7 @@ func TestPoolCreate(t *testing.T) {
 
 func TestPoolCopy(t *testing.T) {
 	expectedHelp := "Copy Airflow pools from one Astro Deployment to another Astro Deployment."
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
 	airflowAPIClient = mockClient
 	mockAstroClient := new(astro_mocks.Client)
@@ -575,7 +575,7 @@ func TestPoolCopy(t *testing.T) {
 	})
 
 	t.Run("successful pool copy", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient.On("GetPools", mock.Anything).Return(mockResp, nil).Twice()
 		mockClient.On("UpdatePool", mock.AnythingOfType("string"), mock.Anything).Return(nil).Twice()
 		mockCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, deploymentListParams1).Return(&mockListDeploymentsResponse, nil).Once()

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -65,7 +65,7 @@ func execDeploymentCmd(args ...string) (string, error) {
 }
 
 func TestDeploymentRootCommand(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
 	deplyCmd := newDeploymentRootCmd(os.Stdout)
 	deplyCmd.SetOut(buf)
@@ -76,7 +76,7 @@ func TestDeploymentRootCommand(t *testing.T) {
 }
 
 func TestDeploymentList(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockClient := new(astro_mocks.Client)
 	mockClient.On("ListDeployments", mock.Anything, "").Return([]astro.Deployment{{ID: "test-id-1"}, {ID: "test-id-2"}}, nil).Once()
@@ -91,7 +91,7 @@ func TestDeploymentList(t *testing.T) {
 }
 
 func TestDeploymentLogs(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	deploymentID := "test-id"
 	logLevels := []string{"WARN", "ERROR", "INFO"}
@@ -114,7 +114,7 @@ func TestDeploymentLogs(t *testing.T) {
 }
 
 func TestDeploymentCreate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	ws := "workspace-id"
 	csID := "test-cluster-id"
@@ -477,7 +477,7 @@ deployment:
 }
 
 func TestDeploymentUpdate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	ws := "test-ws-id"
 	deploymentResp := astro.Deployment{
@@ -552,13 +552,13 @@ func TestDeploymentUpdate(t *testing.T) {
 		assert.ErrorContains(t, err, "KubeExecutor is not a valid executor")
 	})
 	t.Run("returns an error when getting workspace fails", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
 		ctx.Workspace = ""
 		err = ctx.SetContext()
 		assert.NoError(t, err)
-		defer testUtil.InitTestConfig(testUtil.CloudPlatform)
+		defer testUtil.InitTestConfig(testUtil.LocalPlatform)
 		expectedOut := "Usage:\n"
 		cmdArgs := []string{"update", "-n", "doesnotexist"}
 		resp, err := execDeploymentCmd(cmdArgs...)
@@ -724,7 +724,7 @@ deployment:
 }
 
 func TestDeploymentDelete(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	deploymentResp := astro.Deployment{
 		ID:             "test-id",
@@ -744,7 +744,7 @@ func TestDeploymentDelete(t *testing.T) {
 }
 
 func TestDeploymentVariableList(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockResponse := []astro.Deployment{
 		{
@@ -774,7 +774,7 @@ func TestDeploymentVariableList(t *testing.T) {
 }
 
 func TestDeploymentVariableModify(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockListResponse := []astro.Deployment{
 		{
@@ -824,7 +824,7 @@ func TestDeploymentVariableModify(t *testing.T) {
 }
 
 func TestDeploymentVariableUpdate(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockListResponse := []astro.Deployment{
 		{

--- a/cmd/cloud/deployment_workerqueue_test.go
+++ b/cmd/cloud/deployment_workerqueue_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestNewDeploymentWorkerQueueRootCmd(t *testing.T) {
 	expectedHelp := "Manage worker queues for an Astro Deployment."
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
 
 	t.Run("worker-queue command runs", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestNewDeploymentWorkerQueueRootCmd(t *testing.T) {
 
 func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 	expectedHelp := "Create a worker queue for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(astro_mocks.Client)
 	astroClient = mockClient
 	deploymentRespDefaultQueue := []astro.Deployment{
@@ -344,7 +344,7 @@ func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 
 func TestNewDeploymentWorkerQueueDeleteCmd(t *testing.T) {
 	expectedHelp := "Delete a worker queue from an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(astro_mocks.Client)
 	astroClient = mockClient
 
@@ -450,7 +450,7 @@ func TestNewDeploymentWorkerQueueDeleteCmd(t *testing.T) {
 
 func TestNewDeploymentWorkerQueueUpdateCmd(t *testing.T) {
 	expectedHelp := "Update a worker queue for an Astro Deployment"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(astro_mocks.Client)
 	astroClient = mockClient
 

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -36,7 +36,7 @@ func execOrganizationCmd(args ...string) (string, error) {
 
 func TestOrganizationRootCommand(t *testing.T) {
 	testUtil.SetupOSArgsForGinkgo()
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
 	cmd := newOrganizationCmd(os.Stdout)
 	cmd.SetOut(buf)
@@ -47,7 +47,7 @@ func TestOrganizationRootCommand(t *testing.T) {
 
 func TestOrganizationUserRootCommand(t *testing.T) {
 	expectedHelp := "Manage users in your Astro Organization."
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	cmdArgs := []string{"user"}
 	resp, err := execOrganizationCmd(cmdArgs...)
 	assert.NoError(t, err)
@@ -56,7 +56,7 @@ func TestOrganizationUserRootCommand(t *testing.T) {
 
 func TestOrganizationTeamRootCommand(t *testing.T) {
 	expectedHelp := "Manage teams in your Astro Organization."
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	cmdArgs := []string{"team"}
 	resp, err := execOrganizationCmd(cmdArgs...)
 	assert.NoError(t, err)
@@ -343,7 +343,7 @@ var (
 
 func TestUserInvite(t *testing.T) {
 	expectedHelp := "astro user invite [email] --role [ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN, ORGANIZATION_OWNER]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints invite help", func(t *testing.T) {
 		cmdArgs := []string{"user", "invite", "-h"}
@@ -399,7 +399,7 @@ func TestUserInvite(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no email is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		// mock os.Stdin
 		expectedInput := []byte("test-email-input")
 		r, w, err := os.Pipe()
@@ -424,7 +424,7 @@ func TestUserInvite(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 	t.Run("command returns an error when no email is provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		// mock os.Stdin
 		expectedInput := []byte("")
 		r, w, err := os.Pipe()
@@ -445,7 +445,7 @@ func TestUserInvite(t *testing.T) {
 
 func TestUserList(t *testing.T) {
 	expectedHelp := "List all the users in your Astro Organization"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"user", "list", "-h"}
@@ -474,7 +474,7 @@ func TestUserList(t *testing.T) {
 
 func TestUserUpdate(t *testing.T) {
 	expectedHelp := "astro user update [email] --role [ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN, ORGANIZATION_OWNER]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints update help", func(t *testing.T) {
 		cmdArgs := []string{"user", "update", "-h"}
@@ -523,7 +523,7 @@ func TestUserUpdate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no email is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrgUsersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgUsersResponseOK, nil).Twice()
@@ -551,7 +551,7 @@ func TestUserUpdate(t *testing.T) {
 
 func TestTeamList(t *testing.T) {
 	expectedHelp := "List all the teams in your Astro Organization"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"team", "list", "-h"}
@@ -580,7 +580,7 @@ func TestTeamList(t *testing.T) {
 
 func TestTeamUpdate(t *testing.T) {
 	expectedHelp := "organization team update [team-id]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints update help", func(t *testing.T) {
 		cmdArgs := []string{"team", "update", "-h"}
@@ -622,7 +622,7 @@ func TestTeamUpdate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no id is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgTeamsResponseOK, nil).Twice()
@@ -675,7 +675,7 @@ func TestTeamUpdate(t *testing.T) {
 
 func TestTeamCreate(t *testing.T) {
 	expectedHelp := "organization team create"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints update help", func(t *testing.T) {
 		cmdArgs := []string{"team", "create", "-h"}
@@ -761,7 +761,7 @@ func TestTeamCreate(t *testing.T) {
 
 func TestTeamDelete(t *testing.T) {
 	expectedHelp := "organization team delete"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints update help", func(t *testing.T) {
 		cmdArgs := []string{"team", "delete", "-h"}
@@ -802,7 +802,7 @@ func TestTeamDelete(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no id is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgTeamsResponseOK, nil).Twice()
@@ -831,7 +831,7 @@ func TestTeamDelete(t *testing.T) {
 
 func TestAddUser(t *testing.T) {
 	expectedHelp := "organization team user add"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints update help", func(t *testing.T) {
 		cmdArgs := []string{"team", "user", "add", "-h"}
@@ -876,7 +876,7 @@ func TestAddUser(t *testing.T) {
 	})
 
 	t.Run("command asks for input when no team id is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgTeamsResponseOK, nil).Twice()
@@ -904,7 +904,7 @@ func TestAddUser(t *testing.T) {
 	})
 
 	t.Run("command asks for input when no user id is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetTeamWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetTeamWithResponseOK, nil).Twice()
@@ -934,7 +934,7 @@ func TestAddUser(t *testing.T) {
 
 func TestRemoveUser(t *testing.T) {
 	expectedHelp := "organization team user remove"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints update help", func(t *testing.T) {
 		cmdArgs := []string{"team", "user", "remove", "-h"}
@@ -978,7 +978,7 @@ func TestRemoveUser(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no team id is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgTeamsResponseOK, nil).Twice()
@@ -1008,7 +1008,7 @@ func TestRemoveUser(t *testing.T) {
 
 func TestTeamUserList(t *testing.T) {
 	expectedHelp := "Lists users in an Astro Team\n"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"team", "user", "list", "-h"}
@@ -1078,7 +1078,7 @@ var (
 )
 
 func TestOrganizationTokenRootCommand(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
 	cmd := newOrganizationCmd(os.Stdout)
 	cmd.SetOut(buf)
@@ -1089,7 +1089,7 @@ func TestOrganizationTokenRootCommand(t *testing.T) {
 
 func TestOrganizationTokenList(t *testing.T) {
 	expectedHelp := "List all the API tokens in an Astro Organization"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "list", "-h"}
@@ -1098,7 +1098,7 @@ func TestOrganizationTokenList(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and tokens are not listed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil).Twice()
 		astroCoreClient = mockClient
@@ -1117,7 +1117,7 @@ func TestOrganizationTokenList(t *testing.T) {
 	})
 
 	t.Run("tokens are listed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil).Twice()
 		astroCoreClient = mockClient
@@ -1129,7 +1129,7 @@ func TestOrganizationTokenList(t *testing.T) {
 
 func TestOrganizationTokenCreate(t *testing.T) {
 	expectedHelp := "Create an API token in an Astro Organization"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "create", "-h"}
@@ -1138,7 +1138,7 @@ func TestOrganizationTokenCreate(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token is not created", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateOrganizationAPITokenResponseError, nil)
 		astroCoreClient = mockClient
@@ -1156,7 +1156,7 @@ func TestOrganizationTokenCreate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("token is created", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateOrganizationAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
@@ -1165,7 +1165,7 @@ func TestOrganizationTokenCreate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is created with no name provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateOrganizationAPITokenResponseOK, nil)
 		// mock os.Stdin
@@ -1185,7 +1185,7 @@ func TestOrganizationTokenCreate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is created with no role provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateOrganizationAPITokenResponseOK, nil)
 		// mock os.Stdin
@@ -1208,7 +1208,7 @@ func TestOrganizationTokenCreate(t *testing.T) {
 
 func TestOrganizationTokenUpdate(t *testing.T) {
 	expectedHelp := "Update a Organization or Organaization API token"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "update", "-h"}
@@ -1217,7 +1217,7 @@ func TestOrganizationTokenUpdate(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token is not updated", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseError, nil)
@@ -1237,7 +1237,7 @@ func TestOrganizationTokenUpdate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("token is updated", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
@@ -1247,7 +1247,7 @@ func TestOrganizationTokenUpdate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is created with no ID provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
@@ -1271,7 +1271,7 @@ func TestOrganizationTokenUpdate(t *testing.T) {
 
 func TestOrganizationTokenRotate(t *testing.T) {
 	expectedHelp := "Rotate a Organization API token"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "rotate", "-h"}
@@ -1280,7 +1280,7 @@ func TestOrganizationTokenRotate(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token is not rotated", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseError, nil)
@@ -1300,7 +1300,7 @@ func TestOrganizationTokenRotate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("token is rotated", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseOK, nil)
@@ -1310,7 +1310,7 @@ func TestOrganizationTokenRotate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is rotated with no ID provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseOK, nil)
@@ -1331,7 +1331,7 @@ func TestOrganizationTokenRotate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is rotated with and confirmed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("RotateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateOrganizationAPITokenResponseOK, nil)
@@ -1355,7 +1355,7 @@ func TestOrganizationTokenRotate(t *testing.T) {
 
 func TestOrganizationTokenDelete(t *testing.T) {
 	expectedHelp := "Delete a Organization API token or remove an Organization API token from a Organization"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "delete", "-h"}
@@ -1364,7 +1364,7 @@ func TestOrganizationTokenDelete(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token is not deleted", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseError, nil)
@@ -1384,7 +1384,7 @@ func TestOrganizationTokenDelete(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("token is deleted", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseOK, nil)
@@ -1394,7 +1394,7 @@ func TestOrganizationTokenDelete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is deleted with no ID provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseOK, nil)
@@ -1415,7 +1415,7 @@ func TestOrganizationTokenDelete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is delete with and confirmed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("DeleteOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationAPITokenResponseOK, nil)
@@ -1440,7 +1440,7 @@ func TestOrganizationTokenDelete(t *testing.T) {
 func TestOrganizationTokenListRoles(t *testing.T) {
 	expectedHelp := "List roles for an organization API token"
 	mockTokenID := "mockTokenID"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "roles", "-h"}
@@ -1449,7 +1449,7 @@ func TestOrganizationTokenListRoles(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token roles are not listed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseError, nil).Twice()
 		astroCoreClient = mockClient
@@ -1468,7 +1468,7 @@ func TestOrganizationTokenListRoles(t *testing.T) {
 	})
 
 	t.Run("token roles are listed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("GetOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&GetOrganizationAPITokenResponseOK, nil).Twice()
 		astroCoreClient = mockClient

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -305,7 +305,7 @@ func TestCheckAPIKeys(t *testing.T) {
 }
 
 func TestCheckToken(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	t.Run("test check token", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -29,7 +29,7 @@ var (
 )
 
 func TestSetup(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
 
 	t.Run("login cmd", func(t *testing.T) {
 		testUtil.SetupOSArgsForGinkgo()

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -29,7 +29,7 @@ var (
 )
 
 func TestSetup(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("login cmd", func(t *testing.T) {
 		testUtil.SetupOSArgsForGinkgo()
@@ -248,7 +248,7 @@ func TestSetup(t *testing.T) {
 }
 
 func TestCheckAPIKeys(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("test context switch", func(t *testing.T) {
 		mockDeplyResp := []astro.Deployment{
 			{
@@ -305,7 +305,7 @@ func TestCheckAPIKeys(t *testing.T) {
 }
 
 func TestCheckToken(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("test check token", func(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -336,7 +336,7 @@ func TestCheckToken(t *testing.T) {
 }
 
 func TestCheckAPIToken(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 	mockOrgsResponse := astroplatformcore.ListOrganizationsResponse{
 		HTTPResponse: &http.Response{

--- a/cmd/cloud/workspace_test.go
+++ b/cmd/cloud/workspace_test.go
@@ -29,7 +29,7 @@ func execWorkspaceCmd(args ...string) (string, error) {
 }
 
 func TestWorkspaceRootCommand(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
 	cmd := newWorkspaceCmd(os.Stdout)
 	cmd.SetOut(buf)
@@ -66,7 +66,7 @@ var (
 )
 
 func TestWorkspaceList(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
@@ -81,7 +81,7 @@ func TestWorkspaceList(t *testing.T) {
 }
 
 func TestWorkspaceSwitch(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Twice()
@@ -112,7 +112,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 }
 
 func TestWorkspaceUserRootCommand(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
 	cmd := newWorkspaceCmd(os.Stdout)
 	cmd.SetOut(buf)
@@ -229,7 +229,7 @@ var (
 
 func TestWorkspaceUserList(t *testing.T) {
 	expectedHelp := "List all the users in an Astro Workspace"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"user", "list", "-h"}
@@ -258,7 +258,7 @@ func TestWorkspaceUserList(t *testing.T) {
 
 func TestWorkspacUserUpdate(t *testing.T) {
 	expectedHelp := "astro workspace user update [email] --role [WORKSPACE_MEMBER, WORKSPACE_AUTHOR, WORKSPACE_OPERATOR, WORKSPACE_OWNER]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints update help", func(t *testing.T) {
 		cmdArgs := []string{"user", "update", "-h"}
@@ -307,7 +307,7 @@ func TestWorkspacUserUpdate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no email is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceUsersWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceUsersResponseOK, nil).Twice()
@@ -335,7 +335,7 @@ func TestWorkspacUserUpdate(t *testing.T) {
 
 func TestWorkspaceUserAdd(t *testing.T) {
 	expectedHelp := "astro workspace user add [email] --role [WORKSPACE_MEMBER, WORKSPACE_AUTHOR, WORKSPACE_OPERATOR, WORKSPACE_OWNER]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints add help", func(t *testing.T) {
 		cmdArgs := []string{"user", "add", "-h"}
@@ -384,7 +384,7 @@ func TestWorkspaceUserAdd(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no email is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrgUsersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgUsersResponseOK, nil).Twice()
@@ -412,7 +412,7 @@ func TestWorkspaceUserAdd(t *testing.T) {
 
 func TestWorkspacUserRemove(t *testing.T) {
 	expectedHelp := "Remove a user from an Astro Workspace"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints remove help", func(t *testing.T) {
 		cmdArgs := []string{"user", "remove", "-h"}
@@ -451,7 +451,7 @@ func TestWorkspacUserRemove(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no email is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceUsersWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceUsersResponseOK, nil).Twice()
@@ -502,7 +502,7 @@ var (
 
 func TestWorkspaceCreate(t *testing.T) {
 	expectedHelp := "workspace create [flags]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints add help", func(t *testing.T) {
 		cmdArgs := []string{"create", "-h"}
@@ -569,7 +569,7 @@ var (
 
 func TestWorkspaceDelete(t *testing.T) {
 	expectedHelp := "workspace delete [workspace_id] [flags]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints add help", func(t *testing.T) {
 		cmdArgs := []string{"delete", "-h"}
@@ -618,7 +618,7 @@ func TestWorkspaceDelete(t *testing.T) {
 	})
 
 	t.Run("command asks for input when no workspace id is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
@@ -670,7 +670,7 @@ var (
 
 func TestWorkspaceUpdate(t *testing.T) {
 	expectedHelp := "workspace update [workspace_id] [flags]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints add help", func(t *testing.T) {
 		cmdArgs := []string{"update", "-h"}
@@ -719,7 +719,7 @@ func TestWorkspaceUpdate(t *testing.T) {
 	})
 
 	t.Run("command asks for input when no workspace id is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
@@ -748,7 +748,7 @@ func TestWorkspaceUpdate(t *testing.T) {
 
 func TestWorkspaceTeamList(t *testing.T) {
 	expectedHelp := "List all the teams in an Astro Workspace"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"team", "list", "-h"}
@@ -777,7 +777,7 @@ func TestWorkspaceTeamList(t *testing.T) {
 
 func TestWorkspaceTeamUpdate(t *testing.T) {
 	expectedHelp := "astro workspace team update [id] --role [WORKSPACE_MEMBER, WORKSPACE_AUTHOR, WORKSPACE_OPERATOR, WORKSPACE_OWNER]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints update help", func(t *testing.T) {
 		cmdArgs := []string{"team", "update", "-h"}
@@ -826,7 +826,7 @@ func TestWorkspaceTeamUpdate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no email is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceTeamsResponseOK, nil).Twice()
@@ -855,7 +855,7 @@ func TestWorkspaceTeamUpdate(t *testing.T) {
 
 func TestWorkspaceTeamAdd(t *testing.T) {
 	expectedHelp := "astro workspace team add [id] --role [WORKSPACE_MEMBER, WORKSPACE_AUTHOR, WORKSPACE_OPERATOR, WORKSPACE_OWNER]"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints add help", func(t *testing.T) {
 		cmdArgs := []string{"team", "add", "-h"}
@@ -918,7 +918,7 @@ func TestWorkspaceTeamAdd(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no email is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgTeamsResponseOK, nil).Twice()
@@ -947,7 +947,7 @@ func TestWorkspaceTeamAdd(t *testing.T) {
 
 func TestWorkspaceTeamRemove(t *testing.T) {
 	expectedHelp := "Remove a team from an Astro Workspace"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints remove help", func(t *testing.T) {
 		cmdArgs := []string{"team", "remove", "-h"}
@@ -986,7 +986,7 @@ func TestWorkspaceTeamRemove(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("command asks for input when no id is passed in as an arg", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceTeamsResponseOK, nil).Twice()
@@ -1111,7 +1111,7 @@ var (
 )
 
 func TestWorkspaceTokenRootCommand(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
 	cmd := newWorkspaceCmd(os.Stdout)
 	cmd.SetOut(buf)
@@ -1122,7 +1122,7 @@ func TestWorkspaceTokenRootCommand(t *testing.T) {
 
 func TestWorkspaceTokenList(t *testing.T) {
 	expectedHelp := "List all the API tokens in an Astro Workspace"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "list", "-h"}
@@ -1131,7 +1131,7 @@ func TestWorkspaceTokenList(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and tokens are not listed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseError, nil).Twice()
 		astroCoreClient = mockClient
@@ -1150,7 +1150,7 @@ func TestWorkspaceTokenList(t *testing.T) {
 	})
 
 	t.Run("tokens are listed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil).Twice()
 		astroCoreClient = mockClient
@@ -1162,7 +1162,7 @@ func TestWorkspaceTokenList(t *testing.T) {
 
 func TestWorkspaceTokenCreate(t *testing.T) {
 	expectedHelp := "Create an API token in an Astro Workspace"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "create", "-h"}
@@ -1171,7 +1171,7 @@ func TestWorkspaceTokenCreate(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token is not created", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateWorkspaceAPITokenResponseError, nil)
 		astroCoreClient = mockClient
@@ -1189,7 +1189,7 @@ func TestWorkspaceTokenCreate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("token is created", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateWorkspaceAPITokenResponseOK, nil)
 		astroCoreClient = mockClient
@@ -1198,7 +1198,7 @@ func TestWorkspaceTokenCreate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is created with no name provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateWorkspaceAPITokenResponseOK, nil)
 		// mock os.Stdin
@@ -1218,7 +1218,7 @@ func TestWorkspaceTokenCreate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is created with no role provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("CreateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateWorkspaceAPITokenResponseOK, nil)
 		// mock os.Stdin
@@ -1241,7 +1241,7 @@ func TestWorkspaceTokenCreate(t *testing.T) {
 
 func TestWorkspaceTokenUpdate(t *testing.T) {
 	expectedHelp := "Update a Workspace or Organaization API token"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	tokenID = ""
 
 	t.Run("-h prints list help", func(t *testing.T) {
@@ -1251,7 +1251,7 @@ func TestWorkspaceTokenUpdate(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token is not updated", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseError, nil)
@@ -1271,7 +1271,7 @@ func TestWorkspaceTokenUpdate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("token is updated", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
@@ -1281,7 +1281,7 @@ func TestWorkspaceTokenUpdate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is created with no ID provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("UpdateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateWorkspaceAPITokenResponseOK, nil)
@@ -1305,7 +1305,7 @@ func TestWorkspaceTokenUpdate(t *testing.T) {
 
 func TestWorkspaceTokenRotate(t *testing.T) {
 	expectedHelp := "Rotate a Workspace API token"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "rotate", "-h"}
@@ -1314,7 +1314,7 @@ func TestWorkspaceTokenRotate(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token is not rotated", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseError, nil)
@@ -1334,7 +1334,7 @@ func TestWorkspaceTokenRotate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("token is rotated", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseOK, nil)
@@ -1344,7 +1344,7 @@ func TestWorkspaceTokenRotate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is rotated with no ID provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseOK, nil)
@@ -1365,7 +1365,7 @@ func TestWorkspaceTokenRotate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is rotated with and confirmed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("RotateWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&RotateWorkspaceAPITokenResponseOK, nil)
@@ -1389,7 +1389,7 @@ func TestWorkspaceTokenRotate(t *testing.T) {
 
 func TestWorkspaceTokenDelete(t *testing.T) {
 	expectedHelp := "Delete a Workspace API token or remove an Organization API token from a Workspace"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "delete", "-h"}
@@ -1398,7 +1398,7 @@ func TestWorkspaceTokenDelete(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token is not deleted", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseError, nil)
@@ -1418,7 +1418,7 @@ func TestWorkspaceTokenDelete(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("token is deleted", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseOK, nil)
@@ -1428,7 +1428,7 @@ func TestWorkspaceTokenDelete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is deleted with no ID provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseOK, nil)
@@ -1449,7 +1449,7 @@ func TestWorkspaceTokenDelete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is delete with and confirmed", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListWorkspaceApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceAPITokensResponseOK, nil)
 		mockClient.On("DeleteWorkspaceApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceAPITokenResponseOK, nil)
@@ -1518,7 +1518,7 @@ var (
 
 func TestWorkspaceTokenAdd(t *testing.T) {
 	expectedHelp := "Add an Organization API token to an Astro Workspace"
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	t.Run("-h prints list help", func(t *testing.T) {
 		cmdArgs := []string{"token", "add", "-h"}
@@ -1527,7 +1527,7 @@ func TestWorkspaceTokenAdd(t *testing.T) {
 		assert.Contains(t, resp, expectedHelp)
 	})
 	t.Run("any errors from api are returned and token is not added", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseError, nil)
 		astroCoreClient = mockClient
@@ -1546,7 +1546,7 @@ func TestWorkspaceTokenAdd(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("token is added", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
@@ -1556,7 +1556,7 @@ func TestWorkspaceTokenAdd(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is created with no ID provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)
@@ -1577,7 +1577,7 @@ func TestWorkspaceTokenAdd(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("token is created with no role provided", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.CloudPlatform)
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockClient.On("ListOrganizationApiTokensWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListOrganizationAPITokensResponseOK, nil)
 		mockClient.On("UpdateOrganizationApiTokenWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&UpdateOrganizationAPITokenResponseOK, nil)

--- a/cmd/registry/dag_test.go
+++ b/cmd/registry/dag_test.go
@@ -26,7 +26,7 @@ func execDagCmd(args ...string) (string, error) {
 }
 
 func TestDagAdd(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	defer os.Remove("dags/sagemaker-batch-inference.py")
 

--- a/cmd/registry/provider_test.go
+++ b/cmd/registry/provider_test.go
@@ -26,7 +26,7 @@ func execProviderCmd(args ...string) (string, error) {
 }
 
 func TestProviderAdd(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	defer os.Remove("requirements.txt")
 

--- a/cmd/registry/root_test.go
+++ b/cmd/registry/root_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRegistryCommand(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
 	deplyCmd := newRegistryCmd(os.Stdout)
 	deplyCmd.SetOut(buf)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -40,7 +40,7 @@ func TestRootCommandLocal(t *testing.T) {
 }
 
 func TestRootCommandCloudContext(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	version.CurrVersion = "1.0.0"
 	output, err := executeCommand("help")
 	assert.NoError(t, err)

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -91,7 +91,7 @@ func TestIsCloudContext(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	err := Delete("astronomer.io", true)
 	assert.NoError(t, err)
 
@@ -100,7 +100,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDeleteContext(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	err := DeleteContext(&cobra.Command{}, []string{"astronomer.io"}, false)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Fixing unit tests to use LocalPlatform Config

## 🎟 Issue(s)

astronomer/astro#17657

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
