### PR TITLE
Add --dag-only flag to the astro deploy CLI command and also validate the dag_deploy config

### DIFF
--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/astronomer/astro-cli/cmd/utils"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/git"
 	"github.com/astronomer/astro-cli/software/deploy"
 
@@ -52,7 +54,9 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&saveDeployConfig, "save", "s", false, "Save deployment in config for future deploys")
 	cmd.Flags().BoolVarP(&ignoreCacheDeploy, "no-cache", "", false, "Do not use cache when building container image")
 	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "workspace assigned to deployment")
-	cmd.Flags().BoolVarP(&isDagOnlyDeploy, "dag-only", "", false, "Deploy only those dags which are present in the /dags folder")
+	if !context.IsCloudContext() && houston.VerifyVersionMatch(houstonVersion, houston.VersionRestrictions{GTE: "0.34.0"}) {
+		cmd.Flags().BoolVarP(&isDagOnlyDeploy, "dag-only", "", false, "Deploy only those dags which are present in the /dags folder")
+	}
 	return cmd
 }
 

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -20,16 +20,17 @@ var (
 
 	EnsureProjectDir   = utils.EnsureProjectDir
 	DeployAirflowImage = deploy.Airflow
+	isDagOnlyDeploy    bool
 )
 
 var deployExample = `
 Deployment you would like to deploy to Airflow cluster:
 
-  $ astro deploy <deployment-id>
+$ astro deploy <deployment-id>
 
 Menu will be presented if you do not specify a deployment name:
 
-  $ astro deploy
+$ astro deploy
 `
 
 const (
@@ -51,6 +52,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&saveDeployConfig, "save", "s", false, "Save deployment in config for future deploys")
 	cmd.Flags().BoolVarP(&ignoreCacheDeploy, "no-cache", "", false, "Do not use cache when building container image")
 	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "workspace assigned to deployment")
+	cmd.Flags().BoolVarP(&isDagOnlyDeploy, "dag-only", "", false, "Deploy only those dags which are present in the /dags folder")
 	return cmd
 }
 
@@ -90,5 +92,8 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		byoRegistryDomain = appConfig.BYORegistryDomain
 	}
 
+	if isDagOnlyDeploy {
+		return deploy.DeployDagsOnly(houstonClient, appConfig, deploymentID)
+	}
 	return DeployAirflowImage(houstonClient, config.WorkingPath, deploymentID, ws, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, forcePrompt)
 }

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -93,7 +93,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 	}
 
 	if isDagOnlyDeploy {
-		return deploy.DeployDagsOnly(houstonClient, appConfig, deploymentID)
+		return deploy.DagsOnlyDeploy(houstonClient, appConfig, deploymentID)
 	}
 	return DeployAirflowImage(houstonClient, config.WorkingPath, deploymentID, ws, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, forcePrompt)
 }

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -91,7 +91,6 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		byoRegistryEnabled = true
 		byoRegistryDomain = appConfig.BYORegistryDomain
 	}
-
 	if isDagOnlyDeploy {
 		return deploy.DagsOnlyDeploy(houstonClient, appConfig, deploymentID)
 	}

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/astronomer/astro-cli/houston"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/astronomer/astro-cli/software/deploy"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -40,4 +41,9 @@ func TestDeploy(t *testing.T) {
 
 	err = execDeployCmd([]string{"test-deployment-id", "--save"}...)
 	assert.NoError(t, err)
+
+	t.Run("Test for the flag --dag-only", func(t *testing.T) {
+		err := execDeployCmd([]string{"test-deployment-id", "--dag-only", "--force"}...)
+		assert.ErrorIs(t, err, deploy.ErrDagOnlyDeployDisabledInConfig)
+	})
 }

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -40,4 +40,7 @@ func TestDeploy(t *testing.T) {
 
 	err = execDeployCmd([]string{"test-deployment-id", "--save"}...)
 	assert.NoError(t, err)
+
+	err = execDeployCmd([]string{"test-deployment-id", "--dag-only"}...)
+	assert.NoError(t, err)
 }

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -40,7 +40,4 @@ func TestDeploy(t *testing.T) {
 
 	err = execDeployCmd([]string{"test-deployment-id", "--save"}...)
 	assert.NoError(t, err)
-
-	err = execDeployCmd([]string{"test-deployment-id", "--dag-only"}...)
-	assert.NoError(t, err)
 }

