### PR TITLE
fix deployment inspect and list commands

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -517,11 +517,14 @@ func deploymentToTableRow(table *printutil.Table, d *astroplatformcore.Deploymen
 	cloudProvider := notApplicable
 	clusterName := notApplicable
 	region := notApplicable
-	releaseName := d.Namespace
-	if IsDeploymentStandard(*d.Type) {
+	if d.CloudProvider != nil {
 		cloudProvider = *d.CloudProvider
+	}
+	if d.Region != nil {
 		region = *d.Region
-	} else {
+	}
+	releaseName := d.Namespace
+	if !IsDeploymentStandard(*d.Type) {
 		clusterName = *d.ClusterName
 	}
 	cols := []string{
@@ -1113,10 +1116,13 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		clusterName := notApplicable
 		cloudProvider := notApplicable
 		region := notApplicable
-		if IsDeploymentStandard(*d.Type) {
+		if d.CloudProvider != nil {
 			cloudProvider = *d.CloudProvider
+		}
+		if d.Region != nil {
 			region = *d.Region
-		} else {
+		}
+		if !IsDeploymentStandard(*d.Type) {
 			clusterName = *d.ClusterName
 		}
 		tabDeployment.AddRow([]string{d.Name, releaseName, clusterName, cloudProvider, region, d.Id, runtimeVersionText, strconv.FormatBool(d.IsDagDeployEnabled), strconv.FormatBool(d.IsCicdEnforced), string(*d.Type)}, false)

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -456,10 +456,10 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 		}
 		if deployment.IsDeploymentStandard(deploymentType) {
 			var requestedExecutor astroplatformcore.UpdateStandardDeploymentRequestExecutor
-			switch deploymentFromFile.Deployment.Configuration.Executor {
-			case deployment.CeleryExecutor, deployment.CELERY:
+			switch strings.ToUpper(deploymentFromFile.Deployment.Configuration.Executor) {
+			case strings.ToUpper(deployment.CeleryExecutor), deployment.CELERY:
 				requestedExecutor = astroplatformcore.UpdateStandardDeploymentRequestExecutorCELERY
-			case deployment.KubeExecutor, deployment.KUBERNETES:
+			case strings.ToUpper(deployment.KubeExecutor), deployment.KUBERNETES:
 				requestedExecutor = astroplatformcore.UpdateStandardDeploymentRequestExecutorKUBERNETES
 			}
 
@@ -511,10 +511,10 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 		}
 		if deployment.IsDeploymentDedicated(deploymentType) {
 			var requestedExecutor astroplatformcore.UpdateDedicatedDeploymentRequestExecutor
-			switch deploymentFromFile.Deployment.Configuration.Executor {
-			case deployment.CeleryExecutor, deployment.CELERY:
+			switch strings.ToUpper(deploymentFromFile.Deployment.Configuration.Executor) {
+			case strings.ToUpper(deployment.CeleryExecutor), deployment.CELERY:
 				requestedExecutor = astroplatformcore.UpdateDedicatedDeploymentRequestExecutorCELERY
-			case deployment.KubeExecutor, deployment.KUBERNETES:
+			case strings.ToUpper(deployment.KubeExecutor), deployment.KUBERNETES:
 				requestedExecutor = astroplatformcore.UpdateDedicatedDeploymentRequestExecutorKUBERNETES
 			}
 
@@ -565,10 +565,10 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 		}
 		if !deployment.IsDeploymentStandard(deploymentType) && !deployment.IsDeploymentDedicated(deploymentType) {
 			var requestedExecutor astroplatformcore.UpdateHybridDeploymentRequestExecutor
-			switch deploymentFromFile.Deployment.Configuration.Executor {
-			case deployment.CeleryExecutor, deployment.CELERY:
+			switch strings.ToUpper(deploymentFromFile.Deployment.Configuration.Executor) {
+			case strings.ToUpper(deployment.CeleryExecutor), deployment.CELERY:
 				requestedExecutor = astroplatformcore.UpdateHybridDeploymentRequestExecutorCELERY
-			case deployment.KubeExecutor, deployment.KUBERNETES:
+			case strings.ToUpper(deployment.KubeExecutor), deployment.KUBERNETES:
 				requestedExecutor = astroplatformcore.UpdateHybridDeploymentRequestExecutorKUBERNETES
 			}
 

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2862,7 +2862,7 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 		mockPlatformCoreClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
 	})
-	t.Run("transforms formattedDeployment to UpdateDeploymentInput if Kubernetes executor was requested with a queue on standard", func(t *testing.T) {
+	t.Run("transforms formattedDeployment to UpdateDeploymentInput if Kubernetes executor was requested with a queue on dedicated", func(t *testing.T) {
 		deploymentID = "test-deployment-id"
 		deploymentFromFile = inspect.FormattedDeployment{}
 		deploymentFromFile.Deployment.Configuration.ClusterName = "test-cluster"

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2811,6 +2811,108 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 		mockPlatformCoreClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
 	})
+	t.Run("transforms formattedDeployment to UpdateDeploymentInput if Kubernetes executor was requested with a queue on standard", func(t *testing.T) {
+		deploymentID = "test-deployment-id"
+		deploymentFromFile = inspect.FormattedDeployment{}
+		deploymentFromFile.Deployment.Configuration.ClusterName = "test-cluster"
+		deploymentFromFile.Deployment.Configuration.Name = "test-deployment-modified"
+		deploymentFromFile.Deployment.Configuration.Description = "test-description"
+		deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
+		deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
+		deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+		deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+		deploymentFromFile.Deployment.Configuration.DeploymentType = "STANDARD"
+		dagDeploy := true
+		deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
+		deploymentFromFile.Deployment.Configuration.DefaultWorkerType = "test-worker-1"
+		existingPools = []astroplatformcore.NodePool{
+			{
+				Id:               "test-pool-id",
+				IsDefault:        false,
+				NodeInstanceType: "test-worker-1",
+			},
+			{
+				Id:               "test-pool-id-2",
+				IsDefault:        false,
+				NodeInstanceType: "test-worker-2",
+			},
+		}
+		clusterID := "test-cluster-id"
+		clusterName := "test-cluster"
+		defaultTaskPodMemory = "10"
+		defaultTaskPodCpu := "10"
+		resourceQuotaCpu := "10"
+		resourceQuotaMemory := "10"
+		existingDeployment := astroplatformcore.Deployment{
+			Id:                   deploymentID,
+			Name:                 "test-deployment",
+			ClusterId:            &clusterID,
+			ClusterName:          &clusterName,
+			Executor:             &executorCelery,
+			WorkerQueues:         &expectedQList,
+			DefaultTaskPodMemory: &defaultTaskPodMemory,
+			DefaultTaskPodCpu:    &defaultTaskPodCpu,
+			ResourceQuotaCpu:     &resourceQuotaCpu,
+			ResourceQuotaMemory:  &resourceQuotaMemory,
+		}
+
+		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient)
+		assert.NoError(t, err)
+		mockPlatformCoreClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
+	})
+	t.Run("transforms formattedDeployment to UpdateDeploymentInput if Kubernetes executor was requested with a queue on standard", func(t *testing.T) {
+		deploymentID = "test-deployment-id"
+		deploymentFromFile = inspect.FormattedDeployment{}
+		deploymentFromFile.Deployment.Configuration.ClusterName = "test-cluster"
+		deploymentFromFile.Deployment.Configuration.Name = "test-deployment-modified"
+		deploymentFromFile.Deployment.Configuration.Description = "test-description"
+		deploymentFromFile.Deployment.Configuration.RunTimeVersion = "test-runtime-v"
+		deploymentFromFile.Deployment.Configuration.SchedulerAU = 4
+		deploymentFromFile.Deployment.Configuration.SchedulerCount = 2
+		deploymentFromFile.Deployment.Configuration.Executor = deployment.KubeExecutor
+		deploymentFromFile.Deployment.Configuration.DeploymentType = "DEDICATED"
+		dagDeploy := true
+		deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
+		deploymentFromFile.Deployment.Configuration.DefaultWorkerType = "test-worker-1"
+		existingPools = []astroplatformcore.NodePool{
+			{
+				Id:               "test-pool-id",
+				IsDefault:        false,
+				NodeInstanceType: "test-worker-1",
+			},
+			{
+				Id:               "test-pool-id-2",
+				IsDefault:        false,
+				NodeInstanceType: "test-worker-2",
+			},
+		}
+		clusterID := "test-cluster-id"
+		clusterName := "test-cluster"
+		defaultTaskPodMemory = "10"
+		defaultTaskPodCpu := "10"
+		resourceQuotaCpu := "10"
+		resourceQuotaMemory := "10"
+		existingDeployment := astroplatformcore.Deployment{
+			Id:                   deploymentID,
+			Name:                 "test-deployment",
+			ClusterId:            &clusterID,
+			ClusterName:          &clusterName,
+			Executor:             &executorCelery,
+			WorkerQueues:         &expectedQList,
+			DefaultTaskPodMemory: &defaultTaskPodMemory,
+			DefaultTaskPodCpu:    &defaultTaskPodCpu,
+			ResourceQuotaCpu:     &resourceQuotaCpu,
+			ResourceQuotaMemory:  &resourceQuotaMemory,
+		}
+
+		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient)
+		assert.NoError(t, err)
+		mockPlatformCoreClient.AssertExpectations(t)
+		mockCoreClient.AssertExpectations(t)
+	})
 	t.Run("returns correct update deployment input when multiple queues are requested", func(t *testing.T) {
 		deploymentID = "test-deployment-id"
 		deploymentFromFile = inspect.FormattedDeployment{}

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -2840,8 +2840,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 		clusterID := "test-cluster-id"
 		clusterName := "test-cluster"
 		defaultTaskPodMemory = "10"
-		defaultTaskPodCpu := "10"
-		resourceQuotaCpu := "10"
+		defaultTaskPodCPU := "10"
+		resourceQuotaCPU := "10"
 		resourceQuotaMemory := "10"
 		existingDeployment := astroplatformcore.Deployment{
 			Id:                   deploymentID,
@@ -2851,8 +2851,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			Executor:             &executorCelery,
 			WorkerQueues:         &expectedQList,
 			DefaultTaskPodMemory: &defaultTaskPodMemory,
-			DefaultTaskPodCpu:    &defaultTaskPodCpu,
-			ResourceQuotaCpu:     &resourceQuotaCpu,
+			DefaultTaskPodCpu:    &defaultTaskPodCPU,
+			ResourceQuotaCpu:     &resourceQuotaCPU,
 			ResourceQuotaMemory:  &resourceQuotaMemory,
 		}
 
@@ -2891,8 +2891,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 		clusterID := "test-cluster-id"
 		clusterName := "test-cluster"
 		defaultTaskPodMemory = "10"
-		defaultTaskPodCpu := "10"
-		resourceQuotaCpu := "10"
+		defaultTaskPodCPU := "10"
+		resourceQuotaCPU := "10"
 		resourceQuotaMemory := "10"
 		existingDeployment := astroplatformcore.Deployment{
 			Id:                   deploymentID,
@@ -2902,8 +2902,8 @@ func TestGetCreateOrUpdateInput(t *testing.T) {
 			Executor:             &executorCelery,
 			WorkerQueues:         &expectedQList,
 			DefaultTaskPodMemory: &defaultTaskPodMemory,
-			DefaultTaskPodCpu:    &defaultTaskPodCpu,
-			ResourceQuotaCpu:     &resourceQuotaCpu,
+			DefaultTaskPodCpu:    &defaultTaskPodCPU,
+			ResourceQuotaCpu:     &resourceQuotaCPU,
 			ResourceQuotaMemory:  &resourceQuotaMemory,
 		}
 

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -38,12 +38,12 @@ type deploymentConfig struct {
 	RunTimeVersion        string `mapstructure:"runtime_version" yaml:"runtime_version" json:"runtime_version"`
 	DagDeployEnabled      *bool  `mapstructure:"dag_deploy_enabled,omitempty" yaml:"dag_deploy_enabled,omitempty" json:"dag_deploy_enabled,omitempty"`
 	APIKeyOnlyDeployments bool   `mapstructure:"ci_cd_enforcement" yaml:"ci_cd_enforcement" json:"ci_cd_enforcement"`
-	SchedulerSize         string `mapstructure:"scheduler_size" yaml:"scheduler_size" json:"scheduler_size"`
+	SchedulerSize         string `mapstructure:"scheduler_size,omitempty" yaml:"scheduler_size,omitempty" json:"scheduler_size,omitempty"`
 	IsHighAvailability    bool   `mapstructure:"is_high_availability" yaml:"is_high_availability" json:"is_high_availability"`
 	Executor              string `mapstructure:"executor" yaml:"executor" json:"executor"`
-	SchedulerAU           int    `mapstructure:"scheduler_au" yaml:"scheduler_au" json:"scheduler_au"`
+	SchedulerAU           int    `mapstructure:"scheduler_au,omitempty" yaml:"scheduler_au,omitempty" json:"scheduler_au,omitempty"`
 	SchedulerCount        int    `mapstructure:"scheduler_count" yaml:"scheduler_count" json:"scheduler_count"`
-	ClusterName           string `mapstructure:"cluster_name" yaml:"cluster_name" json:"cluster_name"`
+	ClusterName           string `mapstructure:"cluster_name,omitempty" yaml:"cluster_name,omitempty" json:"cluster_name,omitempty"`
 	WorkspaceName         string `mapstructure:"workspace_name" yaml:"workspace_name" json:"workspace_name"`
 	DeploymentType        string `mapstructure:"deployment_type" yaml:"deployment_type" json:"deployment_type"`
 	CloudProvider         string `mapstructure:"cloud_provider" yaml:"cloud_provider" json:"cloud_provider"`
@@ -224,7 +224,6 @@ func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, pl
 	}
 	if deployment.IsDeploymentStandard(*coreDeployment.Type) || deployment.IsDeploymentDedicated(*coreDeployment.Type) {
 		deploymentMap["scheduler_size"] = *coreDeployment.SchedulerSize
-		deploymentMap["cloud_provider"] = *coreDeployment.CloudProvider
 		deploymentMap["default_task_pod_cpu"] = *coreDeployment.DefaultTaskPodCpu
 		deploymentMap["default_task_pod_memory"] = *coreDeployment.DefaultTaskPodMemory
 		deploymentMap["resource_quota_cpu"] = *coreDeployment.ResourceQuotaCpu
@@ -245,6 +244,10 @@ func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, pl
 	}
 	if coreDeployment.SchedulerAu != nil {
 		deploymentMap["scheduler_au"] = *coreDeployment.SchedulerAu
+	}
+	if coreDeployment.CloudProvider != nil {
+		deploymentMap["cloud_provider"] = *coreDeployment.CloudProvider
+
 	}
 
 	return deploymentMap, nil

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -229,9 +229,6 @@ func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, pl
 		deploymentMap["resource_quota_cpu"] = *coreDeployment.ResourceQuotaCpu
 		deploymentMap["resource_quota_memory"] = *coreDeployment.ResourceQuotaMemory
 	}
-	if deployment.IsDeploymentStandard(*coreDeployment.Type) {
-		deploymentMap["region"] = *coreDeployment.Region
-	}
 	if !deployment.IsDeploymentStandard(*coreDeployment.Type) {
 		deploymentMap["default_worker_type"] = defaultWorkerType
 	}
@@ -247,7 +244,9 @@ func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, pl
 	}
 	if coreDeployment.CloudProvider != nil {
 		deploymentMap["cloud_provider"] = *coreDeployment.CloudProvider
-
+	}
+	if coreDeployment.Region != nil {
+		deploymentMap["region"] = *coreDeployment.Region
 	}
 
 	return deploymentMap, nil

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -447,9 +447,9 @@ func TestGetDeploymentConfig(t *testing.T) {
 			SchedulerCount:   sourceDeployment.SchedulerReplicas,
 			DagDeployEnabled: &sourceDeployment.IsDagDeployEnabled,
 			Executor:         string(*sourceDeployment.Executor),
-			Region:           "",
+			Region:           *sourceDeployment.Region,
 			DeploymentType:   string(*sourceDeployment.Type),
-			CloudProvider:    "",
+			CloudProvider:    *sourceDeployment.CloudProvider,
 		}
 		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
 		assert.NoError(t, err)
@@ -707,7 +707,6 @@ func TestFormatPrintableDeployment(t *testing.T) {
         runtime_version: 6.0.0
         dag_deploy_enabled: true
         ci_cd_enforcement: false
-        scheduler_size: ""
         is_high_availability: false
         executor: CELERY
         scheduler_au: 5
@@ -796,7 +795,6 @@ func TestFormatPrintableDeployment(t *testing.T) {
         executor: CELERY
         scheduler_au: 5
         scheduler_count: 3
-        cluster_name: ""
         workspace_name: test-ws
         deployment_type: STANDARD
         cloud_provider: azure
@@ -981,7 +979,6 @@ func TestFormatPrintableDeployment(t *testing.T) {
             "runtime_version": "6.0.0",
             "dag_deploy_enabled": true,
             "ci_cd_enforcement": false,
-            "scheduler_size": "",
             "is_high_availability": false,
             "executor": "KUBERNETES",
             "scheduler_au": 5,


### PR DESCRIPTION
## Description

- Make it so that region and cloud provider show up for all deployment types in deployment list/create/update/inspect
- Make sure that inputs are case insensitive
- Make it so some fields don't show up if they are empty

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
