### PR TITLE
fix worker-queue update

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -241,7 +241,7 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				workerQueue.WorkerConcurrency = listQueues[i].WorkerConcurrency
 				workerQueue.AstroMachine = astroplatformcore.WorkerQueueRequestAstroMachine(strings.ToUpper(*listQueues[i].AstroMachine))
 				// set default values if none were specified
-				requestedWorkerQueue := workerqueue.SetWorkerQueueValues(listQueues[i].MinWorkerCount, listQueues[i].MaxWorkerCount, listQueues[i].WorkerConcurrency, &workerQueue, defaultOptions)
+				requestedWorkerQueue := workerqueue.SetWorkerQueueValues(listQueues[i].MinWorkerCount, listQueues[i].MaxWorkerCount, listQueues[i].WorkerConcurrency, &workerQueue, defaultOptions, &astroMachine)
 				// check if queue is valid
 				if deploymentFromFile.Deployment.Configuration.Executor == deployment.KubeExecutor || deploymentFromFile.Deployment.Configuration.Executor == deployment.KUBERNETES {
 					return errNoUseWorkerQueues

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -88,7 +88,6 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 					AstroMachine:      astroplatformcore.WorkerQueueRequestAstroMachine(*queues[i].AstroMachine),
 				}
 				listToCreate = append(listToCreate, existingQueueRequest)
-				fmt.Println(queues[i].WorkerConcurrency)
 			}
 		}
 		if name == "" {
@@ -125,35 +124,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 			MaxWorkerCount:    wQueueMax,         // use the value from the user input
 			WorkerConcurrency: wQueueConcurrency, // use the value from the user input
 		}
-		fmt.Println("worker con:" + fmt.Sprint(queueToCreateOrUpdate.WorkerConcurrency))
-
-		// // create listToCreate
-		// if requestedDeployment.WorkerQueues != nil {
-		// 	queues := *requestedDeployment.WorkerQueues
-		// 	for i := range *requestedDeployment.WorkerQueues {
-		// 		existingQueueRequest := astroplatformcore.WorkerQueueRequest{
-		// 			Name:              queues[i].Name,
-		// 			Id:                &queues[i].Id,
-		// 			IsDefault:         queues[i].IsDefault,
-		// 			MaxWorkerCount:    queues[i].MaxWorkerCount,
-		// 			MinWorkerCount:    queues[i].MinWorkerCount,
-		// 			WorkerConcurrency: queues[i].WorkerConcurrency,
-		// 			AstroMachine:      astroplatformcore.WorkerQueueRequestAstroMachine(*queues[i].AstroMachine),
-		// 		}
-		// 		listToCreate = append(listToCreate, existingQueueRequest)
-		// 		fmt.Println(queues[i].WorkerConcurrency)
-		// 	}
-		// }
-		// if name == "" {
-		// 	queueToCreateOrUpdate.Name, err = getQueueName(name, action, &requestedDeployment, out)
-		// 	if err != nil {
-		// 		return err
-		// 	}
-		// 	name = queueToCreateOrUpdate.Name
-		// }
 		queueToCreateOrUpdate = SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency, queueToCreateOrUpdate, defaultOptions, &workerMachine)