--- a/houston/constants.go
+++ b/houston/constants.go
@@ -25,4 +25,5 @@ const (
 	GitSyncDeploymentType = "git_sync"
 	VolumeDeploymentType  = "volume"
 	ImageDeploymentType   = "image"
+	DagOnlyDeploymentType = "dag_deploy"
 )

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -35,139 +35,139 @@ var (
 		{
 			version: "0.25.0",
 			query: `
-mutation CreateDeployment(
-$label: String!
-$type: String = "airflow"
-$releaseName: String
-$workspaceId: Uuid!
-$executor: ExecutorType!
-$airflowVersion: String
-$namespace: String
-$config: JSON
-$cloudRole: String
-$dagDeployment: DagDeployment
-) {
-createDeployment(
-label: $label
-type: $type
-workspaceUuid: $workspaceId
-releaseName: $releaseName
-executor: $executor
-airflowVersion: $airflowVersion
-namespace: $namespace
-config: $config
-cloudRole: $cloudRole
-dagDeployment: $dagDeployment
-) {
-id
-type
-label
-releaseName
-version
-airflowVersion
-urls {
-type
-url
-}
-createdAt
-updatedAt
-}
-}`,
+			mutation CreateDeployment(
+				$label: String!
+				$type: String = "airflow"
+				$releaseName: String
+				$workspaceId: Uuid!
+				$executor: ExecutorType!
+				$airflowVersion: String
+				$namespace: String
+				$config: JSON
+				$cloudRole: String
+				$dagDeployment: DagDeployment
+			) {
+				createDeployment(
+					label: $label
+					type: $type
+					workspaceUuid: $workspaceId
+					releaseName: $releaseName
+					executor: $executor
+						airflowVersion: $airflowVersion
+					namespace: $namespace
+					config: $config
+					cloudRole: $cloudRole
+					dagDeployment: $dagDeployment
+				) {
+					id
+					type
+					label
+					releaseName
+					version
+					airflowVersion
+					urls {
+						type
+						url
+					}
+					createdAt
+					updatedAt
+				}
+			}`,
 		},
 		{
 			version: "0.28.0",
 			query: `
-mutation CreateDeployment(
-$label: String!
-$type: String = "airflow"
-$releaseName: String
-$workspaceId: Uuid!
-$executor: ExecutorType!
-$airflowVersion: String
-$namespace: String
-$config: JSON
-$cloudRole: String
-$dagDeployment: DagDeployment
-$triggererReplicas: Int
-) {
-createDeployment(
-label: $label
-type: $type
-workspaceUuid: $workspaceId
-releaseName: $releaseName
-executor: $executor
-airflowVersion: $airflowVersion
-namespace: $namespace
-config: $config
-cloudRole: $cloudRole
-dagDeployment: $dagDeployment
-triggerer: {
-replicas: $triggererReplicas
-}
-) {
-id
-type
-label
-releaseName
-version
-airflowVersion
-urls {
-type
-url
-}
-createdAt
-updatedAt
-}
-}`,
+			mutation CreateDeployment(
+				$label: String!
+				$type: String = "airflow"
+				$releaseName: String
+				$workspaceId: Uuid!
+				$executor: ExecutorType!
+				$airflowVersion: String
+				$namespace: String
+				$config: JSON
+				$cloudRole: String
+				$dagDeployment: DagDeployment
+				$triggererReplicas: Int
+			) {
+				createDeployment(
+					label: $label
+					type: $type
+					workspaceUuid: $workspaceId
+					releaseName: $releaseName
+					executor: $executor
+						airflowVersion: $airflowVersion
+					namespace: $namespace
+					config: $config
+					cloudRole: $cloudRole
+					dagDeployment: $dagDeployment
+					triggerer: {
+						replicas: $triggererReplicas
+					}
+				) {
+					id
+					type
+					label
+					releaseName
+					version
+					airflowVersion
+					urls {
+						type
+						url
+					}
+					createdAt
+					updatedAt
+				}
+			}`,
 		},
 		{
 			version: "0.29.0",
 			query: `
-mutation CreateDeployment(
-$label: String!
-$type: String = "airflow"
-$releaseName: String
-$workspaceId: Uuid!
-$executor: ExecutorType!
-$airflowVersion: String
-$runtimeVersion: String
-$namespace: String
-$config: JSON
-$cloudRole: String
-$dagDeployment: DagDeployment
-$triggererReplicas: Int
-){
-createDeployment(
-label: $label
-type: $type
-workspaceUuid: $workspaceId
-releaseName: $releaseName
-executor: $executor
-airflowVersion: $airflowVersion
-runtimeVersion: $runtimeVersion
-namespace: $namespace
-config: $config
-cloudRole: $cloudRole
-dagDeployment: $dagDeployment
-triggerer: {
-replicas: $triggererReplicas
-}
-){
-id
-type
-label
-releaseName
-version
-airflowVersion
-runtimeVersion
-urls {
-type
-url
-}
-createdAt
-updatedAt
-}
-}`,
+			mutation CreateDeployment(
+				$label: String!
+				$type: String = "airflow"
+				$releaseName: String
+				$workspaceId: Uuid!
+				$executor: ExecutorType!
+				$airflowVersion: String
+				$runtimeVersion: String
+				$namespace: String
+				$config: JSON
+				$cloudRole: String
+				$dagDeployment: DagDeployment
+				$triggererReplicas: Int
+			){
+				createDeployment(
+					label: $label
+					type: $type
+					workspaceUuid: $workspaceId
+					releaseName: $releaseName
+					executor: $executor
+					airflowVersion: $airflowVersion
+					runtimeVersion: $runtimeVersion
+					namespace: $namespace
+					config: $config
+					cloudRole: $cloudRole
+					dagDeployment: $dagDeployment
+					triggerer: {
+						replicas: $triggererReplicas
+					}
+				){
+					id
+					type
+					label
+					releaseName
+					version
+					airflowVersion
+					runtimeVersion
+					urls {
+						type
+						url
+					}
+					createdAt
+					updatedAt
+				}
+			}`,
 		},
 	}
 
@@ -175,61 +175,61 @@ updatedAt
 		{
 			version: "0.25.0",
 			query: `
-query GetDeployment(
-$workspaceId: Uuid!
-$releaseName: String
-) {
-workspaceDeployments(
-workspaceUuid: $workspaceId
-releaseName: $releaseName
-) {
-id
-type
-label
-releaseName
-workspace {
-id
-}
-deployInfo {
-nextCli
-current
-}
-version
-airflowVersion
-createdAt
-updatedAt
-}
-}`,
+			query GetDeployment(
+				$workspaceId: Uuid!
+				$releaseName: String
+			) {
+				workspaceDeployments(
+					workspaceUuid: $workspaceId
+					releaseName: $releaseName
+				) {
+					id
+					type
+					label
+					releaseName
+					workspace {
+						id
+					}
+					deployInfo {
+						nextCli
+						current
+					}
+					version
+					airflowVersion
+					createdAt
+					updatedAt
+				}
+			}`,
 		},
 		{
 			version: "0.29.0",
 			query: `
-query GetDeployment(
-$workspaceId: Uuid!
-$releaseName: String
-){
-workspaceDeployments(
-workspaceUuid: $workspaceId
-releaseName: $releaseName
-){
-id
-type
-label
-releaseName
-workspace {
-id
-}
-deployInfo {
-nextCli
-current
-}
-version
-airflowVersion
-runtimeVersion
-createdAt
-updatedAt
-}
-}`,
+			query GetDeployment(
+				$workspaceId: Uuid!
+				$releaseName: String
+			){
+				workspaceDeployments(
+					workspaceUuid: $workspaceId
+					releaseName: $releaseName
+				){
+					id
+					type
+					label
+					releaseName
+					workspace {
+						id
+					}
+					deployInfo {
+						nextCli
+						current
+					}
+					version
+					airflowVersion
+					runtimeVersion
+					createdAt
+					updatedAt
+				}
+			}`,
 		},
 	}
 
@@ -237,74 +237,74 @@ updatedAt
 		{
 			version: "0.25.0",
 			query: `
-mutation UpdateDeployment(
-$deploymentId: Uuid!,
-$payload: JSON!,
-$cloudRole: String,
-$executor: ExecutorType,
-$dagDeployment: DagDeployment
-){
-updateDeployment(
-deploymentUuid: $deploymentId,
-payload: $payload,
-cloudRole: $cloudRole,
-executor: $executor,
-dagDeployment: $dagDeployment
-){
-id
-type
-label
-description
-releaseName
-version
-airflowVersion
-workspace {
-id
-}
-deployInfo {
-current
-}
-createdAt
-updatedAt
-}
-}`,
+			mutation UpdateDeployment(
+				$deploymentId: Uuid!,
+				$payload: JSON!,
+				$cloudRole: String,
+				$executor: ExecutorType,
+				$dagDeployment: DagDeployment
+			){
+				updateDeployment(
+					deploymentUuid: $deploymentId,
+					payload: $payload,
+					cloudRole: $cloudRole,
+					executor: $executor,
+					dagDeployment: $dagDeployment
+				){
+					id
+					type
+					label
+					description
+					releaseName
+					version
+					airflowVersion
+					workspace {
+						id
+					}
+					deployInfo {
+						current
+					}
+					createdAt
+					updatedAt
+				}
+			}`,
 		},
 		{
 			version: "0.28.0",
 			query: `
-mutation UpdateDeployment(
-$deploymentId: Uuid!,
-$payload: JSON!,
-$executor: ExecutorType,
-$cloudRole: String,
-$dagDeployment: DagDeployment,
-$triggererReplicas: Int
-){
-updateDeployment(
-deploymentUuid: $deploymentId,
-payload: $payload,
-executor: $executor,
-cloudRole: $cloudRole,
-dagDeployment: $dagDeployment,
-triggerer:{ replicas: $triggererReplicas }
-){
-id
-type
-label
-description
-releaseName
-version
-airflowVersion
-workspace {
-id
-}
-deployInfo {
-current
-}
-createdAt
-updatedAt
-}
-}`,
+			mutation UpdateDeployment(
+				$deploymentId: Uuid!,
+				$payload: JSON!,
+				$executor: ExecutorType,
+				$cloudRole: String,
+				$dagDeployment: DagDeployment,
+				$triggererReplicas: Int
+			){
+				updateDeployment(
+					deploymentUuid: $deploymentId,
+					payload: $payload,
+					executor: $executor,
+					cloudRole: $cloudRole,
+					dagDeployment: $dagDeployment,
+					triggerer:{ replicas: $triggererReplicas }
+				){
+					id
+					type
+					label
+					description
+					releaseName
+					version
+					airflowVersion
+					workspace {
+						id
+					}
+					deployInfo {
+						current
+					}
+					createdAt
+					updatedAt
+				}
+			}`,
 		},
 	}
 
@@ -312,159 +312,159 @@ updatedAt
 		{
 			version: "0.25.0",
 			query: `
-query GetDeployment(
-$id: String!
-) {
-deployment(
-where: {id: $id}
-) {
-id
-airflowVersion
-desiredAirflowVersion
-urls {
-type
-url
-}
-}
-}`,
+			query GetDeployment(
+				$id: String!
+			) {
+				deployment(
+					where: {id: $id}
+				) {
+					id
+					airflowVersion
+					desiredAirflowVersion
+					urls {
+						type
+						url
+					}
+				}
+			}`,
 		},
 		{
 			version: "0.29.0",
 			query: `
-query GetDeployment(
-$id: String!
-){
-deployment(
-where: {id: $id}
-){
-id
-airflowVersion
-desiredAirflowVersion
-runtimeVersion
-desiredRuntimeVersion
-runtimeAirflowVersion
-urls {
-type
-url
-}
-dagDeployment {
-type
-}
-}
-}`,
+			query GetDeployment(
+				$id: String!
+			){
+				deployment(
+					where: {id: $id}
+				){
+					id
+					airflowVersion
+					desiredAirflowVersion
+					runtimeVersion
+					desiredRuntimeVersion
+					runtimeAirflowVersion
+					urls {
+						type
+						url
+					}
+					dagDeployment {
+						type
+					}
+				}
+			}`,
 		},
 	}
 
 	DeploymentDeleteRequest = `
-mutation DeleteDeployment(
-$deploymentId: Uuid!
-$deploymentHardDelete: Boolean
-){
-deleteDeployment(
-deploymentUuid: $deploymentId
-deploymentHardDelete: $deploymentHardDelete
-){
-id
-type
-label
-description
-releaseName
-version
-workspace {
-id
-}
-createdAt
-updatedAt
-}
-}`
+	mutation DeleteDeployment(
+		$deploymentId: Uuid!
+		$deploymentHardDelete: Boolean
+	){
+		deleteDeployment(
+			deploymentUuid: $deploymentId
+			deploymentHardDelete: $deploymentHardDelete
+		){
+			id
+			type
+			label
+			description
+			releaseName
+			version
+			workspace {
+				id
+			}
+			createdAt
+			updatedAt
+		}
+	}`
 
 	UpdateDeploymentAirflowRequest = `
-mutation updateDeploymentAirflow($deploymentId: Uuid!, $desiredAirflowVersion: String!) {
-updateDeploymentAirflow(deploymentUuid: $deploymentId, desiredAirflowVersion: $desiredAirflowVersion) {
-id
-label
-version
-releaseName
-airflowVersion
-desiredAirflowVersion
-}
-}`
+	mutation updateDeploymentAirflow($deploymentId: Uuid!, $desiredAirflowVersion: String!) {
+		updateDeploymentAirflow(deploymentUuid: $deploymentId, desiredAirflowVersion: $desiredAirflowVersion) {
+			id
+			label
+			version
+			releaseName
+			airflowVersion
+			desiredAirflowVersion
+		}
+	}`
 
 	DeploymentInfoRequest = `
-query DeploymentInfo {
-deploymentConfig {
-airflowImages {
-version
-tag
-}
-airflowVersions
-defaultAirflowImageTag
-}
-}`
+	query DeploymentInfo {
+		deploymentConfig {
+			airflowImages {
+				version
+				tag
+			}
+			airflowVersions
+			defaultAirflowImageTag
+		}
+	}`
 
 	DeploymentLogsGetRequest = `
-query GetLogs(
-$deploymentId: Uuid!
-$component: String
-$timestamp: DateTime
-$search: String
-){
-logs(
-deploymentUuid: $deploymentId
-component: $component
-timestamp: $timestamp
-search: $search
-){
-id
-createdAt: timestamp
-log: message
-}
-}`
+	query GetLogs(
+		$deploymentId: Uuid!
+		$component: String
+		$timestamp: DateTime
+		$search: String
+	){
+		logs(
+			deploymentUuid: $deploymentId
+			component: $component
+			timestamp: $timestamp
+			search: $search
+		){
+			id
+			createdAt: timestamp
+			log: message
+		}
+	}`
 
 	DeploymentImageUpdateRequest = `
-mutation updateDeploymentImage(
-$releaseName:String!,
-$image:String!,
-$airflowVersion:String,
-$runtimeVersion:String,
-){
-updateDeploymentImage(
-releaseName:$releaseName,
-image:$image,
-airflowVersion:$airflowVersion,
-runtimeVersion:$runtimeVersion
-){
-releaseName
-airflowVersion
-runtimeVersion
-}
-}`
+	mutation updateDeploymentImage(
+		$releaseName:String!,
+		$image:String!,
+		$airflowVersion:String,
+		$runtimeVersion:String,
+	){
+		updateDeploymentImage(
+			releaseName:$releaseName,
+			image:$image,
+			airflowVersion:$airflowVersion,
+			runtimeVersion:$runtimeVersion
+		){
+			releaseName
+			airflowVersion
+			runtimeVersion
+		}
+	}`
 
 	UpdateDeploymentRuntimeRequest = `
-mutation updateDeploymentRuntime($deploymentUuid: Uuid!, $desiredRuntimeVersion: String!) {
-updateDeploymentRuntime(deploymentUuid: $deploymentUuid, desiredRuntimeVersion: $desiredRuntimeVersion) {
-id
-label
-version
-releaseName
-runtimeVersion
-desiredRuntimeVersion
-runtimeAirflowVersion
-}
-}`
+	mutation updateDeploymentRuntime($deploymentUuid: Uuid!, $desiredRuntimeVersion: String!) {
+		updateDeploymentRuntime(deploymentUuid: $deploymentUuid, desiredRuntimeVersion: $desiredRuntimeVersion) {
+		  	id
+			label
+			version
+			releaseName
+		  	runtimeVersion
+		  	desiredRuntimeVersion
+		  	runtimeAirflowVersion
+		}
+	}`
 
 	CancelUpdateDeploymentRuntimeRequest = `
-mutation cancelRuntimeUpdate($deploymentUuid: Uuid!) {
-cancelRuntimeUpdate(deploymentUuid: $deploymentUuid) {
-id
-label
-version
-releaseName
-runtimeVersion
-desiredRuntimeVersion
-runtimeAirflowVersion
-}
-}`
+	mutation cancelRuntimeUpdate($deploymentUuid: Uuid!) {
+		cancelRuntimeUpdate(deploymentUuid: $deploymentUuid) {
+			id
+			label
+			version
+			releaseName
+			runtimeVersion
+			desiredRuntimeVersion
+			runtimeAirflowVersion
+		}
+	}`
 )
 
 // CreateDeployment - create a deployment

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -35,139 +35,139 @@ var (
 		{
 			version: "0.25.0",
 			query: `
-			mutation CreateDeployment(
-				$label: String!
-				$type: String = "airflow"
-				$releaseName: String
-				$workspaceId: Uuid!
-				$executor: ExecutorType!
-				$airflowVersion: String
-				$namespace: String
-				$config: JSON
-				$cloudRole: String
-				$dagDeployment: DagDeployment
-			) {
-				createDeployment(
-					label: $label
-					type: $type
-					workspaceUuid: $workspaceId
-					releaseName: $releaseName
-					executor: $executor
-						airflowVersion: $airflowVersion
-					namespace: $namespace
-					config: $config
-					cloudRole: $cloudRole
-					dagDeployment: $dagDeployment
-				) {
-					id
-					type
-					label
-					releaseName
-					version
-					airflowVersion
-					urls {
-						type
-						url
-					}
-					createdAt
-					updatedAt
-				}
-			}`,
+mutation CreateDeployment(
+$label: String!
+$type: String = "airflow"
+$releaseName: String
+$workspaceId: Uuid!
+$executor: ExecutorType!
+$airflowVersion: String
+$namespace: String
+$config: JSON
+$cloudRole: String
+$dagDeployment: DagDeployment
+) {
+createDeployment(
+label: $label
+type: $type
+workspaceUuid: $workspaceId
+releaseName: $releaseName
+executor: $executor
+airflowVersion: $airflowVersion
+namespace: $namespace
+config: $config
+cloudRole: $cloudRole
+dagDeployment: $dagDeployment
+) {
+id
+type
+label
+releaseName
+version
+airflowVersion
+urls {
+type
+url
+}
+createdAt
+updatedAt
+}
+}`,
 		},
 		{
 			version: "0.28.0",
 			query: `
-			mutation CreateDeployment(
-				$label: String!
-				$type: String = "airflow"
-				$releaseName: String
-				$workspaceId: Uuid!
-				$executor: ExecutorType!
-				$airflowVersion: String
-				$namespace: String
-				$config: JSON
-				$cloudRole: String
-				$dagDeployment: DagDeployment
-				$triggererReplicas: Int
-			) {
-				createDeployment(
-					label: $label
-					type: $type
-					workspaceUuid: $workspaceId
-					releaseName: $releaseName
-					executor: $executor
-						airflowVersion: $airflowVersion
-					namespace: $namespace
-					config: $config
-					cloudRole: $cloudRole
-					dagDeployment: $dagDeployment
-					triggerer: {
-						replicas: $triggererReplicas
-					}
-				) {
-					id
-					type
-					label
-					releaseName
-					version
-					airflowVersion
-					urls {
-						type
-						url
-					}
-					createdAt
-					updatedAt
-				}
-			}`,
+mutation CreateDeployment(
+$label: String!
+$type: String = "airflow"
+$releaseName: String
+$workspaceId: Uuid!
+$executor: ExecutorType!
+$airflowVersion: String
+$namespace: String
+$config: JSON
+$cloudRole: String
+$dagDeployment: DagDeployment
+$triggererReplicas: Int
+) {
+createDeployment(
+label: $label
+type: $type
+workspaceUuid: $workspaceId
+releaseName: $releaseName
+executor: $executor
+airflowVersion: $airflowVersion
+namespace: $namespace
+config: $config
+cloudRole: $cloudRole
+dagDeployment: $dagDeployment
+triggerer: {
+replicas: $triggererReplicas
+}
+) {
+id
+type
+label
+releaseName
+version
+airflowVersion
+urls {
+type
+url
+}
+createdAt
+updatedAt
+}
+}`,
 		},
 		{
 			version: "0.29.0",
 			query: `
-			mutation CreateDeployment(
-				$label: String!
-				$type: String = "airflow"
-				$releaseName: String
-				$workspaceId: Uuid!
-				$executor: ExecutorType!
-				$airflowVersion: String
-				$runtimeVersion: String
-				$namespace: String
-				$config: JSON
-				$cloudRole: String
-				$dagDeployment: DagDeployment
-				$triggererReplicas: Int
-			){
-				createDeployment(
-					label: $label
-					type: $type
-					workspaceUuid: $workspaceId
-					releaseName: $releaseName
-					executor: $executor
-					airflowVersion: $airflowVersion
-					runtimeVersion: $runtimeVersion
-					namespace: $namespace
-					config: $config
-					cloudRole: $cloudRole
-					dagDeployment: $dagDeployment
-					triggerer: {
-						replicas: $triggererReplicas
-					}
-				){
-					id
-					type
-					label
-					releaseName
-					version
-					airflowVersion
-					runtimeVersion
-					urls {
-						type
-						url
-					}
-					createdAt
-					updatedAt
-				}
-			}`,
+mutation CreateDeployment(
+$label: String!
+$type: String = "airflow"
+$releaseName: String
+$workspaceId: Uuid!
+$executor: ExecutorType!
+$airflowVersion: String
+$runtimeVersion: String
+$namespace: String
+$config: JSON
+$cloudRole: String
+$dagDeployment: DagDeployment
+$triggererReplicas: Int
+){
+createDeployment(
+label: $label
+type: $type
+workspaceUuid: $workspaceId
+releaseName: $releaseName
+executor: $executor
+airflowVersion: $airflowVersion
+runtimeVersion: $runtimeVersion
+namespace: $namespace
+config: $config
+cloudRole: $cloudRole
+dagDeployment: $dagDeployment
+triggerer: {
+replicas: $triggererReplicas
+}
+){
+id
+type
+label
+releaseName
+version
+airflowVersion
+runtimeVersion
+urls {
+type
+url
+}
+createdAt
+updatedAt
+}
+}`,
 		},
 	}
 
@@ -175,61 +175,61 @@ var (
 		{
 			version: "0.25.0",
 			query: `
-			query GetDeployment(
-				$workspaceId: Uuid!
-				$releaseName: String
-			) {
-				workspaceDeployments(
-					workspaceUuid: $workspaceId
-					releaseName: $releaseName
-				) {
-					id
-					type
-					label
-					releaseName
-					workspace {
-						id
-					}
-					deployInfo {
-						nextCli
-						current
-					}
-					version
-					airflowVersion
-					createdAt
-					updatedAt
-				}
-			}`,
+query GetDeployment(
+$workspaceId: Uuid!
+$releaseName: String
+) {
+workspaceDeployments(
+workspaceUuid: $workspaceId
+releaseName: $releaseName
+) {
+id
+type
+label
+releaseName
+workspace {
+id
+}
+deployInfo {
+nextCli
+current
+}
+version
+airflowVersion
+createdAt
+updatedAt
+}
+}`,
 		},
 		{
 			version: "0.29.0",
 			query: `
-			query GetDeployment(
-				$workspaceId: Uuid!
-				$releaseName: String
-			){
-				workspaceDeployments(
-					workspaceUuid: $workspaceId
-					releaseName: $releaseName
-				){
-					id
-					type
-					label
-					releaseName
-					workspace {
-						id
-					}
-					deployInfo {
-						nextCli
-						current
-					}
-					version
-					airflowVersion
-					runtimeVersion
-					createdAt
-					updatedAt
-				}
-			}`,
+query GetDeployment(
+$workspaceId: Uuid!
+$releaseName: String
+){
+workspaceDeployments(
+workspaceUuid: $workspaceId
+releaseName: $releaseName
+){
+id
+type
+label
+releaseName
+workspace {
+id
+}
+deployInfo {
+nextCli
+current
+}
+version
+airflowVersion
+runtimeVersion
+createdAt
+updatedAt
+}
+}`,
 		},
 	}
 
@@ -237,74 +237,74 @@ var (
 		{
 			version: "0.25.0",
 			query: `
-			mutation UpdateDeployment(
-				$deploymentId: Uuid!,
-				$payload: JSON!,
-				$cloudRole: String,
-				$executor: ExecutorType,
-				$dagDeployment: DagDeployment
-			){
-				updateDeployment(
-					deploymentUuid: $deploymentId,
-					payload: $payload,
-					cloudRole: $cloudRole,
-					executor: $executor,
-					dagDeployment: $dagDeployment
-				){
-					id
-					type
-					label
-					description
-					releaseName
-					version
-					airflowVersion
-					workspace {
-						id
-					}
-					deployInfo {
-						current
-					}
-					createdAt
-					updatedAt
-				}
-			}`,
+mutation UpdateDeployment(
+$deploymentId: Uuid!,
+$payload: JSON!,
+$cloudRole: String,
+$executor: ExecutorType,
+$dagDeployment: DagDeployment
+){
+updateDeployment(
+deploymentUuid: $deploymentId,
+payload: $payload,
+cloudRole: $cloudRole,
+executor: $executor,
+dagDeployment: $dagDeployment
+){
+id
+type
+label
+description
+releaseName
+version
+airflowVersion
+workspace {
+id
+}
+deployInfo {
+current
+}
+createdAt
+updatedAt
+}
+}`,
 		},
 		{
 			version: "0.28.0",
 			query: `
-			mutation UpdateDeployment(
-				$deploymentId: Uuid!,
-				$payload: JSON!,
-				$executor: ExecutorType,
-				$cloudRole: String,
-				$dagDeployment: DagDeployment,
-				$triggererReplicas: Int
-			){
-				updateDeployment(
-					deploymentUuid: $deploymentId,
-					payload: $payload,
-					executor: $executor,
-					cloudRole: $cloudRole,
-					dagDeployment: $dagDeployment,
-					triggerer:{ replicas: $triggererReplicas }
-				){
-					id
-					type
-					label
-					description
-					releaseName
-					version
-					airflowVersion
-					workspace {
-						id
-					}
-					deployInfo {
-						current
-					}
-					createdAt
-					updatedAt
-				}
-			}`,
+mutation UpdateDeployment(
+$deploymentId: Uuid!,
+$payload: JSON!,
+$executor: ExecutorType,
+$cloudRole: String,
+$dagDeployment: DagDeployment,
+$triggererReplicas: Int
+){
+updateDeployment(
+deploymentUuid: $deploymentId,
+payload: $payload,
+executor: $executor,
+cloudRole: $cloudRole,
+dagDeployment: $dagDeployment,
+triggerer:{ replicas: $triggererReplicas }
+){
+id
+type
+label
+description
+releaseName
+version
+airflowVersion
+workspace {
+id
+}
+deployInfo {
+current
+}
+createdAt
+updatedAt
+}
+}`,
 		},
 	}
 
@@ -312,156 +312,159 @@ var (
 		{
 			version: "0.25.0",
 			query: `
-			query GetDeployment(
-				$id: String!
-			) {
-				deployment(
-					where: {id: $id}
-				) {
-					id
-					airflowVersion
-					desiredAirflowVersion
-					urls {
-						type
-						url
-					}
-				}
-			}`,
+query GetDeployment(
+$id: String!
+) {
+deployment(
+where: {id: $id}
+) {
+id
+airflowVersion
+desiredAirflowVersion
+urls {
+type
+url
+}
+}
+}`,
 		},
 		{
 			version: "0.29.0",
 			query: `
-			query GetDeployment(
-				$id: String!
-			){
-				deployment(
-					where: {id: $id}
-				){
-					id
-					airflowVersion
-					desiredAirflowVersion
-					runtimeVersion
-					desiredRuntimeVersion
-					runtimeAirflowVersion
-					urls {
-						type
-						url
-					}
-				}
-			}`,
+query GetDeployment(
+$id: String!
+){
+deployment(
+where: {id: $id}
+){
+id
+airflowVersion
+desiredAirflowVersion
+runtimeVersion
+desiredRuntimeVersion
+runtimeAirflowVersion
+urls {
+type
+url
+}
+dagDeployment {
+type
+}
+}
+}`,
 		},
 	}
 
 	DeploymentDeleteRequest = `
-	mutation DeleteDeployment(
-		$deploymentId: Uuid!
-		$deploymentHardDelete: Boolean
-	){
-		deleteDeployment(
-			deploymentUuid: $deploymentId
-			deploymentHardDelete: $deploymentHardDelete
-		){
-			id
-			type
-			label
-			description
-			releaseName
-			version
-			workspace {
-				id
-			}
-			createdAt
-			updatedAt
-		}
-	}`
+mutation DeleteDeployment(
+$deploymentId: Uuid!
+$deploymentHardDelete: Boolean
+){
+deleteDeployment(
+deploymentUuid: $deploymentId
+deploymentHardDelete: $deploymentHardDelete
+){
+id
+type
+label
+description
+releaseName
+version
+workspace {
+id
+}
+createdAt
+updatedAt
+}
+}`
 
 	UpdateDeploymentAirflowRequest = `
-	mutation updateDeploymentAirflow($deploymentId: Uuid!, $desiredAirflowVersion: String!) {
-		updateDeploymentAirflow(deploymentUuid: $deploymentId, desiredAirflowVersion: $desiredAirflowVersion) {
-			id
-			label
-			version
-			releaseName
-			airflowVersion
-			desiredAirflowVersion
-		}
-	}`
+mutation updateDeploymentAirflow($deploymentId: Uuid!, $desiredAirflowVersion: String!) {
+updateDeploymentAirflow(deploymentUuid: $deploymentId, desiredAirflowVersion: $desiredAirflowVersion) {
+id
+label
+version
+releaseName
+airflowVersion
+desiredAirflowVersion
+}
+}`
 
 	DeploymentInfoRequest = `
-	query DeploymentInfo {
-		deploymentConfig {
-			airflowImages {
-				version
-				tag
-			}
-			airflowVersions
-			defaultAirflowImageTag
-		}
-	}`
+query DeploymentInfo {
+deploymentConfig {
+airflowImages {
+version
+tag
+}
+airflowVersions
+defaultAirflowImageTag
+}
+}`
 
 	DeploymentLogsGetRequest = `
-	query GetLogs(
-		$deploymentId: Uuid!
-		$component: String
-		$timestamp: DateTime
-		$search: String
-	){
-		logs(
-			deploymentUuid: $deploymentId
-			component: $component
-			timestamp: $timestamp
-			search: $search
-		){
-			id
-			createdAt: timestamp
-			log: message
-		}
-	}`
+query GetLogs(
+$deploymentId: Uuid!
+$component: String
+$timestamp: DateTime
+$search: String
+){
+logs(
+deploymentUuid: $deploymentId
+component: $component
+timestamp: $timestamp
+search: $search
+){
+id
+createdAt: timestamp
+log: message
+}
+}`
 
 	DeploymentImageUpdateRequest = `
-	mutation updateDeploymentImage(
-		$releaseName:String!,
-		$image:String!,
-		$airflowVersion:String,
-		$runtimeVersion:String,
-	){
-		updateDeploymentImage(
-			releaseName:$releaseName,
-			image:$image,
-			airflowVersion:$airflowVersion,
-			runtimeVersion:$runtimeVersion
-		){
-			releaseName
-			airflowVersion
-			runtimeVersion
-		}
-	}`
+mutation updateDeploymentImage(
+$releaseName:String!,
+$image:String!,
+$airflowVersion:String,
+$runtimeVersion:String,
+){
+updateDeploymentImage(
+releaseName:$releaseName,
+image:$image,
+airflowVersion:$airflowVersion,
+runtimeVersion:$runtimeVersion
+){
+releaseName
+airflowVersion
+runtimeVersion
+}
+}`
 
 	UpdateDeploymentRuntimeRequest = `
-	mutation updateDeploymentRuntime($deploymentUuid: Uuid!, $desiredRuntimeVersion: String!) {
-		updateDeploymentRuntime(deploymentUuid: $deploymentUuid, desiredRuntimeVersion: $desiredRuntimeVersion) {
-		  	id
-			label
-			version
-			releaseName
-		  	runtimeVersion
-		  	desiredRuntimeVersion
-		  	runtimeAirflowVersion
-		}
-	}`
+mutation updateDeploymentRuntime($deploymentUuid: Uuid!, $desiredRuntimeVersion: String!) {
+updateDeploymentRuntime(deploymentUuid: $deploymentUuid, desiredRuntimeVersion: $desiredRuntimeVersion) {
+id
+label
+version
+releaseName
+runtimeVersion
+desiredRuntimeVersion
+runtimeAirflowVersion
+}
+}`
 
 	CancelUpdateDeploymentRuntimeRequest = `
-	mutation cancelRuntimeUpdate($deploymentUuid: Uuid!) {
-		cancelRuntimeUpdate(deploymentUuid: $deploymentUuid) {
-			id
-			label
-			version
-			releaseName
-			runtimeVersion
-			desiredRuntimeVersion
-			runtimeAirflowVersion
-		}
-	}`
+mutation cancelRuntimeUpdate($deploymentUuid: Uuid!) {
+cancelRuntimeUpdate(deploymentUuid: $deploymentUuid) {
+id
+label
+version
+releaseName
+runtimeVersion
+desiredRuntimeVersion
+runtimeAirflowVersion
+}
+}`
 )
 
 // CreateDeployment - create a deployment

--- a/houston/types.go
+++ b/houston/types.go
@@ -102,21 +102,26 @@ type Decoded struct {
 
 // Deployment defines structure of a houston response Deployment object
 type Deployment struct {
-	ID                    string          `json:"id"`
-	Type                  string          `json:"type"`
-	Label                 string          `json:"label"`
-	ReleaseName           string          `json:"releaseName"`
-	Version               string          `json:"version"`
-	AirflowVersion        string          `json:"airflowVersion"`
-	DesiredAirflowVersion string          `json:"desiredAirflowVersion"`
-	RuntimeVersion        string          `json:"runtimeVersion"`
-	RuntimeAirflowVersion string          `json:"runtimeAirflowVersion"`
-	DesiredRuntimeVersion string          `json:"desiredRuntimeVersion"`
-	DeploymentInfo        DeploymentInfo  `json:"deployInfo"`
-	Workspace             Workspace       `json:"workspace"`
-	Urls                  []DeploymentURL `json:"urls"`
-	CreatedAt             time.Time       `json:"createdAt"`
-	UpdatedAt             time.Time       `json:"updatedAt"`
+	ID                    string              `json:"id"`
+	Type                  string              `json:"type"`
+	Label                 string              `json:"label"`
+	ReleaseName           string              `json:"releaseName"`
+	Version               string              `json:"version"`
+	AirflowVersion        string              `json:"airflowVersion"`
+	DesiredAirflowVersion string              `json:"desiredAirflowVersion"`
+	RuntimeVersion        string              `json:"runtimeVersion"`
+	RuntimeAirflowVersion string              `json:"runtimeAirflowVersion"`
+	DesiredRuntimeVersion string              `json:"desiredRuntimeVersion"`
+	DeploymentInfo        DeploymentInfo      `json:"deployInfo"`
+	Workspace             Workspace           `json:"workspace"`
+	Urls                  []DeploymentURL     `json:"urls"`
+	CreatedAt             time.Time           `json:"createdAt"`
+	UpdatedAt             time.Time           `json:"updatedAt"`
+	DagDeployment         DagDeploymentConfig `json:"dagDeployment"`
+}
+
+type DagDeploymentConfig struct {
+	Type string `json:"type"`
 }
 
 // DeploymentURL defines structure of a houston response DeploymentURL object
@@ -364,6 +369,7 @@ type FeatureFlags struct {
 	NamespaceFreeFormEntry bool `json:"namespaceFreeFormEntry"`
 	BYORegistryEnabled     bool `json:"byoUpdateRegistryEnabled"`
 	AstroRuntimeEnabled    bool `json:"astroRuntimeEnabled"`
+	DagOnlyDeployment      bool `json:"dagOnlyDeployment"`
 }
 
 // coerce a string into SemVer if possible

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -291,6 +291,7 @@ func getAirflowUILink(deploymentID string, deploymentURLs []houston.DeploymentUR
 	}
 	return ""
 }
+
 func isDagOnlyDeploymentEnabled(appConfig *houston.AppConfig) bool {
 	return appConfig != nil && appConfig.Flags.DagOnlyDeployment
 }
@@ -300,7 +301,6 @@ func isDagOnlyDeploymentEnabledForDeployment(deploymentInfo *houston.Deployment)
 }
 
 func DeployDagsOnly(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, deploymentID string) error {
-
 	// Throw error if the feature is disabled at Houston level
 	if !isDagOnlyDeploymentEnabled(appConfig) {
 		return errDagOnlyDeployDisabledInConfig

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -33,7 +33,7 @@ var (
 	errInvalidDeploymentID                  = errors.New("please specify a valid deployment ID")
 	errDeploymentNotFound                   = errors.New("no airflow deployments found")
 	errInvalidDeploymentSelected            = errors.New("invalid deployment selection\n") //nolint
-	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, use software version >= 0.34.0 and set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in the Astronomer Platform")
+	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in the Astronomer Platform")
 	errDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the deployment type to 'dag_only' via the UI or the API")
 )
 

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -33,7 +33,7 @@ var (
 	errInvalidDeploymentID                  = errors.New("please specify a valid deployment ID")
 	errDeploymentNotFound                   = errors.New("no airflow deployments found")
 	errInvalidDeploymentSelected            = errors.New("invalid deployment selection\n") //nolint
-	errDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in the Astronomer Platform")
+	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in the Astronomer Platform")
 	errDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the deployment type to 'dag_only' via the UI or the API")
 )
 
@@ -303,7 +303,7 @@ func isDagOnlyDeploymentEnabledForDeployment(deploymentInfo *houston.Deployment)
 func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, deploymentID string) error {
 	// Throw error if the feature is disabled at Houston level
 	if !isDagOnlyDeploymentEnabled(appConfig) {
-		return errDagOnlyDeployDisabledInConfig
+		return ErrDagOnlyDeployDisabledInConfig
 	}
 
 	// Throw error if the feature is disabled at Deployment level

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -299,7 +299,7 @@ func isDagOnlyDeploymentEnabledForDeployment(deploymentInfo *houston.Deployment)
 	return deploymentInfo != nil && deploymentInfo.DagDeployment.Type == houston.DagOnlyDeploymentType
 }
 
-func DeployDagsOnly(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, deploymentId string) error {
+func DeployDagsOnly(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, deploymentID string) error {
 
 	// Throw error if the feature is disabled at Houston level
 	if !isDagOnlyDeploymentEnabled(appConfig) {
@@ -307,7 +307,7 @@ func DeployDagsOnly(houstonClient houston.ClientInterface, appConfig *houston.Ap
 	}
 
 	// Throw error if the feature is disabled at Deployment level
-	deploymentInfo, err := houston.Call(houstonClient.GetDeployment)(deploymentId)
+	deploymentInfo, err := houston.Call(houstonClient.GetDeployment)(deploymentID)
 	if err != nil {
 		return fmt.Errorf("failed to get deployment info: %w", err)
 	}

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -33,7 +33,7 @@ var (
 	errInvalidDeploymentID                  = errors.New("please specify a valid deployment ID")
 	errDeploymentNotFound                   = errors.New("no airflow deployments found")
 	errInvalidDeploymentSelected            = errors.New("invalid deployment selection\n") //nolint
-	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in the Astronomer Platform")
+	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, use software version >= 0.34.0 and set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in the Astronomer Platform")
 	errDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the deployment type to 'dag_only' via the UI or the API")
 )
 

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -300,7 +300,7 @@ func isDagOnlyDeploymentEnabledForDeployment(deploymentInfo *houston.Deployment)
 	return deploymentInfo != nil && deploymentInfo.DagDeployment.Type == houston.DagOnlyDeploymentType
 }
 
-func DeployDagsOnly(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, deploymentID string) error {
+func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, deploymentID string) error {
 	// Throw error if the feature is disabled at Houston level
 	if !isDagOnlyDeploymentEnabled(appConfig) {
 		return errDagOnlyDeployDisabledInConfig

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -367,7 +367,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		houstonMock.On("GetAppConfig", nil).Return(appConfig, nil)
 
 		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID)
-		assert.ErrorIs(t, err, errDagOnlyDeployDisabledInConfig)
+		assert.ErrorIs(t, err, ErrDagOnlyDeployDisabledInConfig)
 	})
 
 	t.Run("When config flag is set to true but an error occurs in the GetDeployment api call", func(t *testing.T) {

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -404,4 +404,24 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID)
 		assert.ErrorIs(t, err, errDagOnlyDeployNotEnabledForDeployment)
 	})
+
+	t.Run("When it runs successfully as the feature is enabled at all levels", func(t *testing.T) {
+		featureFlags := &houston.FeatureFlags{
+			DagOnlyDeployment: true,
+		}
+		appConfig := &houston.AppConfig{
+			Flags: *featureFlags,
+		}
+		houstonMock := new(houston_mocks.ClientInterface)
+		houstonMock.On("GetAppConfig", nil).Return(appConfig, nil)
+		dagDeployment := &houston.DagDeploymentConfig{
+			Type: houston.DagOnlyDeploymentType,
+		}
+		deployment := &houston.Deployment{
+			DagDeployment: *dagDeployment,
+		}
+		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
+		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID)
+		assert.ErrorIs(t, err, nil)
+	})
 }

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -422,6 +422,6 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		}
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
 		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID)
