### PR TITLE
remove org short name

### DIFF
--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -303,7 +303,7 @@ func CheckUserSession(c *config.Context, coreClient astrocore.CoreClient, platfo
 	if activeOrg.Product != nil {
 		orgProduct = fmt.Sprintf("%s", *activeOrg.Product) //nolint
 	}
-	err = c.SetOrganizationContext(activeOrg.Id, activeOrg.Name, orgProduct)
+	err = c.SetOrganizationContext(activeOrg.Id, orgProduct)
 	if err != nil {
 		return err
 	}

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -202,7 +202,7 @@ const (
 	ws        = "workspace-id"
 	dagDeploy = "disable"
 	region    = "us-central1"
-	mockOrgId = "test-org-id"
+	mockOrgID = "test-org-id"
 )
 
 var (
@@ -1138,7 +1138,7 @@ func TestSelectCluster(t *testing.T) {
 	t.Run("list cluster failure", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.ListClustersResponse{}, errMock).Once()
 
-		_, err := selectCluster("", mockOrgId, mockPlatformCoreClient)
+		_, err := selectCluster("", mockOrgID, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errMock)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
@@ -1162,7 +1162,7 @@ func TestSelectCluster(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		resp, err := selectCluster("", mockOrgId, mockPlatformCoreClient)
+		resp, err := selectCluster("", mockOrgID, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, csID, resp)
 	})
@@ -1186,14 +1186,14 @@ func TestSelectCluster(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		_, err = selectCluster("", mockOrgId, mockPlatformCoreClient)
+		_, err = selectCluster("", mockOrgID, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, ErrInvalidClusterKey)
 	})
 
 	t.Run("not able to find cluster", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 
-		_, err := selectCluster("test-invalid-id", mockOrgId, mockPlatformCoreClient)
+		_, err := selectCluster("test-invalid-id", mockOrgID, mockPlatformCoreClient)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to find specified Cluster")
 	})

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -198,11 +198,11 @@ var (
 )
 
 const (
-	org              = "test-org-id"
-	ws               = "workspace-id"
-	dagDeploy        = "disable"
-	region           = "us-central1"
-	mockOrgShortName = "test-org-short-name"
+	org       = "test-org-id"
+	ws        = "workspace-id"
+	dagDeploy = "disable"
+	region    = "us-central1"
+	mockOrgId = "test-org-id"
 )
 
 var (
@@ -1138,7 +1138,7 @@ func TestSelectCluster(t *testing.T) {
 	t.Run("list cluster failure", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.ListClustersResponse{}, errMock).Once()
 
-		_, err := selectCluster("", mockOrgShortName, mockPlatformCoreClient)
+		_, err := selectCluster("", mockOrgId, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errMock)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
@@ -1162,7 +1162,7 @@ func TestSelectCluster(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		resp, err := selectCluster("", mockOrgShortName, mockPlatformCoreClient)
+		resp, err := selectCluster("", mockOrgId, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, csID, resp)
 	})
@@ -1186,14 +1186,14 @@ func TestSelectCluster(t *testing.T) {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		_, err = selectCluster("", mockOrgShortName, mockPlatformCoreClient)
+		_, err = selectCluster("", mockOrgId, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, ErrInvalidClusterKey)
 	})
 
 	t.Run("not able to find cluster", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 
-		_, err := selectCluster("test-invalid-id", mockOrgShortName, mockPlatformCoreClient)
+		_, err := selectCluster("test-invalid-id", mockOrgId, mockPlatformCoreClient)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to find specified Cluster")
 	})
@@ -1221,7 +1221,6 @@ func TestCanCiCdDeploy(t *testing.T) {
 	permissions = []string{
 		"workspaceId:workspace-id",
 		"organizationId:org-ID",
-		"orgShortName:org-short-name",
 	}
 	mockClaims = util.CustomClaims{
 		Permissions: permissions,

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	mockOrgShortName = "test-org-short-name"
+	mockOrgId = "test-org-id"
 )
 
 var (
@@ -3068,14 +3068,14 @@ func TestGetClusterFromName(t *testing.T) {
 	clusterName = "test-cluster"
 	t.Run("returns a cluster id if cluster exists in organization", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgShortName, mockPlatformCoreClient)
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgId, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedClusterID, actualClusterID)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 	t.Run("returns error from api if listing cluster fails", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.ListClustersResponse{}, errTest).Once()
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgShortName, mockPlatformCoreClient)
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgId, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errTest)
 		assert.Equal(t, "", actualClusterID)
 		assert.Equal(t, []astroplatformcore.NodePool(nil), actualNodePools)
