### PR TITLE
Remove unsupported inline comment from .gitignore

### DIFF
--- a/airflow/include/gitignore
+++ b/airflow/include/gitignore
@@ -1,6 +1,6 @@
 .git
 .env
-.DS_Store # macOS specific ignore
+.DS_Store
 airflow_settings.yaml
 __pycache__/
 astro


### PR DESCRIPTION
## Description

.gitignore files do not support inline comments, these will be interpreted as a pattern. Therefore, the `.DS_Store` file wasn't ignored in Astro projects. This PR removes the comment which ignores `.DS_Store` files.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
