### PR TITLE
Fix secret environment variables being updated with empty string

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -164,7 +164,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 			clusterID = *existingDeployment.ClusterId
 		}
 		// create environment variables
-		envVars = createEnvVarsRequest(&formattedDeployment, action)
+		envVars = createEnvVarsRequest(&formattedDeployment)
 		if err != nil {
 			return fmt.Errorf("%w \n failed to %s alert emails", err, action)
 		}
@@ -941,8 +941,8 @@ func checkEnvVars(deploymentFromFile *inspect.FormattedDeployment, action string
 			missingField := fmt.Sprintf("deployment.environment_variables[%d].key", i)
 			return fmt.Errorf("%w: %s", errRequiredField, missingField)
 		}
-		if action == createAction {
-			if envVar.Value == "" {
+		if action == createAction || (action == updateAction && !envVar.IsSecret) {
+			if envVar.Value == nil {
 				missingField := fmt.Sprintf("deployment.environment_variables[%d].value", i)
 				return fmt.Errorf("%w: %s", errRequiredField, missingField)
 			}
@@ -951,16 +951,13 @@ func checkEnvVars(deploymentFromFile *inspect.FormattedDeployment, action string
 	return nil
 }
 
-func createEnvVarsRequest(deploymentFromFile *inspect.FormattedDeployment, action string) (envVars []astroplatformcore.DeploymentEnvironmentVariableRequest) {
+func createEnvVarsRequest(deploymentFromFile *inspect.FormattedDeployment) (envVars []astroplatformcore.DeploymentEnvironmentVariableRequest) {
 	envVars = []astroplatformcore.DeploymentEnvironmentVariableRequest{}
 	for i := range deploymentFromFile.Deployment.EnvVars {
 		var envVar astroplatformcore.DeploymentEnvironmentVariableRequest
 		envVar.IsSecret = deploymentFromFile.Deployment.EnvVars[i].IsSecret
 		envVar.Key = deploymentFromFile.Deployment.EnvVars[i].Key
-		// If the action is update, isSecret is true and value is empty, then the value should be left as nil
-		if !(action == updateAction && deploymentFromFile.Deployment.EnvVars[i].IsSecret && deploymentFromFile.Deployment.EnvVars[i].Value == "") {
-			envVar.Value = &deploymentFromFile.Deployment.EnvVars[i].Value
-		}
+		envVar.Value = deploymentFromFile.Deployment.EnvVars[i].Value
 		envVars = append(envVars, envVar)
 	}
 	return envVars

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -164,7 +164,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 			clusterID = *existingDeployment.ClusterId
 		}
 		// create environment variables
-		envVars = createEnvVarsRequest(&formattedDeployment)
+		envVars = createEnvVarsRequest(&formattedDeployment, action)
 		if err != nil {
 			return fmt.Errorf("%w \n failed to %s alert emails", err, action)
 		}
@@ -951,13 +951,16 @@ func checkEnvVars(deploymentFromFile *inspect.FormattedDeployment, action string
 	return nil
 }
 
-func createEnvVarsRequest(deploymentFromFile *inspect.FormattedDeployment) (envVars []astroplatformcore.DeploymentEnvironmentVariableRequest) {
+func createEnvVarsRequest(deploymentFromFile *inspect.FormattedDeployment, action string) (envVars []astroplatformcore.DeploymentEnvironmentVariableRequest) {
 	envVars = []astroplatformcore.DeploymentEnvironmentVariableRequest{}
 	for i := range deploymentFromFile.Deployment.EnvVars {
 		var envVar astroplatformcore.DeploymentEnvironmentVariableRequest
 		envVar.IsSecret = deploymentFromFile.Deployment.EnvVars[i].IsSecret
 		envVar.Key = deploymentFromFile.Deployment.EnvVars[i].Key
-		envVar.Value = &deploymentFromFile.Deployment.EnvVars[i].Value
+		// If the action is update, isSecret is true and value is empty, then the value should be left as nil
+		if !(action == updateAction && deploymentFromFile.Deployment.EnvVars[i].IsSecret && deploymentFromFile.Deployment.EnvVars[i].Value == "") {
+			envVar.Value = &deploymentFromFile.Deployment.EnvVars[i].Value
+		}
 		envVars = append(envVars, envVar)
 	}
 	return envVars

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -3278,7 +3278,7 @@ func TestCreateEnvVars(t *testing.T) {
 		deploymentFromFile inspect.FormattedDeployment
 		err                error
 	)
-	t.Run("creates env vars if they were requested in a formatted deployment", func(t *testing.T) {
+	t.Run("creates env vars if they were requested in a formatted deployment with create", func(t *testing.T) {
 		deploymentFromFile = inspect.FormattedDeployment{}
 		list := []inspect.EnvironmentVariable{
 			{
@@ -3309,7 +3309,54 @@ func TestCreateEnvVars(t *testing.T) {
 			},
 		}
 		deploymentFromFile.Deployment.EnvVars = list
-		actualEnvVars = createEnvVarsRequest(&deploymentFromFile)
+		actualEnvVars = createEnvVarsRequest(&deploymentFromFile, createAction)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedList, actualEnvVars)
+	})
+
+	t.Run("creates env vars if they were requested in a formatted deployment with update and with a secret env var with empty string", func(t *testing.T) {
+		deploymentFromFile = inspect.FormattedDeployment{}
+		list := []inspect.EnvironmentVariable{
+			{
+				IsSecret:  false,
+				Key:       "key-1",
+				UpdatedAt: "",
+				Value:     "val-1",
+			},
+			{
+				IsSecret:  true,
+				Key:       "key-2",
+				UpdatedAt: "",
+				Value:     "val-2",
+			},
+			{
+				IsSecret:  true,
+				Key:       "key-3",
+				UpdatedAt: "",
+				Value:     "",
+			},
+		}
+		val1 := "val-1"
+		val2 := "val-2"
+		expectedList := []astroplatformcore.DeploymentEnvironmentVariableRequest{
+			{
+				IsSecret: false,
+				Key:      "key-1",
+				Value:    &val1,
+			},
+			{
+				IsSecret: true,
+				Key:      "key-2",
+				Value:    &val2,
+			},
+			{
+				IsSecret: true,
+				Key:      "key-3",
+				Value:    nil,
+			},
+		}
+		deploymentFromFile.Deployment.EnvVars = list
+		actualEnvVars = createEnvVarsRequest(&deploymentFromFile, updateAction)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedList, actualEnvVars)
 	})

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -29,6 +29,8 @@ var (
 	errTest                = errors.New("test error")
 	poolID                 = "test-pool-id"
 	poolID2                = "test-pool-id-2"
+	val1                   = "val-1"
+	val2                   = "val-2"
 	workloadIdentity       = "astro-great-release-name@provider-account.iam.gserviceaccount.com"
 	clusterID              = "test-cluster-id"
 	clusterName            = "test-cluster"
@@ -3017,13 +3019,13 @@ func TestCheckRequiredFields(t *testing.T) {
 				IsSecret:  false,
 				Key:       "",
 				UpdatedAt: "",
-				Value:     "val-1",
+				Value:     &val1,
 			},
 			{
 				IsSecret:  true,
 				Key:       "key-2",
 				UpdatedAt: "",
-				Value:     "val-2",
+				Value:     &val2,
 			},
 		}
 		input.Deployment.EnvVars = list
@@ -3252,13 +3254,13 @@ func TestHasEnvVars(t *testing.T) {
 				IsSecret:  false,
 				Key:       "key-1",
 				UpdatedAt: "",
-				Value:     "val-1",
+				Value:     &val1,
 			},
 			{
 				IsSecret:  true,
 				Key:       "key-2",
 				UpdatedAt: "",
-				Value:     "val-2",
+				Value:     &val2,
 			},
 		}
 		deploymentFromFile.Deployment.EnvVars = list
@@ -3278,66 +3280,28 @@ func TestCreateEnvVars(t *testing.T) {
 		deploymentFromFile inspect.FormattedDeployment
 		err                error
 	)
-	t.Run("creates env vars if they were requested in a formatted deployment with create", func(t *testing.T) {
-		deploymentFromFile = inspect.FormattedDeployment{}
-		list := []inspect.EnvironmentVariable{
-			{
-				IsSecret:  false,
-				Key:       "key-1",
-				UpdatedAt: "",
-				Value:     "val-1",
-			},
-			{
-				IsSecret:  true,
-				Key:       "key-2",
-				UpdatedAt: "",
-				Value:     "val-2",
-			},
-		}
-		val1 := "val-1"
-		val2 := "val-2"
-		expectedList := []astroplatformcore.DeploymentEnvironmentVariableRequest{
-			{
-				IsSecret: false,
-				Key:      "key-1",
-				Value:    &val1,
-			},
-			{
-				IsSecret: true,
-				Key:      "key-2",
-				Value:    &val2,
-			},
-		}
-		deploymentFromFile.Deployment.EnvVars = list
-		actualEnvVars = createEnvVarsRequest(&deploymentFromFile, createAction)
-		assert.NoError(t, err)
-		assert.Equal(t, expectedList, actualEnvVars)
-	})
 
-	t.Run("creates env vars if they were requested in a formatted deployment with update and with a secret env var with empty string", func(t *testing.T) {
+	t.Run("creates env vars if they were requested in a formatted deployment", func(t *testing.T) {
 		deploymentFromFile = inspect.FormattedDeployment{}
 		list := []inspect.EnvironmentVariable{
 			{
 				IsSecret:  false,
 				Key:       "key-1",
 				UpdatedAt: "",
-				Value:     "val-1",
+				Value:     &val1,
 			},
 			{
 				IsSecret:  true,
 				Key:       "key-2",
 				UpdatedAt: "",
-				Value:     "val-2",
+				Value:     &val2,
 			},
 			{
 				IsSecret:  true,
 				Key:       "key-3",
 				UpdatedAt: "",
-				Value:     "",
 			},
 		}
-		val1 := "val-1"
-		val2 := "val-2"
 		expectedList := []astroplatformcore.DeploymentEnvironmentVariableRequest{
 			{
 				IsSecret: false,
@@ -3356,7 +3320,7 @@ func TestCreateEnvVars(t *testing.T) {
 			},
 		}
 		deploymentFromFile.Deployment.EnvVars = list
-		actualEnvVars = createEnvVarsRequest(&deploymentFromFile, updateAction)
+		actualEnvVars = createEnvVarsRequest(&deploymentFromFile)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedList, actualEnvVars)
 	})
@@ -3763,13 +3727,13 @@ func TestCheckEnvVars(t *testing.T) {
 				IsSecret:  false,
 				Key:       "",
 				UpdatedAt: "",
-				Value:     "val-1",
+				Value:     &val1,
 			},
 			{
 				IsSecret:  true,
 				Key:       "key-2",
 				UpdatedAt: "",
-				Value:     "val-2",
+				Value:     &val2,
 			},
 		}
 		input.Deployment.EnvVars = list
@@ -3785,13 +3749,12 @@ func TestCheckEnvVars(t *testing.T) {
 				IsSecret:  false,
 				Key:       "key-1",
 				UpdatedAt: "",
-				Value:     "val-1",
+				Value:     &val1,
 			},
 			{
 				IsSecret:  true,
 				Key:       "key-2",
 				UpdatedAt: "",
-				Value:     "",
 			},
 		}
 		input.Deployment.EnvVars = list
@@ -3807,13 +3770,13 @@ func TestCheckEnvVars(t *testing.T) {
 				IsSecret:  false,
 				Key:       "key-1",
 				UpdatedAt: "",
-				Value:     "val-1",
+				Value:     &val1,
 			},
 			{
 				IsSecret:  true,
 				Key:       "",
 				UpdatedAt: "",
-				Value:     "val-2",
+				Value:     &val2,
 			},
 		}
 		input.Deployment.EnvVars = list
@@ -3821,7 +3784,7 @@ func TestCheckEnvVars(t *testing.T) {
 		assert.ErrorIs(t, err, errRequiredField)
 		assert.ErrorContains(t, err, "missing required field: deployment.environment_variables[1].key")
 	})
-	t.Run("returns nil if env var values are missing on update", func(t *testing.T) {
+	t.Run("returns an error if env var values are missing on update for non-secret env var", func(t *testing.T) {
 		input.Deployment.Configuration.Name = "test-deployment"
 		input.Deployment.Configuration.ClusterName = "test-cluster-id"
 		list := []inspect.EnvironmentVariable{
@@ -3829,13 +3792,33 @@ func TestCheckEnvVars(t *testing.T) {
 				IsSecret:  false,
 				Key:       "key-1",
 				UpdatedAt: "",
-				Value:     "val-1",
+			},
+		}
+		input.Deployment.EnvVars = list
+		err = checkEnvVars(&input, "update")
+		assert.ErrorIs(t, err, errRequiredField)
+		assert.ErrorContains(t, err, "missing required field: deployment.environment_variables[0].value")
+	})
+	t.Run("returns nil if env var values are valid on update", func(t *testing.T) {
+		input.Deployment.Configuration.Name = "test-deployment"
+		input.Deployment.Configuration.ClusterName = "test-cluster-id"
+		list := []inspect.EnvironmentVariable{
+			{
+				IsSecret:  false,
+				Key:       "key-1",
+				UpdatedAt: "",
+				Value:     &val1,
 			},
 			{
 				IsSecret:  true,
 				Key:       "key-2",
 				UpdatedAt: "",
-				Value:     "",
+				Value:     &val2,
+			},
+			{
+				IsSecret:  true,
+				Key:       "key-3",
+				UpdatedAt: "",
 			},
 		}
 		input.Deployment.EnvVars = list

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -73,10 +73,10 @@ type Workerq struct {
 }
 
 type EnvironmentVariable struct {
-	IsSecret  bool   `mapstructure:"is_secret" yaml:"is_secret" json:"is_secret"`
-	Key       string `mapstructure:"key" yaml:"key" json:"key"`
-	UpdatedAt string `mapstructure:"updated_at,omitempty" yaml:"updated_at,omitempty" json:"updated_at,omitempty"`
-	Value     string `mapstructure:"value" yaml:"value" json:"value"`
+	IsSecret  bool    `mapstructure:"is_secret" yaml:"is_secret" json:"is_secret"`
+	Key       string  `mapstructure:"key" yaml:"key" json:"key"`
+	UpdatedAt string  `mapstructure:"updated_at,omitempty" yaml:"updated_at,omitempty" json:"updated_at,omitempty"`
+	Value     *string `mapstructure:"value" yaml:"value" json:"value"`
 }
 
 type HibernationSchedule struct {


### PR DESCRIPTION
## Description
Fix secret environment variables being updated. Nil values for existing secret env vars will no longer update the secret variables but keep them with the same value.

## 🎟 Issue(s)
https://github.com/astronomer/astro-cli/issues/1593

## 🧪 Functional Testing
- Added/updated unit tests
> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots
Updated the secret variable via `./astro deployment update <deploymentId> --deployment-file deployment.yaml`
![Screenshot 2024-04-11 at 11 30 10 AM](https://github.com/astronomer/astro-cli/assets/33995460/05865814-7ac0-4b5f-94b6-ca6207a7a79f)

Saw on airflow UI that the env var did not get set back to `""`

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