@@ -3091,7 +3091,7 @@ func TestGetClusterFromName(t *testing.T) {
 			},
 		}
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgShortName, mockPlatformCoreClient)
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgId, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errNotFound)
 		assert.ErrorContains(t, err, "cluster_name: test-cluster does not exist in organization")
 		assert.Equal(t, "", actualClusterID)

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	mockOrgId = "test-org-id"
+	mockOrgID = "test-org-id"
 )
 
 var (
@@ -3068,14 +3068,14 @@ func TestGetClusterFromName(t *testing.T) {
 	clusterName = "test-cluster"
 	t.Run("returns a cluster id if cluster exists in organization", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgId, mockPlatformCoreClient)
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgID, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedClusterID, actualClusterID)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 	t.Run("returns error from api if listing cluster fails", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.ListClustersResponse{}, errTest).Once()
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgId, mockPlatformCoreClient)
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgID, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errTest)
 		assert.Equal(t, "", actualClusterID)
 		assert.Equal(t, []astroplatformcore.NodePool(nil), actualNodePools)
@@ -3091,7 +3091,7 @@ func TestGetClusterFromName(t *testing.T) {
 			},
 		}
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
-		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgId, mockPlatformCoreClient)
+		actualClusterID, actualNodePools, err = getClusterInfoFromName(clusterName, mockOrgID, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errNotFound)
 		assert.ErrorContains(t, err, "cluster_name: test-cluster does not exist in organization")
 		assert.Equal(t, "", actualClusterID)

--- a/cloud/organization/organization_test.go
+++ b/cloud/organization/organization_test.go
@@ -328,7 +328,7 @@ func TestListClusters(t *testing.T) {
 	// initialize empty config
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-	orgId := "test-org-id"
+	orgID := "test-org-id"
 	mockListClustersResponse := astroplatformcore.ListClustersResponse{
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
@@ -349,14 +349,14 @@ func TestListClusters(t *testing.T) {
 
 	t.Run("successful list all clusters", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
-		clusters, err := ListClusters(orgId, mockPlatformCoreClient)
+		clusters, err := ListClusters(orgID, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, len(clusters), 2)
 	})
 
 	t.Run("error on listing clusters", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.ListClustersResponse{}, errNetwork).Once()
-		_, err := ListClusters(orgId, mockPlatformCoreClient)
+		_, err := ListClusters(orgID, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errNetwork)
 	})
 }

