### PR TITLE
dont write workload identity to yaml file on deployment inspect

### DIFF
--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -53,7 +53,7 @@ type deploymentConfig struct {
 	ResourceQuotaCPU      string `mapstructure:"resource_quota_cpu,omitempty" yaml:"resource_quota_cpu,omitempty" json:"resource_quota_cpu,omitempty"`
 	ResourceQuotaMemory   string `mapstructure:"resource_quota_memory,omitempty" yaml:"resource_quota_memory,omitempty" json:"resource_quota_memory,omitempty"`
 	DefaultWorkerType     string `mapstructure:"default_worker_type,omitempty" yaml:"default_worker_type,omitempty" json:"default_worker_type,omitempty"`
-	WorkloadIdentity      string `mapstructure:"workload_identity,omitempty" yaml:"workload_identity,omitempty" json:"workload_identity,omitempty"`
+	WorkloadIdentity      string `mapstructure:"workload_identity" yaml:"workload_identity" json:"workload_identity"` // intentionally removing omitempty so we have an empty placeholder for this value if someone wants to set it
 }
 
 type Workerq struct {
@@ -254,9 +254,6 @@ func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, pl
 	}
 	if coreDeployment.Region != nil {
 		deploymentMap["region"] = *coreDeployment.Region
-	}
-	if coreDeployment.WorkloadIdentity != nil {
-		deploymentMap["workload_identity"] = *coreDeployment.WorkloadIdentity
 	}
 
 	return deploymentMap, nil

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -467,7 +467,6 @@ func TestGetDeploymentConfig(t *testing.T) {
 			Region:            *sourceDeployment.Region,
 			DeploymentType:    string(*sourceDeployment.Type),
 			CloudProvider:     *sourceDeployment.CloudProvider,
-			WorkloadIdentity:  *sourceDeployment.WorkloadIdentity,
 			IsDevelopmentMode: *sourceDeployment.IsDevelopmentMode,
 		}
 		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -742,6 +742,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
         deployment_type: HYBRID
         cloud_provider: ""
         region: ""
+        workload_identity: ""
     worker_queues:
         - name: default
           max_worker_count: 130
@@ -830,6 +831,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
         default_task_pod_memory: "1"
         resource_quota_cpu: "1"
         resource_quota_memory: "1"
+        workload_identity: ""
     worker_queues:
         - name: default
           max_worker_count: 130
@@ -1014,7 +1016,8 @@ func TestFormatPrintableDeployment(t *testing.T) {
             "workspace_name": "test-ws",
             "deployment_type": "HYBRID",
             "cloud_provider": "",
-            "region": ""
+            "region": "",
+            "workload_identity": ""
         },
         "worker_queues": [],
         "alert_emails": [


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

don't write workload identity to yaml file on deployment inspect. this was breaking the flow of:
1. `astro deployment inspect` on an existing deployment
2. modify file with new deployment config
3. create deployment

the breakage was happening because the new deployment's create payload would contain the Workload Identity from the previous deployment. instead we can leave the value empty upon `astro deployment inspect`, and the API will default it. if someone has an override to pass in, they can enter it in the deployments-as-code file.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
