### PR TITLE
Include active hibernation override info in deployment metadata

### DIFF
--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -636,6 +636,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 				"alert_emails":          additional["alert_emails"],
 				"worker_queues":         additional["worker_queues"],
 				"environment_variables": additional["environment_variables"],
+				"hibernation_schedules": additional["hibernation_schedules"],
 			},
 		}
 		expectedDeployment := `deployment:
@@ -730,6 +731,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 				"alert_emails":          additional["alert_emails"],
 				"worker_queues":         additional["worker_queues"],
 				"environment_variables": additional["environment_variables"],
+				"hibernation_schedules": additional["hibernation_schedules"],
 			},
 		}
 		expectedDeployment := `deployment:
@@ -769,6 +771,11 @@ func TestFormatPrintableDeployment(t *testing.T) {
     alert_emails:
         - email1
         - email2
+    hibernation_schedules:
+        - hibernate_at: 1 * * * *
+          wake_at: 2 * * * *
+          description: hibernation schedule 1
+          enabled: true
 `
 		var orderedAndTaggedDeployment FormattedDeployment
 		actualPrintableDeployment, err := formatPrintableDeployment("", true, printableDeployment)
@@ -813,6 +820,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 				"alert_emails":          additional["alert_emails"],
 				"worker_queues":         additional["worker_queues"],
 				"environment_variables": additional["environment_variables"],
+				"hibernation_schedules": additional["hibernation_schedules"],
 			},
 		}
 		expectedDeployment := `deployment:
@@ -875,6 +883,11 @@ func TestFormatPrintableDeployment(t *testing.T) {
     alert_emails:
         - email1
         - email2
+    hibernation_schedules:
+        - hibernate_at: 1 * * * *
+          wake_at: 2 * * * *
+          description: hibernation schedule 1
+          enabled: true
 `
 		var orderedAndTaggedDeployment FormattedDeployment
 		actualPrintableDeployment, err := formatPrintableDeployment("", false, printableDeployment)
@@ -903,6 +916,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 				"alert_emails":          additional["alert_emails"],
 				"worker_queues":         additional["worker_queues"],
 				"environment_variables": additional["environment_variables"],
+				"hibernation_schedules": additional["hibernation_schedules"],
 			},
 		}
 		expectedDeployment := `{
@@ -1009,6 +1023,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 				"alert_emails":          additional["alert_emails"],
 				"worker_queues":         additional["worker_queues"],
 				"environment_variables": additional["environment_variables"],
+				"hibernation_schedules": additional["hibernation_schedules"],
 			},
 		}
 
@@ -1044,6 +1059,14 @@ func TestFormatPrintableDeployment(t *testing.T) {
         "alert_emails": [
             "email1",
             "email2"
+        ],
+        "hibernation_schedules": [
+            {
+                "hibernate_at": "1 * * * *",
+                "wake_at": "2 * * * *",
+                "description": "hibernation schedule 1",
+                "enabled": true
+            }
         ]
     }
 }`
@@ -1103,136 +1126,71 @@ func TestGetSpecificField(t *testing.T) {
 	config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
 	assert.NoError(t, err)
 	additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
+	printableDeployment := map[string]interface{}{
+		"deployment": map[string]interface{}{
+			"metadata":              info,
+			"configuration":         config,
+			"alert_emails":          additional["alert_emails"],
+			"worker_queues":         additional["worker_queues"],
+			"environment_variables": additional["environment_variables"],
+			"hibernation_schedules": additional["hibernation_schedules"],
+		},
+	}
 	t.Run("returns a value if key is found in deployment.metadata", func(t *testing.T) {
 		requestedField := "metadata.workspace_id"
-		printableDeployment := map[string]interface{}{
-			"deployment": map[string]interface{}{
-				"metadata":              info,
-				"configuration":         config,
-				"alert_emails":          additional["alert_emails"],
-				"worker_queues":         additional["worker_queues"],
-				"environment_variables": additional["environment_variables"],
-			},
-		}
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, sourceDeployment.WorkspaceId, actual)
 	})
 	t.Run("returns a value if key is found in deployment.configuration", func(t *testing.T) {
 		requestedField := "configuration.scheduler_count"
-		printableDeployment := map[string]interface{}{
-			"deployment": map[string]interface{}{
-				"metadata":              info,
-				"configuration":         config,
-				"alert_emails":          additional["alert_emails"],
-				"worker_queues":         additional["worker_queues"],
-				"environment_variables": additional["environment_variables"],
-			},
-		}
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, sourceDeployment.SchedulerReplicas, actual)
 	})
 	t.Run("returns a value if key is alert_emails", func(t *testing.T) {
 		requestedField := "alert_emails"
-		printableDeployment := map[string]interface{}{
-			"deployment": map[string]interface{}{
-				"metadata":              info,
-				"configuration":         config,
-				"alert_emails":          additional["alert_emails"],
-				"worker_queues":         additional["worker_queues"],
-				"environment_variables": additional["environment_variables"],
-			},
-		}
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, sourceDeployment.ContactEmails, actual)
 	})
 	t.Run("returns a value if key is environment_variables", func(t *testing.T) {
 		requestedField := "environment_variables"
-		printableDeployment := map[string]interface{}{
-			"deployment": map[string]interface{}{
-				"metadata":              info,
-				"configuration":         config,
-				"alert_emails":          additional["alert_emails"],
-				"worker_queues":         additional["worker_queues"],
-				"environment_variables": additional["environment_variables"],
-			},
-		}
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, getVariablesMap(*sourceDeployment.EnvironmentVariables), actual)
 	})
 	t.Run("returns a value if key is worker_queues", func(t *testing.T) {
 		requestedField := "worker_queues"
-		printableDeployment := map[string]interface{}{
-			"deployment": map[string]interface{}{
-				"metadata":              info,
-				"configuration":         config,
-				"alert_emails":          additional["alert_emails"],
-				"worker_queues":         additional["worker_queues"],
-				"environment_variables": additional["environment_variables"],
-			},
-		}
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, getQMap(&sourceDeployment, nodePools), actual)
 	})
+	t.Run("returns a value if key is hibernation_schedules", func(t *testing.T) {
+		requestedField := "hibernation_schedules"
+		actual, err := getSpecificField(printableDeployment, requestedField)
+		assert.NoError(t, err)
+		assert.Equal(t, getHibernationSchedulesMap(*sourceDeployment.ScalingSpec.HibernationSpec.Schedules), actual)
+	})
 	t.Run("returns a value if key is metadata", func(t *testing.T) {
 		requestedField := "metadata"
-		printableDeployment := map[string]interface{}{
-			"deployment": map[string]interface{}{
-				"metadata":              info,
-				"configuration":         config,
-				"alert_emails":          additional["alert_emails"],
-				"worker_queues":         additional["worker_queues"],
-				"environment_variables": additional["environment_variables"],
-			},
-		}
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, info, actual)
 	})
 	t.Run("returns value regardless of upper or lower case key", func(t *testing.T) {
 		requestedField := "Configuration.Cluster_NAME"
-		printableDeployment := map[string]interface{}{
-			"deployment": map[string]interface{}{
-				"metadata":              info,
-				"configuration":         config,
-				"alert_emails":          additional["alert_emails"],
-				"worker_queues":         additional["worker_queues"],
-				"environment_variables": additional["environment_variables"],
-			},
-		}
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, *sourceDeployment.ClusterName, actual)
 	})
 	t.Run("returns error if no value is found", func(t *testing.T) {
-		printableDeployment := map[string]interface{}{
-			"deployment": map[string]interface{}{
-				"metadata":              info,
-				"configuration":         config,
-				"alert_emails":          additional["alert_emails"],
-				"worker_queues":         additional["worker_queues"],
-				"environment_variables": additional["astronomer_variables"],
-			},
-		}
 		requestedField := "does-not-exist"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.ErrorContains(t, err, "requested key "+requestedField+" not found in deployment")
 		assert.Equal(t, nil, actual)
 	})
 	t.Run("returns error if incorrect field is requested", func(t *testing.T) {
-		printableDeployment := map[string]interface{}{
-			"deployment": map[string]interface{}{
-				"metadata":              info,
-				"configuration":         config,
-				"alert_emails":          additional["alert_emails"],
-				"worker_queues":         additional["worker_queues"],
-				"environment_variables": additional["astronomer_variables"],
-			},
-		}
 		requestedField := "configuration.does-not-exist"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.ErrorIs(t, err, errKeyNotFound)

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -154,6 +154,14 @@ var (
 			IsEnabled:       true,
 		},
 	}
+	hibernationIsActive      = true
+	hibernationIsHibernating = true
+	hibernationOverrideUntil = time.Now()
+	hibernationOverride      = astroplatformcore.DeploymentHibernationOverride{
+		IsActive:      &hibernationIsActive,
+		IsHibernating: &hibernationIsHibernating,
+		OverrideUntil: &hibernationOverrideUntil,
+	}
 	isDevelopmentMode = true
 	sourceDeployment  = astroplatformcore.Deployment{
 		Id:                     deploymentID,
@@ -187,6 +195,7 @@ var (
 		IsDevelopmentMode:      &isDevelopmentMode,
 		ScalingSpec: &astroplatformcore.DeploymentScalingSpec{
 			HibernationSpec: &astroplatformcore.DeploymentHibernationSpec{
+				Override:  &hibernationOverride,
 				Schedules: &hibernationSchedules,
 			},
 		},
@@ -674,6 +683,9 @@ func TestFormatPrintableDeployment(t *testing.T) {
         updated_at: 2022-11-17T13:25:55.275697-08:00
         deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
         webserver_url: some-url
+        hibernation_override:
+            is_hibernating: true
+            override_until: 2022-11-17T13:25:55.275697-08:00
     alert_emails:
         - email1
         - email2
@@ -786,6 +798,8 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		sourceDeployment2.CloudProvider = &provider
 		sourceDeployment2.ImageTag = "some-tag"
 		sourceDeployment2.Status = "UNHEALTHY"
+		overrideUntil := time.Date(2023, time.February, 1, 12, 0, 0, 0, time.UTC)
+		sourceDeployment2.ScalingSpec.HibernationSpec.Override.OverrideUntil = &overrideUntil
 
 		info, _ := getDeploymentInfo(sourceDeployment2)
 		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient)
@@ -855,6 +869,9 @@ func TestFormatPrintableDeployment(t *testing.T) {
         updated_at: 2023-02-01T12:00:00Z
         deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
         webserver_url: some-url
+        hibernation_override:
+            is_hibernating: true
+            override_until: 2023-02-01T12:00:00Z
     alert_emails:
         - email1
         - email2
@@ -944,7 +961,11 @@ func TestFormatPrintableDeployment(t *testing.T) {
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
             "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
-            "webserver_url": "some-url"
+            "webserver_url": "some-url",
+			"hibernation_override": {
+				"is_hibernating": true,
+				"override_until": "2022-11-17T12:26:45.362983-08:00"
+			}
         },
         "alert_emails": [
             "email1",


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

closes: #1575 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

For a deployment with override defined:
```
❯ ./astro deployment inspect cltwui4j6009401nwoqev94g7
deployment:
    configuration:
        name: create hosted dedicated
        description: desc
        runtime_version: 10.5.0
        dag_deploy_enabled: true
        ci_cd_enforcement: false
        scheduler_size: SMALL
        is_high_availability: false
        is_development_mode: true
        executor: CELERY
        scheduler_count: 1
        cluster_name: Sample AWS Cluster
        workspace_name: Sample Workspace 1
        deployment_type: DEDICATED
        cloud_provider: AWS
        region: ap-northeast-1
        default_task_pod_cpu: "0.25"
        default_task_pod_memory: 0.5Gi
        resource_quota_cpu: "2"
        resource_quota_memory: 4Gi
        workload_identity: ""
    worker_queues:
        - name: default
          max_worker_count: 4
          min_worker_count: 0
          worker_concurrency: 6
          worker_type: A10
    metadata:
        deployment_id: cltwui4j6009401nwoqev94g7
        workspace_id: cltwu72pz0198f7hgnnal41us
        cluster_id: cltwu71tx0004eehg6gnt39pc
        release_name: N/A
        airflow_version: 2.8.3
        current_tag: 10.5.0
        status: CREATING
        created_at: 2024-03-18T11:11:25.634Z
        updated_at: 2024-03-18T11:12:48.325Z
        deployment_url: cloud.astronomer-dev.io/cltwu72pz0198f7hgnnal41us/deployments/cltwui4j6009401nwoqev94g7/overview
        webserver_url: sampleorgpr19854-pr19854.astronomer-dev.run/dqev94g7?orgId=org_LL0XyTELYJS9ZOE0
        hibernation_override:
            is_hibernating: true
            override_until: 2100-01-01T00:00:00Z
