### PR TITLE
Confirm from user when deployment is created/upserted, if current deployment type or new deployment type  is dag_deploy

### DIFF
--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -57,7 +57,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&ignoreCacheDeploy, "no-cache", "", false, "Do not use cache when building container image")
 	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "workspace assigned to deployment")
 	if !context.IsCloudContext() && houston.VerifyVersionMatch(houstonVersion, houston.VersionRestrictions{GTE: "0.34.0"}) {
-		cmd.Flags().BoolVarP(&isDagOnlyDeploy, "dags", "", false, "Push only DAGs to your Deployment")
+		cmd.Flags().BoolVarP(&isDagOnlyDeploy, "dags", "d", false, "Push only DAGs to your Deployment")
 	}
 	return cmd
 }

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -475,13 +475,13 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 	}
 
 	// new dag deployment type or current dag deployment type is dag_deploy, confirm from user
-	if !skipPrompt {
+	if !skipPrompt && dagDeploymentType == houston.DagOnlyDeploymentType {
 		deploymentInfo, err := houston.Call(houstonClient.GetDeployment)(args[0])
 		if err != nil {
 			return fmt.Errorf("failed to get deployment info: %w", err)
 		}
 
-		if deploymentInfo.DagDeployment.Type != houston.DagOnlyDeploymentType && dagDeploymentType == houston.DagOnlyDeploymentType {
+		if deploymentInfo.DagDeployment.Type != houston.DagOnlyDeploymentType {
 			y, _ := input.Confirm(UpdateDeploymentTypeToDagDeployPromptMsg)
 			if !y {
 				fmt.Println("canceling deployment update..")

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/software/deployment"
 	"github.com/spf13/cobra"
@@ -15,11 +16,17 @@ const (
 	kubernetesExecutorArg = "kubernetes"
 	k8sExecutorArg        = "k8s"
 
-	cliDeploymentHardDeletePrompt = "\nWarning: This action permanently deletes all data associated with this Deployment, including the database. You will not be able to recover it. Proceed with hard delete?"
-	deploymentTypeCmdMessage      = "DAG Deployment mechanism: image, volume, git_sync, dag_deploy"
+	cliDeploymentHardDeletePrompt              = "\nWarning: This action permanently deletes all data associated with this Deployment, including the database. You will not be able to recover it. Proceed with hard delete?"
+	deploymentTypeCmdMessage                   = "DAG Deployment mechanism: image, volume, git_sync, dag_deploy"
+	CreateDeploymentWithTypeDagDeployPromptMsg = "\nthis is an experimental feature. Please use with caution. See the Software documentation at " + houston.DagDeployDocsLink + " for more details. Do you want to continue?"
+	UpdateDeploymentTypeToDagDeployPromptMsg   = "\nthis is an experimental feature. Please use with caution. Changing to a DAG-only Deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the Software documentation at " + houston.DagDeployDocsLink + " for more details. Do you want to continue?"
+	UpdateDeploymentTypeFromDagDeployPromptMsg = "\nchanging from a DAG-only deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the Software documentation at " + houston.DeployViaCLIDocsLink + " for more details. Do you want to continue?"
+	SkipUserPromptMsgForCreateDeployment       = "Skip user confirmation prompt for creating a deployment with type: dag_deploy (experimental feature)"
+	SkipUserPromptMsgForUpdateDeployment       = "Skip user confirmation prompt for updating the deployment type to/from dag_deploy (experimental feature)"
 )
 
 var (
+	skipPrompt                  bool
 	allDeployments              bool
 	cancel                      bool
 	hardDelete                  bool
@@ -121,6 +128,8 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVarP(&skipPrompt, "force", "f", false, SkipUserPromptMsgForCreateDeployment)
+
 	var nfsMountDAGDeploymentEnabled, triggererEnabled, gitSyncDAGDeploymentEnabled, runtimeEnabled, dagOnlyDeployEnabled bool
 	if appConfig != nil {
 		nfsMountDAGDeploymentEnabled = appConfig.Flags.NfsMountDagDeployment
@@ -211,6 +220,8 @@ $ astro deployment update [deployment ID] --dag-deployment-type=volume --nfs-loc
 			return deploymentUpdate(cmd, args, dagDeploymentType, nfsLocation, out)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&skipPrompt, "force", "f", false, SkipUserPromptMsgForUpdateDeployment)
 
 	var nfsMountDAGDeploymentEnabled, triggererEnabled, gitSyncDAGDeploymentEnabled, dagOnlyDeployEnabled bool
 	if appConfig != nil {
@@ -374,6 +385,15 @@ func deploymentCreate(cmd *cobra.Command, out io.Writer) error {
 		createTriggererReplicas = -1
 	}
 
+	// If it's a dag_deploy type, validate from the user first
+	if !skipPrompt && dagDeploymentType == houston.DagOnlyDeploymentType {
+		y, _ := input.Confirm(CreateDeploymentWithTypeDagDeployPromptMsg)
+		if !y {
+			fmt.Println("canceling deployment create..")
+			return nil
+		}
+	}
+
 	// we should validate only in case when this feature has been enabled
 	if nfsMountDAGDeploymentEnabled || gitSyncDAGDeploymentEnabled || dagOnlyDeployEnabled {
 		err = validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL, false)
@@ -435,6 +455,7 @@ func deploymentList(cmd *cobra.Command, out io.Writer) error {
 }
 
 func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsLocation string, out io.Writer) error {
+	deploymentID := args[0]
 	argsMap := map[string]string{}
 	if deploymentUpdateDescription != "" {
 		argsMap["description"] = deploymentUpdateDescription
@@ -451,6 +472,32 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 		nfsMountDAGDeploymentEnabled = appConfig.Flags.NfsMountDagDeployment
 		gitSyncDAGDeploymentEnabled = appConfig.Flags.GitSyncEnabled
 		dagOnlyDeployEnabled = appConfig.Flags.DagOnlyDeployment
+	}
+
+	// new dag deployment type or current dag deployment type is dag_deploy, confirm from user
+	if !skipPrompt {
+		deploymentInfo, err := houston.Call(houstonClient.GetDeployment)(deploymentID)
+		if err != nil {
+			return fmt.Errorf("failed to get deployment info: %w", err)
+		}
+
+		if deploymentInfo.DagDeployment.Type != houston.DagOnlyDeploymentType && dagDeploymentType == houston.DagOnlyDeploymentType {
+			y, _ := input.Confirm(UpdateDeploymentTypeToDagDeployPromptMsg)
+			if !y {
+				fmt.Println("canceling deployment update..")
+				return nil
+			}
+
+		}
+
+		if deploymentInfo.DagDeployment.Type == houston.DagOnlyDeploymentType && dagDeploymentType != houston.DagOnlyDeploymentType {
+			y, _ := input.Confirm(UpdateDeploymentTypeFromDagDeployPromptMsg)
+			if !y {
+				fmt.Println("canceling deployment update..")
+				return nil
+			}
+
+		}
 	}
 
 	// we should validate only in case when this feature has been enabled
@@ -470,7 +517,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 		}
 	}
 
-	return deployment.Update(args[0], cloudRole, argsMap, dagDeploymentType, nfsLocation, gitRepoURL, gitRevision, gitBranchName, gitDAGDir, sshKey, knowHosts, executorType, gitSyncInterval, updateTriggererReplicas, houstonClient, out)
+	return deployment.Update(deploymentID, cloudRole, argsMap, dagDeploymentType, nfsLocation, gitRepoURL, gitRevision, gitBranchName, gitDAGDir, sshKey, knowHosts, executorType, gitSyncInterval, updateTriggererReplicas, houstonClient, out)
 }
 
 func deploymentAirflowUpgrade(cmd *cobra.Command, out io.Writer) error {

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -18,9 +18,10 @@ const (
 
 	cliDeploymentHardDeletePrompt              = "\nWarning: This action permanently deletes all data associated with this Deployment, including the database. You will not be able to recover it. Proceed with hard delete?"
 	deploymentTypeCmdMessage                   = "DAG Deployment mechanism: image, volume, git_sync, dag_deploy"
-	CreateDeploymentWithTypeDagDeployPromptMsg = "\nthis is an experimental feature. Please use with caution. See the Software documentation at " + houston.DagDeployDocsLink + " for more details. Do you want to continue?"
-	UpdateDeploymentTypeToDagDeployPromptMsg   = "\nthis is an experimental feature. Please use with caution. Changing to a DAG-only Deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the Software documentation at " + houston.DagDeployDocsLink + " for more details. Do you want to continue?"
-	UpdateDeploymentTypeFromDagDeployPromptMsg = "\nchanging from a DAG-only deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the Software documentation at " + houston.DeployViaCLIDocsLink + " for more details. Do you want to continue?"
+	continueSubMsg                             = " for more details. Do you want to continue?"
+	CreateDeploymentWithTypeDagDeployPromptMsg = "\nthis is an experimental feature. Please use with caution. See the Software documentation at " + houston.DagDeployDocsLink + continueSubMsg
+	UpdateDeploymentTypeToDagDeployPromptMsg   = "\nthis is an experimental feature. Please use with caution. Changing to a DAG-only Deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the Software documentation at " + houston.DagDeployDocsLink + continueSubMsg
+	UpdateDeploymentTypeFromDagDeployPromptMsg = "\nchanging from a DAG-only deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the Software documentation at " + houston.DeployViaCLIDocsLink + continueSubMsg
 	SkipUserPromptMsgForCreateDeployment       = "Skip user confirmation prompt for creating a deployment with type: dag_deploy (experimental feature)"
 	SkipUserPromptMsgForUpdateDeployment       = "Skip user confirmation prompt for updating the deployment type to/from dag_deploy (experimental feature)"
 )
@@ -455,7 +456,6 @@ func deploymentList(cmd *cobra.Command, out io.Writer) error {
 }
 
 func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsLocation string, out io.Writer) error {
-	deploymentID := args[0]
 	argsMap := map[string]string{}
 	if deploymentUpdateDescription != "" {
 		argsMap["description"] = deploymentUpdateDescription
@@ -476,7 +476,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 
 	// new dag deployment type or current dag deployment type is dag_deploy, confirm from user
 	if !skipPrompt {
-		deploymentInfo, err := houston.Call(houstonClient.GetDeployment)(deploymentID)
+		deploymentInfo, err := houston.Call(houstonClient.GetDeployment)(args[0])
 		if err != nil {
 			return fmt.Errorf("failed to get deployment info: %w", err)
 		}
@@ -487,7 +487,6 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 				fmt.Println("canceling deployment update..")
 				return nil
 			}
-
 		}
 
 		if deploymentInfo.DagDeployment.Type == houston.DagOnlyDeploymentType && dagDeploymentType != houston.DagOnlyDeploymentType {
@@ -496,7 +495,6 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 				fmt.Println("canceling deployment update..")
 				return nil
 			}
-
 		}
 	}
 
@@ -517,7 +515,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 		}
 	}
 
-	return deployment.Update(deploymentID, cloudRole, argsMap, dagDeploymentType, nfsLocation, gitRepoURL, gitRevision, gitBranchName, gitDAGDir, sshKey, knowHosts, executorType, gitSyncInterval, updateTriggererReplicas, houstonClient, out)
+	return deployment.Update(args[0], cloudRole, argsMap, dagDeploymentType, nfsLocation, gitRepoURL, gitRevision, gitBranchName, gitDAGDir, sshKey, knowHosts, executorType, gitSyncInterval, updateTriggererReplicas, houstonClient, out)
 }
 
 func deploymentAirflowUpgrade(cmd *cobra.Command, out io.Writer) error {

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -475,13 +475,14 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 	}
 
 	// new dag deployment type or current dag deployment type is dag_deploy, confirm from user
