### PR TITLE
Adding cli configurations doc link on astro config --help

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,7 +30,7 @@ func newConfigRootCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "config",
 		Short:             "Manage a project's configurations",
-		Long:              "Manage the project configurations stored at '.astro/config.yaml'",
+		Long:              "Manage the project configurations stored at '.astro/config.yaml'. Please see https://docs.astronomer.io/astro/cli/configure-cli#available-cli-configurations for list of available cli configurations",
 		PersistentPreRunE: ensureGlobalFlag,
 	}
 	cmd.PersistentFlags().BoolVarP(&globalFlag, "global", "g", false, "view or modify global config")


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Adding cli configurations doc link on astro config --help

![Screenshot 2024-02-06 at 10 16 52](https://github.com/astronomer/astro-cli/assets/65428224/2b1eb0af-f078-4ba6-a7bf-5e6c70c49048)


## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
