### PR TITLE
prevent cli from sending request when no user is found for provided email

### DIFF
--- a/cloud/user/user.go
+++ b/cloud/user/user.go
@@ -461,6 +461,9 @@ func getUserID(email string, users []astrocore.User, roleEntity string) (userID,
 			}
 		}
 	}
+	if userID == "" {
+		return userID, email, ErrUserNotFound
+	}
 	return userID, email, nil
 }
 

--- a/cloud/user/user_test.go
+++ b/cloud/user/user_test.go
@@ -880,6 +880,15 @@ func TestUpdateDeploymentUserRole(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expectedOut, out.String())
 	})
+
+	t.Run("error path UpdateDeploymentUserRole user not found", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListDeploymentUsersWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&ListDeploymentUsersResponseOK, nil).Twice()
+		mockClient.On("MutateDeploymentUserRoleWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&MutateDeploymentUserRoleResponseOK, nil).Once()
+		err := UpdateDeploymentUserRole("notfound@1.com", "DEPLOYMENT_ADMIN", deploymentID, out, mockClient)
+		assert.EqualError(t, err, "no user was found for the email you provided")
+	})
 }
 
 func TestAddDeploymentUser(t *testing.T) {


### PR DESCRIPTION
## Description

prevent cli from sending request when no user is found for provided email
## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.
Tested the following against dev.

- Attempted to update a deployment users role using an email address that did not exist in the org.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