--- a/cloud/organization/organization_test.go
+++ b/cloud/organization/organization_test.go
@@ -309,7 +309,7 @@ func TestIsOrgHosted(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("org product is hosted", func(t *testing.T) {
 		ctx := config.Context{Domain: "localhost"}
-		ctx.SetOrganizationContext("org1", "org_short_name_1", "HOSTED")
+		ctx.SetOrganizationContext("org1", "HOSTED")
 
 		isHosted := IsOrgHosted()
 		assert.Equal(t, isHosted, true)
@@ -317,7 +317,7 @@ func TestIsOrgHosted(t *testing.T) {
 
 	t.Run("org product is hybrid", func(t *testing.T) {
 		ctx := config.Context{Domain: "localhost"}
-		ctx.SetOrganizationContext("org1", "org_short_name_1", "HYBRID")
+		ctx.SetOrganizationContext("org1", "HYBRID")
 
 		isHosted := IsOrgHosted()
 		assert.Equal(t, isHosted, false)
@@ -328,7 +328,7 @@ func TestListClusters(t *testing.T) {
 	// initialize empty config
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-	orgShortName := "test-org-name"
+	orgId := "test-org-id"
 	mockListClustersResponse := astroplatformcore.ListClustersResponse{
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
@@ -349,14 +349,14 @@ func TestListClusters(t *testing.T) {
 
 	t.Run("successful list all clusters", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
-		clusters, err := ListClusters(orgShortName, mockPlatformCoreClient)
+		clusters, err := ListClusters(orgId, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		assert.Equal(t, len(clusters), 2)
 	})
 
 	t.Run("error on listing clusters", func(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.ListClustersResponse{}, errNetwork).Once()
-		_, err := ListClusters(orgShortName, mockPlatformCoreClient)
+		_, err := ListClusters(orgId, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errNetwork)
 	})
 }
@@ -367,6 +367,7 @@ func TestExportAuditLogs(t *testing.T) {
 	t.Run("export audit logs success", func(t *testing.T) {
 		mockPlatformClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
 		mockClient.On("GetOrganizationAuditLogsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockOKAuditLogResponse, nil).Once()
 		err := ExportAuditLogs(mockClient, mockPlatformClient, "", "", 1)
 		assert.NoError(t, err)
@@ -386,6 +387,7 @@ func TestExportAuditLogs(t *testing.T) {
 	t.Run("export failure", func(t *testing.T) {
 		mockPlatformClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
 		mockClient.On("GetOrganizationAuditLogsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errNetwork).Once()
 		err := ExportAuditLogs(mockClient, mockPlatformClient, "", "", 1)
 		assert.Contains(t, err.Error(), "network error")
@@ -404,6 +406,7 @@ func TestExportAuditLogs(t *testing.T) {
 	t.Run("organization list error", func(t *testing.T) {
 		mockPlatformClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
 		mockClient.On("GetOrganizationAuditLogsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockOKAuditLogResponseError, nil).Once()
 		err := ExportAuditLogs(mockClient, mockPlatformClient, "", "", 1)
 		assert.Contains(t, err.Error(), "failed to fetch organizations audit logs")

--- a/cloud/organization/organization_token.go
+++ b/cloud/organization/organization_token.go
@@ -59,9 +59,6 @@ func AddOrgTokenToWorkspace(id, name, role, workspace string, out io.Writer, cli
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
 	if workspace == "" {
 		workspace = ctx.Workspace
 	}
@@ -163,10 +160,6 @@ func getOrganizationTokens(client astrocore.CoreClient) ([]astrocore.ApiToken, e
 	if err != nil {
 		return []astrocore.ApiToken{}, err
 	}
-	if ctx.OrganizationShortName == "" {
-		return []astrocore.ApiToken{}, user.ErrNoShortName
-	}
-
 	resp, err := client.ListOrganizationApiTokensWithResponse(httpContext.Background(), ctx.Organization, &astrocore.ListOrganizationApiTokensParams{})
 	if err != nil {
 		return []astrocore.ApiToken{}, err
@@ -181,8 +174,8 @@ func getOrganizationTokens(client astrocore.CoreClient) ([]astrocore.ApiToken, e
 	return APITokens, nil
 }
 
-func getOrganizationTokenByID(id, orgShortName string, client astrocore.CoreClient) (token astrocore.ApiToken, err error) {
-	resp, err := client.GetOrganizationApiTokenWithResponse(httpContext.Background(), orgShortName, id)
+func getOrganizationTokenByID(id, orgID string, client astrocore.CoreClient) (token astrocore.ApiToken, err error) {
+	resp, err := client.GetOrganizationApiTokenWithResponse(httpContext.Background(), orgID, id)
 	if err != nil {
 		return astrocore.ApiToken{}, err
 	}
@@ -321,10 +314,6 @@ func CreateToken(name, description, role string, expiration int, cleanOutput boo
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
-
 	CreateOrganizationAPITokenRequest := astrocore.CreateOrganizationApiTokenJSONRequestBody{
 		Description: &description,
 		Name:        name,
@@ -359,10 +348,6 @@ func UpdateToken(id, name, newName, description, role string, out io.Writer, cli
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
-
 	var token astrocore.ApiToken
 	if id == "" {
 		tokens, err := getOrganizationTokens(client)
@@ -448,10 +433,6 @@ func RotateToken(id, name string, cleanOutput, force bool, out io.Writer, client
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
-
 	var token astrocore.ApiToken
 
 	if id == "" {
@@ -507,12 +488,7 @@ func DeleteToken(id, name string, force bool, out io.Writer, client astrocore.Co
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
-
 	var token astrocore.ApiToken
-
 	if id == "" {
 		tokens, err := getOrganizationTokens(client)
 		if err != nil {

--- a/cloud/team/team.go
+++ b/cloud/team/team.go
@@ -24,7 +24,6 @@ var (
 	ErrInvalidName              = errors.New("no name provided for the team. Retry with a valid name")
 	ErrTeamNotFound             = errors.New("no team was found for the ID you provided")
 	ErrWrongEnforceInput        = errors.New("the input to the `--enforce-cicd` flag")
-	ErrNoShortName              = errors.New("cannot retrieve organization short name from context")
 	ErrNoTeamsFoundInOrg        = errors.New("no teams found in your organization")
 	ErrNoTeamsFoundInWorkspace  = errors.New("no teams found in your workspace")
 	ErrNoTeamMembersFoundInTeam = errors.New("no team members found in team")

--- a/cloud/team/team.go
+++ b/cloud/team/team.go
@@ -54,9 +54,6 @@ func CreateTeam(name, description, role string, out io.Writer, client astrocore.
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
 	teamCreateRequest := astrocore.CreateTeamJSONRequestBody{
 		Description:      &description,
 		Name:             name,
@@ -79,10 +76,6 @@ func GetTeam(client astrocore.CoreClient, teamID string) (team astrocore.Team, e
 	if err != nil {
 		return team, err
 	}
-	if ctx.OrganizationShortName == "" {
-		return team, ErrNoShortName
-	}
-
 	resp, err := client.GetTeamWithResponse(httpContext.Background(), ctx.Organization, teamID)
 	if err != nil {
 		return team, err
@@ -105,9 +98,6 @@ func UpdateWorkspaceTeamRole(id, role, workspace string, out io.Writer, client a
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
 	}
 	if workspace == "" {
 		workspace = ctx.Workspace
@@ -155,9 +145,6 @@ func UpdateTeam(id, name, description, role string, out io.Writer, client astroc
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
 	}
 
 	var team astrocore.Team
@@ -238,9 +225,6 @@ func RemoveWorkspaceTeam(id, workspace string, out io.Writer, client astrocore.C
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
 	if workspace == "" {
 		workspace = ctx.Workspace
 	}
@@ -317,9 +301,6 @@ func GetWorkspaceTeams(client astrocore.CoreClient, workspace string, limit int)
 	if err != nil {
 		return nil, err
 	}
-	if ctx.OrganizationShortName == "" {
-		return nil, ErrNoShortName
-	}
 	if workspace == "" {
 		workspace = ctx.Workspace
 	}
@@ -394,9 +375,6 @@ func AddWorkspaceTeam(id, role, workspace string, out io.Writer, client astrocor
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return ErrNoShortName
-	}
 	if workspace == "" {
 		workspace = ctx.Workspace
 	}
@@ -449,9 +427,6 @@ func GetOrgTeams(client astrocore.CoreClient) ([]astrocore.Team, error) {
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return nil, err
-	}
-	if ctx.OrganizationShortName == "" {
-		return nil, ErrNoShortName
 	}
 
 	for {
@@ -509,9 +484,6 @@ func Delete(id string, out io.Writer, client astrocore.CoreClient) error {
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
 
 	var team astrocore.Team
 	if id == "" {
@@ -559,9 +531,6 @@ func RemoveUser(teamID, teamMemberID string, out io.Writer, client astrocore.Cor
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
 	}
 
 	var team astrocore.Team
@@ -634,9 +603,6 @@ func AddUser(teamID, userID string, out io.Writer, client astrocore.CoreClient) 
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
 	}
 
 	var team astrocore.Team

--- a/cloud/team/team_test.go
+++ b/cloud/team/team_test.go
@@ -14,7 +14,6 @@ import (
 
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
-	"github.com/astronomer/astro-cli/config"
 	"github.com/stretchr/testify/mock"
 
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
@@ -379,18 +378,6 @@ func TestListWorkspaceTeam(t *testing.T) {
 		mockClient.On("ListWorkspaceTeamsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceTeamsResponseError, nil).Twice()
 		err := ListWorkspaceTeams(out, mockClient, "")
 		assert.EqualError(t, err, "failed to list teams")
-	})
-
-	t.Run("error path when no Workspaceanization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = ListWorkspaceTeams(out, mockClient, "")
-		assert.ErrorIs(t, err, ErrNoShortName)
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {

--- a/cloud/team/team_test.go
+++ b/cloud/team/team_test.go
@@ -341,18 +341,6 @@ func TestListOrgTeam(t *testing.T) {
 		assert.EqualError(t, err, "failed to list teams")
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = ListOrgTeams(out, mockClient)
-		assert.ErrorIs(t, err, ErrNoShortName)
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -471,18 +459,6 @@ func TestUpdateWorkspaceTeamRole(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = UpdateWorkspaceTeamRole(team1.Id, "WORKSPACE_MEMBER", "", out, mockClient)
-		assert.EqualError(t, err, "cannot retrieve organization short name from context")
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -567,18 +543,6 @@ func TestAddWorkspaceTeam(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = AddWorkspaceTeam(team1.Id, "WORKSPACE_MEMBER", "", out, mockClient)
-		assert.ErrorIs(t, err, ErrNoShortName)
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -653,18 +617,6 @@ func TestRemoveWorkspaceTeam(t *testing.T) {
 		mockClient.On("DeleteWorkspaceTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceTeamResponseError, nil).Once()
 		err := RemoveWorkspaceTeam(team1.Id, "", out, mockClient)
 		assert.EqualError(t, err, "failed to update team")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = RemoveWorkspaceTeam(team1.Id, "", out, mockClient)
-		assert.EqualError(t, err, "cannot retrieve organization short name from context")
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
@@ -772,18 +724,6 @@ func TestDelete(t *testing.T) {
 		mockClient.On("DeleteTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&DeleteOrganizationTeamResponseError, nil).Once()
 		err := Delete(team1.Id, out, mockClient)
 		assert.EqualError(t, err, "failed to update team")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = Delete(team1.Id, out, mockClient)
-		assert.EqualError(t, err, "cannot retrieve organization short name from context")
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
@@ -959,18 +899,6 @@ func TestUpdate(t *testing.T) {
 		assert.EqualError(t, err, "failed to update team")
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = UpdateTeam(team1.Id, "name", "description", "", out, mockClient)
-		assert.EqualError(t, err, "cannot retrieve organization short name from context")
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -1045,18 +973,6 @@ func TestCreate(t *testing.T) {
 		mockClient.On("CreateTeamWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&CreateTeamResponseError, nil).Once()
 		err := CreateTeam(team1.Name, *team1.Description, "ORGANIZATION_MEMBER", out, mockClient)
 		assert.EqualError(t, err, "failed to update team")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = CreateTeam(team1.Name, *team1.Description, "ORGANIZATION_MEMBER", out, mockClient)
-		assert.EqualError(t, err, "cannot retrieve organization short name from context")
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
@@ -1150,18 +1066,6 @@ func TestAddUser(t *testing.T) {
 		mockClient.On("AddTeamMembersWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&AddTeamMemberResponseError, nil).Once()
 		err := AddUser(team1.Id, user1.Id, out, mockClient)
 		assert.EqualError(t, err, "failed to update team membership")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = AddUser(team1.Id, user1.Id, out, mockClient)
-		assert.EqualError(t, err, "cannot retrieve organization short name from context")
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
@@ -1337,18 +1241,6 @@ func TestRemoveUser(t *testing.T) {
 		assert.EqualError(t, err, "failed to update team membership")
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = RemoveUser(team1.Id, user1.Id, out, mockClient)
-		assert.EqualError(t, err, "cannot retrieve organization short name from context")
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -1450,18 +1342,6 @@ func TestListTeamUsers(t *testing.T) {
 		assert.EqualError(t, err, "failed to get team")
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = ListTeamUsers(team1.Id, out, mockClient)
-		assert.ErrorIs(t, err, ErrNoShortName)
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -1524,17 +1404,6 @@ func TestGetTeam(t *testing.T) {
 
 		_, err := GetTeam(mockClient, team1.Id)
 		assert.EqualError(t, err, "failed to get team")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		_, err = GetTeam(mockClient, team1.Id)
-		assert.ErrorIs(t, err, ErrNoShortName)
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {

--- a/cloud/user/user.go
+++ b/cloud/user/user.go
@@ -18,7 +18,6 @@ import (
 )
 
 var (
-	ErrNoShortName             = errors.New("cannot retrieve organization short name from context")
 	ErrInvalidRole             = errors.New("requested role is invalid. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")
 	ErrInvalidWorkspaceRole    = errors.New("requested role is invalid. Possible values are WORKSPACE_MEMBER, WORKSPACE_AUTHOR, WORKSPACE_OPERATOR and WORKSPACE_OWNER ")
 	ErrInvalidOrganizationRole = errors.New("requested role is invalid. Possible values are ORGANIZATION_MEMBER, ORGANIZATION_BILLING_ADMIN and ORGANIZATION_OWNER ")

--- a/cloud/user/user.go
+++ b/cloud/user/user.go
@@ -45,9 +45,6 @@ func CreateInvite(email, role string, out io.Writer, client astrocore.CoreClient
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return ErrNoShortName
-	}
 	userInviteInput = astrocore.CreateUserInviteRequest{
 		InviteeEmail: email,
 		Role:         role,
@@ -73,9 +70,6 @@ func UpdateUserRole(email, role string, out io.Writer, client astrocore.CoreClie
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return ErrNoShortName
 	}
 	// Get all org users
 	users, err := GetOrgUsers(client)
@@ -187,9 +181,6 @@ func GetOrgUsers(client astrocore.CoreClient) ([]astrocore.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ctx.OrganizationShortName == "" {
-		return nil, ErrNoShortName
-	}
 
 	for {
 		resp, err := client.ListOrgUsersWithResponse(httpContext.Background(), ctx.Organization, &astrocore.ListOrgUsersParams{
@@ -256,9 +247,6 @@ func AddWorkspaceUser(email, role, workspace string, out io.Writer, client astro
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return ErrNoShortName
-	}
 	if workspace == "" {
 		workspace = ctx.Workspace
 	}
@@ -294,9 +282,6 @@ func UpdateWorkspaceUserRole(email, role, workspace string, out io.Writer, clien
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return ErrNoShortName
 	}
 	if workspace == "" {
 		workspace = ctx.Workspace
@@ -363,9 +348,7 @@ func GetWorkspaceUsers(client astrocore.CoreClient, workspace string, limit int)
 	if err != nil {
 		return nil, err
 	}
-	if ctx.OrganizationShortName == "" {
-		return nil, ErrNoShortName
-	}
+
 	if workspace == "" {
 		workspace = ctx.Workspace
 	}
@@ -424,9 +407,6 @@ func RemoveWorkspaceUser(email, workspace string, out io.Writer, client astrocor
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return ErrNoShortName
-	}
 	if workspace == "" {
 		workspace = ctx.Workspace
 	}
@@ -473,9 +453,6 @@ func GetUser(client astrocore.CoreClient, userID string) (user astrocore.User, e
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return user, err
-	}
-	if ctx.OrganizationShortName == "" {
-		return user, ErrNoShortName
 	}
 
 	resp, err := client.GetUserWithResponse(httpContext.Background(), ctx.Organization, userID)

--- a/cloud/user/user_test.go
+++ b/cloud/user/user_test.go
@@ -230,19 +230,6 @@ func TestCreateInvite(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockClient.On("CreateUserInviteWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&createInviteResponseOK, nil).Once()
-		err = CreateInvite("test-email@test.com", "ORGANIZATION_MEMBER", out, mockClient)
-		assert.ErrorIs(t, err, ErrNoShortName)
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -329,18 +316,6 @@ func TestUpdateUserRole(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = UpdateUserRole("user@1.com", "ORGANIZATION_MEMBER", out, mockClient)
-		assert.ErrorIs(t, err, ErrNoShortName)
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -401,18 +376,6 @@ func TestListOrgUser(t *testing.T) {
 		mockClient.On("ListOrgUsersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListOrgUsersResponseError, nil).Twice()
 		err := ListOrgUsers(out, mockClient)
 		assert.EqualError(t, err, "failed to list users")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = ListOrgUsers(out, mockClient)
-		assert.ErrorIs(t, err, ErrNoShortName)
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
@@ -534,18 +497,6 @@ func TestUpdateWorkspaceUserRole(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = UpdateWorkspaceUserRole("user@1.com", "WORKSPACE_MEMBER", "", out, mockClient)
-		assert.ErrorIs(t, err, ErrNoShortName)
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -622,18 +573,6 @@ func TestAddWorkspaceUser(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = AddWorkspaceUser("user@1.com", "WORKSPACE_MEMBER", "", out, mockClient)
-		assert.ErrorIs(t, err, ErrNoShortName)
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -702,18 +641,6 @@ func TestDeleteWorkspaceUser(t *testing.T) {
 		assert.EqualError(t, err, "failed to update user")
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = RemoveWorkspaceUser("user@1.com", "", out, mockClient)
-		assert.ErrorIs(t, err, ErrNoShortName)
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -776,17 +703,6 @@ func TestGetUser(t *testing.T) {
 
 		_, err := GetUser(mockClient, user1.Id)
 		assert.EqualError(t, err, "network error")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		_, err = GetUser(mockClient, user1.Id)
-		assert.ErrorIs(t, err, ErrNoShortName)
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {

--- a/cloud/user/user_test.go
+++ b/cloud/user/user_test.go
@@ -11,7 +11,6 @@ import (
 
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
-	"github.com/astronomer/astro-cli/config"
 	"github.com/stretchr/testify/mock"
 
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
@@ -433,18 +432,6 @@ func TestListWorkspaceUser(t *testing.T) {
 		mockClient.On("ListWorkspaceUsersWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspaceUsersResponseError, nil).Twice()
 		err := ListWorkspaceUsers(out, mockClient, "")
 		assert.EqualError(t, err, "failed to list users")
-	})
-
-	t.Run("error path when no Workspaceanization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = ListWorkspaceUsers(out, mockClient, "")
-		assert.ErrorIs(t, err, ErrNoShortName)
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {

--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
-	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
@@ -152,7 +151,7 @@ func Switch(id string, client astrocore.CoreClient, out io.Writer) error {
 		return err
 	}
 
-	err = c.SetOrganizationContext(c.Organization, c.OrganizationShortName, c.OrganizationProduct)
+	err = c.SetOrganizationContext(c.Organization, c.OrganizationProduct)
 	if err != nil {
 		return err
 	}
@@ -186,9 +185,6 @@ func Create(name, description, enforceCD string, out io.Writer, client astrocore
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
 	enforce, err := validateEnforceCD(enforceCD)
 	if err != nil {
 		return err
@@ -214,9 +210,6 @@ func Update(id, name, description, enforceCD string, out io.Writer, client astro
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
 	}
 	workspaces, err := GetWorkspaces(client)
 	if err != nil {
@@ -281,9 +274,6 @@ func Delete(id string, out io.Writer, client astrocore.CoreClient) error {
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
 	}
 	workspaces, err := GetWorkspaces(client)
 	if err != nil {
@@ -367,9 +357,6 @@ func GetWorkspaces(client astrocore.CoreClient) ([]astrocore.Workspace, error) {
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return []astrocore.Workspace{}, err
-	}
-	if ctx.OrganizationShortName == "" {
-		return []astrocore.Workspace{}, user.ErrNoShortName
 	}
 
 	sorts := []astrocore.ListWorkspacesParamsSorts{"name:asc"}

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -10,7 +10,6 @@ import (
 
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
-	"github.com/astronomer/astro-cli/cloud/user"
 	"github.com/astronomer/astro-cli/config"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/stretchr/testify/assert"
@@ -309,18 +308,6 @@ func TestCreate(t *testing.T) {
 		assert.Equal(t, expectedOutMessage, out.String())
 	})
 
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = Create("workspace-test", "a test workspace", "on", out, mockClient)
-		assert.ErrorIs(t, err, user.ErrNoShortName)
-	})
-
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOutMessage := ""
@@ -401,18 +388,6 @@ func TestDelete(t *testing.T) {
 		mockClient.On("DeleteWorkspaceWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&DeleteWorkspaceResponseError, nil).Once()
 		err := Delete("workspace-id", out, mockClient)
 		assert.EqualError(t, err, "failed to delete workspace")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = Delete("workspace-id", out, mockClient)
-		assert.ErrorIs(t, err, user.ErrNoShortName)
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {
@@ -560,18 +535,6 @@ func TestUpdate(t *testing.T) {
 		mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
 		err := Update("workspace-id", "", "", "", out, mockClient)
 		assert.EqualError(t, err, "failed to update workspace")
-	})
-
-	t.Run("error path when no organization shortname found", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("organization_short_name", "")
-		assert.NoError(t, err)
-		out := new(bytes.Buffer)
-		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		err = Update("workspace-id", "", "", "", out, mockClient)
-		assert.ErrorIs(t, err, user.ErrNoShortName)
 	})
 
 	t.Run("error path when getting current context returns an error", func(t *testing.T) {

--- a/cloud/workspace/workspace_token.go
+++ b/cloud/workspace/workspace_token.go
@@ -96,9 +96,6 @@ func CreateToken(name, description, role, workspace string, expiration int, clea
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
 	if workspace == "" {
 		workspace = ctx.Workspace
 	}
@@ -135,9 +132,6 @@ func UpdateToken(id, name, newName, description, role, workspace string, out io.
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
 	}
 	if workspace == "" {
 		workspace = ctx.Workspace
@@ -213,9 +207,6 @@ func RotateToken(id, name, workspace string, cleanOutput, force bool, out io.Wri
 	if err != nil {
 		return err
 	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
-	}
 	if workspace == "" {
 		workspace = ctx.Workspace
 	}
@@ -272,9 +263,6 @@ func DeleteToken(id, name, workspace string, force bool, out io.Writer, client a
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return err
-	}
-	if ctx.OrganizationShortName == "" {
-		return user.ErrNoShortName
 	}
 	if workspace == "" {
 		workspace = ctx.Workspace
@@ -387,9 +375,6 @@ func getWorkspaceTokens(workspace string, client astrocore.CoreClient) ([]astroc
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
 		return []astrocore.ApiToken{}, err
-	}
-	if ctx.OrganizationShortName == "" {
-		return []astrocore.ApiToken{}, user.ErrNoShortName
 	}
 	if workspace == "" {
 		workspace = ctx.Workspace

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -180,10 +180,6 @@ func checkToken(coreClient astrocore.CoreClient, platformCoreClient astroplatfor
 		if err != nil {
 			return err
 		}
-		err = c.SetContextKey("organization_short_name", c.OrganizationShortName)
-		if err != nil {
-			return err
-		}
 		err = c.SetContextKey("organization_product", c.OrganizationProduct)
 		if err != nil {
 			return err
@@ -336,7 +332,6 @@ func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, isDeploymentF
 
 	org := orgs[0]
 	orgID := org.Id
-	orgName := org.Name
 	orgProduct := fmt.Sprintf("%s", *org.Product) //nolint
 
 	// get workspace ID
@@ -351,7 +346,7 @@ func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, isDeploymentF
 		fmt.Println("no workspace set")
 	}
 
-	err = c.SetOrganizationContext(orgID, orgName, orgProduct)
+	err = c.SetOrganizationContext(orgID, orgProduct)
 	if err != nil {
 		fmt.Println("no organization context set")
 	}
@@ -413,7 +408,7 @@ func checkAPIToken(isDeploymentFile bool, platformCoreClient astroplatformcore.C
 		return false, errNotAPIToken
 	}
 
-	var wsID, orgID, orgShortName string
+	var wsID, orgID string
 	for _, permission := range claims.Permissions {
 		splitPermission := strings.Split(permission, ":")
 		permissionType := splitPermission[0]
@@ -423,8 +418,6 @@ func checkAPIToken(isDeploymentFile bool, platformCoreClient astroplatformcore.C
 			wsID = id
 		case "organizationId":
 			orgID = id
-		case "orgShortName":
-			orgShortName = id
 		}
 	}
 
@@ -444,7 +437,7 @@ func checkAPIToken(isDeploymentFile bool, platformCoreClient astroplatformcore.C
 	if err != nil {
 		fmt.Println("no workspace set")
 	}
-	err = c.SetOrganizationContext(orgID, orgShortName, orgProduct)
+	err = c.SetOrganizationContext(orgID, orgProduct)
 	if err != nil {
 		fmt.Println("no organization context set")
 	}

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -344,7 +344,6 @@ func TestCheckAPIToken(t *testing.T) {
 		permissions := []string{
 			"workspaceId:workspace-id",
 			"organizationId:org-ID",
-			"orgShortName:org-short-name",
 		}
 		mockClaims := util.CustomClaims{
 			Permissions: permissions,

--- a/config/context.go
+++ b/config/context.go
@@ -26,15 +26,14 @@ type Contexts struct {
 
 // Context represents a single context
 type Context struct {
-	Domain                string `mapstructure:"domain"`
-	Organization          string `mapstructure:"organization"`
-	OrganizationShortName string `mapstructure:"organization_short_name"`
-	OrganizationProduct   string `mapstructure:"organization_product"`
-	Workspace             string `mapstructure:"workspace"`
-	LastUsedWorkspace     string `mapstructure:"last_used_workspace"`
-	Token                 string `mapstructure:"token"`
-	RefreshToken          string `mapstructure:"refreshtoken"`
-	UserEmail             string `mapstructure:"user_email"`
+	Domain              string `mapstructure:"domain"`
+	Organization        string `mapstructure:"organization"`
+	OrganizationProduct string `mapstructure:"organization_product"`
+	Workspace           string `mapstructure:"workspace"`
+	LastUsedWorkspace   string `mapstructure:"last_used_workspace"`
+	Token               string `mapstructure:"token"`
+	RefreshToken        string `mapstructure:"refreshtoken"`
+	UserEmail           string `mapstructure:"user_email"`
 }
 
 // GetCurrentContext looks up current context and gets corresponding Context struct
@@ -115,15 +114,14 @@ func (c *Context) SetContext() error {
 	}
 
 	context := map[string]string{
-		"token":                   c.Token,
-		"domain":                  c.Domain,
-		"organization":            c.Organization,
-		"organization_short_name": c.OrganizationShortName,
-		"organization_product":    c.OrganizationProduct,
-		"workspace":               c.Workspace,
-		"last_used_workspace":     c.Workspace,
-		"refreshtoken":            c.RefreshToken,
-		"user_email":              c.UserEmail,
+		"token":                c.Token,
+		"domain":               c.Domain,
+		"organization":         c.Organization,
+		"organization_product": c.OrganizationProduct,
+		"workspace":            c.Workspace,
+		"last_used_workspace":  c.Workspace,
+		"refreshtoken":         c.RefreshToken,
+		"user_email":           c.UserEmail,
 	}
 
 	viperHome.Set(contextsKey+"."+key, context)
@@ -153,12 +151,8 @@ func (c *Context) SetContextKey(key, value string) error {
 }
 
 // set organization id and short name in context config
-func (c *Context) SetOrganizationContext(orgID, orgShortName, orgProduct string) error {
+func (c *Context) SetOrganizationContext(orgID, orgProduct string) error {
 	err := c.SetContextKey("organization", orgID) // c.Organization
-	if err != nil {
-		return err
-	}
-	err = c.SetContextKey("organization_short_name", orgShortName)
 	if err != nil {
 		return err
 	}

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -198,7 +198,7 @@ func TestGetContexts(t *testing.T) {
 	initTestConfig()
 	ctxs, err := GetContexts()
 	assert.NoError(t, err)
-	assert.Equal(t, Contexts{Contexts: map[string]Context{"test_com": {"test.com", "test-org-id", "test-org-short-name", "", "ck05r3bor07h40d02y2hw4n4v", "ck05r3bor07h40d02y2hw4n4v", "token", "", ""}, "example_com": {"example.com", "test-org-id", "test-org-short-name", "", "ck05r3bor07h40d02y2hw4n4v", "ck05r3bor07h40d02y2hw4n4v", "token", "", ""}}}, ctxs)
+	assert.Equal(t, Contexts{Contexts: map[string]Context{"test_com": {"test.com", "test-org-id", "", "ck05r3bor07h40d02y2hw4n4v", "ck05r3bor07h40d02y2hw4n4v", "token", "", ""}, "example_com": {"example.com", "test-org-id", "", "ck05r3bor07h40d02y2hw4n4v", "ck05r3bor07h40d02y2hw4n4v", "token", "", ""}}}, ctxs)
 }
 
 func TestSetContextKey(t *testing.T) {
@@ -214,18 +214,17 @@ func TestSetOrganizationContext(t *testing.T) {
 	initTestConfig()
 	t.Run("set organization context", func(t *testing.T) {
 		ctx := Context{Domain: "localhost"}
-		ctx.SetOrganizationContext("org1", "org_short_name_1", "HYBRID")
+		ctx.SetOrganizationContext("org1", "HYBRID")
 		outCtx, err := ctx.GetContext()
 		assert.NoError(t, err)
 		assert.Equal(t, "org1", outCtx.Organization)
-		assert.Equal(t, "org_short_name_1", outCtx.OrganizationShortName)
 		assert.Equal(t, "HYBRID", outCtx.OrganizationProduct)
 	})
 
 	t.Run("set organization context error", func(t *testing.T) {
 		ctx := Context{Domain: ""}
 		assert.NoError(t, err)
-		err = ctx.SetOrganizationContext("org1", "org_short_name_1", "HYBRID")
+		err = ctx.SetOrganizationContext("org1", "HYBRID")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "context config invalid, no domain specified")
 	})


### PR DESCRIPTION
## Description

Org short name has deprecated as input for the API. This PR removes it from the CLI code base
## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1529

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
