### PR TITLE
Fix deployment selection filter and validation logic

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -1590,11 +1590,6 @@ func GetDeployment(ws, deploymentID, deploymentName string, disableCreateFlow bo
 		return astroplatformcore.Deployment{}, errors.Wrap(err, errInvalidDeployment.Error())
 	}
 
-	// filter deployments
-	if selectionFilter != nil {
-		deployments = util.Filter(deployments, selectionFilter)
-	}
-
 	if len(deployments) == 0 && disableCreateFlow {
 		return astroplatformcore.Deployment{}, nil
 	}
@@ -1625,9 +1620,10 @@ func GetDeployment(ws, deploymentID, deploymentName string, disableCreateFlow bo
 	}
 
 	var currentDeployment astroplatformcore.Deployment
+
 	// select deployment if deploymentID is empty
 	if deploymentID == "" {
-		currentDeployment, err = deploymentSelectionProcess(ws, deployments, platformCoreClient, coreClient)
+		currentDeployment, err = deploymentSelectionProcess(ws, deployments, selectionFilter, platformCoreClient, coreClient, disableCreateFlow)
 		if err != nil {
 			return astroplatformcore.Deployment{}, err
 		}
@@ -1649,7 +1645,14 @@ func GetDeployment(ws, deploymentID, deploymentName string, disableCreateFlow bo
 	return currentDeployment, nil
 }
 
-func deploymentSelectionProcess(ws string, deployments []astroplatformcore.Deployment, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) (astroplatformcore.Deployment, error) {
+func deploymentSelectionProcess(ws string, deployments []astroplatformcore.Deployment, deploymentFilter func(deployment astroplatformcore.Deployment) bool, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, disableCreateFlow bool) (astroplatformcore.Deployment, error) {
+	// filter deployments
+	if deploymentFilter != nil {
+		deployments = util.Filter(deployments, deploymentFilter)
+	}
+	if len(deployments) == 0 && disableCreateFlow {
+		return astroplatformcore.Deployment{}, fmt.Errorf("No Deployments found in workspace %s", ws)
+	}
 	currentDeployment, err := SelectDeployment(deployments, "Select a Deployment")
 	if err != nil {
 		return astroplatformcore.Deployment{}, err

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -37,6 +37,7 @@ var (
 	ErrWrongEnforceInput         = errors.New("the input to the `--enforce-cicd` flag is invalid. Make sure to use either 'enable' or 'disable'")
 	ErrInvalidResourceRequest    = errors.New("invalid resource request")
 	ErrNotADevelopmentDeployment = errors.New("the Deployment specified is not a development Deployment")
+	errNoDeploymentInWSMsg       = "No Deployments found in workspace %s"
 	// Monkey patched to write unit tests
 	createDeployment = Create
 	canCiCdDeploy    = CanCiCdDeploy
@@ -1651,7 +1652,7 @@ func deploymentSelectionProcess(ws string, deployments []astroplatformcore.Deplo
 		deployments = util.Filter(deployments, deploymentFilter)
 	}
 	if len(deployments) == 0 && disableCreateFlow {
-		return astroplatformcore.Deployment{}, fmt.Errorf("No Deployments found in workspace %s", ws)
+		return astroplatformcore.Deployment{}, fmt.Errorf(errNoDeploymentInWSMsg, ws) //nolint:goerr113
 	}
 	currentDeployment, err := SelectDeployment(deployments, "Select a Deployment")
 	if err != nil {

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -37,7 +37,6 @@ var (
 	ErrWrongEnforceInput         = errors.New("the input to the `--enforce-cicd` flag is invalid. Make sure to use either 'enable' or 'disable'")
 	ErrInvalidResourceRequest    = errors.New("invalid resource request")
 	ErrNotADevelopmentDeployment = errors.New("the Deployment specified is not a development Deployment")
-	errNoDeploymentInWSMsg       = "No Deployments found in workspace %s"
 	// Monkey patched to write unit tests
 	createDeployment = Create
 	canCiCdDeploy    = CanCiCdDeploy
@@ -46,24 +45,25 @@ var (
 )
 
 const (
-	noWorkspaceMsg  = "no workspaces with id (%s) found"
-	KubeExecutor    = "KubernetesExecutor"
-	CeleryExecutor  = "CeleryExecutor"
-	KUBERNETES      = "KUBERNETES"
-	CELERY          = "CELERY"
-	notApplicable   = "N/A"
-	gcpCloud        = "gcp"
-	awsCloud        = "aws"
-	azureCloud      = "azure"
-	standard        = "standard"
-	LargeScheduler  = "large"
-	MediumScheduler = "medium"
-	SmallScheduler  = "small"
-	SMALL           = "SMALL"
-	MEDIUM          = "MEDIUM"
-	LARGE           = "LARGE"
-	disable         = "disable"
-	enable          = "enable"
+	NoDeploymentInWSMsg = "No Deployments found in workspace"
+	noWorkspaceMsg      = "no workspaces with id (%s) found"
+	KubeExecutor        = "KubernetesExecutor"
+	CeleryExecutor      = "CeleryExecutor"
+	KUBERNETES          = "KUBERNETES"
+	CELERY              = "CELERY"
+	notApplicable       = "N/A"
+	gcpCloud            = "gcp"
+	awsCloud            = "aws"
+	azureCloud          = "azure"
+	standard            = "standard"
+	LargeScheduler      = "large"
+	MediumScheduler     = "medium"
+	SmallScheduler      = "small"
+	SMALL               = "SMALL"
+	MEDIUM              = "MEDIUM"
+	LARGE               = "LARGE"
+	disable             = "disable"
+	enable              = "enable"
 )
 
 var (
@@ -125,7 +125,7 @@ func List(ws string, fromAllWorkspaces bool, platformCoreClient astroplatformcor
 	}
 
 	if len(deployments) == 0 {
-		fmt.Printf("No Deployments found in workspace %s\n", ansi.Bold(ws))
+		fmt.Printf("%s %s\n", NoDeploymentInWSMsg, ansi.Bold(ws))
 		return nil
 	}
 
@@ -1156,7 +1156,7 @@ func Delete(deploymentID, ws, deploymentName string, forceDelete bool, platformC
 	}
 
 	if currentDeployment.Id == "" {
-		fmt.Printf("No Deployments found in workspace %s to delete\n", ansi.Bold(ws))
+		fmt.Printf("%s %s to delete\n", NoDeploymentInWSMsg, ansi.Bold(ws))
 		return nil
 	}
 
@@ -1196,7 +1196,7 @@ func UpdateDeploymentHibernationOverride(deploymentID, ws, deploymentName string
 		return err
 	}
 	if currentDeployment.Id == "" {
-		fmt.Printf("No Deployments found in workspace %s to %s\n", ansi.Bold(ws), action)
+		fmt.Printf("%s %s to %s\n", NoDeploymentInWSMsg, ansi.Bold(ws), action)
 		return nil
 	}
 
@@ -1652,7 +1652,7 @@ func deploymentSelectionProcess(ws string, deployments []astroplatformcore.Deplo
 		deployments = util.Filter(deployments, deploymentFilter)
 	}
 	if len(deployments) == 0 && disableCreateFlow {
-		return astroplatformcore.Deployment{}, fmt.Errorf(errNoDeploymentInWSMsg, ws) //nolint:goerr113
+		return astroplatformcore.Deployment{}, fmt.Errorf("%s %s", NoDeploymentInWSMsg, ws) //nolint:goerr113
 	}
 	currentDeployment, err := SelectDeployment(deployments, "Select a Deployment")
 	if err != nil {

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -45,7 +45,7 @@ var (
 )
 
 const (
-	NoDeploymentInWSMsg = "No Deployments found in workspace"
+	NoDeploymentInWSMsg = "no Deployments found in workspace"
 	noWorkspaceMsg      = "no workspaces with id (%s) found"
 	KubeExecutor        = "KubernetesExecutor"
 	CeleryExecutor      = "CeleryExecutor"

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -46,7 +46,7 @@ var (
 
 const (
 	NoDeploymentInWSMsg = "no Deployments found in workspace"
-	noWorkspaceMsg      = "no workspaces with id (%s) found"
+	noWorkspaceMsg      = "no Workspace with id (%s) found"
 	KubeExecutor        = "KubernetesExecutor"
 	CeleryExecutor      = "CeleryExecutor"
 	KUBERNETES          = "KUBERNETES"

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -1590,6 +1590,11 @@ func GetDeployment(ws, deploymentID, deploymentName string, disableCreateFlow bo
 		return astroplatformcore.Deployment{}, errors.Wrap(err, errInvalidDeployment.Error())
 	}
 
+	// filter deployments
+	if selectionFilter != nil {
+		deployments = util.Filter(deployments, selectionFilter)
+	}
+
 	if len(deployments) == 0 && disableCreateFlow {
 		return astroplatformcore.Deployment{}, nil
 	}
@@ -1620,10 +1625,9 @@ func GetDeployment(ws, deploymentID, deploymentName string, disableCreateFlow bo
 	}
 
 	var currentDeployment astroplatformcore.Deployment
-
 	// select deployment if deploymentID is empty
 	if deploymentID == "" {
-		currentDeployment, err = deploymentSelectionProcess(ws, deployments, selectionFilter, platformCoreClient, coreClient)
+		currentDeployment, err = deploymentSelectionProcess(ws, deployments, platformCoreClient, coreClient)
 		if err != nil {
 			return astroplatformcore.Deployment{}, err
 		}
@@ -1645,11 +1649,7 @@ func GetDeployment(ws, deploymentID, deploymentName string, disableCreateFlow bo
 	return currentDeployment, nil
 }
 
-func deploymentSelectionProcess(ws string, deployments []astroplatformcore.Deployment, deploymentFilter func(deployment astroplatformcore.Deployment) bool, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) (astroplatformcore.Deployment, error) {
-	// filter deployments
-	if deploymentFilter != nil {
-		deployments = util.Filter(deployments, deploymentFilter)
-	}
+func deploymentSelectionProcess(ws string, deployments []astroplatformcore.Deployment, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) (astroplatformcore.Deployment, error) {
 	currentDeployment, err := SelectDeployment(deployments, "Select a Deployment")
 	if err != nil {
 		return astroplatformcore.Deployment{}, err

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1957,7 +1957,7 @@ func TestUpdateDeploymentHibernationOverride(t *testing.T) {
 
 		err := UpdateDeploymentHibernationOverride("", ws, "", true, nil, false, mockPlatformCoreClient)
 		assert.Error(t, err)
-		assert.Equal(t, err.Error(), "No Deployments found in workspace workspace-id")
+		assert.Equal(t, err.Error(), fmt.Sprintf("%s %s", NoDeploymentInWSMsg, ws))
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1214,7 +1214,7 @@ func TestCreate(t *testing.T) {
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
 
 		err := Create("test-name", "wrong-workspace", "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
-		assert.ErrorContains(t, err, "no workspaces with id")
+		assert.ErrorContains(t, err, "no Workspace with id")
 		mockCoreClient.AssertExpectations(t)
 	})
 }

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -119,7 +119,7 @@ func Inspect(wsID, deploymentName, deploymentID, outputFormat string, platformCo
 	}
 
 	if requestedDeployment.Id == "" {
-		fmt.Printf("No Deployments found in workspace %s\n", ansi.Bold(wsID))
+		fmt.Printf("%s %s\n", deployment.NoDeploymentInWSMsg, ansi.Bold(wsID))
 		return nil
 	}
 	// create a map for deployment.information

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -61,7 +61,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	}
 
 	if requestedDeployment.Id == "" {
-		fmt.Printf("No Deployments found in workspace %s\n", ansi.Bold(ws))
+		fmt.Printf("%s %s\n", deployment.NoDeploymentInWSMsg, ansi.Bold(ws))
 		return nil
 	}
 
@@ -517,7 +517,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, platformC
 	}
 
 	if requestedDeployment.Id == "" {
-		fmt.Printf("No Deployments found in workspace %s\n", ansi.Bold(ws))
+		fmt.Printf("%s %s\n", deployment.NoDeploymentInWSMsg, ansi.Bold(ws))
 		return nil
 	}
 


### PR DESCRIPTION
## Description
This PR fixes the logic around the deployment filter, as of now the filtering process was happening right before the selection, but no validation was happening after that, which means we used to run into a case where no deployments were left after filtering then the logic ran into creating a new deployment, but in case the command behavior is configured not to create a new deployment, we run into code panic.

I have added a check as part of this PR to cover that case

## 🎟 Issue(s)

Related #1570

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

- Ran the command against a workspace that had a deployment that was not a development deployment
<img width="666" alt="Screenshot 2024-02-28 at 9 26 11 PM" src="https://github.com/astronomer/astro-cli/assets/92356010/16fc3c0f-d162-47b1-bf03-d147f53267a0">

- Ran the command against a workspace that had no deployments
<img width="597" alt="Screenshot 2024-02-28 at 9 26 17 PM" src="https://github.com/astronomer/astro-cli/assets/92356010/dc581d75-2621-4d3a-8453-2ecc51838c93">



## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
