### PR TITLE
Allow users to add dag_integrity_exceptions.txt to ignore errors

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -115,6 +115,7 @@ func Init(path, airflowImageName, airflowImageTag string) error {
 		"README.md":                            Readme,
 		"tests/dags/test_dag_example.py":       DagExampleTest,
 		".astro/test_dag_integrity_default.py": DagIntegrityTestDefault,
+		".astro/dag_integrity_exceptions.txt":  "# Add dag files to exempt from parse test below. ex: dags/<test-file>",
 	}
 
 	// Initailize directories

--- a/airflow/include/dagintegritytestdefault.py
+++ b/airflow/include/dagintegritytestdefault.py
@@ -129,7 +129,11 @@ def get_import_errors():
 )
 def test_file_imports(rel_path, rv):
     """Test for import errors on a file"""
-    if rv != "No import errors":
+    if os.path.exists(".astro/dag_integrity_exceptions.txt"):
+        with open(".astro/dag_integrity_exceptions.txt", "r") as f:
+            exceptions = f.readlines()
+    print(f"Exceptions: {exceptions}")
+    if (rv != "No import errors") and rel_path not in exceptions:
         # If rv is not "No import errors," consider it a failed test
         raise Exception(f"{rel_path} failed to import with message \n {rv}")
     else:


### PR DESCRIPTION
## Description

Sometime a DAG doesn't parse in a CI pipeline for a reason that is ok. This provides a way to make that exception just for one dag file instead of having to use `-f`. What I'm not sure of right now is how to put this code such that astro dev parse is what's affected, as we were using an existing astro project.


## 🧪 Functional Testing

I wrote a dag that doesn't parse, made sure it failed astro dev parse. Then added it to tests/dag_integrity_exceptions.txt and it didn't fail to astro dev parse anymore.


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
