### PR TITLE
pytest args mixed up with build secret args

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -827,7 +827,7 @@ func airflowPytest(cmd *cobra.Command, args []string) error {
 
 	buildSecretString = util.GetbuildSecretString(buildSecrets)
 
-	exitCode, err := containerHandler.Pytest(pytestFile, customImageName, "", buildSecretString, pytestArgs)
+	exitCode, err := containerHandler.Pytest(pytestFile, customImageName, "", pytestArgs, buildSecretString)
 	if err != nil {
 		if strings.Contains(exitCode, "1") { // exit code is 1 meaning tests failed
 			return errors.New("pytests failed")

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -104,7 +104,7 @@ astro dev init --airflow-version 2.2.3
 	pytestDir = "/tests"
 
 	airflowUpgradeCheckCmd = []string{"bash", "-c", "pip install --no-deps 'apache-airflow-upgrade-check'; python -c 'from packaging.version import Version\nfrom airflow import __version__\nif Version(__version__) < Version(\"1.10.14\"):\n  print(\"Please upgrade your image to Airflow 1.10.14 first, then try again.\");exit(1)\nelse:\n  from airflow.upgrade.checker import __main__;__main__()'"}
-	errPytestArgs          = errors.New("")
+	errPytestArgs          = errors.New("you can ony pass one pytest file or directory")
 	buildSecrets           = []string{}
 )
 

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -104,7 +104,7 @@ astro dev init --airflow-version 2.2.3
 	pytestDir = "/tests"
 
 	airflowUpgradeCheckCmd = []string{"bash", "-c", "pip install --no-deps 'apache-airflow-upgrade-check'; python -c 'from packaging.version import Version\nfrom airflow import __version__\nif Version(__version__) < Version(\"1.10.14\"):\n  print(\"Please upgrade your image to Airflow 1.10.14 first, then try again.\");exit(1)\nelse:\n  from airflow.upgrade.checker import __main__;__main__()'"}
-	errPytestArgs          = errors.New("you can ony pass one pytest file or directory")
+	errPytestArgs          = errors.New("you can only pass one pytest file or directory")
 	buildSecrets           = []string{}
 )
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1130,6 +1130,14 @@ func TestAirflowPytest(t *testing.T) {
 		err := airflowPytest(cmd, args)
 		assert.ErrorIs(t, err, errMock)
 	})
+
+	t.Run("too many args failure failure", func(t *testing.T) {
+		cmd := newAirflowParseCmd()
+		args := []string{"arg1", "arg2"}
+
+		err := airflowPytest(cmd, args)
+		assert.ErrorIs(t, err, errPytestArgs)
+	})
 }
 
 func TestAirflowParse(t *testing.T) {

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1031,12 +1031,15 @@ func TestAirflowPytest(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 		cmd := newAirflowPytestCmd()
+		cmd.Flag("args").Value.Set("args-string")
+		cmd.Flag("build-secrets").Value.Set("id=mysecret,src=secrets.txt")
+		cmd.Flag("image-name").Value.Set("custom-image")
 		args := []string{"test-pytest-file"}
 		pytestDir = ""
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", "").Return("0", nil).Once()
+			mockContainerHandler.On("Pytest", "test-pytest-file", "custom-image", "", "args-string", "id=mysecret,src=secrets.txt").Return("0", nil).Once()
 			return mockContainerHandler, nil
 		}
 


### PR DESCRIPTION
## Description

the command `astro dev pytest --args "-c pyproject.toml"` fails with:

```
Running Pytest
This may take a minute if you have not run this command before…
[build -t sirius_4026ab/airflow:latest -f Dockerfile . --secret -c pyproject.toml]
ERROR: invalid field '-c pyproject.toml' must be a key=value pair
Error: command 'docker build -t sirius_4026ab/airflow:latest failed: failed to execute cmd: exit status 1
```

These are both strings passed to a command exec and could be what ever the user wants them to be

This PR fixes the failure

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1515

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