-		fmt.Println("default options:")
-		fmt.Println(defaultOptions.WorkerConcurrency)
 	} else {
 		// get the node poolID to use
 		cluster, err := deployment.CoreGetCluster("", *requestedDeployment.ClusterId, platformCoreClient)
@@ -198,10 +169,6 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	switch *requestedDeployment.Executor {
 	case astroplatformcore.DeploymentExecutorCELERY:
 		if deployment.IsDeploymentStandard(*requestedDeployment.Type) || deployment.IsDeploymentDedicated(*requestedDeployment.Type) {
-			fmt.Println(queueToCreateOrUpdate.WorkerConcurrency)
-			fmt.Println("worker machine options:")
-			fmt.Println(workerMachine.Concurrency.Ceiling)
-			fmt.Println(workerMachine.Concurrency.Default)
 			err = IsHostedCeleryWorkerQueueInputValid(queueToCreateOrUpdate, defaultOptions, &workerMachine)
 			if err != nil {
 				return err
@@ -296,7 +263,6 @@ func SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency int, workerQue
 		// set default value as user input did not have it
 		workerQueueToCreate.MaxWorkerCount = int(workerQueueDefaultOptions.MaxWorkers.Default)
 	}
-	fmt.Println(workerQueueDefaultOptions.WorkerConcurrency.Default)
 	if wQueueConcurrency == 0 {
 		// set default value as user input did not have it
 		workerQueueToCreate.WorkerConcurrency = int(machineOptions.Concurrency.Default)
@@ -363,7 +329,6 @@ func IsHostedCeleryWorkerQueueInputValid(requestedWorkerQueue *astroplatformcore
 		return fmt.Errorf("%w: %s", errInvalidWorkerQueueOption, errorMessage)
 	}
 	// The floor for worker concurrency for hosted deployments is always 1 for all astro machines
-	fmt.Println(requestedWorkerQueue.WorkerConcurrency)
 	workerConcurrenyFloor := 1
 	if !(requestedWorkerQueue.WorkerConcurrency >= workerConcurrenyFloor) ||
 		!(requestedWorkerQueue.WorkerConcurrency <= int(machineOptions.Concurrency.Ceiling)) {

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -91,11 +91,10 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 			}
 		}
 		if name == "" {
-			queueToCreateOrUpdate.Name, err = getQueueName(name, action, &requestedDeployment, out)
+			name, err = getQueueName(name, action, &requestedDeployment, out)
 			if err != nil {
 				return err
 			}
-			name = queueToCreateOrUpdate.Name
 		}
 		if action == updateAction && workerType == "" {
 			// get workerType

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -74,6 +74,39 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	defaultOptions = deploymentOptions.WorkerQueues
 
 	if deployment.IsDeploymentStandard(*requestedDeployment.Type) || deployment.IsDeploymentDedicated(*requestedDeployment.Type) {
+		// create listToCreate
+		if requestedDeployment.WorkerQueues != nil {
+			queues := *requestedDeployment.WorkerQueues
+			for i := range *requestedDeployment.WorkerQueues {
+				existingQueueRequest := astroplatformcore.WorkerQueueRequest{
+					Name:              queues[i].Name,
+					Id:                &queues[i].Id,
+					IsDefault:         queues[i].IsDefault,
+					MaxWorkerCount:    queues[i].MaxWorkerCount,
+					MinWorkerCount:    queues[i].MinWorkerCount,
+					WorkerConcurrency: queues[i].WorkerConcurrency,
+					AstroMachine:      astroplatformcore.WorkerQueueRequestAstroMachine(*queues[i].AstroMachine),
+				}
+				listToCreate = append(listToCreate, existingQueueRequest)
+				fmt.Println(queues[i].WorkerConcurrency)
+			}
+		}
+		if name == "" {
+			queueToCreateOrUpdate.Name, err = getQueueName(name, action, &requestedDeployment, out)
+			if err != nil {
+				return err
+			}
+			name = queueToCreateOrUpdate.Name
+		}
+		if action == updateAction && workerType == "" {
+			// get workerType
+			for i := range listToCreate {
+				if name == listToCreate[i].Name {
+					workerType = string(listToCreate[i].AstroMachine)
+				}
+			}
+		}
+
 		WorkerMachines := deploymentOptions.WorkerMachines
 		// get the machine to use
 		workerMachine, err = selectWorkerMachine(workerType, WorkerMachines, out)
@@ -92,30 +125,35 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 			MaxWorkerCount:    wQueueMax,         // use the value from the user input
 			WorkerConcurrency: wQueueConcurrency, // use the value from the user input
 		}
-		// create listToCreate
-		if requestedDeployment.WorkerQueues != nil {
-			queues := *requestedDeployment.WorkerQueues
-			for i := range *requestedDeployment.WorkerQueues {
-				existingQueueRequest := astroplatformcore.WorkerQueueRequest{
-					Name:              queues[i].Name,
-					Id:                &queues[i].Id,
-					IsDefault:         queues[i].IsDefault,
-					MaxWorkerCount:    queues[i].MaxWorkerCount,
-					MinWorkerCount:    queues[i].MinWorkerCount,
-					WorkerConcurrency: queues[i].WorkerConcurrency,
-					AstroMachine:      astroplatformcore.WorkerQueueRequestAstroMachine(*queues[i].AstroMachine),
-				}
-				listToCreate = append(listToCreate, existingQueueRequest)
-			}
-		}
-		if name == "" {
-			queueToCreateOrUpdate.Name, err = getQueueName(name, action, &requestedDeployment, out)
-			if err != nil {
-				return err
-			}
-			name = queueToCreateOrUpdate.Name
-		}
-		queueToCreateOrUpdate = SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency, queueToCreateOrUpdate, defaultOptions)
+		fmt.Println("worker con:" + fmt.Sprint(queueToCreateOrUpdate.WorkerConcurrency))
+
+		// // create listToCreate
+		// if requestedDeployment.WorkerQueues != nil {
+		// 	queues := *requestedDeployment.WorkerQueues
+		// 	for i := range *requestedDeployment.WorkerQueues {
+		// 		existingQueueRequest := astroplatformcore.WorkerQueueRequest{
+		// 			Name:              queues[i].Name,
+		// 			Id:                &queues[i].Id,
+		// 			IsDefault:         queues[i].IsDefault,
+		// 			MaxWorkerCount:    queues[i].MaxWorkerCount,
+		// 			MinWorkerCount:    queues[i].MinWorkerCount,
+		// 			WorkerConcurrency: queues[i].WorkerConcurrency,
+		// 			AstroMachine:      astroplatformcore.WorkerQueueRequestAstroMachine(*queues[i].AstroMachine),
+		// 		}
+		// 		listToCreate = append(listToCreate, existingQueueRequest)
+		// 		fmt.Println(queues[i].WorkerConcurrency)
+		// 	}
+		// }
+		// if name == "" {
+		// 	queueToCreateOrUpdate.Name, err = getQueueName(name, action, &requestedDeployment, out)
+		// 	if err != nil {
+		// 		return err
+		// 	}
+		// 	name = queueToCreateOrUpdate.Name
+		// }
+		queueToCreateOrUpdate = SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency, queueToCreateOrUpdate, defaultOptions, &workerMachine)
+		fmt.Println("default options:")
+		fmt.Println(defaultOptions.WorkerConcurrency)
 	} else {
 		// get the node poolID to use
 		cluster, err := deployment.CoreGetCluster("", *requestedDeployment.ClusterId, platformCoreClient)
@@ -160,6 +198,10 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	switch *requestedDeployment.Executor {
 	case astroplatformcore.DeploymentExecutorCELERY:
 		if deployment.IsDeploymentStandard(*requestedDeployment.Type) || deployment.IsDeploymentDedicated(*requestedDeployment.Type) {
+			fmt.Println(queueToCreateOrUpdate.WorkerConcurrency)
+			fmt.Println("worker machine options:")
+			fmt.Println(workerMachine.Concurrency.Ceiling)
+			fmt.Println(workerMachine.Concurrency.Default)
 			err = IsHostedCeleryWorkerQueueInputValid(queueToCreateOrUpdate, defaultOptions, &workerMachine)
 			if err != nil {
 				return err
@@ -243,7 +285,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 }
 
 // SetWorkerQueueValues sets default values for MinWorkerCount, MaxWorkerCount and WorkerConcurrency if none were requested.
-func SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency int, workerQueueToCreate *astroplatformcore.WorkerQueueRequest, workerQueueDefaultOptions astroplatformcore.WorkerQueueOptions) *astroplatformcore.WorkerQueueRequest {
+func SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency int, workerQueueToCreate *astroplatformcore.WorkerQueueRequest, workerQueueDefaultOptions astroplatformcore.WorkerQueueOptions, machineOptions *astroplatformcore.WorkerMachine) *astroplatformcore.WorkerQueueRequest {
 	// -1 is the CLI default to allow users to request wQueueMin=0
 	if wQueueMin == -1 {
 		// set default value as user input did not have it
@@ -254,10 +296,10 @@ func SetWorkerQueueValues(wQueueMin, wQueueMax, wQueueConcurrency int, workerQue
 		// set default value as user input did not have it
 		workerQueueToCreate.MaxWorkerCount = int(workerQueueDefaultOptions.MaxWorkers.Default)
 	}
-
+	fmt.Println(workerQueueDefaultOptions.WorkerConcurrency.Default)
 	if wQueueConcurrency == 0 {
 		// set default value as user input did not have it
-		workerQueueToCreate.WorkerConcurrency = int(workerQueueDefaultOptions.WorkerConcurrency.Default)
+		workerQueueToCreate.WorkerConcurrency = int(machineOptions.Concurrency.Default)
 	}
 	return workerQueueToCreate
 }
@@ -321,6 +363,7 @@ func IsHostedCeleryWorkerQueueInputValid(requestedWorkerQueue *astroplatformcore
 		return fmt.Errorf("%w: %s", errInvalidWorkerQueueOption, errorMessage)
 	}
 	// The floor for worker concurrency for hosted deployments is always 1 for all astro machines
+	fmt.Println(requestedWorkerQueue.WorkerConcurrency)
 	workerConcurrenyFloor := 1
 	if !(requestedWorkerQueue.WorkerConcurrency >= workerConcurrenyFloor) ||
 		!(requestedWorkerQueue.WorkerConcurrency <= int(machineOptions.Concurrency.Ceiling)) {

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -417,6 +417,7 @@ func TestCreateHostedShared(t *testing.T) {
 	t.Run("for hosted shared deployments", func(t *testing.T) {
 		deploymentResponse.JSON200.Type = &standardType
 		defer testUtil.MockUserInput(t, "test-worker-queue")()
+		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsPlatformResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -417,7 +417,6 @@ func TestCreateHostedShared(t *testing.T) {
 	t.Run("for hosted shared deployments", func(t *testing.T) {
 		deploymentResponse.JSON200.Type = &standardType
 		defer testUtil.MockUserInput(t, "test-worker-queue")()
-		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsPlatformResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)

--- a/cloud/deployment/workerqueue/workerqueue_test.go
+++ b/cloud/deployment/workerqueue/workerqueue_test.go
@@ -886,28 +886,36 @@ func TestSetWorkerQueueValues(t *testing.T) {
 		MinWorkerCount:    0,
 		WorkerConcurrency: 0,
 	}
+	mockMachineOptions := &astroplatformcore.WorkerMachine{
+		Name: "a5",
+		Concurrency: astroplatformcore.Range{
+			Default: 180,
+			Ceiling: 275,
+			Floor:   175,
+		},
+	}
 	t.Run("sets user provided min worker count for queue", func(t *testing.T) {
-		actualQueue := SetWorkerQueueValues(0, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(0, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
 		assert.Equal(t, mockWorkerQueue.MinWorkerCount, actualQueue.MinWorkerCount)
 	})
 	t.Run("sets user provided max worker count for queue", func(t *testing.T) {
-		actualQueue := SetWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
 		assert.Equal(t, mockWorkerQueue.MaxWorkerCount, actualQueue.MaxWorkerCount)
 	})
 	t.Run("sets user provided worker concurrency for queue", func(t *testing.T) {
-		actualQueue := SetWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(10, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
 		assert.Equal(t, mockWorkerQueue.WorkerConcurrency, actualQueue.WorkerConcurrency)
 	})
 	t.Run("sets default min worker count for queue if user did not provide it", func(t *testing.T) {
-		actualQueue := SetWorkerQueueValues(-1, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(-1, 150, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
 		assert.Equal(t, int(mockWorkerQueueDefaultOptions.MinWorkers.Default), actualQueue.MinWorkerCount)
 	})
 	t.Run("sets default max worker count for queue if user did not provide it", func(t *testing.T) {
-		actualQueue := SetWorkerQueueValues(10, 0, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(10, 0, 225, mockWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
 		assert.Equal(t, int(mockWorkerQueueDefaultOptions.MaxWorkers.Default), actualQueue.MaxWorkerCount)
 	})
 	t.Run("sets default worker concurrency for queue if user did not provide it", func(t *testing.T) {
-		actualQueue := SetWorkerQueueValues(10, 150, 0, mockWorkerQueue, mockWorkerQueueDefaultOptions)
+		actualQueue := SetWorkerQueueValues(10, 150, 0, mockWorkerQueue, mockWorkerQueueDefaultOptions, mockMachineOptions)
 		assert.Equal(t, int(mockWorkerQueueDefaultOptions.WorkerConcurrency.Default), actualQueue.WorkerConcurrency)
 	})
 }


### PR DESCRIPTION
## Description

Worker queue update command was using worker concurrency default values for hybrid when it should be using the value for hosted.

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1527
- https://github.com/astronomer/astro-cli/issues/1524

## 🧪 Functional Testing

manual testing
## 📸 Screenshots

<img width="1399" alt="Screenshot 2024-02-06 at 1 50 12 PM" src="https://github.com/astronomer/astro-cli/assets/63181127/63325089-d9c2-49d1-9af4-487992f37ad6">

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
