### PR TITLE
astro deploy should upload the current directory dags to the dag server

### DIFF
--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -98,5 +98,10 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 	if isDagOnlyDeploy {
 		return deploy.DagsOnlyDeploy(houstonClient, appConfig, deploymentID, config.WorkingPath, nil, true)
 	}
-	return DeployAirflowImage(houstonClient, config.WorkingPath, deploymentID, ws, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, forcePrompt)
+	// Since we prompt the user to enter the deploymentID in come cases for DeployAirflowImage, reusing the same  deploymentID for DagsOnlyDeploy
+	deploymentID, err = DeployAirflowImage(houstonClient, config.WorkingPath, deploymentID, ws, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, forcePrompt)
+	if err != nil {
+		return err
+	}
+	return deploy.DagsOnlyDeploy(houstonClient, appConfig, deploymentID, config.WorkingPath, nil, true)
 }

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -319,10 +319,7 @@ func UploadFile(args *UploadFileArguments) error {
 			break
 		}
 
-		strippedOutData, err := util.StripOutKeysFromJSONByteArray(data, []string{"exceptions", "args", "path", "status"})
-		if err != nil {
-			return fmt.Errorf("error in parsing the response body: %w", err)
-		}
+		strippedOutData, _ := util.StripOutKeysFromJSONByteArray(data, []string{"exceptions", "args", "path", "status"})
 		currentUploadError = fmt.Errorf("file upload failed. Status code: %d and Message: %s", responseStatusCode, string(strippedOutData)) //nolint
 
 		// don't retry for 4xx since it is a client side error

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -292,7 +292,6 @@ func UploadFile(args UploadFileArguments) error {
 		headers := args.Headers
 		headers["Content-Type"] = writer.FormDataContentType()
 		req, err := newRequestWithContext(http_context.Background(), "POST", args.TargetURL, body)
-
 		if err != nil {
 			currentUploadError = err
 			continue
@@ -304,7 +303,6 @@ func UploadFile(args UploadFileArguments) error {
 		}
 		client := &http.Client{}
 		response, err := client.Do(req)
-
 		if err != nil {
 			currentUploadError = err
 			// If we have a dial tcp error, we should retry with exponential backoff
@@ -324,7 +322,7 @@ func UploadFile(args UploadFileArguments) error {
 		if err != nil {
 			return fmt.Errorf("error in parsing the response body: %w", err)
 		}
-		currentUploadError = fmt.Errorf("file upload failed. Status code: %d and Message: %s", response.StatusCode, string(strippedOutData))
+		currentUploadError = fmt.Errorf("file upload failed. Status code: %d and Message: %s", response.StatusCode, string(strippedOutData)) //nolint
 
 		// don't retry for 4xx since it is a client side error
 		if response.StatusCode >= http.StatusBadRequest && response.StatusCode < http.StatusInternalServerError {

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -271,7 +271,7 @@ func UploadFile(args *UploadFileArguments) error {
 		// exponential backoff
 		time.Sleep(time.Duration(retryDelayInMS) * time.Millisecond)
 		retryDelayInMS *= args.BackoffFactor
-		fmt.Print(args.RetryDisplayMessage + "\n")
+		fmt.Println(args.RetryDisplayMessage)
 
 		// Create a new buffer to store the multipart/form-data request
 		body := &bytes.Buffer{}
@@ -315,7 +315,7 @@ func UploadFile(args *UploadFileArguments) error {
 		// Return success for 2xx status code
 		if response.StatusCode == http.StatusOK {
 			currentUploadError = nil
-			fmt.Print("upload successful\n")
+			fmt.Println("upload successful")
 			break
 		}
 

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	http_context "context"
+	"fmt"
 	"io"
 	f "io/fs"
 	"net/http"
@@ -523,9 +524,47 @@ func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(h.ResponseBody))
 }
 
+type MockServerWithHitCountReturning500 struct {
+	hitCount int
+}
+
+func (m *MockServerWithHitCountReturning500) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.hitCount++
+	w.WriteHeader(http.StatusInternalServerError)
+	fmt.Fprint(w, "Internal Server Error")
+}
+
+func createMockServerWithHitCountReturning500() *MockServerWithHitCountReturning500 {
+	return &MockServerWithHitCountReturning500{}
+}
+
+type MockServerWithHitCountReturning400 struct {
+	hitCount int
+}
+
+func (m *MockServerWithHitCountReturning400) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.hitCount++
+	w.WriteHeader(http.StatusBadRequest)
+	fmt.Fprint(w, "Bad Request")
+}
+
+func createMockServerWithHitCountReturning400() *MockServerWithHitCountReturning400 {
+	return &MockServerWithHitCountReturning400{}
+}
+
 func TestUploadFile(t *testing.T) {
 	t.Run("attempt to upload a non-existent file", func(t *testing.T) {
-		err := UploadFile("non-existent-file.txt", "http://localhost:8080/upload", "file1", map[string]string{})
+		uploadFileArgs := UploadFileArguments{
+			FilePath:            "non-existent-file.txt",
+			TargetURL:           "http://localhost:8080/upload",
+			FormFileFieldName:   "file",
+			Headers:             map[string]string{},
+			MaxTries:            3,
+			InitialDelayInMS:    1 * 1000,
+			BackoffFactor:       2,
+			RetryDisplayMessage: "please wait, attempting to upload the dags",
+		}
+		err := UploadFile(uploadFileArgs)
 		assert.EqualError(t, err, "error opening file: open non-existent-file.txt: no such file or directory")
 	})
 
@@ -543,9 +582,19 @@ func TestUploadFile(t *testing.T) {
 		assert.NoError(t, err, "Error creating test file")
 		defer os.Remove(filePath)
 
-		err = UploadFile(filePath, "testURL", "file1", map[string]string{})
-		assert.ErrorIs(t, err, ioCopyError)
+		uploadFileArgs := UploadFileArguments{
+			FilePath:            filePath,
+			TargetURL:           "testURL",
+			FormFileFieldName:   "file",
+			Headers:             map[string]string{},
+			MaxTries:            3,
+			InitialDelayInMS:    1 * 1000,
+			BackoffFactor:       2,
+			RetryDisplayMessage: "please wait, attempting to upload the dags",
+		}
+		err = UploadFile(uploadFileArgs)
 
+		assert.ErrorIs(t, err, ioCopyError)
 		ioCopy = io.Copy
 	})
 
@@ -561,13 +610,27 @@ func TestUploadFile(t *testing.T) {
 		assert.NoError(t, err, "Error creating test file")
 		defer os.Remove(filePath)
 
-		err = UploadFile(filePath, "testURL", "file1", map[string]string{})
-		assert.ErrorIs(t, err, requestError)
+		uploadFileArgs := UploadFileArguments{
+			FilePath:            filePath,
+			TargetURL:           "testURL",
+			FormFileFieldName:   "file",
+			Headers:             map[string]string{},
+			MaxTries:            3,
+			InitialDelayInMS:    1 * 1000,
+			BackoffFactor:       2,
+			RetryDisplayMessage: "please wait, attempting to upload the dags",
+		}
+		err = UploadFile(uploadFileArgs)
 
+		assert.ErrorIs(t, err, requestError)
 		newRequestWithContext = http.NewRequestWithContext
 	})
 
-	t.Run("uploaded the file but got non-OK response", func(t *testing.T) {
+	t.Run("uploaded the file but got 500 response code. Uploading should be retried", func(t *testing.T) {
+		mockServer := createMockServerWithHitCountReturning500()
+		testServer := httptest.NewServer(mockServer)
+		defer testServer.Close()
+
 		// Prepare a test server to respond with a non-OK status code
 		server := createMockServer(http.StatusInternalServerError, "Internal Server Error", make(map[string][]string))
 		defer server.Close()
@@ -584,27 +647,31 @@ func TestUploadFile(t *testing.T) {
 			"Content-Type":  "application/json",
 		}
 
-		// Execute the function under test
-		err = UploadFile(filePath, server.URL, "file1", headers)
+		uploadFileArgs := UploadFileArguments{
+			FilePath:            filePath,
+			TargetURL:           testServer.URL,
+			FormFileFieldName:   "file",
+			Headers:             headers,
+			MaxTries:            2,
+			InitialDelayInMS:    1 * 1000,
+			BackoffFactor:       2,
+			RetryDisplayMessage: "please wait, attempting to upload the dags",
+		}
+		err = UploadFile(uploadFileArgs)
 
 		// Assert the error is as expected
 		assert.EqualError(t, err, "file upload failed. Status code: 500 and Message: Internal Server Error")
+		// Assert that the server is hit required number of times
+		assert.Equal(t, 2, mockServer.hitCount)
 	})
 
-	t.Run("error making POST request due to invalid URL", func(t *testing.T) {
-		// Prepare a test server to capture the request
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Assert the request method is POST
-			assert.Equal(t, http.MethodPost, r.Method)
+	t.Run("uploaded the file but got 400 response code. Uploading should not be retried", func(t *testing.T) {
+		mockServer := createMockServerWithHitCountReturning400()
+		testServer := httptest.NewServer(mockServer)
+		defer testServer.Close()
 
-			// Assert the correct form field name
-			err := r.ParseMultipartForm(10 << 20) // 10 MB
-			assert.NoError(t, err, "Error parsing multipart form")
-			assert.NotNil(t, r.MultipartForm.File["file1"], "Form file not found in request")
-
-			// Respond with a success status code
-			w.WriteHeader(http.StatusOK)
-		}))
+		// Prepare a test server to respond with a non-OK status code
+		server := createMockServer(http.StatusInternalServerError, "Internal Server Error", make(map[string][]string))
 		defer server.Close()
 
 		// Create a temporary file with some content for testing
@@ -614,7 +681,49 @@ func TestUploadFile(t *testing.T) {
 		assert.NoError(t, err, "Error creating test file")
 		defer os.Remove(filePath)
 
-		err = UploadFile(filePath, "https://astro.unit.test", "file1", map[string]string{})
+		headers := map[string]string{
+			"Authorization": "Bearer token",
+			"Content-Type":  "application/json",
+		}
+
+		uploadFileArgs := UploadFileArguments{
+			FilePath:            filePath,
+			TargetURL:           testServer.URL,
+			FormFileFieldName:   "file",
+			Headers:             headers,
+			MaxTries:            2,
+			InitialDelayInMS:    1 * 1000,
+			BackoffFactor:       2,
+			RetryDisplayMessage: "please wait, attempting to upload the dags",
+		}
+		err = UploadFile(uploadFileArgs)
+
+		// Assert the error is as expected
+		assert.EqualError(t, err, "file upload failed. Status code: 400 and Message: Bad Request")
+		// Assert that the server is hit required number of times
+		assert.Equal(t, 1, mockServer.hitCount)
+	})
+
+	t.Run("error making POST request due to invalid URL.", func(t *testing.T) {
+		// Create a temporary file with some content for testing
+		filePath := "./testFile.txt"
+		fileContent := []byte("This is a test file.")
+		err := os.WriteFile(filePath, fileContent, os.ModePerm)
+		assert.NoError(t, err, "Error creating test file")
+		defer os.Remove(filePath)
+
+		uploadFileArgs := UploadFileArguments{
+			FilePath:            filePath,
+			TargetURL:           "https://astro.unit.test",
+			FormFileFieldName:   "file",
+			Headers:             map[string]string{},
+			MaxTries:            2,
+			InitialDelayInMS:    1 * 1000,
+			BackoffFactor:       2,
+			RetryDisplayMessage: "please wait, attempting to upload the dags",
+		}
+		err = UploadFile(uploadFileArgs)
+
 		assert.ErrorContains(t, err, "astro.unit.test")
 	})
 
@@ -635,9 +744,19 @@ func TestUploadFile(t *testing.T) {
 			"Content-Type":  "application/json",
 		}
 
-		err = UploadFile(filePath, server.URL, "file1", headers)
-		assert.NoError(t, err, "Expected no error")
+		uploadFileArgs := UploadFileArguments{
+			FilePath:            filePath,
+			TargetURL:           server.URL,
+			FormFileFieldName:   "file",
+			Headers:             headers,
+			MaxTries:            2,
+			InitialDelayInMS:    1 * 1000,
+			BackoffFactor:       2,
+			RetryDisplayMessage: "please wait, attempting to upload the dags",
+		}
+		err = UploadFile(uploadFileArgs)
 
+		assert.NoError(t, err, "Expected no error")
 		// assert the received headers
 		request := getCapturedRequest(server)
 		assert.Equal(t, "Bearer token", request.Header.Get("Authorization"))

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -564,7 +564,7 @@ func TestUploadFile(t *testing.T) {
 			BackoffFactor:       2,
 			RetryDisplayMessage: "please wait, attempting to upload the dags",
 		}
-		err := UploadFile(uploadFileArgs)
+		err := UploadFile(&uploadFileArgs)
 		assert.EqualError(t, err, "error opening file: open non-existent-file.txt: no such file or directory")
 	})
 
@@ -592,7 +592,7 @@ func TestUploadFile(t *testing.T) {
 			BackoffFactor:       2,
 			RetryDisplayMessage: "please wait, attempting to upload the dags",
 		}
-		err = UploadFile(uploadFileArgs)
+		err = UploadFile(&uploadFileArgs)
 
 		assert.ErrorIs(t, err, ioCopyError)
 		ioCopy = io.Copy
@@ -620,7 +620,7 @@ func TestUploadFile(t *testing.T) {
 			BackoffFactor:       2,
 			RetryDisplayMessage: "please wait, attempting to upload the dags",
 		}
-		err = UploadFile(uploadFileArgs)
+		err = UploadFile(&uploadFileArgs)
 
 		assert.ErrorIs(t, err, requestError)
 		newRequestWithContext = http.NewRequestWithContext
@@ -630,10 +630,6 @@ func TestUploadFile(t *testing.T) {
 		mockServer := createMockServerWithHitCountReturning500()
 		testServer := httptest.NewServer(mockServer)
 		defer testServer.Close()
-
-		// Prepare a test server to respond with a non-OK status code
-		server := createMockServer(http.StatusInternalServerError, "Internal Server Error", make(map[string][]string))
-		defer server.Close()
 
 		// Create a temporary file with some content for testing
 		filePath := "./testFile.txt"
@@ -657,7 +653,7 @@ func TestUploadFile(t *testing.T) {
 			BackoffFactor:       2,
 			RetryDisplayMessage: "please wait, attempting to upload the dags",
 		}
-		err = UploadFile(uploadFileArgs)
+		err = UploadFile(&uploadFileArgs)
 
 		// Assert the error is as expected
 		assert.EqualError(t, err, "file upload failed. Status code: 500 and Message: Internal Server Error")
@@ -670,10 +666,6 @@ func TestUploadFile(t *testing.T) {
 		testServer := httptest.NewServer(mockServer)
 		defer testServer.Close()
 
-		// Prepare a test server to respond with a non-OK status code
-		server := createMockServer(http.StatusInternalServerError, "Internal Server Error", make(map[string][]string))
-		defer server.Close()
-
 		// Create a temporary file with some content for testing
 		filePath := "./testFile.txt"
 		fileContent := []byte("This is a test file.")
@@ -696,7 +688,7 @@ func TestUploadFile(t *testing.T) {
 			BackoffFactor:       2,
 			RetryDisplayMessage: "please wait, attempting to upload the dags",
 		}
-		err = UploadFile(uploadFileArgs)
+		err = UploadFile(&uploadFileArgs)
 
 		// Assert the error is as expected
 		assert.EqualError(t, err, "file upload failed. Status code: 400 and Message: Bad Request")
@@ -722,7 +714,7 @@ func TestUploadFile(t *testing.T) {
 			BackoffFactor:       2,
 			RetryDisplayMessage: "please wait, attempting to upload the dags",
 		}
-		err = UploadFile(uploadFileArgs)
+		err = UploadFile(&uploadFileArgs)
 
 		assert.ErrorContains(t, err, "astro.unit.test")
 	})
@@ -754,7 +746,7 @@ func TestUploadFile(t *testing.T) {
 			BackoffFactor:       2,
 			RetryDisplayMessage: "please wait, attempting to upload the dags",
 		}
-		err = UploadFile(uploadFileArgs)
+		err = UploadFile(&uploadFileArgs)
 
 		assert.NoError(t, err, "Expected no error")
 		// assert the received headers

--- a/pkg/httputil/http.go
+++ b/pkg/httputil/http.go
@@ -163,5 +163,3 @@ func RequestAndGetJSONBody(route string) map[string]interface{} {
 	logrus.Debugf("%s - GET %s %s", res.Status, route, string(body))
 	return bodyJSON
 }
-
-

--- a/pkg/httputil/http.go
+++ b/pkg/httputil/http.go
@@ -163,3 +163,5 @@ func RequestAndGetJSONBody(route string) map[string]interface{} {
 	logrus.Debugf("%s - GET %s %s", res.Status, route, string(body))
 	return bodyJSON
 }
+
+

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -128,14 +128,15 @@ func GetbuildSecretString(buildSecret []string) (buildSecretString string) {
 }
 
 func StripOutKeysFromJSONByteArray(jsonData []byte, keys []string) ([]byte, error) {
-	if !json.Valid(jsonData) {
+	var jsonDataStruct map[string]interface{}
+	err := json.Unmarshal(jsonData, &jsonDataStruct)
+	if err != nil {
+		// If not a valid json, return the original data itself
 		return jsonData, nil
 	}
-	var jsonDataStruct map[string]interface{}
-	json.Unmarshal(jsonData, &jsonDataStruct)
 	for _, key := range keys {
 		delete(jsonDataStruct, key)
 	}
-	resultJson, _ := json.Marshal(jsonDataStruct)
-	return resultJson, nil
+	resultJSON, _ := json.Marshal(jsonDataStruct)
+	return resultJSON, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	b64 "encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -124,4 +125,17 @@ func GetbuildSecretString(buildSecret []string) (buildSecretString string) {
 	}
 
 	return buildSecretString
+}
+
+func StripOutKeysFromJSONByteArray(jsonData []byte, keys []string) ([]byte, error) {
+	if !json.Valid(jsonData) {
+		return jsonData, nil
+	}
+	var jsonDataStruct map[string]interface{}
+	json.Unmarshal(jsonData, &jsonDataStruct)
+	for _, key := range keys {
+		delete(jsonDataStruct, key)
+	}
+	resultJson, _ := json.Marshal(jsonDataStruct)
+	return resultJson, nil
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -261,3 +261,32 @@ func TestGetbuildSecretString(t *testing.T) {
 		assert.Equal(t, "override_secret", GetbuildSecretString([]string{}))
 	})
 }
+
+func TestStripOutKeysFromJSONByteArray(t *testing.T) {
+	t.Run("valid JSON, strip out keys", func(t *testing.T) {
+		jsonData := []byte(`{"a": 1, "b": 2, "c": 3}`)
+		keys := []string{"a", "c"}
+		expectedResult := []byte(`{"b":2}`)
+		result, err := StripOutKeysFromJSONByteArray(jsonData, keys)
+		assert.Nil(t, err)
+		assert.Equal(t, result, expectedResult)
+	})
+
+	t.Run("invalid JSON, return as is - case 1", func(t *testing.T) {
+		jsonData := []byte(`{invalid: json}`)
+		keys := []string{"a", "c"}
+		expectedResult := jsonData
+		result, err := StripOutKeysFromJSONByteArray(jsonData, keys)
+		assert.Nil(t, err)
+		assert.Equal(t, result, expectedResult)
+	})
+
+	t.Run("invalid JSON, return as is - case 2", func(t *testing.T) {
+		jsonData := []byte(``)
+		keys := []string{"a", "c"}
+		expectedResult := jsonData
+		result, err := StripOutKeysFromJSONByteArray(jsonData, keys)
+		assert.Nil(t, err)
+		assert.Equal(t, result, expectedResult)
+	})
+}

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -392,5 +392,5 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.Ap
 		BackoffFactor:       2,
 		RetryDisplayMessage: "please wait, attempting to upload the dags",
 	}
