### PR TITLE
fix executor update

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -65,9 +65,10 @@ const (
 )
 
 var (
-	sleepTime  = 180
-	tickNum    = 10
-	timeoutNum = 180
+	sleepTime                  = 180
+	tickNum                    = 10
+	timeoutNum                 = 180
+	dedicatedDeploymentRequest = astroplatformcore.UpdateDedicatedDeploymentRequest{}
 )
 
 func newTableOut() *printutil.Table {
@@ -934,7 +935,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 			case KubeExecutor:
 				requestedExecutor = astroplatformcore.UpdateDedicatedDeploymentRequestExecutorKUBERNETES
 			}
-			dedicatedDeploymentRequest := astroplatformcore.UpdateDedicatedDeploymentRequest{
+			dedicatedDeploymentRequest = astroplatformcore.UpdateDedicatedDeploymentRequest{
 				Description:          &description,
 				Name:                 name,
 				Executor:             requestedExecutor,
@@ -976,6 +977,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 					dedicatedDeploymentRequest.WorkerQueues = nil
 				}
 			}
+			fmt.Println(dedicatedDeploymentRequest.WorkerQueues)
 			err := updateDeploymentRequest.FromUpdateDedicatedDeploymentRequest(dedicatedDeploymentRequest)
 			if err != nil {
 				return err

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -977,7 +977,6 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 					dedicatedDeploymentRequest.WorkerQueues = nil
 				}
 			}
-			fmt.Println(dedicatedDeploymentRequest.WorkerQueues)
 			err := updateDeploymentRequest.FromUpdateDedicatedDeploymentRequest(dedicatedDeploymentRequest)
 			if err != nil {
 				return err

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -973,6 +973,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 			case astroplatformcore.UpdateDedicatedDeploymentRequestExecutorKUBERNETES:
 				if *currentDeployment.Executor == astroplatformcore.DeploymentExecutorCELERY {
 					confirmWithUser = true
+					dedicatedDeploymentRequest.WorkerQueues = nil
 				}
 			}
 			err := updateDeploymentRequest.FromUpdateDedicatedDeploymentRequest(dedicatedDeploymentRequest)

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1530,6 +1530,7 @@ func TestUpdate(t *testing.T) { //nolint
 		err = Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "disable", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 
 		assert.NoError(t, err)
+		assert.Equal(t, (*[]astroplatformcore.WorkerQueueRequest)(nil), dedicatedDeploymentRequest.WorkerQueues)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})


### PR DESCRIPTION
## Description

When updating from Clery to Kuberenetes executor you get the following error: 
```
Error: Invalid field values: field workerQueues failed check on excluded_if; workerQueues is excluded if Executor is 'KUBERNETES';
```

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
