### PR TITLE
Add the Airflow API URL to the `deployment inspect` output

### DIFF
--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -29,7 +29,7 @@ type deploymentMetadata struct {
 	UpdatedAt           *time.Time           `mapstructure:"updated_at" yaml:"updated_at" json:"updated_at"`
 	DeploymentURL       *string              `mapstructure:"deployment_url" yaml:"deployment_url" json:"deployment_url"`
 	WebserverURL        *string              `mapstructure:"webserver_url" yaml:"webserver_url" json:"webserver_url"`
-	AirflowAPIURL              *string              `mapstructure:"airflow_api_url" yaml:"airflow_api_url" json:"airflow_api_url"`
+	AirflowAPIURL       *string              `mapstructure:"airflow_api_url" yaml:"airflow_api_url" json:"airflow_api_url"`
 	HibernationOverride *HibernationOverride `mapstructure:"hibernation_override,omitempty" yaml:"hibernation_override,omitempty" json:"hibernation_override,omitempty"`
 }
 
@@ -201,7 +201,7 @@ func getDeploymentInfo(coreDeployment astroplatformcore.Deployment) (map[string]
 		"release_name":    releaseName,
 		"deployment_url":  deploymentURL,
 		"webserver_url":   coreDeployment.WebServerUrl,
-		"airflow_api_url":         coreDeployment.WebServerAirflowApiUrl,
+		"airflow_api_url": coreDeployment.WebServerAirflowApiUrl,
 		"created_at":      coreDeployment.CreatedAt,
 		"updated_at":      coreDeployment.UpdatedAt,
 		"status":          coreDeployment.Status,

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -29,6 +29,7 @@ type deploymentMetadata struct {
 	UpdatedAt           *time.Time           `mapstructure:"updated_at" yaml:"updated_at" json:"updated_at"`
 	DeploymentURL       *string              `mapstructure:"deployment_url" yaml:"deployment_url" json:"deployment_url"`
 	WebserverURL        *string              `mapstructure:"webserver_url" yaml:"webserver_url" json:"webserver_url"`
+	APIURL              *string              `mapstructure:"api_url" yaml:"api_url" json:"api_url"`
 	HibernationOverride *HibernationOverride `mapstructure:"hibernation_override,omitempty" yaml:"hibernation_override,omitempty" json:"hibernation_override,omitempty"`
 }
 
@@ -200,6 +201,7 @@ func getDeploymentInfo(coreDeployment astroplatformcore.Deployment) (map[string]
 		"release_name":    releaseName,
 		"deployment_url":  deploymentURL,
 		"webserver_url":   coreDeployment.WebServerUrl,
+		"api_url":         coreDeployment.WebServerAirflowApiUrl,
 		"created_at":      coreDeployment.CreatedAt,
 		"updated_at":      coreDeployment.UpdatedAt,
 		"status":          coreDeployment.Status,

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -29,7 +29,7 @@ type deploymentMetadata struct {
 	UpdatedAt           *time.Time           `mapstructure:"updated_at" yaml:"updated_at" json:"updated_at"`
 	DeploymentURL       *string              `mapstructure:"deployment_url" yaml:"deployment_url" json:"deployment_url"`
 	WebserverURL        *string              `mapstructure:"webserver_url" yaml:"webserver_url" json:"webserver_url"`
-	APIURL              *string              `mapstructure:"api_url" yaml:"api_url" json:"api_url"`
+	AirflowAPIURL              *string              `mapstructure:"airflow_api_url" yaml:"airflow_api_url" json:"airflow_api_url"`
 	HibernationOverride *HibernationOverride `mapstructure:"hibernation_override,omitempty" yaml:"hibernation_override,omitempty" json:"hibernation_override,omitempty"`
 }
 
@@ -201,7 +201,7 @@ func getDeploymentInfo(coreDeployment astroplatformcore.Deployment) (map[string]
 		"release_name":    releaseName,
 		"deployment_url":  deploymentURL,
 		"webserver_url":   coreDeployment.WebServerUrl,
-		"api_url":         coreDeployment.WebServerAirflowApiUrl,
+		"airflow_api_url":         coreDeployment.WebServerAirflowApiUrl,
 		"created_at":      coreDeployment.CreatedAt,
 		"updated_at":      coreDeployment.UpdatedAt,
 		"status":          coreDeployment.Status,

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -180,7 +180,7 @@ var (
 		AirflowVersion:         "2.4.0",
 		SchedulerAu:            &schedulerAU,
 		SchedulerReplicas:      schedulerReplicas,
-		WebServerAirflowApiUrl: "some-url",
+		WebServerAirflowApiUrl: "some-url/api/v1",
 		EnvironmentVariables:   &deploymentEnvironmentVariable,
 		WorkerQueues:           &workerqueue,
 		UpdatedAt:              time.Now(),
@@ -877,6 +877,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
         updated_at: 2023-02-01T12:00:00Z
         deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
         webserver_url: some-url
+        api_url: some-url/api/v1
         hibernation_override:
             is_hibernating: true
             override_until: 2023-02-01T12:00:00Z
@@ -976,6 +977,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
             "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url",
+            "api_url": "some-url/api/v1"
 			"hibernation_override": {
 				"is_hibernating": true,
 				"override_until": "2022-11-17T12:26:45.362983-08:00"

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -877,7 +877,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
         updated_at: 2023-02-01T12:00:00Z
         deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
         webserver_url: some-url
-        api_url: some-url/api/v1
+        airflow_api_url: some-url/api/v1
         hibernation_override:
             is_hibernating: true
             override_until: 2023-02-01T12:00:00Z
@@ -977,7 +977,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
             "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
             "webserver_url": "some-url",
-            "api_url": "some-url/api/v1"
+            "airflow_api_url": "some-url/api/v1"
 			"hibernation_override": {
 				"is_hibernating": true,
 				"override_until": "2022-11-17T12:26:45.362983-08:00"


### PR DESCRIPTION
Our docs currently tell people to get the webserver_url and then manually strip off the org id which is error prone (people forget to do it).

Given that the API already has a field for exactly this lets just expose it for users to use!
