### PR TITLE
Fix login and organization list/switch

### DIFF
--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -2,13 +2,17 @@ package astroplatformcore
 
 import (
 	"bytes"
+	httpContext "context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"runtime"
 
-	astrocore "github.com/astronomer/astro-cli/astro-client-core"
+	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/version"
 )
 
 var (
@@ -24,8 +28,29 @@ type CoreClient = ClientWithResponsesInterface
 // create api client for astro platform core services
 func NewPlatformCoreClient(c *httputil.HTTPClient) *ClientWithResponses {
 	// we append base url in request editor, so set to an empty string here
-	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(astrocore.CoreRequestEditor))
+	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(requestEditor))
 	return cl
+}
+
+func requestEditor(ctx httpContext.Context, req *http.Request) error {
+	currentCtx, err := context.GetCurrentContext()
+	if err != nil {
+		return nil
+	}
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+	baseURL := currentCtx.GetPublicRESTAPIURL("platform/v1beta1")
+	requestURL, err := url.Parse(baseURL + req.URL.String())
+	if err != nil {
+		return fmt.Errorf("%w, %s", ErrorBaseURL, baseURL)
+	}
+	req.URL = requestURL
+	req.Header.Add("authorization", currentCtx.Token)
+	req.Header.Add("x-astro-client-identifier", "cli")
+	req.Header.Add("x-astro-client-version", "1.19.0") // version.CurrVersion)
+	req.Header.Add("x-client-os-identifier", os+"-"+arch)
+	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
+	return nil
 }
 
 func NormalizeAPIError(httpResp *http.Response, body []byte) error {

--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -47,7 +47,7 @@ func requestEditor(ctx httpContext.Context, req *http.Request) error {
 	req.URL = requestURL
 	req.Header.Add("authorization", currentCtx.Token)
 	req.Header.Add("x-astro-client-identifier", "cli")
-	req.Header.Add("x-astro-client-version", "1.19.0") // version.CurrVersion)
+	req.Header.Add("x-astro-client-version", version.CurrVersion) // version.CurrVersion)
 	req.Header.Add("x-client-os-identifier", os+"-"+arch)
 	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
 	return nil

--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -379,7 +379,7 @@ func GetWorkspaces(client astrocore.CoreClient) ([]astrocore.Workspace, error) {
 		Sorts: &sorts,
 	}
 
-	resp, err := client.ListWorkspacesWithResponse(httpContext.Background(), ctx.OrganizationShortName, workspaceListParams)
+	resp, err := client.ListWorkspacesWithResponse(httpContext.Background(), ctx.Organization, workspaceListParams)
 	if err != nil {
 		return []astrocore.Workspace{}, err
 	}

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -188,7 +188,7 @@ func newOrganizationUserUpdateCmd(out io.Writer) *cobra.Command {
 func organizationList(cmd *cobra.Command, out io.Writer) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
-	return orgList(out, astroPlatformCoreClient)
+	return orgList(out, platformCoreClient)
 }
 
 func organizationSwitch(cmd *cobra.Command, out io.Writer, args []string) error {
@@ -201,7 +201,7 @@ func organizationSwitch(cmd *cobra.Command, out io.Writer, args []string) error 
 		organizationNameOrID = args[0]
 	}
 
-	return orgSwitch(organizationNameOrID, astroClient, astroCoreClient, astroPlatformCoreClient, out, shouldDisplayLoginLink)
+	return orgSwitch(organizationNameOrID, astroClient, astroCoreClient, platformCoreClient, out, shouldDisplayLoginLink)
 }
 
 func organizationExportAuditLogs(cmd *cobra.Command) error {

--- a/cmd/cloud/root.go
+++ b/cmd/cloud/root.go
@@ -19,7 +19,7 @@ var (
 )
 
 // AddCmds adds all the command initialized in this package for the cmd package to import
-func AddCmds(client astro.Client, coreClient astrocore.CoreClient, airflowClient airflow.Client, out io.Writer) []*cobra.Command {
+func AddCmds(client astro.Client, astroPlatformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, airflowClient airflow.Client, out io.Writer) []*cobra.Command {
 	astroClient = client
 	astroCoreClient = coreClient
 	platformCoreClient = astroPlatformCoreClient

--- a/cmd/cloud/root.go
+++ b/cmd/cloud/root.go
@@ -12,16 +12,17 @@ import (
 )
 
 var (
-	astroClient             astro.Client
-	astroCoreClient         astrocore.CoreClient
-	astroPlatformCoreClient astroplatformcore.CoreClient
-	airflowAPIClient        airflow.Client
+	astroClient        astro.Client
+	astroCoreClient    astrocore.CoreClient
+	platformCoreClient astroplatformcore.CoreClient
+	airflowAPIClient   airflow.Client
 )
 
 // AddCmds adds all the command initialized in this package for the cmd package to import
 func AddCmds(client astro.Client, coreClient astrocore.CoreClient, airflowClient airflow.Client, out io.Writer) []*cobra.Command {
 	astroClient = client
 	astroCoreClient = coreClient
+	platformCoreClient = astroPlatformCoreClient
 	airflowAPIClient = airflowClient
 	return []*cobra.Command{
 		NewDeployCmd(),

--- a/cmd/cloud/root_test.go
+++ b/cmd/cloud/root_test.go
@@ -11,7 +11,7 @@ import (
 func TestAddCmds(t *testing.T) {
 	astroMock := new(astro_mocks.Client)
 	buf := new(bytes.Buffer)
-	cmds := AddCmds(astroMock, nil, nil, buf)
+	cmds := AddCmds(astroMock, nil, nil, nil, buf)
 	for cmdIdx := range cmds {
 		assert.Contains(t, []string{"deployment", "deploy DEPLOYMENT-ID", "workspace", "user", "organization"}, cmds[cmdIdx].Use)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,7 @@ func NewRootCmd() *cobra.Command {
 	airflowClient := airflowclient.NewAirflowClient(httputil.NewHTTPClient())
 	astroClient := astro.NewAstroClient(httputil.NewHTTPClient())
 	astroCoreClient := astrocore.NewCoreClient(httputil.NewHTTPClient())
-	astroPlatformCoreClient := astroplatformcore.NewPlatformCoreClient(httputil.NewHTTPClient())
+	platformCoreClient := astroplatformcore.NewPlatformCoreClient(httputil.NewHTTPClient())
 
 	ctx := cloudPlatform
 	isCloudCtx := context.IsCloudContext()
@@ -84,7 +84,7 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 				}
 			}
 			if isCloudCtx {
-				err = cloudCmd.Setup(cmd, astroClient, astroCoreClient, astroPlatformCoreClient)
+				err = cloudCmd.Setup(cmd, astroClient, astroCoreClient, platformCoreClient)
 				if err != nil {
 					softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error during cmd setup: "+err.Error())
 				}
@@ -100,7 +100,7 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 	}
 
 	rootCmd.AddCommand(
-		newLoginCommand(astroClient, astroCoreClient, astroPlatformCoreClient, os.Stdout),
+		newLoginCommand(astroClient, astroCoreClient, platformCoreClient, os.Stdout),
 		newLogoutCommand(os.Stdout),
 		newVersionCommand(),
 		newDevRootCmd(astroClient, astroCoreClient),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,7 +111,7 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 
 	if context.IsCloudContext() { // Include all the commands to be exposed for cloud users
 		rootCmd.AddCommand(
-			cloudCmd.AddCmds(astroClient, astroCoreClient, airflowClient, os.Stdout)...,
+			cloudCmd.AddCmds(astroClient, platformCoreClient, astroCoreClient, airflowClient, os.Stdout)...,
 		)
 	} else { // Include all the commands to be exposed for software users
 		rootCmd.AddCommand(

--- a/pkg/domainutil/domain.go
+++ b/pkg/domainutil/domain.go
@@ -55,7 +55,7 @@ func GetURLToEndpoint(protocol, domain, endpoint string) string {
 }
 
 func TransformToCoreAPIEndpoint(addr string) string {
-	if strings.Contains(addr, "v1alpha1") {
+	if strings.Contains(addr, "v1alpha1") || strings.Contains(addr, "v1beta1") {
 		addr = strings.Replace(addr, "/hub", "", 1)
 		addr = strings.Replace(addr, "localhost:8871", "localhost:8888", 1)
 	}


### PR DESCRIPTION
## Description

This PR fixes the commands login and organization list/switch. Changes introduced in a earlier PR broke these commands because the v1beta1 client was not established correctly

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1477

## 🧪 Functional Testing

ran each broken command manually

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
