### PR TITLE
Add appropriate error message when trying to create standard deployment with a clusterId

### DIFF
--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -439,6 +439,9 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 	if deploymentCreateEnforceCD && cicdEnforcement == disable {
 		return errors.New("flags --enforce-cicd and --cicd-enforcment contradict each other. Use only --cicd-enforcment")
 	}
+	if clusterID != "" && deploymentType == standard {
+		return errors.New("flag --cluster-id cannot be used with standard deployments. If you want to create a dedicated deployment, use --type dedicated along with --cluster-id")
+	}
 	if deploymentCreateEnforceCD {
 		cicdEnforcement = enable
 	}

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -440,7 +440,7 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 		return errors.New("flags --enforce-cicd and --cicd-enforcment contradict each other. Use only --cicd-enforcment")
 	}
 	if clusterID != "" && deploymentType == standard {
-		return errors.New("flag --cluster-id cannot be used with standard deployments. If you want to create a dedicated deployment, use --type dedicated along with --cluster-id")
+		return errors.New("flag --cluster-id cannot be used to create a standard deployment. If you want to create a dedicated deployment, use --type dedicated along with --cluster-id")
 	}
 	if deploymentCreateEnforceCD {
 		cicdEnforcement = enable

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -439,7 +439,7 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 	if deploymentCreateEnforceCD && cicdEnforcement == disable {
 		return errors.New("flags --enforce-cicd and --cicd-enforcment contradict each other. Use only --cicd-enforcment")
 	}
-	if clusterID != "" && deploymentType == standard {
+	if organization.IsOrgHosted() && clusterID != "" && (deploymentType == standard || deploymentType == fromfile.HostedStandard || deploymentType == fromfile.HostedShared) {
 		return errors.New("flag --cluster-id cannot be used to create a standard deployment. If you want to create a dedicated deployment, use --type dedicated along with --cluster-id")
 	}
 	if deploymentCreateEnforceCD {

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -384,7 +384,7 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		cmdArgs := []string{"create", "--name", "test", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable"}
+		cmdArgs := []string{"create", "--name", "test", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "disable"}
 		astroCoreClient = mockCoreClient
 		platformCoreClient = mockPlatformCoreClient
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -400,7 +400,7 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "enable"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "enable"}
 		astroCoreClient = mockCoreClient
 		platformCoreClient = mockPlatformCoreClient
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -416,7 +416,7 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable", "--executor", "KubernetesExecutor"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "disable", "--executor", "KubernetesExecutor"}
 		astroCoreClient = mockCoreClient
 		platformCoreClient = mockPlatformCoreClient
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -432,7 +432,7 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "disable"}
 		astroCoreClient = mockCoreClient
 		platformCoreClient = mockPlatformCoreClient
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -452,27 +452,27 @@ func TestDeploymentCreate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if dag-deploy flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if cluster-type flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--cluster-type", "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--cluster-type", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if type flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--type", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if cicd-enforcement flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--cicd-enforcement", "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--cicd-enforcement", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if executor has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable", "--executor", "KubeExecutor"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "disable", "--executor", "KubeExecutor"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "KubeExecutor is not a valid executor")
 	})

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -441,6 +441,16 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
 	})