-		assert.ErrorIs(t, err, nil)
+		assert.NoError(t, err)
 	})
 }

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -404,5 +404,4 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		err := DeployDagsOnly(houstonMock, appConfig, deploymentID)
 		assert.ErrorIs(t, err, errDagOnlyDeployNotEnabledForDeployment)
 	})
-
 }

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -401,7 +401,6 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 			DagDeployment: *dagDeployment,
 		}
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
-
 		err := DeployDagsOnly(houstonMock, appConfig, deploymentID)
 		assert.ErrorIs(t, err, errDagOnlyDeployNotEnabledForDeployment)
 	})

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -366,7 +366,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		houstonMock := new(houston_mocks.ClientInterface)
 		houstonMock.On("GetAppConfig", nil).Return(appConfig, nil)
 
-		err := DeployDagsOnly(houstonMock, appConfig, deploymentID)
+		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID)
 		assert.ErrorIs(t, err, errDagOnlyDeployDisabledInConfig)
 	})
 
@@ -381,7 +381,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		houstonMock.On("GetAppConfig", nil).Return(appConfig, nil)
 		houstonMock.On("GetDeployment", mock.Anything).Return(nil, errMockHouston).Once()
 
-		err := DeployDagsOnly(houstonMock, appConfig, deploymentID)
+		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID)
 		assert.ErrorContains(t, err, "failed to get deployment info: some houston error")
 	})
 
