### PR TITLE
Ask for deployment id from the user if no deployment id is passed in astro deploy --dags

### DIFF
--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -97,12 +97,12 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		byoRegistryDomain = appConfig.BYORegistryDomain
 	}
 	if isDagOnlyDeploy {
-		return DagsOnlyDeploy(houstonClient, appConfig, deploymentID, config.WorkingPath, nil, true)
+		return DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true)
 	}
 	// Since we prompt the user to enter the deploymentID in come cases for DeployAirflowImage, reusing the same  deploymentID for DagsOnlyDeploy
 	deploymentID, err = DeployAirflowImage(houstonClient, config.WorkingPath, deploymentID, ws, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, forcePrompt)
 	if err != nil {
 		return err
 	}
-	return DagsOnlyDeploy(houstonClient, appConfig, deploymentID, config.WorkingPath, nil, true)
+	return DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true)
 }

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -33,7 +33,7 @@ func TestDeploy(t *testing.T) {
 		return deploymentID, nil
 	}
 
-	DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
+	DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
 		return nil
 	}
 

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -29,7 +29,7 @@ var (
 
 	gzipFile = fileutil.GzipFile
 
-	getDeploymentIdForCurrentCommandVar = getDeploymentIdForCurrentCommand
+	getDeploymentIDForCurrentCommandVar = getDeploymentIdForCurrentCommand
 )
 
 var (
@@ -240,7 +240,7 @@ func getAirflowUILink(deploymentID string, deploymentURLs []houston.DeploymentUR
 	return ""
 }
 
-func getDeploymentIdForCurrentCommand(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+func getDeploymentIdForCurrentCommand(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 	if wsID == "" {
 		return deploymentID, []houston.Deployment{}, ErrNoWorkspaceID
 	}
@@ -332,17 +332,17 @@ func getDagDeployURL(deploymentInfo *houston.Deployment) string {
 	return fmt.Sprintf("https://deployments.%s/%s/dags/upload", c.Domain, deploymentInfo.ReleaseName)
 }
 
-func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID string, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
+func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
 	// Throw error if the feature is disabled at Houston level
 	if !isDagOnlyDeploymentEnabled(appConfig) {
 		return ErrDagOnlyDeployDisabledInConfig
 	}
 
-	deploymentIdForCurrentCmd, _, err := getDeploymentIdForCurrentCommandVar(houstonClient, wsID, deploymentID, deploymentID == "")
+	deploymentIDForCurrentCmd, _, err := getDeploymentIDForCurrentCommandVar(houstonClient, wsID, deploymentID, deploymentID == "")
 	if err != nil {
 		return err
 	}
-	deploymentID = deploymentIdForCurrentCmd
+	deploymentID = deploymentIDForCurrentCmd
 
 	if deploymentID == "" {
 		return errInvalidDeploymentID

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -29,7 +29,7 @@ var (
 
 	gzipFile = fileutil.GzipFile
 
-	getDeploymentIDForCurrentCommandVar = getDeploymentIdForCurrentCommand
+	getDeploymentIDForCurrentCommandVar = getDeploymentIDForCurrentCommand
 )
 
 var (
@@ -66,7 +66,7 @@ var tab = printutil.Table{
 }
 
 func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID, byoRegistryDomain string, ignoreCacheDeploy, byoRegistryEnabled, prompt bool) (string, error) {
-	deploymentID, deployments, err := getDeploymentIdForCurrentCommand(houstonClient, wsID, deploymentID, prompt)
+	deploymentID, deployments, err := getDeploymentIDForCurrentCommand(houstonClient, wsID, deploymentID, prompt)
 	if err != nil {
 		return deploymentID, err
 	}
@@ -240,7 +240,7 @@ func getAirflowUILink(deploymentID string, deploymentURLs []houston.DeploymentUR
 	return ""
 }
 
-func getDeploymentIdForCurrentCommand(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+func getDeploymentIDForCurrentCommand(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 	if wsID == "" {
 		return deploymentID, []houston.Deployment{}, ErrNoWorkspaceID
 	}

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -381,8 +381,8 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		houstonMock.AssertExpectations(t)
 	})
 
-	t.Run("When getDeploymentIdForCurrentCommandVar gives an error", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+	t.Run("When getDeploymentIDForCurrentCommandVar gives an error", func(t *testing.T) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, errDeploymentNotFound
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -399,7 +399,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("When config flag is set to true but an error occurs in the GetDeployment api call", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -417,7 +417,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("When config flag is set to true but it is disabled at the deployment level", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -440,7 +440,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config, but unable to get context from astro-cli config", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -466,7 +466,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config, able to get context from config but no release name present", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -490,7 +490,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is empty. User doesn't give operation confirmation", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -541,7 +541,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is empty. User gives the operation confirmation", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -615,7 +615,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is non-empty. Tar creation throws an error", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -663,7 +663,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is non-empty. Tar is successfully created. But gzip creation throws an error", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -716,7 +716,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is non-empty. No need of User confirmation", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{
@@ -776,7 +776,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is non-empty. No need of User confirmation. Files should be auto-cleaned", func(t *testing.T) {
-		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, nil
 		}
 		featureFlags := &houston.FeatureFlags{

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -365,19 +365,7 @@ func TestAirflowSuccess(t *testing.T) {
 func TestDeployDagsOnlyFailure(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
 	deploymentID := "test-deployment-id"
-
-	t.Run("When no deployment id is passed", func(t *testing.T) {
-		featureFlags := &houston.FeatureFlags{
-			DagOnlyDeployment: true,
-		}
-		appConfig := &houston.AppConfig{
-			Flags: *featureFlags,
-		}
-		houstonMock := new(houston_mocks.ClientInterface)
-		err := DagsOnlyDeploy(houstonMock, appConfig, "", config.WorkingPath, nil, false)
-		assert.ErrorIs(t, err, errInvalidDeploymentID)
-		houstonMock.AssertExpectations(t)
-	})
+	wsID := "test-workspace-id"
 
 	t.Run("When config flag is set to false", func(t *testing.T) {
 		featureFlags := &houston.FeatureFlags{
@@ -388,12 +376,32 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		}
 		houstonMock := new(houston_mocks.ClientInterface)
 
-		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
 		assert.ErrorIs(t, err, ErrDagOnlyDeployDisabledInConfig)
 		houstonMock.AssertExpectations(t)
 	})
 
+	t.Run("When getDeploymentIdForCurrentCommandVar gives an error", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, errDeploymentNotFound
+		}
+		featureFlags := &houston.FeatureFlags{
+			DagOnlyDeployment: true,
+		}
+		appConfig := &houston.AppConfig{
+			Flags: *featureFlags,
+		}
+		houstonMock := new(houston_mocks.ClientInterface)
+
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
+		assert.ErrorIs(t, err, errDeploymentNotFound)
+		houstonMock.AssertExpectations(t)
+	})
+
 	t.Run("When config flag is set to true but an error occurs in the GetDeployment api call", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -403,12 +411,15 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		houstonMock := new(houston_mocks.ClientInterface)
 		houstonMock.On("GetDeployment", mock.Anything).Return(nil, errMockHouston).Once()
 
-		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
 		assert.ErrorContains(t, err, "failed to get deployment info: some houston error")
 		houstonMock.AssertExpectations(t)
 	})
 
 	t.Run("When config flag is set to true but it is disabled at the deployment level", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -423,12 +434,15 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 			DagDeployment: *dagDeployment,
 		}
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
-		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
 		assert.ErrorIs(t, err, errDagOnlyDeployNotEnabledForDeployment)
 		houstonMock.AssertExpectations(t)
 	})
 
 	t.Run("Valid Houston config, but unable to get context from astro-cli config", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -445,13 +459,16 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
 		config.ResetCurrentContext()
 
-		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
 		assert.EqualError(t, err, "could not get current context! Error: no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 		houstonMock.AssertExpectations(t)
 		context.Switch("localhost")
 	})
 
 	t.Run("Valid Houston config, able to get context from config but no release name present", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -467,12 +484,15 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 			DagDeployment: *dagDeployment,
 		}
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
-		err := DagsOnlyDeploy(houstonMock, appConfig, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
 		houstonMock.AssertExpectations(t)
 		assert.ErrorIs(t, err, errInvalidDeploymentID)
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is empty. User doesn't give operation confirmation", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -511,7 +531,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.RemoveAll("dags")
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, deploymentID, ".", nil, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", nil, false)
 		assert.EqualError(t, err, ErrEmptyDagFolderUserCancelledOperation.Error())
 
 		// assert that no tar or gz file exists
@@ -521,6 +541,9 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is empty. User gives the operation confirmation", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -574,7 +597,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, deploymentID, ".", &server.URL, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", &server.URL, false)
 		assert.NoError(t, err)
 		houstonMock.AssertExpectations(t)
 
@@ -592,6 +615,9 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is non-empty. Tar creation throws an error", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -625,7 +651,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		os.Stdin = r
 		defer testUtil.MockUserInput(t, "y")()
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, deploymentID, "./dags", nil, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, "./dags", nil, false)
 		assert.EqualError(t, err, "open dags/dags.tar: no such file or directory")
 		houstonMock.AssertExpectations(t)
 
@@ -637,6 +663,9 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is non-empty. Tar is successfully created. But gzip creation throws an error", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -668,7 +697,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 			return gzipMockError
 		}
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, deploymentID, ".", nil, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, deploymentID, wsID, ".", nil, false)
 		assert.ErrorIs(t, err, gzipMockError)
 		houstonMock.AssertExpectations(t)
 
@@ -687,6 +716,9 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is non-empty. No need of User confirmation", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -726,7 +758,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, deploymentID, ".", &server.URL, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", &server.URL, false)
 		assert.NoError(t, err)
 		houstonMock.AssertExpectations(t)
 
@@ -744,6 +776,9 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 	})
 
 	t.Run("Valid Houston config. Valid Houston deployment. The Dags folder is non-empty. No need of User confirmation. Files should be auto-cleaned", func(t *testing.T) {
+		getDeploymentIdForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID string, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
+			return deploymentID, nil, nil
+		}
 		featureFlags := &houston.FeatureFlags{
 			DagOnlyDeployment: true,
 		}
@@ -783,7 +818,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, deploymentID, ".", &server.URL, true)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", &server.URL, true)
 		assert.NoError(t, err)
 		houstonMock.AssertExpectations(t)
 


### PR DESCRIPTION
## Description

Ask for deployment id from the user if no deplpyment id is passed in astro deploy --dags

## 🎟 Issue(s)

[Related #6142
](https://github.com/astronomer/issues/issues/6142)

## 🧪 Functional Testing

Locally

## 📸 Screenshots
<img width="1715" alt="Screenshot 2024-02-07 at 4 28 58 PM" src="https://github.com/astronomer/astro-cli/assets/95576577/10669eae-1655-48d3-a7e2-248b449cdacc">


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