+	t.Run("returns an error if cluster-id is provided with implicit standard deployment", func(t *testing.T) {
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.Error(t, err)
+	})
+	t.Run("returns an error if cluster-id is provided with explicit standard deployment", func(t *testing.T) {
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", standard}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.Error(t, err)
+	})
 	t.Run("returns an error if dag-deploy flag has an incorrect value", func(t *testing.T) {
 		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -457,12 +457,12 @@ func TestDeploymentCreate(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if cluster-type flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--cluster-type", "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if type flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--type", "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--type", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -384,7 +384,7 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		cmdArgs := []string{"create", "--name", "test", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "disable"}
+		cmdArgs := []string{"create", "--name", "test", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable"}
 		astroCoreClient = mockCoreClient
 		platformCoreClient = mockPlatformCoreClient
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -400,7 +400,7 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "enable"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "enable"}
 		astroCoreClient = mockCoreClient
 		platformCoreClient = mockPlatformCoreClient
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -416,7 +416,7 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "disable", "--executor", "KubernetesExecutor"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable", "--executor", "KubernetesExecutor"}
 		astroCoreClient = mockCoreClient
 		platformCoreClient = mockPlatformCoreClient
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -432,7 +432,7 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "disable"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable"}
 		astroCoreClient = mockCoreClient
 		platformCoreClient = mockPlatformCoreClient
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -441,38 +441,28 @@ func TestDeploymentCreate(t *testing.T) {
 		mockPlatformCoreClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
 	})
-	t.Run("returns an error if cluster-id is provided with implicit standard deployment", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID}
-		_, err = execDeploymentCmd(cmdArgs...)
-		assert.Error(t, err)
-	})
-	t.Run("returns an error if cluster-id is provided with explicit standard deployment", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", standard}
-		_, err = execDeploymentCmd(cmdArgs...)
-		assert.Error(t, err)
-	})
 	t.Run("returns an error if dag-deploy flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if cluster-type flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--cluster-type", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if type flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--type", "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if cicd-enforcement flag has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--cicd-enforcement", "some-value"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--cicd-enforcement", "some-value"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
 	})
 	t.Run("returns an error if executor has an incorrect value", func(t *testing.T) {
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", dedicated, "--dag-deploy", "disable", "--executor", "KubeExecutor"}
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--dag-deploy", "disable", "--executor", "KubeExecutor"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "KubeExecutor is not a valid executor")
 	})
@@ -871,6 +861,28 @@ deployment:
 		cmdArgs := []string{"update", "test-id", "--name", "test-name", "--workspace-id", ws, "--high-availability", "some-value", "--force"}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "Invalid --high-availability value")
+	})
+	t.Run("returns an error if cluster-id is provided with implicit standard deployment", func(t *testing.T) {
+		ctx, err := context.GetCurrentContext()
+		assert.NoError(t, err)
+		ctx.SetContextKey("organization_product", "HOSTED")
+		ctx.SetContextKey("organization", "test-org-id")
+		ctx.SetContextKey("workspace", ws)
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "flag --cluster-id cannot be used to create a standard deployment")
+	})
+	t.Run("returns an error if cluster-id is provided with explicit standard deployment", func(t *testing.T) {
+		ctx, err := context.GetCurrentContext()
+		assert.NoError(t, err)
+		ctx.SetContextKey("organization_product", "HOSTED")
+		ctx.SetContextKey("organization", "test-org-id")
+		ctx.SetContextKey("workspace", ws)
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--type", standard}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "flag --cluster-id cannot be used to create a standard deployment")
 	})
 }
 

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -358,7 +358,6 @@ func TestDeploymentCreate(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	ws := "workspace-id"
-	csID := "test-cluster-id"
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 


### PR DESCRIPTION
## Description
We should error early if a user tries to create a standard deployment with a clusterId.
> Describe the purpose of this pull request.

## 🎟 Issue(s)
https://github.com/astronomer/astro-cli/issues/1338
Related #XXX

## 🧪 Functional Testing
I tested the feature by trying to create a standard deployment with a clusterId and receiving the correct error message.
I created a dedicated deployment with a clusterId and saw there were no regressions.
I also added some unit tests.
> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots
Error message with standard deployment
<img width="874" alt="Screenshot 2024-02-21 at 12 11 33 PM" src="https://github.com/astronomer/astro-cli/assets/33995460/48f98a0c-7c1d-414f-bed9-5aba0f967148">
Success with dedicated deployment
<img width="1350" alt="Screenshot 2024-02-21 at 12 09 23 PM" src="https://github.com/astronomer/astro-cli/assets/33995460/6f65b678-3c33-4cae-9e07-4b0af322f663">

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
