### PR TITLE
throw error when an api token is bad or invalid

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/astronomer/astro-cli/cmd/registry"
@@ -83,6 +85,9 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 			if isCloudCtx {
 				err = cloudCmd.Setup(cmd, platformCoreClient, astroCoreClient)
 				if err != nil {
+					if strings.Contains(err.Error(), "token is invalid or malformed") {
+						return errors.New("API Token is invalid or malformed") //nolint
+					}
 					softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error during cmd setup: "+err.Error())
 				}
 			}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -105,6 +105,9 @@ func ParseAPIToken(astroAPIToken string) (*CustomClaims, error) {
 	// Parse the token to peek at the custom claims
 	jwtParser := jwt.NewParser()
 	parsedToken, _, err := jwtParser.ParseUnverified(astroAPIToken, &CustomClaims{})
+	if err != nil {
+		return nil, errors.Wrap(err, "token is invalid or malformed")
+	}
 	claims, ok := parsedToken.Claims.(*CustomClaims)
 	if !ok {
 		return nil, errors.Wrap(err, "failed to parse auth token")

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -218,6 +218,23 @@ func TestCheckEnvBool(t *testing.T) {
 	}
 }
 
+func TestParseAPIToken(t *testing.T) {
+	t.Run("throw error is token is invalid", func(t *testing.T) {
+		token := "invalid-token"
+		_, err := ParseAPIToken(token)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "token is invalid or malformed")
+	})
+
+	t.Run("returns token claims if token is valid", func(t *testing.T) {
+		// dummy token
+		token := "eyJhbGciOiAibm9uZSIsICJ0eXAiOiAiSldUIn0K.eyJ1c2VybmFtZSI6ImFkbWluaW5pc3RyYXRvciIsImlzX2FkbWluIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MTUxNjI0MjYyMn0."
+		claims, err := ParseAPIToken(token)
+		assert.NotNil(t, claims)
+		assert.Nil(t, err)
+	})
+}
+
 func TestIsM1(t *testing.T) {
 	t.Run("returns true if running on arm architecture", func(t *testing.T) {
 		assert.True(t, IsM1("darwin", "arm64"))


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

throw error when an api token is bad or invalid

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

export ASTRO_API_TOKEN=test

![Screenshot 2024-03-15 at 16 17 40](https://github.com/astronomer/astro-cli/assets/65428224/c3b3c64e-92a8-4775-951e-161694bbb20c)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
