### PR TITLE
Fix upgrade check input

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -579,16 +579,6 @@ func airflowUpgradeTest(cmd *cobra.Command, platformCoreClient astroplatformcore
 	if airflowVersion != "" && runtimeVersion != "" {
 		return errInvalidBothAirflowAndRuntimeVersionsUpgrade
 	}
-	// error if both custom image and deployment id is used
-	if deploymentID != "" && customImageName != "" {
-		return errInvalidBothDeploymentIDandCustomImage
-	}
-	if airflowVersion != "" && deploymentID != "" {
-		return errInvalidBothDeploymentIDandVersion
-	}
-	if runtimeVersion != "" && deploymentID != "" {
-		return errInvalidBothDeploymentIDandVersion
-	}
 	if runtimeVersion != "" && customImageName != "" {
 		return errInvalidBothCustomImageandVersion
 	}

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -595,36 +595,6 @@ func TestAirflowUpgradeTest(t *testing.T) {
 		assert.ErrorIs(t, err, errInvalidBothAirflowAndRuntimeVersionsUpgrade)
 	})
 
-	t.Run("Both custom image and deployment id used", func(t *testing.T) {
-		cmd := newAirflowUpgradeTestCmd(nil)
-
-		deploymentID = "something"
-		customImageName = "something"
-
-		err := airflowUpgradeTest(cmd, nil)
-		assert.ErrorIs(t, err, errInvalidBothDeploymentIDandCustomImage)
-	})
-
-	t.Run("Both airflow version and deployment id used", func(t *testing.T) {
-		cmd := newAirflowUpgradeTestCmd(nil)
-
-		deploymentID = "something"
-		airflowVersion = "something"
-
-		err := airflowUpgradeTest(cmd, nil)
-		assert.ErrorIs(t, err, errInvalidBothDeploymentIDandVersion)
-	})
-
-	t.Run("Both runtime version and deployment id used", func(t *testing.T) {
-		cmd := newAirflowUpgradeTestCmd(nil)
-
-		deploymentID = "something"
-		runtimeVersion = "something"
-
-		err := airflowUpgradeTest(cmd, nil)
-		assert.ErrorIs(t, err, errInvalidBothDeploymentIDandVersion)
-	})
-
 	t.Run("Both runtime version and custom image used", func(t *testing.T) {
 		cmd := newAirflowUpgradeTestCmd(nil)
 

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -5,11 +5,9 @@ import (
 )
 
 var (
-	errInvalidBothAirflowAndRuntimeVersions        = errors.New("You provided both a runtime version and an Airflow version. You have to provide only one of these to initialize your project.") //nolint
-	errInvalidBothAirflowAndRuntimeVersionsUpgrade = errors.New("You provided both a runtime version and an Airflow version. You have to provide only one of these to upgrade.")                 //nolint
-	errInvalidBothDeploymentIDandCustomImage       = errors.New("You provided both a Deployment ID and a Custom image. You have to provide only one of these to upgrade.")                       //nolint
-	errInvalidBothDeploymentIDandVersion           = errors.New("You provided both a Deployment ID and a version. You have to provide only one of these to upgrade.")                            //nolint
-	errInvalidBothCustomImageandVersion            = errors.New("You provided both a Custom image and a version. You have to provide only one of these to upgrade.")                             //nolint
+	errInvalidBothAirflowAndRuntimeVersions        = errors.New("you provided both a runtime version and an Airflow version. You have to provide only one of these to initialize your project") //nolint
+	errInvalidBothAirflowAndRuntimeVersionsUpgrade = errors.New("you provided both a runtime version and an Airflow version. You have to provide only one of these to upgrade")                 //nolint
+	errInvalidBothCustomImageandVersion            = errors.New("you provided both a Custom image and a version. You have to provide only one of these to upgrade")                             //nolint
 
 	errConfigProjectName = errors.New("project name is invalid")
 	errProjectNameSpaces = errors.New("this project name is invalid, a project name cannot contain spaces. Try using '-' instead")


### PR DESCRIPTION
## Description

Make it so you can provide a deployment id with an airflow version, runtime version, or a custom image.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
