### PR TITLE
Deployment APi Token Improvements

### DIFF
--- a/cloud/apitoken/apitoken.go
+++ b/cloud/apitoken/apitoken.go
@@ -51,6 +51,7 @@ func CreateDeploymentAPIToken(name, role, description, deployment string, out io
 		return err
 	}
 	fmt.Fprintf(out, "The apiToken was successfully created with the role %s\n", role)
+	fmt.Fprintf(out, "Token: %s\n", *resp.JSON200.Token)
 	return nil
 }
 
@@ -234,24 +235,27 @@ func ListDeploymentAPITokens(out io.Writer, client astrocore.CoreClient, deploym
 	if err != nil {
 		return err
 	}
-
-	for i := range apiTokens {
-		var deploymentRole string
-		for _, role := range apiTokens[i].Roles {
-			if role.EntityId == deployment {
-				deploymentRole = role.Role
+	if len(apiTokens) > 0 {
+		for i := range apiTokens {
+			var deploymentRole string
+			for _, role := range apiTokens[i].Roles {
+				if role.EntityId == deployment {
+					deploymentRole = role.Role
+				}
 			}
+			table.AddRow([]string{
+				apiTokens[i].Name,
+				apiTokens[i].Description,
+				apiTokens[i].Id,
+				deploymentRole,
+				apiTokens[i].CreatedAt.Format(time.RFC3339),
+				apiTokens[i].UpdatedAt.Format(time.RFC3339),
+			}, false)
 		}
-		table.AddRow([]string{
-			apiTokens[i].Name,
-			apiTokens[i].Description,
-			apiTokens[i].Id,
-			deploymentRole,
-			apiTokens[i].CreatedAt.Format(time.RFC3339),
-			apiTokens[i].UpdatedAt.Format(time.RFC3339),
-		}, false)
+		table.Print(out)
+		return nil
 	}
 
-	table.Print(out)
+	fmt.Println("The selected deployment has no api tokens")
 	return nil
 }

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -953,7 +953,7 @@ func newDeploymentAPITokenCreateCmd(out io.Writer) *cobra.Command {
 			return createDeploymentAPIToken(cmd, nil, out)
 		},
 	}
-	cmd.Flags().StringVarP(&apiTokenRole, "role", "r", "", "The role for the "+
+	cmd.Flags().StringVarP(&apiTokenRole, "role", "r", "DEPLOYMENT_ADMIN", "The role for the "+
 		"new apiToken. Possible values are DEPLOYMENT_ADMIN or the custom role name.")
 	cmd.Flags().StringVarP(&apiTokenName, "name", "n", "", "The unique name for the "+
 		"new apiToken.")


### PR DESCRIPTION
## Description

- Adds a default of DEPLOYMENT_ADMIN for the role when creating a deployment api token
- Prints an error when listing api tokens when none are found in a given deployment
- Prints to console the api token on creation so that it can actually be used


## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
