### PR TITLE
Don't hardcode the registry URL to authenticate to, use the API response

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,7 @@ linters-settings:
       mnd:
         # don't include the "operation" and "assign"
         checks: [argument, case, condition, return]
-        ignored-numbers: 10,64  # numbers used by strconv
+        ignored-numbers: 2,10,64  # numbers used by strconv
   govet:
     check-shadowing: true
     settings:
@@ -136,6 +136,7 @@ issues:
         - typecheck
         - revive
         - unused
+        - goerr113
   exclude:
     - "shadow: declaration of .err. shadows declaration"
     - "sloppyTestFuncName: function cleanUpInitFiles should be of form"

--- a/airflow/container.go
+++ b/airflow/container.go
@@ -46,8 +46,8 @@ type RegistryHandler interface {
 // ImageHandler defines methods require to handle all operations on/for container images
 type ImageHandler interface {
 	Build(dockerfile, buildSecretString string, config types.ImageBuildConfig) error
-	Push(registry, username, token, remoteImage string) error
-	Pull(registry, username, token, remoteImage string) error
+	Push(remoteImage, username, token string) error
+	Pull(remoteImage, username, token string) error
 	GetLabel(altImageName, labelName string) (string, error)
 	DoesImageExist(image string) error
 	ListLabels() (map[string]string, error)

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -36,6 +36,12 @@ const (
 
 var errGetImageLabel = errors.New("error getting image label")
 
+func realGetDockerClient() (client.APIClient, error) {
+	return client.NewClientWithOpts(client.FromEnv)
+}
+
+var getDockerClient func() (client.APIClient, error) = realGetDockerClient
+
 type DockerImage struct {
 	imageName string
 }
@@ -299,11 +305,16 @@ func (d *DockerImage) CreatePipFreeze(altImageName, pipFreezeFile string) error 
 	return nil
 }
 
-func (d *DockerImage) Push(registry, username, token, remoteImage string) error {
+func (d *DockerImage) Push(remoteImage, username, token string) error {
 	dockerCommand := config.CFG.DockerCommand.GetString()
 	err := cmdExec(dockerCommand, nil, nil, "tag", d.imageName, remoteImage)
 	if err != nil {
 		return fmt.Errorf("command '%s tag %s %s' failed: %w", dockerCommand, d.imageName, remoteImage, err)
+	}
+
+	registry, err := d.getRegistryToAuth(remoteImage)
+	if err != nil {
+		return err
 	}
 
 	// Push image to registry
@@ -334,13 +345,31 @@ func (d *DockerImage) Push(registry, username, token, remoteImage string) error 
 
 	log.Debugf("Exec Push %s creds %v \n", dockerCommand, authConfig)
 
+	err = d.pushWithClient(&authConfig, remoteImage)
+
+	if err != nil {
+		// if it does not work with the go library use bash to run docker commands. Support for (old?) versions of Colima
+		err = pushWithBash(&authConfig, remoteImage)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Delete the image tags we just generated
+	err = cmdExec(dockerCommand, nil, nil, "rmi", remoteImage)
+	if err != nil {
+		return fmt.Errorf("command '%s rmi %s' failed: %w", dockerCommand, remoteImage, err)
+	}
+	return nil
+}
+
+func (d *DockerImage) pushWithClient(authConfig *cliTypes.AuthConfig, remoteImage string) error {
 	ctx := context.Background()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := getDockerClient()
 	if err != nil {
 		log.Debugf("Error setting up new Client ops %v", err)
-		// if NewClientWithOpt does not work use bash to run docker commands
-		return useBash(&authConfig, remoteImage)
+		return err
 	}
 	cli.NegotiateAPIVersion(ctx)
 	buf, err := json.Marshal(authConfig)
@@ -353,27 +382,40 @@ func (d *DockerImage) Push(registry, username, token, remoteImage string) error 
 	if err != nil {
 		log.Debugf("Error pushing image to docker: %v", err)
 		// if NewClientWithOpt does not work use bash to run docker commands
-		return useBash(&authConfig, remoteImage)
+		return err
 	}
 	defer responseBody.Close()
-	err = displayJSONMessagesToStream(responseBody, nil)
-	if err != nil {
-		return useBash(&authConfig, remoteImage)
-	}
-	// Delete the image tags we just generated
-	err = cmdExec(dockerCommand, nil, nil, "rmi", remoteImage)
-	if err != nil {
-		return fmt.Errorf("command '%s rmi %s' failed: %w", dockerCommand, remoteImage, err)
-	}
-	return nil
+	return displayJSONMessagesToStream(responseBody, nil)
 }
 
-func (d *DockerImage) Pull(registry, username, token, remoteImage string) error {
+// Get the registry name to authenticate against
+func (d *DockerImage) getRegistryToAuth(imageName string) (string, error) {
+	domain, err := config.GetCurrentDomain()
+	if err != nil {
+		return "", err
+	}
+
+	if domain == "localhost" {
+		return config.CFG.LocalRegistry.GetString(), nil
+	}
+	parts := strings.SplitN(imageName, "/", 2)
+	if len(parts) != 2 || !strings.Contains(parts[1], "/") {
+		// This _should_ be impossible for users to hit
+		return "", fmt.Errorf("internal logic error: unsure how to get registry from image name %q", imageName) //nolint:goerr113
+	}
+	return parts[0], nil
+}
+
+func (d *DockerImage) Pull(remoteImage, username, token string) error {
 	// Pulling image to registry
 	fmt.Println(pullingImagePrompt)
 	dockerCommand := config.CFG.DockerCommand.GetString()
 	var err error
 	if username != "" { // Case for cloud image push where we have both registry user & pass, for software login happens during `astro login` itself
+		var registry string
+		if registry, err = d.getRegistryToAuth(remoteImage); err != nil {
+			return err
+		}
 		pass := token
 		pass = strings.TrimPrefix(pass, prefix)
 		cmd := "echo \"" + pass + "\"" + " | " + dockerCommand + " login " + registry + " -u " + username + " --password-stdin"
@@ -583,7 +625,7 @@ var cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 }
 
 // When login and push do not work use bash to run docker commands, this function is for users using colima
-func useBash(authConfig *cliTypes.AuthConfig, image string) error {
+func pushWithBash(authConfig *cliTypes.AuthConfig, image string) error {
 	dockerCommand := config.CFG.DockerCommand.GetString()
 
 	var err error
@@ -592,19 +634,10 @@ func useBash(authConfig *cliTypes.AuthConfig, image string) error {
 		pass = strings.TrimPrefix(pass, prefix)
 		cmd := "echo \"" + pass + "\"" + " | " + dockerCommand + " login " + authConfig.ServerAddress + " -u " + authConfig.Username + " --password-stdin"
 		err = cmdExec("bash", os.Stdout, os.Stderr, "-c", cmd) // This command will only work on machines that have bash. If users have issues we will revist
-	}
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	// docker push <image>
-	err = cmdExec(dockerCommand, os.Stdout, os.Stderr, "push", image)
-	if err != nil {
-		return err
-	}
-	// Delete the image tags we just generated
-	err = cmdExec(dockerCommand, nil, nil, "rmi", image)
-	if err != nil {
-		return fmt.Errorf("command '%s rmi %s' failed: %w", dockerCommand, image, err)
-	}
-	return nil
+	return cmdExec(dockerCommand, os.Stdout, os.Stderr, "push", image)
 }

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -36,11 +36,9 @@ const (
 
 var errGetImageLabel = errors.New("error getting image label")
 
-func realGetDockerClient() (client.APIClient, error) {
+var getDockerClient = func() (client.APIClient, error) {
 	return client.NewClientWithOpts(client.FromEnv)
 }
-
-var getDockerClient func() (client.APIClient, error) = realGetDockerClient
 
 type DockerImage struct {
 	imageName string

--- a/airflow/mocks/ImageHandler.go
+++ b/airflow/mocks/ImageHandler.go
@@ -128,13 +128,13 @@ func (_m *ImageHandler) ListLabels() (map[string]string, error) {
 	return r0, r1
 }
 
-// Pull provides a mock function with given fields: registry, username, token, remoteImage
-func (_m *ImageHandler) Pull(registry string, username string, token string, remoteImage string) error {
-	ret := _m.Called(registry, username, token, remoteImage)
+// Pull provides a mock function with given fields: remoteImage, username, token
+func (_m *ImageHandler) Pull(remoteImage string, username string, token string) error {
+	ret := _m.Called(remoteImage, username, token)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
-		r0 = rf(registry, username, token, remoteImage)
+	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = rf(remoteImage, username, token)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -142,13 +142,13 @@ func (_m *ImageHandler) Pull(registry string, username string, token string, rem
 	return r0
 }
 
-// Push provides a mock function with given fields: registry, username, token, remoteImage
-func (_m *ImageHandler) Push(registry string, username string, token string, remoteImage string) error {
-	ret := _m.Called(registry, username, token, remoteImage)
+// Push provides a mock function with given fields: remoteImage, username, token
+func (_m *ImageHandler) Push(remoteImage string, username string, token string) error {
+	ret := _m.Called(remoteImage, username, token)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
-		r0 = rf(registry, username, token, remoteImage)
+	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = rf(remoteImage, username, token)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -178,7 +178,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 	mockContainerHandler := new(mocks.ContainerHandler)
 	containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 		mockContainerHandler.On("Parse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+		mockContainerHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockContainerHandler, nil
 	}
 

--- a/config/context.go
+++ b/config/context.go
@@ -40,14 +40,23 @@ type Context struct {
 // GetCurrentContext looks up current context and gets corresponding Context struct
 func GetCurrentContext() (Context, error) {
 	c := Context{}
+	var err error
+	c.Domain, err = GetCurrentDomain()
+	if err != nil {
+		return Context{}, err
+	}
+	return c.GetContext()
+}
+
+// Get CurrentDonain returns the currently configured astro domain, or an error if one is not set
+func GetCurrentDomain() (string, error) {
 	var domain string
 	if domain = os.Getenv("ASTRO_DOMAIN"); domain == "" {
 		if domain = CFG.Context.GetHomeString(); domain == "" {
-			return Context{}, ErrGetHomeString
+			return "", ErrGetHomeString
 		}
 	}
-	c.Domain = domain
-	return c.GetContext()
+	return domain, nil
 }
 
 // ResetCurrentContext reset the current context and is used when someone logs out

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -244,7 +244,7 @@ func buildPushDockerImage(houstonClient houston.ClientInterface, c *config.Conte
 		token = c.Token
 	}
 
-	err = imageHandler.Push(registry, "", token, remoteImage)
+	err = imageHandler.Push(remoteImage, "", token)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

There were a few paths where the registry to log in to was hardcoded
based on the environment (but not all of them -- for instance the Push
path using the go client library was already using this field to auth against!)

This change makes the Push and Pull flow use the pre-existing
`ImageRepository` flow in the Deploy(ment) response from Astro.

This also removes a bit of duplicated code -- various places were
stripping of the `Bearer ` prefix from the password before calling the
Push function, but that function itself did that.

## 🧪 Functional Testing

I have used this to deploy to Astro cloud without trouble

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
