### PR TITLE
Build Secrets Flag

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -22,7 +22,7 @@ import (
 )
 
 type ContainerHandler interface {
-	Start(imageName, settingsFile, composeFile string, noCache, noBrowser bool, waitTime time.Duration, envConns map[string]astrocore.EnvironmentObjectConnection) error
+	Start(imageName, settingsFile, composeFile, buildSecretString string, noCache, noBrowser bool, waitTime time.Duration, envConns map[string]astrocore.EnvironmentObjectConnection) error
 	Stop(waitForExit bool) error
 	PS() error
 	Kill() error
@@ -33,9 +33,9 @@ type ContainerHandler interface {
 	ImportSettings(settingsFile, envFile string, connections, variables, pools bool) error
 	ExportSettings(settingsFile, envFile string, connections, variables, pools, envExport bool) error
 	ComposeExport(settingsFile, composeFile string) error
-	Pytest(pytestFile, customImageName, deployImageName, pytestArgsString string) (string, error)
-	Parse(customImageName, deployImageName string) error
-	UpgradeTest(runtimeVersion, deploymentID, newImageName, customImageName string, dependencyTest, versionTest, dagTest bool, client astro.Client) error
+	Pytest(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString string) (string, error)
+	Parse(customImageName, deployImageName, buildSecretString string) error
+	UpgradeTest(runtimeVersion, deploymentID, newImageName, customImageName, buildSecretString string, dependencyTest, versionTest, dagTest bool, client astro.Client) error
 }
 
 // RegistryHandler defines methods require to handle all operations with registry
@@ -45,7 +45,7 @@ type RegistryHandler interface {
 
 // ImageHandler defines methods require to handle all operations on/for container images
 type ImageHandler interface {
-	Build(dockerfile string, config types.ImageBuildConfig) error
+	Build(dockerfile, buildSecretString string, config types.ImageBuildConfig) error
 	Push(registry, username, token, remoteImage string) error
 	Pull(registry, username, token, remoteImage string) error
 	GetLabel(altImageName, labelName string) (string, error)

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -46,7 +46,7 @@ func TestDockerImageBuild(t *testing.T) {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 			return nil
 		}
-		err = handler.Build("", "", options)
+		err = handler.Build("", "secret", options)
 		assert.NoError(t, err)
 	})
 

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -46,7 +46,7 @@ func TestDockerImageBuild(t *testing.T) {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 			return nil
 		}
-		err = handler.Build("", options)
+		err = handler.Build("", "", options)
 		assert.NoError(t, err)
 	})
 
@@ -57,7 +57,7 @@ func TestDockerImageBuild(t *testing.T) {
 			assert.Contains(t, args, "--no-cache")
 			return nil
 		}
-		err = handler.Build("", options)
+		err = handler.Build("", "", options)
 		assert.NoError(t, err)
 	})
 
@@ -65,7 +65,7 @@ func TestDockerImageBuild(t *testing.T) {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 			return errMock
 		}