-	if !skipPrompt && dagDeploymentType == houston.DagOnlyDeploymentType {
+	if !skipPrompt {
 		deploymentInfo, err := houston.Call(houstonClient.GetDeployment)(args[0])
 		if err != nil {
 			return fmt.Errorf("failed to get deployment info: %w", err)
 		}
 
-		if deploymentInfo.DagDeployment.Type != houston.DagOnlyDeploymentType {
+		// non dag_deploy to dag_deploy
+		if deploymentInfo.DagDeployment.Type != houston.DagOnlyDeploymentType && dagDeploymentType == houston.DagOnlyDeploymentType {
 			y, _ := input.Confirm(UpdateDeploymentTypeToDagDeployPromptMsg)
 			if !y {
 				fmt.Println("canceling deployment update..")
@@ -489,6 +490,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 			}
 		}
 
+		// dag_deploy to non dag_deploy
 		if deploymentInfo.DagDeployment.Type == houston.DagOnlyDeploymentType && dagDeploymentType != houston.DagOnlyDeploymentType {
 			y, _ := input.Confirm(UpdateDeploymentTypeFromDagDeployPromptMsg)
 			if !y {

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -110,129 +110,6 @@ func TestDeploymentCreateCommandNfsMountDisabled(t *testing.T) {
 	}
 }
 
-func TestDeploymentCreateWithTypeDagDeploy(t *testing.T) {
-	t.Run("user should not be prompted if deployment type is not dag_deploy", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-		appConfig = &houston.AppConfig{
-			TriggererEnabled: true,
-			Flags: houston.FeatureFlags{
-				TriggererEnabled: true,
-			},
-		}
-		api := new(mocks.ClientInterface)
-		api.On("GetAppConfig", nil).Return(appConfig, nil)
-		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
-
-		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--triggerer-replicas=1"}
-		expectedOutput := "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs"
-		houstonClient = api
-		output, err := execDeploymentCmd(cmdArgs...)
-		assert.NoError(t, err)
-		assert.Contains(t, output, expectedOutput)
-		api.AssertExpectations(t)
-	})
-
-	t.Run("user should not be prompted if deployment type is dag_deploy but -f flag is sent", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-		appConfig = &houston.AppConfig{
-			TriggererEnabled: true,
-			Flags: houston.FeatureFlags{
-				TriggererEnabled:  true,
-				DagOnlyDeployment: true,
-			},
-		}
-		api := new(mocks.ClientInterface)
-		api.On("GetAppConfig", nil).Return(appConfig, nil)
-		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
-
-		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--triggerer-replicas=1", "--force"}
-		expectedOutput := "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs"
-		houstonClient = api
-		output, err := execDeploymentCmd(cmdArgs...)
-		assert.NoError(t, err)
-		assert.Contains(t, output, expectedOutput)
-		api.AssertExpectations(t)
-	})
-
-	t.Run("user should be prompted if deployment type is dag_deploy and -f flag is not sent. No deployment is created without confirmation.", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-		appConfig = &houston.AppConfig{
-			TriggererEnabled: true,
-			Flags: houston.FeatureFlags{
-				TriggererEnabled:  true,
-				DagOnlyDeployment: true,
-			},
-		}
-
-		api := new(mocks.ClientInterface)
-		api.On("GetAppConfig", nil).Return(appConfig, nil)
-		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
-		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--triggerer-replicas=1"}
-		houstonClient = api
-
-		// mock os.Stdin
-		input := []byte("1")
-		r, w, err := os.Pipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = w.Write(input)
-		if err != nil {
-			t.Error(err)
-		}
-		w.Close()
-		stdin := os.Stdin
-		// Restore stdin right after the test.
-		defer func() { os.Stdin = stdin }()
-		os.Stdin = r
-		defer testUtil.MockUserInput(t, "n")()
-
-		_, err = execDeploymentCmd(cmdArgs...)
-		assert.NoError(t, err)
-		// Houston CreateDeployment API should not be called if user does not confirm the prompt
-		api.AssertNotCalled(t, "CreateDeployment", mock.Anything)
-	})
-
-	t.Run("user should be prompted if deployment type is dag_deploy and -f flag is not sent. Deployment is created with confirmation.", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-		appConfig = &houston.AppConfig{
-			TriggererEnabled: true,
-			Flags: houston.FeatureFlags{
-				TriggererEnabled:  true,
-				DagOnlyDeployment: true,
-			},
-		}
-
-		api := new(mocks.ClientInterface)
-		api.On("GetAppConfig", nil).Return(appConfig, nil)
-		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
-		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--triggerer-replicas=1"}
-		houstonClient = api
-
-		// mock os.Stdin
-		input := []byte("1")
-		r, w, err := os.Pipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = w.Write(input)
-		if err != nil {
-			t.Error(err)
-		}
-		w.Close()
-		stdin := os.Stdin
-		// Restore stdin right after the test.
-		defer func() { os.Stdin = stdin }()
-		os.Stdin = r
-		defer testUtil.MockUserInput(t, "y")()
-
-		_, err = execDeploymentCmd(cmdArgs...)
-		assert.NoError(t, err)
-		// Houston CreateDeployment API should be called if user confirms the prompt
-		api.AssertCalled(t, "CreateDeployment", mock.Anything)
-	})
-}
-
 func TestDeploymentCreateCommandTriggererDisabled(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
 	appConfig = &houston.AppConfig{TriggererEnabled: false}
@@ -422,6 +299,129 @@ func TestDeploymentCreateCommandGitSyncDisabled(t *testing.T) {
 		}
 		assert.Contains(t, output, tt.expectedOutput)
 	}
