### PR TITLE
fix env var output

### DIFF
--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -138,7 +138,11 @@ func VariableModify(deploymentID, variableKey, variableValue, ws, envFile, deplo
 	var index int
 	for i := range environmentVariablesObjects {
 		index = i + 1
-		varTab.AddRow([]string{strconv.Itoa(index), environmentVariablesObjects[i].Key, *environmentVariablesObjects[i].Value, strconv.FormatBool(environmentVariablesObjects[i].IsSecret)}, false)
+		printValue := notApplicable
+		if environmentVariablesObjects[i].Value != nil {
+			printValue = *environmentVariablesObjects[i].Value
+		}
+		varTab.AddRow([]string{strconv.Itoa(index), environmentVariablesObjects[i].Key, printValue, strconv.FormatBool(environmentVariablesObjects[i].IsSecret)}, false)
 	}
 
 	if index == 0 {


### PR DESCRIPTION
## Description

fix problem causing `astro deployment variable update/create --secret` to end in a segmentation error. The value coming from the API was null so the print statement at the end of the command was getting a panic error. This PR makes it so the value prints as N/A when it is null. The variable value is null because it is secret

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
