### PR TITLE
Changed deployment type msg from dag_only to dag_deploy

### DIFF
--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -16,7 +16,7 @@ const (
 	k8sExecutorArg        = "k8s"
 
 	cliDeploymentHardDeletePrompt = "\nWarning: This action permanently deletes all data associated with this Deployment, including the database. You will not be able to recover it. Proceed with hard delete?"
-	deploymentTypeCmdMessage      = "DAG Deployment mechanism: image, volume, git_sync, dag_only"
+	deploymentTypeCmdMessage      = "DAG Deployment mechanism: image, volume, git_sync, dag_deploy"
 )
 
 var (

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -37,7 +37,7 @@ var (
 	errDeploymentNotFound                   = errors.New("no airflow deployments found")
 	errInvalidDeploymentSelected            = errors.New("invalid deployment selection\n") //nolint
 	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in your Astronomer cluster")
-	errDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the Deployment type to 'dag_only' via the UI or the API")
+	errDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the Deployment type to 'dag_deploy' via the UI or the API")
 	ErrEmptyDagFolderUserCancelledOperation = errors.New("no DAGs found in the dags folder. User canceled the operation")
 )
 


### PR DESCRIPTION
## Description

Changed deployment type msg from dag_only to dag_deploy

## 🎟 Issue(s)

Related #6119

## 🧪 Functional Testing

locally

## 📸 Screenshots


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