-	return fileutil.UploadFile(uploadFileArgs)
+	return fileutil.UploadFile(&uploadFileArgs)
 }

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -382,5 +382,15 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.Ap
 		"authorization": c.Token,
 	}
 
-	return fileutil.UploadFile(dagsParentPath+"/dags.tar.gz", uploadURL, "file", headers)
+	uploadFileArgs := fileutil.UploadFileArguments{
+		FilePath:            dagsParentPath + "/dags.tar.gz",
+		TargetURL:           uploadURL,
+		FormFileFieldName:   "file",
+		Headers:             headers,
+		MaxTries:            7,
+		InitialDelayInMS:    1 * 1000,
+		BackoffFactor:       2,
+		RetryDisplayMessage: "please wait, attempting to upload the dags",
+	}
+	return fileutil.UploadFile(uploadFileArgs)
 }

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -63,15 +63,15 @@ var tab = printutil.Table{
 	Header:         []string{"#", "LABEL", "DEPLOYMENT NAME", "WORKSPACE", "DEPLOYMENT ID"},
 }
 
-func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, byoRegistryDomain string, ignoreCacheDeploy, byoRegistryEnabled, prompt bool) error {
+func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, byoRegistryDomain string, ignoreCacheDeploy, byoRegistryEnabled, prompt bool) (string, error) {
 	if wsID == "" {
-		return errNoWorkspaceID
+		return deploymentID, errNoWorkspaceID
 	}
 
 	// Validate workspace
 	currentWorkspace, err := houston.Call(houstonClient.GetWorkspace)(wsID)
 	if err != nil {
-		return err
+		return deploymentID, err
 	}
 
 	// Get Deployments from workspace ID
@@ -80,17 +80,17 @@ func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, by
 	}
 	deployments, err := houston.Call(houstonClient.ListDeployments)(request)
 	if err != nil {
-		return err
+		return deploymentID, err
 	}
 
 	c, err := config.GetCurrentContext()
 	if err != nil {
-		return err
+		return deploymentID, err
 	}
 
 	cloudDomain := c.Domain
 	if cloudDomain == "" {
-		return errNoDomainSet
+		return deploymentID, errNoDomainSet
 	}
 
 	// Use config deployment if provided
