### PR TITLE
Serialize extra object with `json.Marshal`

### DIFF
--- a/settings/settings.go
+++ b/settings/settings.go
@@ -475,9 +475,12 @@ func ExportConnections(id string) error {
 	}
 	// add connections to settings file
 	for i := range connections {
-		port, err := strconv.Atoi(connections[i].ConnPort)
-		if err != nil {
-			fmt.Printf("Issue with parsing port number: %s", err.Error())
+		var port int
+		if connections[i].ConnPort != "" {
+			port, err = strconv.Atoi(connections[i].ConnPort)
+			if err != nil {
+				fmt.Printf("Issue with parsing port number: %s", err.Error())
+			}
 		}
 		for j := range settings.Airflow.Connections {
 			if settings.Airflow.Connections[j].ConnID == connections[i].ConnID {
@@ -604,32 +607,40 @@ func ExportPools(id string) error {
 }
 
 func jsonString(conn *Connection) string {
-	var extraString string
-	connExtra, ok := conn.ConnExtra.(map[interface{}]interface{})
-	if !ok {
-		t, ok := conn.ConnExtra.(string)
-		if ok {
-			extraString = t
-		}
-		return extraString
-	}
-	i := 0
-	for k, v := range connExtra {
-		key, ok := k.(string)
-		value, ok2 := v.(string)
-		if ok && ok2 {
-			if i == 0 {
-				extraString = extraString + "\"" + key + "\": \"" + value + "\""
-			} else {
-				extraString = extraString + ", \"" + key + "\": \"" + value + "\""
+	var extraMap map[string]any
+
+	switch connExtra := conn.ConnExtra.(type) {
+	case string:
+		// if extra is already a string we assume it is a JSON-encoded extra string
+		return connExtra
+	case map[any]any:
+		// the extra map is loaded as a map[any]any, but it needs to be map[string]any to be
+		// marshaled to JSON, and for it to be a valid Airflow connection extra, so we convert it
+		extraMap = make(map[string]any)
+		for k, v := range connExtra {
+			kStr, ok := k.(string)
+			if !ok {
+				fmt.Printf("Error asserting extra key as string for %s, found type: %T\n", conn.ConnID, k)
+				continue
 			}
-			i++
+			extraMap[kStr] = v
 		}
+	case map[string]any:
+		// if some future code provides a map[string]any, we can use that directly
+		extraMap = connExtra
+	default:
+		// if the extra type is something else entirely, we log a warning and proceed with an empty extra
+		fmt.Printf("Error converting extra to map for %s, found type: %T\n", conn.ConnID, conn.ConnExtra)
+		return ""
 	}
-	if extraString != "" {
-		extraString = "{" + extraString + "}"
+
+	// marshal the extra map to a JSON string
+	extraBytes, err := json.Marshal(extraMap)
+	if err != nil {
+		fmt.Printf("Error marshaling extra for %s: %s\n", conn.ConnID, err.Error())
+		return ""
 	}
-	return extraString
+	return string(extraBytes)
 }
 
 func WriteAirflowSettingstoYAML(settingsFile string) error {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -114,7 +114,7 @@ func TestAddConnectionsAirflowTwoWithEnvConns(t *testing.T) {
 	expectedDelCmd := "airflow connections delete   \"test-id\""
 	expectedListCmd := "airflow connections list -o plain"
 
-	expectedEnvAddCmd := "airflow connections add   'test-env-id' --conn-type 'test-env-type' --conn-extra '{\"test-extra-key\": \"test-extra-value\"}' --conn-host 'test-env-host' --conn-login 'test-env-login' --conn-password 'test-env-password' --conn-schema 'test-env-schema' --conn-port 2"
+	expectedEnvAddCmd := "airflow connections add   'test-env-id' --conn-type 'test-env-type' --conn-extra '{\"test-extra-key\":\"test-extra-value\"}' --conn-host 'test-env-host' --conn-login 'test-env-login' --conn-password 'test-env-password' --conn-schema 'test-env-schema' --conn-port 2"
 
 	execAirflowCommand = func(id, airflowCommand string) string {
 		assert.Contains(t, []string{expectedAddCmd, expectedEnvAddCmd, expectedListCmd, expectedDelCmd}, airflowCommand)

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -374,6 +374,22 @@ func TestJsonString(t *testing.T) {
 		assert.Equal(t, result["key2"], "value2")
 	})
 
+	t.Run("string-keyed map", func(t *testing.T) {
+		conn := Connection{ConnExtra: map[string]interface{}{"key1": "value1", "key2": "value2"}}
+		res := jsonString(&conn)
+		var result map[string]interface{}
+		json.Unmarshal([]byte(res), &result)
+
+		assert.Equal(t, result["key1"], "value1")
+		assert.Equal(t, result["key2"], "value2")
+	})
+
+	t.Run("unexpected type", func(t *testing.T) {
+		conn := Connection{ConnExtra: []string{"key1", "value1", "key2", "value2"}}
+		res := jsonString(&conn)
+		assert.Equal(t, res, "")
+	})
+
 	t.Run("empty extra", func(t *testing.T) {
 		conn := Connection{ConnExtra: ""}
 		res := jsonString(&conn)


### PR DESCRIPTION
## Description

This changes how the CLI serializes a connection's "extra" object (for use in the `airflow connections add --conn-extra` command) to use the standard library `json.Marshal` function, instead of hand-rolling JSON with string concatenation.

## 🎟 Issue(s)

Related #1608

## 🧪 Functional Testing

- Unit tests pass
- `astro dev object import` and `astro dev object export` work with no errors
- "extra" example from #1608 now imports correctly

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