-		err = handler.Build("", options)
+		err = handler.Build("", "", options)
 		assert.Contains(t, err.Error(), errMock.Error())
 	})
 	t.Run("unable to read file error", func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestDockerImageBuild(t *testing.T) {
 			Output:          false,
 		}
 
-		err = handler.Build("", options)
+		err = handler.Build("", "", options)
 		assert.Error(t, err)
 	})
 

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1186,7 +1186,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 	t.Run("Create old pip freeze failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze).Return(errMockDocker).Once()

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1215,12 +1215,12 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 	t.Run("build new image for pytest failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Twice()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Times(2)
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze).Return(nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze2).Return(nil).Once()
-		imageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -362,7 +362,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Times(4)
 		imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
 
@@ -379,10 +379,10 @@ func TestDockerComposeStart(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Start("", "", "", noCache, false, waitTime, nil)
+		err := mockDockerCompose.Start("", "", "", "", noCache, false, waitTime, nil)
 		assert.NoError(t, err)
 
-		err = mockDockerCompose.Start("custom-image", "", "", noCache, false, waitTime, nil)
+		err = mockDockerCompose.Start("custom-image", "", "", "", noCache, false, waitTime, nil)
 		assert.NoError(t, err)
 
 		imageHandler.AssertExpectations(t)
@@ -393,7 +393,7 @@ func TestDockerComposeStart(t *testing.T) {
 		defaultTimeOut := 1 * time.Minute
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Times(2)
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -415,7 +415,7 @@ func TestDockerComposeStart(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Start("", "", "", noCache, false, defaultTimeOut, nil)
+		err := mockDockerCompose.Start("", "", "", "", noCache, false, defaultTimeOut, nil)
 		assert.NoError(t, err)
 
 		imageHandler.AssertExpectations(t)
@@ -427,7 +427,7 @@ func TestDockerComposeStart(t *testing.T) {
 		expectedTimeout := 5 * time.Minute
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Times(2)
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -449,7 +449,7 @@ func TestDockerComposeStart(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Start("", "", "", noCache, false, defaultTimeOut, nil)
+		err := mockDockerCompose.Start("", "", "", "", noCache, false, defaultTimeOut, nil)
 		assert.NoError(t, err)
 
 		imageHandler.AssertExpectations(t)
@@ -460,7 +460,7 @@ func TestDockerComposeStart(t *testing.T) {
 		userProvidedTimeOut := 8 * time.Minute
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Times(2)
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -477,7 +477,7 @@ func TestDockerComposeStart(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Start("", "", "", noCache, false, userProvidedTimeOut, nil)
+		err := mockDockerCompose.Start("", "", "", "", noCache, false, userProvidedTimeOut, nil)
 		assert.NoError(t, err)
 
 		imageHandler.AssertExpectations(t)
@@ -487,7 +487,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("success with invalid airflow version label", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: "2.3.4.dev+astro1"}, nil).Times(4)
 		imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
 
@@ -504,10 +504,10 @@ func TestDockerComposeStart(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Start("", "", "", noCache, false, waitTime, nil)
+		err := mockDockerCompose.Start("", "", "", "", noCache, false, waitTime, nil)
 		assert.NoError(t, err)
 
-		err = mockDockerCompose.Start("custom-image", "", "", noCache, false, waitTime, nil)
+		err = mockDockerCompose.Start("custom-image", "", "", "", noCache, false, waitTime, nil)
 		assert.NoError(t, err)
 
 		imageHandler.AssertExpectations(t)
@@ -520,7 +520,7 @@ func TestDockerComposeStart(t *testing.T) {
 
 		mockDockerCompose.composeService = composeMock
 
-		err := mockDockerCompose.Start("", "", "", false, false, waitTime, nil)
+		err := mockDockerCompose.Start("", "", "", "", false, false, waitTime, nil)
 		assert.Contains(t, err.Error(), "cannot start, project already running")
 
 		composeMock.AssertExpectations(t)
@@ -532,7 +532,7 @@ func TestDockerComposeStart(t *testing.T) {
 
 		mockDockerCompose.composeService = composeMock
 
-		err := mockDockerCompose.Start("", "", "", false, false, waitTime, nil)
+		err := mockDockerCompose.Start("", "", "", "", false, false, waitTime, nil)
 		assert.ErrorIs(t, err, errMockDocker)
 
 		composeMock.AssertExpectations(t)
@@ -541,7 +541,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("image build failure", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(errMockDocker).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Once()
@@ -555,7 +555,7 @@ func TestDockerComposeStart(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Start("", "", "", noCache, false, waitTime, nil)
+		err := mockDockerCompose.Start("", "", "", "", noCache, false, waitTime, nil)
 		assert.ErrorIs(t, err, errMockDocker)
 
 		imageHandler.AssertExpectations(t)
@@ -565,7 +565,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("list label failure", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{}, errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -580,7 +580,7 @@ func TestDockerComposeStart(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Start("", "", "", noCache, false, waitTime, nil)
+		err := mockDockerCompose.Start("", "", "", "", noCache, false, waitTime, nil)
 		assert.ErrorIs(t, err, errMockDocker)
 
 		imageHandler.AssertExpectations(t)
@@ -590,7 +590,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("compose up failure", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{}, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -606,7 +606,7 @@ func TestDockerComposeStart(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Start("", "", "", noCache, false, waitTime, nil)
+		err := mockDockerCompose.Start("", "", "", "", noCache, false, waitTime, nil)
 		assert.ErrorIs(t, err, errMockDocker)
 
 		imageHandler.AssertExpectations(t)
@@ -616,7 +616,7 @@ func TestDockerComposeStart(t *testing.T) {
 	t.Run("webserver health check failure", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Twice()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -632,7 +632,7 @@ func TestDockerComposeStart(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Start("", "", "", noCache, false, waitTime, nil)
+		err := mockDockerCompose.Start("", "", "", "", noCache, false, waitTime, nil)
 		assert.ErrorIs(t, err, errMockDocker)
 
 		imageHandler.AssertExpectations(t)
@@ -1019,12 +1019,12 @@ func TestDockerComposePytest(t *testing.T) {
 	mockDockerCompose := DockerCompose{projectName: "test"}
 	t.Run("success", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("0", nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("", "", "", "")
+		resp, err := mockDockerCompose.Pytest("", "", "", "", "")
 
 		assert.NoError(t, err)
 		assert.Equal(t, "", resp)
@@ -1038,7 +1038,7 @@ func TestDockerComposePytest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("", "custom-image-name", "", "")
+		resp, err := mockDockerCompose.Pytest("", "custom-image-name", "", "", "")
 
 		assert.NoError(t, err)
 		assert.Equal(t, "", resp)
@@ -1047,13 +1047,13 @@ func TestDockerComposePytest(t *testing.T) {
 
 	t.Run("unexpected exit code", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("1", nil).Once()
 
 		mockResponse := "1"
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("", "", "", "")
+		resp, err := mockDockerCompose.Pytest("", "", "", "", "")
 		assert.Contains(t, err.Error(), "something went wrong while Pytesting your DAGs")
 		assert.Equal(t, mockResponse, resp)
 		imageHandler.AssertExpectations(t)
@@ -1061,11 +1061,11 @@ func TestDockerComposePytest(t *testing.T) {
 
 	t.Run("image build failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		_, err := mockDockerCompose.Pytest("", "", "", "")
+		_, err := mockDockerCompose.Pytest("", "", "", "", "")
 		assert.ErrorIs(t, err, errMockDocker)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1101,7 +1101,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 	t.Run("success no deployment id", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Times(3)
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Times(3)
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze).Return(nil).Once()
@@ -1110,7 +1110,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 
 		assert.NoError(t, err)
 		imageHandler.AssertExpectations(t)
@@ -1121,7 +1121,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 		mockClient := new(astro_mocks.Client)
 		mockClient.On("ListDeployments", mock.Anything, mock.Anything).Return([]astro.Deployment{{ID: "deployment-id"}}, nil).Once()
 		imageHandler.On("Pull", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Times(2)
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Times(2)
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze).Return(nil).Once()
@@ -1130,7 +1130,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", true, false, false, mockClient)
+		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", "", true, false, false, mockClient)
 
 		assert.NoError(t, err)
 		imageHandler.AssertExpectations(t)
@@ -1138,77 +1138,77 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 	t.Run("image build failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
 
 	t.Run("GetLabel failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", errMockDocker)
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
 
 	t.Run("GetLabel failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", errMockDocker)
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
 
 	t.Run("ConflictTest failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
 
 	t.Run("Create old pip freeze failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
 
 	t.Run("build new image failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze).Return(nil).Once()
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1220,18 +1220,18 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze).Return(nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze2).Return(nil).Once()
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
 
 	t.Run("pytest failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Times(3)
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Times(3)
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze).Return(nil).Once()
@@ -1240,7 +1240,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1252,7 +1252,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", true, false, false, mockClient)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", "", true, false, false, mockClient)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1265,14 +1265,14 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", true, false, false, mockClient)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", "", true, false, false, mockClient)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
 
 	t.Run("build new image failure", func(t *testing.T) {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Twice()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return(nil).Twice()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 		imageHandler.On("ConflictTest", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: false}).Return("", nil).Once()
 		imageHandler.On("CreatePipFreeze", mock.Anything, cwd+"/"+pipFreeze).Return(nil).Once()
@@ -1280,7 +1280,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", true, false, false, nil)
 		assert.Error(t, err)
 		imageHandler.AssertExpectations(t)
 	})
@@ -1289,7 +1289,7 @@ func TestDockerComposedUpgradeTest(t *testing.T) {
 		err := config.ResetCurrentContext()
 		assert.NoError(t, err)
 
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", "", false, false, false, nil)
 		assert.Error(t, err)
 	})
 }
@@ -1307,7 +1307,7 @@ func TestDockerComposeParse(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("", "test")
+		err := mockDockerCompose.Parse("", "test", "")
 		assert.NoError(t, err)
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -1323,7 +1323,7 @@ func TestDockerComposeParse(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("", "test")
+		err := mockDockerCompose.Parse("", "test", "")
 		assert.Contains(t, err.Error(), "See above for errors detected in your DAGs")
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -1339,7 +1339,7 @@ func TestDockerComposeParse(t *testing.T) {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("", "test")
+		err := mockDockerCompose.Parse("", "test", "")
 		assert.Contains(t, err.Error(), "something went wrong while parsing your DAGs")
 		composeMock.AssertExpectations(t)
 		imageHandler.AssertExpectations(t)
@@ -1353,7 +1353,7 @@ func TestDockerComposeParse(t *testing.T) {
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 
-		err := mockDockerCompose.Parse("", "test")
+		err := mockDockerCompose.Parse("", "test", "")
 		assert.NoError(t, err)
 
 		w.Close()
@@ -1365,7 +1365,7 @@ func TestDockerComposeParse(t *testing.T) {
 	t.Run("invalid file name", func(t *testing.T) {
 		DefaultTestPath = "\x0004"
 
-		err := mockDockerCompose.Parse("", "test")
+		err := mockDockerCompose.Parse("", "test", "")
 		assert.Contains(t, err.Error(), "invalid argument")
 	})
 }
@@ -1671,7 +1671,7 @@ func TestDockerComposeRunDAG(t *testing.T) {
 	t.Run("success without container", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -1690,7 +1690,7 @@ func TestDockerComposeRunDAG(t *testing.T) {
 	t.Run("error without container", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -1709,7 +1709,7 @@ func TestDockerComposeRunDAG(t *testing.T) {
 	t.Run("build error without container", func(t *testing.T) {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(errMockDocker).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, Output: true, NoCache: noCache}).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Once()

--- a/airflow/mocks/ContainerHandler.go
+++ b/airflow/mocks/ContainerHandler.go
@@ -121,13 +121,13 @@ func (_m *ContainerHandler) PS() error {
 	return r0
 }
 
-// Parse provides a mock function with given fields: customImageName, deployImageName
-func (_m *ContainerHandler) Parse(customImageName string, deployImageName string) error {
-	ret := _m.Called(customImageName, deployImageName)
+// Parse provides a mock function with given fields: customImageName, deployImageName, buildSecretString
+func (_m *ContainerHandler) Parse(customImageName string, deployImageName string, buildSecretString string) error {
+	ret := _m.Called(customImageName, deployImageName, buildSecretString)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = rf(customImageName, deployImageName)
+	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = rf(customImageName, deployImageName, buildSecretString)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -135,23 +135,23 @@ func (_m *ContainerHandler) Parse(customImageName string, deployImageName string
 	return r0
 }
 
-// Pytest provides a mock function with given fields: pytestFile, customImageName, deployImageName, pytestArgsString
-func (_m *ContainerHandler) Pytest(pytestFile string, customImageName string, deployImageName string, pytestArgsString string) (string, error) {
-	ret := _m.Called(pytestFile, customImageName, deployImageName, pytestArgsString)
+// Pytest provides a mock function with given fields: pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString
+func (_m *ContainerHandler) Pytest(pytestFile string, customImageName string, deployImageName string, pytestArgsString string, buildSecretString string) (string, error) {
+	ret := _m.Called(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string) (string, error)); ok {
-		return rf(pytestFile, customImageName, deployImageName, pytestArgsString)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, string) (string, error)); ok {
+		return rf(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString)
 	}
-	if rf, ok := ret.Get(0).(func(string, string, string, string) string); ok {
-		r0 = rf(pytestFile, customImageName, deployImageName, pytestArgsString)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, string) string); ok {
+		r0 = rf(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string, string, string) error); ok {
-		r1 = rf(pytestFile, customImageName, deployImageName, pytestArgsString)
+	if rf, ok := ret.Get(1).(func(string, string, string, string, string) error); ok {
+		r1 = rf(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -187,13 +187,13 @@ func (_m *ContainerHandler) RunDAG(dagID string, settingsFile string, dagFile st
 	return r0
 }
 
-// Start provides a mock function with given fields: imageName, settingsFile, composeFile, noCache, noBrowser, waitTime, envConns
-func (_m *ContainerHandler) Start(imageName string, settingsFile string, composeFile string, noCache bool, noBrowser bool, waitTime time.Duration, envConns map[string]astrocore.EnvironmentObjectConnection) error {
-	ret := _m.Called(imageName, settingsFile, composeFile, noCache, noBrowser, waitTime, envConns)
+// Start provides a mock function with given fields: imageName, settingsFile, composeFile, buildSecretString, noCache, noBrowser, waitTime, envConns
+func (_m *ContainerHandler) Start(imageName string, settingsFile string, composeFile string, buildSecretString string, noCache bool, noBrowser bool, waitTime time.Duration, envConns map[string]astrocore.EnvironmentObjectConnection) error {
+	ret := _m.Called(imageName, settingsFile, composeFile, buildSecretString, noCache, noBrowser, waitTime, envConns)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, bool, bool, time.Duration, map[string]astrocore.EnvironmentObjectConnection) error); ok {
-		r0 = rf(imageName, settingsFile, composeFile, noCache, noBrowser, waitTime, envConns)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, time.Duration, map[string]astrocore.EnvironmentObjectConnection) error); ok {
+		r0 = rf(imageName, settingsFile, composeFile, buildSecretString, noCache, noBrowser, waitTime, envConns)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -215,13 +215,13 @@ func (_m *ContainerHandler) Stop(waitForExit bool) error {
 	return r0
 }
 
-// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, newImageName, customImageName, dependencyTest, versionTest, dagTest, client
-func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, newImageName string, customImageName string, dependencyTest bool, versionTest bool, dagTest bool, client astro.Client) error {
-	ret := _m.Called(runtimeVersion, deploymentID, newImageName, customImageName, dependencyTest, versionTest, dagTest, client)
+// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, newImageName, customImageName, buildSecretString, dependencyTest, versionTest, dagTest, client
+func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, newImageName string, customImageName string, buildSecretString string, dependencyTest bool, versionTest bool, dagTest bool, client astro.Client) error {
+	ret := _m.Called(runtimeVersion, deploymentID, newImageName, customImageName, buildSecretString, dependencyTest, versionTest, dagTest, client)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, bool, astro.Client) error); ok {
-		r0 = rf(runtimeVersion, deploymentID, newImageName, customImageName, dependencyTest, versionTest, dagTest, client)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, string, bool, bool, bool, astro.Client) error); ok {
+		r0 = rf(runtimeVersion, deploymentID, newImageName, customImageName, buildSecretString, dependencyTest, versionTest, dagTest, client)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/airflow/mocks/ImageHandler.go
+++ b/airflow/mocks/ImageHandler.go
@@ -12,13 +12,13 @@ type ImageHandler struct {
 	mock.Mock
 }
 
-// Build provides a mock function with given fields: dockerfile, config
-func (_m *ImageHandler) Build(dockerfile string, config types.ImageBuildConfig) error {
-	ret := _m.Called(dockerfile, config)
+// Build provides a mock function with given fields: dockerfile, buildSecretString, config
+func (_m *ImageHandler) Build(dockerfile string, buildSecretString string, config types.ImageBuildConfig) error {
+	ret := _m.Called(dockerfile, buildSecretString, config)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, types.ImageBuildConfig) error); ok {
-		r0 = rf(dockerfile, config)
+	if rf, ok := ret.Get(0).(func(string, string, types.ImageBuildConfig) error); ok {
+		r0 = rf(dockerfile, buildSecretString, config)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -449,7 +449,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}
 
@@ -604,7 +604,7 @@ func TestDagsDeployFailed(t *testing.T) {
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(errMock)
-		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errMock)
+		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errMock)
 		return mockContainerHandler, nil
 	}
 
@@ -802,7 +802,7 @@ func TestDeployMonitoringDAGNonHosted(t *testing.T) {
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}
 
@@ -907,7 +907,7 @@ func TestDeployNoMonitoringDAGHosted(t *testing.T) {
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}
 
@@ -1012,7 +1012,7 @@ func TestCheckPyTest(t *testing.T) {
 	mockDeployImage := "test-image"
 
 	mockContainerHandler := new(mocks.ContainerHandler)
-	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "").Return("", errMock).Once()
+	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "", "").Return("", errMock).Once()
 
 	// random error on running airflow pytest
 	err := checkPytest("", mockDeployImage, "", mockContainerHandler)
@@ -1020,7 +1020,7 @@ func TestCheckPyTest(t *testing.T) {
 	mockContainerHandler.AssertExpectations(t)
 
 	// airflow pytest exited with status code 1
-	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "").Return("exit code 1", errMock).Once()
+	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "", "").Return("exit code 1", errMock).Once()
 	err = checkPytest("", mockDeployImage, "", mockContainerHandler)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least 1 pytest in your tests directory failed. Fix the issues listed or rerun the command without the '--pytest' flag to deploy")

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -132,7 +132,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
@@ -278,7 +278,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
@@ -439,7 +439,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 	// Test pytest with dags deploy
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
@@ -596,7 +596,7 @@ func TestDagsDeployFailed(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("4.2.5", nil)
 		return mockImageHandler
 	}
@@ -673,7 +673,7 @@ func TestDeployFailure(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("4.2.5", nil)
 		return mockImageHandler
 	}
@@ -792,7 +792,7 @@ func TestDeployMonitoringDAGNonHosted(t *testing.T) {
 	// Test pytest with dags deploy
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
@@ -897,7 +897,7 @@ func TestDeployNoMonitoringDAGHosted(t *testing.T) {
 	// Test pytest with dags deploy
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
@@ -940,28 +940,28 @@ func TestBuildImageFailure(t *testing.T) {
 
 	// image build failure
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(errMock).Once()
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(errMock).Once()
 		return mockImageHandler
 	}
-	_, err := buildImage("./testfiles/", "4.2.5", "", "", "", false, nil)
+	_, err := buildImage("./testfiles/", "4.2.5", "", "", "", "", false, nil)
 	assert.ErrorIs(t, err, errMock)
 
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("4.2.5", nil)
 		return mockImageHandler
 	}
 
 	// dockerfile parsing error
 	dockerfile = "Dockerfile.invalid"
-	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", false, nil)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse dockerfile")
 
 	// failed to get runtime releases
 	dockerfile = "Dockerfile"
 	mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentOptionsResponse, errMock).Once()
-	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", false, mockCoreClient)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, mockCoreClient)
 	assert.ErrorIs(t, err, errMock)
 	mockCoreClient.AssertExpectations(t)
 	mockImageHandler.AssertExpectations(t)
@@ -1015,13 +1015,13 @@ func TestCheckPyTest(t *testing.T) {
 	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "").Return("", errMock).Once()
 
 	// random error on running airflow pytest
-	err := checkPytest("", mockDeployImage, mockContainerHandler)
+	err := checkPytest("", mockDeployImage, "", mockContainerHandler)
 	assert.ErrorIs(t, err, errMock)
 	mockContainerHandler.AssertExpectations(t)
 
 	// airflow pytest exited with status code 1
 	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "").Return("exit code 1", errMock).Once()
-	err = checkPytest("", mockDeployImage, mockContainerHandler)
+	err = checkPytest("", mockDeployImage, "", mockContainerHandler)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least 1 pytest in your tests directory failed. Fix the issues listed or rerun the command without the '--pytest' flag to deploy")
 	mockContainerHandler.AssertExpectations(t)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -141,7 +141,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(nil)
+		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}
@@ -287,8 +287,8 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(nil)
-		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}
 
@@ -448,7 +448,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(nil)
+		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}
@@ -603,7 +603,7 @@ func TestDagsDeployFailed(t *testing.T) {
 
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(errMock)
+		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(errMock)
 		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errMock)
 		return mockContainerHandler, nil
 	}
@@ -680,7 +680,7 @@ func TestDeployFailure(t *testing.T) {
 
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(errMock)
+		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(errMock)
 		return mockContainerHandler, nil
 	}
 
@@ -801,7 +801,7 @@ func TestDeployMonitoringDAGNonHosted(t *testing.T) {
 
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(nil)
+		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}
@@ -906,7 +906,7 @@ func TestDeployNoMonitoringDAGHosted(t *testing.T) {
 
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-		mockContainerHandler.On("Parse", mock.Anything, mock.Anything).Return(nil)
+		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -191,7 +191,7 @@ func newAirflowUpgradeTestCmd(astroClient astro.Client) *cobra.Command {
 	cmd.Flags().BoolVarP(&dagTest, "dag-test", "d", false, "Only run DAG tests. These tests check whether your DAGs will generate import errors after you upgrade.")
 	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "i", "", "ID of the Deployment you want run dependency tests against.")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "n", "", "Name of the upgraded image. Updates the FROM line in your Dockerfile to pull this image for the upgrade.")
-	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Expose a secret to containers. Equivalent to 'docker build --secret'. Example input id=mysecret,src=secrets.txt")
 	var err error
 	var avoidACFlag bool
 

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -341,6 +341,7 @@ func newAirflowRestartCmd(astroCoreClient astrocore.CoreClient) *cobra.Command {
 			return airflowRestart(cmd, args, astroCoreClient)
 		},
 	}
+	cmd.Flags().DurationVar(&waitTime, "wait", 1*time.Minute, "Duration to wait for webserver to get healthy. The default is 5 minutes on M1 architecture and 1 minute for everything else. Use --wait 2m to wait for 2 minutes.")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "Do not use cache when building container image")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to restart airflow with")

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -550,7 +550,7 @@ func TestAirflowUpgradeTest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, nil).Return(nil).Once()
+			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, nil).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -564,7 +564,7 @@ func TestAirflowUpgradeTest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, nil).Return(errMock).Once()
+			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, nil).Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -900,7 +900,7 @@ func TestAirflowRestart(t *testing.T) {
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 			mockContainerHandler.On("Stop", true).Return(nil).Once()
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", true, true, 0, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(nil).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", true, true, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -900,7 +900,7 @@ func TestAirflowRestart(t *testing.T) {
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 			mockContainerHandler.On("Stop", true).Return(nil).Once()
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", true, true, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(nil).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", true, true, 0, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -935,7 +935,7 @@ func TestAirflowRestart(t *testing.T) {
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 			mockContainerHandler.On("Stop", true).Return(nil).Once()
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", true, true, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection{envObj.ObjectKey: *envObj.Connection}).Return(nil).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", true, true, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection{envObj.ObjectKey: *envObj.Connection}).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -970,7 +970,7 @@ func TestAirflowRestart(t *testing.T) {
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 			mockContainerHandler.On("Stop", true).Return(nil).Once()
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", true, true, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection{envObj.ObjectKey: *envObj.Connection}).Return(nil).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", true, true, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection{envObj.ObjectKey: *envObj.Connection}).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1003,7 +1003,7 @@ func TestAirflowRestart(t *testing.T) {
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 			mockContainerHandler.On("Stop", true).Return(nil).Once()
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", true, true, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(errMock).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", true, true, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1036,7 +1036,7 @@ func TestAirflowPytest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "").Return("0", nil).Once()
+			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", "").Return("0", nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1054,7 +1054,7 @@ func TestAirflowPytest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "").Return("exit code 1", errMock).Once()
+			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", "").Return("exit code 1", errMock).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1072,7 +1072,7 @@ func TestAirflowPytest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "").Return("0", nil).Once()
+			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", "").Return("0", nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1090,7 +1090,7 @@ func TestAirflowPytest(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "").Return("0", errMock).Once()
+			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", "").Return("0", errMock).Once()
 			return mockContainerHandler, nil
 		}
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1136,7 +1136,7 @@ func TestAirflowParse(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Parse", "", "").Return(nil).Once()
+			mockContainerHandler.On("Parse", "", "", "").Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1151,7 +1151,7 @@ func TestAirflowParse(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Parse", "", "").Return(errMock).Once()
+			mockContainerHandler.On("Parse", "", "", "").Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -412,7 +412,7 @@ func TestAirflowStart(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(nil).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -433,7 +433,7 @@ func TestAirflowStart(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(nil).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -469,7 +469,7 @@ func TestAirflowStart(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection{envObj.ObjectKey: *envObj.Connection}).Return(nil).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection{envObj.ObjectKey: *envObj.Connection}).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -505,7 +505,7 @@ func TestAirflowStart(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection{envObj.ObjectKey: *envObj.Connection}).Return(nil).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection{envObj.ObjectKey: *envObj.Connection}).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -521,7 +521,7 @@ func TestAirflowStart(t *testing.T) {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(errMock).Once()
+			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", false, false, 1*time.Minute, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/astronomer/astro-cli/cmd/utils"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/git"
+	"github.com/astronomer/astro-cli/pkg/util"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -39,6 +40,7 @@ Menu will be presented if you do not specify a deployment ID:
 
 	DeployImage      = cloud.Deploy
 	EnsureProjectDir = utils.EnsureProjectDir
+	buildSecrets     = []string{}
 )
 
 const (
@@ -71,6 +73,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&waitForDeploy, "wait", "w", false, "Wait for the Deployment to become healthy before ending the command")
 	cmd.Flags().MarkHidden("dags-path") //nolint:errcheck
 	cmd.Flags().StringVarP(&deployDescription, "description", "", "", "Add a description for more context on this deploy")
+	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
 	return cmd
 }
 
@@ -133,20 +136,23 @@ func deploy(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
+	BuildSecretString := util.GetbuildSecretString(buildSecrets)
+
 	deployInput := cloud.InputDeploy{
-		Path:           config.WorkingPath,
-		RuntimeID:      deploymentID,
-		WsID:           workspaceID,
-		Pytest:         pytestFile,
-		EnvFile:        envFile,
-		ImageName:      imageName,
-		DeploymentName: deploymentName,
-		Prompt:         forcePrompt,
-		Dags:           dags,
-		Image:          image,
-		WaitForStatus:  waitForDeploy,
-		DagsPath:       dagsPath,
-		Description:    deployDescription,
+		Path:              config.WorkingPath,
+		RuntimeID:         deploymentID,
+		WsID:              workspaceID,
+		Pytest:            pytestFile,
+		EnvFile:           envFile,
+		ImageName:         imageName,
+		DeploymentName:    deploymentName,
+		Prompt:            forcePrompt,
+		Dags:              dags,
+		Image:             image,
+		WaitForStatus:     waitForDeploy,
+		DagsPath:          dagsPath,
+		Description:       deployDescription,
+		BuildSecretString: BuildSecretString,
 	}
 
 	return DeployImage(deployInput, astroClient, astroCoreClient)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -119,8 +119,9 @@ func GetbuildSecretString(buildSecret []string) (buildSecretString string) {
 			buildSecretString = buildSecretString + "," + secret
 		}
 	}
-
-	if os.Getenv("BUILD_SECRET_INPUT") != "" && buildSecretString != "" {
+	fmt.Println(os.Getenv("BUILD_SECRET_INPUT"))
+	fmt.Println(buildSecretString)
+	if os.Getenv("BUILD_SECRET_INPUT") != "" && buildSecretString == "" {
 		buildSecretString = os.Getenv("BUILD_SECRET_INPUT")
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -119,8 +119,6 @@ func GetbuildSecretString(buildSecret []string) (buildSecretString string) {
 			buildSecretString = buildSecretString + "," + secret
 		}
 	}
-	fmt.Println(os.Getenv("BUILD_SECRET_INPUT"))
-	fmt.Println(buildSecretString)
 	if os.Getenv("BUILD_SECRET_INPUT") != "" && buildSecretString == "" {
 		buildSecretString = os.Getenv("BUILD_SECRET_INPUT")
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -112,7 +112,6 @@ func ParseAPIToken(astroAPIToken string) (*CustomClaims, error) {
 }
 
 func GetbuildSecretString(buildSecret []string) (buildSecretString string) {
-
 	for i, secret := range buildSecret {
 		if i == 0 {
 			buildSecretString = secret

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -110,3 +110,20 @@ func ParseAPIToken(astroAPIToken string) (*CustomClaims, error) {
 	}
 	return claims, nil
 }
+
+func GetbuildSecretString(buildSecret []string) (buildSecretString string) {
+
+	for i, secret := range buildSecret {
+		if i == 0 {
+			buildSecretString = secret
+		} else {
+			buildSecretString = buildSecretString + "," + secret
+		}
+	}
+
+	if os.Getenv("BUILD_SECRET_INPUT") != "" && buildSecretString != "" {
+		buildSecretString = os.Getenv("BUILD_SECRET_INPUT")
+	}
+
+	return buildSecretString
+}

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -223,7 +223,7 @@ func buildPushDockerImage(houstonClient houston.ClientInterface, c *config.Conte
 		TargetPlatforms: deployImagePlatformSupport,
 		Output:          true,
 	}
-	err = imageHandler.Build("", buildConfig)
+	err = imageHandler.Build("", "", buildConfig)
 	if err != nil {
 		return err
 	}

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -100,7 +100,7 @@ func TestBuildPushDockerImageSuccessWithTagWarning(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		return mockImageHandler
 	}
@@ -131,7 +131,7 @@ func TestBuildPushDockerImageSuccessWithImageRepoWarning(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		return mockImageHandler
 	}
@@ -162,7 +162,7 @@ func TestBuildPushDockerImageSuccessWithBYORegistry(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("GetLabel", "", runtimeImageLabel).Return("", nil).Once()
 		mockImageHandler.On("GetLabel", "", airflowImageLabel).Return("1.10.12", nil).Once()
@@ -209,7 +209,7 @@ func TestBuildPushDockerImageFailure(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(errSomeContainerIssue)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(errSomeContainerIssue)
 		return mockImageHandler
 	}
 
@@ -220,7 +220,7 @@ func TestBuildPushDockerImageFailure(t *testing.T) {
 
 	mockImageHandler = new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errSomeContainerIssue)
 		return mockImageHandler
 	}
@@ -328,7 +328,7 @@ func TestAirflowSuccess(t *testing.T) {
 
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		return mockImageHandler
 	}


### PR DESCRIPTION
## Description

Add build secrets flag to following commands:

- astro dev start --build-secrets
- astro dev restart --build-secrets
- astro deploy --build-secrets
- astro dev upgrade-test --build-secrets 

This flag mimics the docker build --secrets flag. More information: https://docs.docker.com/build/building/secrets/

example use:

astro dev upgrade-test --build-secrets id=mysecret,src=secrets.txt

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/559

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