@@ -99,13 +99,13 @@ func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, by
 	}
 
 	if deploymentID != "" && !deploymentExists(deploymentID, deployments) {
-		return errInvalidDeploymentID
+		return deploymentID, errInvalidDeploymentID
 	}
 
 	// Prompt user for deployment if no deployment passed in
 	if deploymentID == "" || prompt {
 		if len(deployments) == 0 {
-			return errDeploymentNotFound
+			return deploymentID, errDeploymentNotFound
 		}
 
 		fmt.Printf(houstonDeploymentHeader, cloudDomain)
@@ -124,7 +124,7 @@ func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, by
 		choice := input.Text("\n> ")
 		selected, ok := deployMap[choice]
 		if !ok {
-			return errInvalidDeploymentSelected
+			return deploymentID, errInvalidDeploymentSelected
 		}
 		deploymentID = selected.ID
 	}
@@ -145,7 +145,7 @@ func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, by
 
 	deploymentInfo, err := houston.Call(houstonClient.GetDeployment)(deploymentID)
 	if err != nil {
-		return fmt.Errorf("failed to get deployment info: %w", err)
+		return deploymentID, fmt.Errorf("failed to get deployment info: %w", err)
 	}
 
 	fmt.Printf(houstonDeploymentPrompt, releaseName)
