### PR TITLE
fix dag deploy updating on accident

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -69,6 +69,7 @@ var (
 	tickNum                    = 10
 	timeoutNum                 = 180
 	dedicatedDeploymentRequest = astroplatformcore.UpdateDedicatedDeploymentRequest{}
+	dagDeployEnabled           bool
 )
 
 func newTableOut() *printutil.Table {

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -745,7 +745,8 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		}
 	}
 	// determine isDagDeployEnabled
-	if dagDeploy == enable {
+	switch dagDeploy {
+	case enable:
 		if currentDeployment.IsDagDeployEnabled {
 			fmt.Println("\nDAG deploys are already enabled for this Deployment. Your DAGs will continue to run as scheduled.")
 			return nil
@@ -754,7 +755,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		fmt.Printf("\nYou enabled DAG-only deploys for this Deployment. Running tasks are not interrupted but new tasks will not be scheduled." +
 			"\nRun `astro deploy --dags` to complete enabling this feature and resume your DAGs. It may take a few minutes for the Airflow UI to update..\n\n")
 		dagDeployEnabled = true
-	} else if dagDeploy == disable {
+	case disable:
 		if !currentDeployment.IsDagDeployEnabled {
 			fmt.Println("\nDAG-only deploys is already disabled for this deployment.")
 			return nil
@@ -765,12 +766,9 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 			confirmWithUser = true
 		}
 		dagDeployEnabled = false
-	}
-
-	if dagDeploy == "" {
+	case "":
 		dagDeployEnabled = currentDeployment.IsDagDeployEnabled
 	}
-
 	configOption, err := GetDeploymentOptions("", astrocore.GetDeploymentOptionsParams{}, coreClient)
 	if err != nil {
 		return err

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -220,7 +220,6 @@ func Logs(deploymentID, ws, deploymentName string, warnLogs, errorLogs, infoLogs
 func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy, executor, cloudProvider, region, schedulerSize, highAvailability, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory string, deploymentType astroplatformcore.DeploymentType, schedulerAU, schedulerReplicas int, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, waitForStatus bool) error { //nolint
 	var organizationID string
 	var currentWorkspace astrocore.Workspace
-	var dagDeployEnabled bool
 
 	c, err := config.GetCurrentContext()
 	if err != nil {
@@ -746,7 +745,6 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		}
 	}
 	// determine isDagDeployEnabled
-	var dagDeployEnabled bool
 	if dagDeploy == enable {
 		if currentDeployment.IsDagDeployEnabled {
 			fmt.Println("\nDAG deploys are already enabled for this Deployment. Your DAGs will continue to run as scheduled.")

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -768,6 +768,10 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		dagDeployEnabled = false
 	}
 
+	if dagDeploy == "" {
+		dagDeployEnabled = currentDeployment.IsDagDeployEnabled
+	}
+
 	configOption, err := GetDeploymentOptions("", astrocore.GetDeploymentOptionsParams{}, coreClient)
 	if err != nil {
 		return err

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1288,6 +1288,7 @@ func TestUpdate(t *testing.T) { //nolint
 		// success with hybrid type
 		err := Update("", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, true, mockCoreClient, mockPlatformCoreClient)
 		assert.NoError(t, err)
+		assert.Equal(t, deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
 
 		// Mock user input for deployment name
 		// defer testUtil.MockUserInput(t, "1")()

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1285,7 +1285,7 @@ func TestUpdate(t *testing.T) { //nolint
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(t, "1")()
 
-		// success with hybrid type
+		// success with hybrid type in this test nothing is being change just ensuring that dag deploy stays true. Addtionally no deployment id/name is given so user input is needed to select one
 		err := Update("", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, true, mockCoreClient, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
@@ -1294,7 +1294,7 @@ func TestUpdate(t *testing.T) { //nolint
 		// defer testUtil.MockUserInput(t, "1")()
 		defer testUtil.MockUserInput(t, "y")()
 
-		// kubernetes executor
+		// success updating the kubernetes executor on hybrid type. deployment name is given
 		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		assert.NoError(t, err)
 
@@ -1306,14 +1306,15 @@ func TestUpdate(t *testing.T) { //nolint
 		// defer testUtil.MockUserInput(t, "1")()
 		defer testUtil.MockUserInput(t, "y")()
 
-		// success with standard type
+		// success with standard type and deployment name input and dag deploy stays the same
 		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		assert.NoError(t, err)
+		assert.Equal(t, deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
 
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(t, "y")()
 
-		// kubernetes executor
+		// sucesses updating to kubernetes executor on standard type
 		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		assert.NoError(t, err)
 
@@ -1323,14 +1324,16 @@ func TestUpdate(t *testing.T) { //nolint
 		// Mock user input for deployment name
 		// defer testUtil.MockUserInput(t, "1")()
 
-		// success with dedicated type
+		// success with dedicated type no changes made asserts that dag deploy stays the same
 		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		assert.NoError(t, err)
+		assert.Equal(t, deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
+
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(t, "y")()
 
-		// kubernetes executor
-		err = Update("test-id-1", "", ws, "", "", "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
+		// success with dedicated updating to kubernetes executor
+		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1314,7 +1314,7 @@ func TestUpdate(t *testing.T) { //nolint
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(t, "y")()
 
-		// sucesses updating to kubernetes executor on standard type
+		// success updating to kubernetes executor on standard type
 		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		assert.NoError(t, err)
 


### PR DESCRIPTION
## Description

When running the command `astro deployment update` dag deploy is always turned off. This is because the case for dag deploy not changing didn't exist.

Added an assert to the update test to test for this bug.

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots
screenshot of updating the description of both a deployment with dag deploy enabled and disabled. Showing that in both cases dag deploy stays the same:
<img width="1511" alt="Screenshot 2024-02-02 at 11 46 31 AM" src="https://github.com/astronomer/astro-cli/assets/63181127/9953c222-4aa1-4d5f-8356-fef9244b9e12">


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
