### PR TITLE
Do not throw the error for astro deploy if dag-deploy itself is disabled

### DIFF
--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -104,5 +104,11 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true)
+
+	err = DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true)
+	// Don't throw the error if dag-deploy itself is disabled
+	if err == deploy.ErrDagOnlyDeployDisabledInConfig || err == deploy.ErrDagOnlyDeployNotEnabledForDeployment {
+		return nil
+	}
+	return err
 }

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -1,6 +1,7 @@
 package software
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/astronomer/astro-cli/cmd/utils"
@@ -107,7 +108,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 
 	err = DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true)
 	// Don't throw the error if dag-deploy itself is disabled
-	if err == deploy.ErrDagOnlyDeployDisabledInConfig || err == deploy.ErrDagOnlyDeployNotEnabledForDeployment {
+	if errors.Is(err, deploy.ErrDagOnlyDeployDisabledInConfig) || errors.Is(err, deploy.ErrDagOnlyDeployNotEnabledForDeployment) {
 		return nil
 	}
 	return err

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -61,9 +61,18 @@ func TestDeploy(t *testing.T) {
 		}
 	})
 
-	t.Run("error should be returned for astro deploy, if dags deploy throws error", func(t *testing.T) {
+	t.Run("error should be returned for astro deploy, if dags deploy throws error and the feature is enabled", func(t *testing.T) {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
+			return deploy.ErrNoWorkspaceID
+		}
 		err := execDeployCmd([]string{"-f"}...)
-		assert.ErrorIs(t, err, deploy.ErrDagOnlyDeployDisabledInConfig)
+		assert.ErrorIs(t, err, deploy.ErrNoWorkspaceID)
+		DagsOnlyDeploy = deploy.DagsOnlyDeploy
+	})
+
+	t.Run("No error should be returned for astro deploy, if dags deploy throws error but the feature itself is disabled", func(t *testing.T) {
+		err := execDeployCmd([]string{"-f"}...)
+		assert.ErrorIs(t, err, nil)
 	})
 
 	t.Run("Test for the flag --dags", func(t *testing.T) {

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -39,7 +39,7 @@ var (
 	errDeploymentNotFound                   = errors.New("no airflow deployments found")
 	errInvalidDeploymentSelected            = errors.New("invalid deployment selection\n") //nolint
 	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in your Astronomer cluster")
-	ErrDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the Deployment type to 'dag_deploy' via the UI or the API")
+	ErrDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the Deployment type to 'dag_deploy' via the UI or the API or the CLI")
 	ErrEmptyDagFolderUserCancelledOperation = errors.New("no DAGs found in the dags folder. User canceled the operation")
 )
 

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -39,7 +39,7 @@ var (
 	errDeploymentNotFound                   = errors.New("no airflow deployments found")
 	errInvalidDeploymentSelected            = errors.New("invalid deployment selection\n") //nolint
 	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in your Astronomer cluster")
-	errDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the Deployment type to 'dag_deploy' via the UI or the API")
+	ErrDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the Deployment type to 'dag_deploy' via the UI or the API")
 	ErrEmptyDagFolderUserCancelledOperation = errors.New("no DAGs found in the dags folder. User canceled the operation")
 )
 
@@ -354,7 +354,7 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.Ap
 		return fmt.Errorf("failed to get deployment info: %w", err)
 	}
 	if !isDagOnlyDeploymentEnabledForDeployment(deploymentInfo) {
-		return errDagOnlyDeployNotEnabledForDeployment
+		return ErrDagOnlyDeployNotEnabledForDeployment
 	}
 
 	uploadURL := ""

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -435,7 +435,7 @@ func TestDeployDagsOnlyFailure(t *testing.T) {
 		}
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
 		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
-		assert.ErrorIs(t, err, errDagOnlyDeployNotEnabledForDeployment)
+		assert.ErrorIs(t, err, ErrDagOnlyDeployNotEnabledForDeployment)
 		houstonMock.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
## Description

Do not throw the error for astro deploy if dag-deploy itself is disabled

## 🎟 Issue(s)

[Related #XXX
](https://github.com/astronomer/issues/issues/6151)

## 🧪 Functional Testing

Tested on Local

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