@@ -153,13 +153,13 @@ func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, by
 	// Build the image to deploy
 	err = buildPushDockerImage(houstonClient, &c, deploymentInfo, releaseName, path, nextTag, cloudDomain, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled)
 	if err != nil {
-		return err
+		return deploymentID, err
 	}
 
 	deploymentLink := getAirflowUILink(deploymentID, deploymentInfo.Urls)
 	fmt.Printf("Successfully pushed Docker image to Astronomer registry, it can take a few minutes to update the deployment with the new image. Navigate to the Astronomer UI to confirm the state of your deployment (%s).\n", deploymentLink)
 
-	return nil
+	return deploymentID, nil
 }
 
 // Find deployment ID in deployments slice
@@ -324,6 +324,10 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.Ap
 	// Throw error if the feature is disabled at Houston level
 	if !isDagOnlyDeploymentEnabled(appConfig) {
 		return ErrDagOnlyDeployDisabledInConfig
+	}
+
+	if deploymentID == "" {
+		return errInvalidDeploymentID
 	}
 
 	// Throw error if the feature is disabled at Deployment level


### PR DESCRIPTION
## Description

astro deploy should upload the current directory dags to the dag server

## 🎟 Issue(s)

Related #6124

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.
Locally

## 📸 Screenshots

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
