### PR TITLE
Fix Env Var Issues

### DIFF
--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -48,7 +48,7 @@ func VariableList(deploymentID, variableKey, ws, envFile, deploymentName string,
 
 	var nbEnvVarFound int
 	for i := range environmentVariablesObjects {
-		if environmentVariablesObjects[i].Value != nil {
+		if environmentVariablesObjects[i].Value != nil && !environmentVariablesObjects[i].IsSecret {
 			printValue = *environmentVariablesObjects[i].Value
 		}
 		if environmentVariablesObjects[i].Key == variableKey {
@@ -142,7 +142,8 @@ func VariableModify(deploymentID, variableKey, variableValue, ws, envFile, deplo
 	var index int
 	for i := range environmentVariablesObjects {
 		index = i + 1
-		if environmentVariablesObjects[i].Value != nil {
+
+		if environmentVariablesObjects[i].Value != nil && !environmentVariablesObjects[i].IsSecret {
 			printValue = *environmentVariablesObjects[i].Value
 		}
 		varTab.AddRow([]string{strconv.Itoa(index), environmentVariablesObjects[i].Key, printValue, strconv.FormatBool(environmentVariablesObjects[i].IsSecret)}, false)

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -18,6 +18,7 @@ var (
 	errVarBool                  = false
 	errVarCreateUpdate          = errors.New("there was an error while creating or updating one or more of the environment variables. Check the logs above for more information")
 	environmentVariablesObjects = []astroplatformcore.DeploymentEnvironmentVariable{}
+	printValue                  = "****"
 )
 
 func VariableList(deploymentID, variableKey, ws, envFile, deploymentName string, useEnvFile bool, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
@@ -47,13 +48,16 @@ func VariableList(deploymentID, variableKey, ws, envFile, deploymentName string,
 
 	var nbEnvVarFound int
 	for i := range environmentVariablesObjects {
+		if environmentVariablesObjects[i].Value != nil {
+			printValue = *environmentVariablesObjects[i].Value
+		}
 		if environmentVariablesObjects[i].Key == variableKey {
 			nbEnvVarFound++
-			varTab.AddRow([]string{strconv.Itoa(nbEnvVarFound), environmentVariablesObjects[i].Key, *environmentVariablesObjects[i].Value, strconv.FormatBool(environmentVariablesObjects[i].IsSecret)}, false)
+			varTab.AddRow([]string{strconv.Itoa(nbEnvVarFound), environmentVariablesObjects[i].Key, printValue, strconv.FormatBool(environmentVariablesObjects[i].IsSecret)}, false)
 			break
 		} else if variableKey == "" {
 			nbEnvVarFound++
-			varTab.AddRow([]string{strconv.Itoa(nbEnvVarFound), environmentVariablesObjects[i].Key, *environmentVariablesObjects[i].Value, strconv.FormatBool(environmentVariablesObjects[i].IsSecret)}, false)
+			varTab.AddRow([]string{strconv.Itoa(nbEnvVarFound), environmentVariablesObjects[i].Key, printValue, strconv.FormatBool(environmentVariablesObjects[i].IsSecret)}, false)
 		}
 	}
 
@@ -138,7 +142,6 @@ func VariableModify(deploymentID, variableKey, variableValue, ws, envFile, deplo
 	var index int
 	for i := range environmentVariablesObjects {
 		index = i + 1
-		printValue := notApplicable
 		if environmentVariablesObjects[i].Value != nil {
 			printValue = *environmentVariablesObjects[i].Value
 		}

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	errVarBool                  = false
-	errVarCreateUpdate          = errors.New("there was an error while creating or updating one or more of the environment variables. Check the logs above for more information")
+	errVarCreateUpdate          = errors.New("there was an error while creating or updating one or more of the environment variables. Check the command output above for more information")
 	environmentVariablesObjects = []astroplatformcore.DeploymentEnvironmentVariable{}
 	printValue                  = "****"
 )

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -148,6 +148,8 @@ func TestVariableModify(t *testing.T) {
 	})
 
 	t.Run("success with secret value", func(t *testing.T) {
+		printValue = "****"
+
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)
@@ -168,7 +170,7 @@ func TestVariableModify(t *testing.T) {
 		}
 
 		buf := new(bytes.Buffer)
-		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", "", []string{}, false, false, false, mockCoreClient, mockPlatformCoreClient, buf)
+		err := VariableModify("test-id-1", "test-key-2", "test-value-2", ws, "", "", []string{}, false, false, true, mockCoreClient, mockPlatformCoreClient, buf)
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "test-key-1")
 		assert.Contains(t, buf.String(), "test-key-2")

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -172,7 +172,7 @@ func TestVariableModify(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "test-key-1")
 		assert.Contains(t, buf.String(), "test-key-2")
-		assert.Contains(t, buf.String(), "N/A")
+		assert.Contains(t, buf.String(), "****")
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -383,7 +383,7 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 		return errors.New("Invalid --type value")
 	}
 	if cicdEnforcement != "" && !(cicdEnforcement == enable || cicdEnforcement == disable) {
-		return errors.New("Invalid --enforce-cicd value")
+		return errors.New("Invalid --cicd-enforcment value")
 	}
 	if deploymentCreateEnforceCD && cicdEnforcement == disable {
 		return errors.New("flags --enforce-cicd and --cicd-enforcment contradict each other. Use only --cicd-enforcment")


### PR DESCRIPTION
## Description

- [minor bug] deployment create -h and error message call the same cmd line arg different things
- deployment list variables when there is a secret variable in the list
- Adding secret env variables shouldn't display N/A in the command output
- Confusing error message tells you to look at logs when it should tell you to look at output
## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