```
For a deployment without override defined:
```
❯ ./astro deployment inspect cltwui4j6009401nwoqev94g7
deployment:
    configuration:
        name: create hosted dedicated
        description: desc
        runtime_version: 10.5.0
        dag_deploy_enabled: true
        ci_cd_enforcement: false
        scheduler_size: SMALL
        is_high_availability: false
        is_development_mode: true
        executor: CELERY
        scheduler_count: 1
        cluster_name: Sample AWS Cluster
        workspace_name: Sample Workspace 1
        deployment_type: DEDICATED
        cloud_provider: AWS
        region: ap-northeast-1
        default_task_pod_cpu: "0.25"
        default_task_pod_memory: 0.5Gi
        resource_quota_cpu: "2"
        resource_quota_memory: 4Gi
        workload_identity: ""
    worker_queues:
        - name: default
          max_worker_count: 4
          min_worker_count: 0
          worker_concurrency: 6
          worker_type: A10
    metadata:
        deployment_id: cltwui4j6009401nwoqev94g7
        workspace_id: cltwu72pz0198f7hgnnal41us
        cluster_id: cltwu71tx0004eehg6gnt39pc
        release_name: N/A
        airflow_version: 2.8.3
        current_tag: 10.5.0
        status: CREATING
        created_at: 2024-03-18T11:11:25.634Z
        updated_at: 2024-03-18T11:28:25.717Z
        deployment_url: cloud.astronomer-dev.io/cltwu72pz0198f7hgnnal41us/deployments/cltwui4j6009401nwoqev94g7/overview
        webserver_url: sampleorgpr19854-pr19854.astronomer-dev.run/dqev94g7?orgId=org_LL0XyTELYJS9ZOE0
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