+}
+
+func TestDeploymentCreateWithTypeDagDeploy(t *testing.T) {
+	t.Run("user should not be prompted if deployment type is not dag_deploy", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+		appConfig = &houston.AppConfig{
+			TriggererEnabled: true,
+			Flags: houston.FeatureFlags{
+				TriggererEnabled: true,
+			},
+		}
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig", nil).Return(appConfig, nil)
+		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
+
+		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--triggerer-replicas=1"}
+		expectedOutput := "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs"
+		houstonClient = api
+		output, err := execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, output, expectedOutput)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("user should not be prompted if deployment type is dag_deploy but -f flag is sent", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+		appConfig = &houston.AppConfig{
+			TriggererEnabled: true,
+			Flags: houston.FeatureFlags{
+				TriggererEnabled:  true,
+				DagOnlyDeployment: true,
+			},
+		}
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig", nil).Return(appConfig, nil)
+		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
+
+		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--triggerer-replicas=1", "--force"}
+		expectedOutput := "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs"
+		houstonClient = api
+		output, err := execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, output, expectedOutput)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("user should be prompted if deployment type is dag_deploy and -f flag is not sent. No deployment is created without confirmation.", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+		appConfig = &houston.AppConfig{
+			TriggererEnabled: true,
+			Flags: houston.FeatureFlags{
+				TriggererEnabled:  true,
+				DagOnlyDeployment: true,
+			},
+		}
+
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig", nil).Return(appConfig, nil)
+		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
+		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--triggerer-replicas=1"}
+		houstonClient = api
+
+		// mock os.Stdin
+		input := []byte("1")
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = w.Write(input)
+		if err != nil {
+			t.Error(err)
+		}
+		w.Close()
+		stdin := os.Stdin
+		// Restore stdin right after the test.
+		defer func() { os.Stdin = stdin }()
+		os.Stdin = r
+		defer testUtil.MockUserInput(t, "n")()
+
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		// Houston CreateDeployment API should not be called if user does not confirm the prompt
+		api.AssertNotCalled(t, "CreateDeployment", mock.Anything)
+	})
+
+	t.Run("user should be prompted if deployment type is dag_deploy and -f flag is not sent. Deployment is created with confirmation.", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+		appConfig = &houston.AppConfig{
+			TriggererEnabled: true,
+			Flags: houston.FeatureFlags{
+				TriggererEnabled:  true,
+				DagOnlyDeployment: true,
+			},
+		}
+
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig", nil).Return(appConfig, nil)
+		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
+		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--triggerer-replicas=1"}
+		houstonClient = api
+
+		// mock os.Stdin
+		input := []byte("1")
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = w.Write(input)
+		if err != nil {
+			t.Error(err)
+		}
+		w.Close()
+		stdin := os.Stdin
+		// Restore stdin right after the test.
+		defer func() { os.Stdin = stdin }()
+		os.Stdin = r
+		defer testUtil.MockUserInput(t, "y")()
+
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		// Houston CreateDeployment API should be called if user confirms the prompt
+		api.AssertCalled(t, "CreateDeployment", mock.Anything)
+	})
 }
 
 func TestDeploymentUpdateTriggererEnabledCommand(t *testing.T) {
@@ -689,8 +689,8 @@ func TestDeploymentUpdateCommandDagOnlyDeployEnabled(t *testing.T) {
 		expectedOutput string
 		expectedError  string
 	}{
-		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222", "--dag-deployment-type=dag_deploy"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
-		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222", "--dag-deployment-type=invalid"}, expectedOutput: "", expectedError: ErrInvalidDAGDeploymentType.Error()},
+		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222", "--dag-deployment-type=dag_deploy", "--force"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
+		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222", "--dag-deployment-type=invalid", "--force"}, expectedOutput: "", expectedError: ErrInvalidDAGDeploymentType.Error()},
 	}
 	for _, tt := range myTests {
 		houstonClient = api

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -424,37 +424,6 @@ func TestDeploymentCreateWithTypeDagDeploy(t *testing.T) {
 	})
 }
 