@@ -401,7 +401,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 			DagDeployment: *dagDeployment,
 		}
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
-		err := DeployDagsOnly(houstonMock, appConfig, deploymentID)
+		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID)
 		assert.ErrorIs(t, err, errDagOnlyDeployNotEnabledForDeployment)
 	})
 }

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -354,7 +354,7 @@ func TestAirflowSuccess(t *testing.T) {
 
 func TestDeployDagsOnlyFailure(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-	deploymentId := "test-deployment-id"
+	deploymentID := "test-deployment-id"
 
 	t.Run("When config flag is set to false", func(t *testing.T) {
 		featureFlags := &houston.FeatureFlags{
@@ -366,7 +366,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		houstonMock := new(houston_mocks.ClientInterface)
 		houstonMock.On("GetAppConfig", nil).Return(appConfig, nil)
 
-		err := DeployDagsOnly(houstonMock, appConfig, deploymentId)
+		err := DeployDagsOnly(houstonMock, appConfig, deploymentID)
 		assert.ErrorIs(t, err, errDagOnlyDeployDisabledInConfig)
 	})
 
@@ -379,10 +379,10 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		}
 		houstonMock := new(houston_mocks.ClientInterface)
 		houstonMock.On("GetAppConfig", nil).Return(appConfig, nil)
-		houstonMock.On("GetDeployment", mock.Anything).Return(nil, errors.New("test_error")).Once()
+		houstonMock.On("GetDeployment", mock.Anything).Return(nil, errMockHouston).Once()
 
-		err := DeployDagsOnly(houstonMock, appConfig, deploymentId)
-		assert.ErrorContains(t, err, "failed to get deployment info: test_error")
+		err := DeployDagsOnly(houstonMock, appConfig, deploymentID)
+		assert.ErrorContains(t, err, "failed to get deployment info: some houston error")
 	})
 
 	t.Run("When config flag is set to true but it is disabled at the deployment level", func(t *testing.T) {
@@ -402,7 +402,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		}
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
 
-		err := DeployDagsOnly(houstonMock, appConfig, deploymentId)
+		err := DeployDagsOnly(houstonMock, appConfig, deploymentID)
 		assert.ErrorIs(t, err, errDagOnlyDeployNotEnabledForDeployment)
 	})
 


### PR DESCRIPTION
## Description

Add --dag-only flag to the astro deploy CLI command and also validate the dag_deploy config.
Will write the code to upload dags in the next PR

## 🎟 Issue(s)

Related #6055

## 🧪 Functional Testing

Tested it locally.
Added unit tests.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
