### PR TITLE
fix deployment variable create

### DIFF
--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -250,8 +250,8 @@ func addVariablesFromArgs(oldKeyList []string, oldEnvironmentVariables []astropl
 	// validate each key-value pair and add it to the new variables list
 	for i := range variableList {
 		// split pair
-		pair := strings.Split(variableList[i], "=")
-		if len(pair) > 1 {
+		pair := strings.SplitN(variableList[i], "=", 2)
+		if len(pair) == 2 {
 			key = pair[0]
 			val = pair[1]
 			if key == "" || val == "" {

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -17,6 +17,7 @@ var (
 	testValue1 = "test-value-1"
 	testValue2 = "test-value-2"
 	testValue3 = "test-value-3"
+	testValue4 = "test-value=4"
 )
 
 func TestVariableList(t *testing.T) {
@@ -355,4 +356,11 @@ func TestAddVariablesFromArgs(t *testing.T) {
 		[]string{"test-key-2=test-value-3", "test-key-3=", "test-key-3"}, false, false, buf,
 	)
 	assert.Equal(t, []astroplatformcore.DeploymentEnvironmentVariableRequest{{Key: "test-key-2", Value: &testValue3}}, resp)
+
+	resp = addVariablesFromArgs([]string{"test-key-1"},
+		[]astroplatformcore.DeploymentEnvironmentVariable{},
+		[]astroplatformcore.DeploymentEnvironmentVariableRequest{},
+		[]string{"test-key-2=test-value=4", "test-key-3=", "test-key-3"}, false, false, buf,
+	)
+	assert.Equal(t, []astroplatformcore.DeploymentEnvironmentVariableRequest{{Key: "test-key-2", Value: &testValue4}}, resp)
 }


### PR DESCRIPTION
## Description

Fix the issue with deployment variable create where it cuts off the value at the first "=" character 

## 🎟 Issue(s)

- https://github.com/astronomer/astro-cli/issues/1595

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