-func TestDeploymentUpdateTriggererEnabledCommand(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-	appConfig = &houston.AppConfig{
-		TriggererEnabled: true,
-		Flags:            houston.FeatureFlags{TriggererEnabled: true},
-	}
-
-	api := new(mocks.ClientInterface)
-	api.On("GetAppConfig", nil).Return(appConfig, nil)
-	api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil).Twice()
-
-	myTests := []struct {
-		cmdArgs        []string
-		expectedOutput string
-		expectedError  string
-	}{
-		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222", "--triggerer-replicas=1"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
-		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
-	}
-	for _, tt := range myTests {
-		houstonClient = api
-		output, err := execDeploymentCmd(tt.cmdArgs...)
-		if tt.expectedError != "" {
-			assert.EqualError(t, err, tt.expectedError)
-		} else {
-			assert.NoError(t, err)
-		}
-		assert.Contains(t, output, tt.expectedOutput)
-	}
-}
-
 func TestDeploymentUpdateWithTypeDagDeploy(t *testing.T) {
 	t.Run("user should not be prompted if new deployment type is not dag_deploy", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.SoftwarePlatform)
@@ -625,6 +594,37 @@ func TestDeploymentUpdateCommand(t *testing.T) {
 		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222", "--dag-deployment-type=wrong", "--nfs-location=test:/test"}, expectedOutput: "", expectedError: ErrInvalidDAGDeploymentType.Error()},
 		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222", "--executor=local"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
 		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--cloud-role=arn:aws:iam::1234567890:role/test_role4c2301381e"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
+	}
+	for _, tt := range myTests {
+		houstonClient = api
+		output, err := execDeploymentCmd(tt.cmdArgs...)
+		if tt.expectedError != "" {
+			assert.EqualError(t, err, tt.expectedError)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Contains(t, output, tt.expectedOutput)
+	}
+}
+
+func TestDeploymentUpdateTriggererEnabledCommand(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	appConfig = &houston.AppConfig{
+		TriggererEnabled: true,
+		Flags:            houston.FeatureFlags{TriggererEnabled: true},
+	}
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig", nil).Return(appConfig, nil)
+	api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil).Twice()
+
+	myTests := []struct {
+		cmdArgs        []string
+		expectedOutput string
+		expectedError  string
+	}{
+		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222", "--triggerer-replicas=1"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
+		{cmdArgs: []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222"}, expectedOutput: "Successfully updated deployment", expectedError: ""},
 	}
 	for _, tt := range myTests {
 		houstonClient = api

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -256,8 +256,8 @@ func TestDeploymentCreateCommandDagOnlyDeployEnabled(t *testing.T) {
 		expectedOutput string
 		expectedError  string
 	}{
-		{cmdArgs: []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy"}, expectedOutput: "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs", expectedError: ""},
-		{cmdArgs: []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dummy"}, expectedOutput: "", expectedError: ErrInvalidDAGDeploymentType.Error()},
+		{cmdArgs: []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--force"}, expectedOutput: "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs", expectedError: ""},
+		{cmdArgs: []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dummy", "--force"}, expectedOutput: "", expectedError: ErrInvalidDAGDeploymentType.Error()},
 	}
 	for _, tt := range myTests {
 		houstonClient = api

--- a/houston/constants.go
+++ b/houston/constants.go
@@ -26,4 +26,7 @@ const (
 	VolumeDeploymentType  = "volume"
 	ImageDeploymentType   = "image"
 	DagOnlyDeploymentType = "dag_deploy"
+
+	DagDeployDocsLink    = "https://docs.astronomer.io/software/deploy-dags/"
+	DeployViaCLIDocsLink = "https://docs.astronomer.io/software/deploy-cli/"
 )


### PR DESCRIPTION
## Description

Confirm from user when deployment is created/upserted, if deployment type is dag_deploy

## 🎟 Issue(s)

[Related #6156
](https://github.com/astronomer/issues/issues/6156)

## 🧪 Functional Testing

Locally

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
