### PR TITLE
Remove Warning message on astro login

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
@@ -10,7 +9,6 @@ import (
 	cloudAuth "github.com/astronomer/astro-cli/cloud/auth"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
-	"github.com/astronomer/astro-cli/pkg/input"
 	softwareAuth "github.com/astronomer/astro-cli/software/auth"
 
 	"github.com/spf13/cobra"
@@ -64,18 +62,6 @@ func login(cmd *cobra.Command, args []string, coreClient astrocore.CoreClient, p
 	if len(args) == 1 {
 		// check if user provided a valid cloud domain
 		if !context.IsCloudDomain(args[0]) {
-			// get the domain from context as an extra check
-			ctx, _ := context.GetCurrentContext()
-			if context.IsCloudDomain(ctx.Domain) {
-				// print an error if context domain is a valid cloud domain
-				fmt.Fprintf(out, "Error: %s is an invalid domain to login into Astro.\n", args[0])
-				// give the user an option to login to software
-				y, _ := input.Confirm("Are you trying to authenticate to Astronomer Software?")
-				if !y {
-					fmt.Println("Canceling login...")
-					return nil
-				}
-			}
 			return softwareLogin(args[0], oAuth, "", "", houstonVersion, houstonClient, out)
 		}
 		return cloudLogin(args[0], token, coreClient, platformCoreClient, out, shouldDisplayLoginLink)

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
@@ -62,6 +63,11 @@ func login(cmd *cobra.Command, args []string, coreClient astrocore.CoreClient, p
 	if len(args) == 1 {
 		// check if user provided a valid cloud domain
 		if !context.IsCloudDomain(args[0]) {
+			// get the domain from context as an extra check
+			ctx, _ := context.GetCurrentContext()
+			if context.IsCloudDomain(ctx.Domain) {
+				fmt.Fprintf(out, "To login to Astronomer Software follow the instructions below. If you are attempting to login in to Astro cancel the login and run 'astro login'.\n\n")
+			}
 			return softwareLogin(args[0], oAuth, "", "", houstonVersion, houstonClient, out)
 		}
 		return cloudLogin(args[0], token, coreClient, platformCoreClient, out, shouldDisplayLoginLink)

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -58,16 +58,8 @@ func TestLogin(t *testing.T) {
 	login(&cobra.Command{}, []string{}, nil, nil, buf)
 
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	defer testUtil.MockUserInput(t, "n")()
-	login(&cobra.Command{}, []string{"fail.astronomer.io"}, nil, nil, buf)
-	assert.Contains(t, buf.String(), "fail.astronomer.io is an invalid domain to login into Astro.\n")
-
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	softwareDomain = "software.astronomer.io"
-	buf = new(bytes.Buffer)
-	defer testUtil.MockUserInput(t, "y")()
-	login(&cobra.Command{}, []string{"software.astronomer.io"}, nil, nil, buf)
-	assert.Contains(t, buf.String(), "software.astronomer.io is an invalid domain to login into Astro.\n")
+	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, buf)
 }
 
 func TestLogout(t *testing.T) {

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -60,6 +60,7 @@ func TestLogin(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	softwareDomain = "software.astronomer.io"
 	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, buf)
+	assert.Contains(t, buf.String(), "To login to Astronomer Software follow the instructions below. If you are attempting to login in to Astro cancel the login and run 'astro login'.\n\n")
 }
 
 func TestLogout(t *testing.T) {


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Remove Warning message on astro login when a non astro domain is passed

<img width="861" alt="Screenshot 2024-04-17 at 12 42 16" src="https://github.com/astronomer/astro-cli/assets/65428224/2f020bb2-160f-40ac-b7b1-35ac53c3cfa1">



## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
