### PR TITLE
Stderr upgrade notice so it doesnt mess output

### DIFF
--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -43,6 +43,11 @@ func Blue(text string) string {
 	return color.Sprintf(color.Blue(text))
 }
 
+// Cyan returns text colored blue
+func Cyan(text string) string {
+	return color.Sprintf(color.Cyan(text))
+}
+
 func shouldUseColors() bool {
 	if EnvironmentOverrideColors {
 		force, ok := os.LookupEnv(cliColorForce)

--- a/version/version.go
+++ b/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"context"
 	"fmt"
+	"github.com/astronomer/astro-cli/pkg/ansi"
 	"os"
 	"runtime"
 	"strings"
@@ -77,6 +78,7 @@ func CompareVersions(client *github.Client, owner, repo string) error {
 		} else {
 			fmt.Fprintf(os.Stderr, "\nA newer version of Astro CLI is available: %s\nPlease see https://docs.astronomer.io/astro/cli/install-cli#upgrade-the-cli for information on how to update the Astro CLI\n\n", latestSemver)
 		}
+		fmt.Fprintf(os.Stderr, ansi.Cyan("\nTo learn more about what's new in this version, please see https://docs.astronomer.io/astro/cli/release-notes\n\n"))
 		fmt.Fprintf(os.Stderr, "If you don't want to see this message again run 'astro config set -g upgrade_message false'or pass '2>/dev/null | head' to print this text to stderr\n\n")
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -3,10 +3,11 @@ package version
 import (
 	"context"
 	"fmt"
-	"github.com/astronomer/astro-cli/pkg/ansi"
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/astronomer/astro-cli/pkg/ansi"
 
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/google/go-github/v48/github"
@@ -78,7 +79,7 @@ func CompareVersions(client *github.Client, owner, repo string) error {
 		} else {
 			fmt.Fprintf(os.Stderr, "\nA newer version of Astro CLI is available: %s\nPlease see https://docs.astronomer.io/astro/cli/install-cli#upgrade-the-cli for information on how to update the Astro CLI\n\n", latestSemver)
 		}
-		fmt.Fprintf(os.Stderr, ansi.Cyan("\nTo learn more about what's new in this version, please see https://docs.astronomer.io/astro/cli/release-notes\n\n"))
+		fmt.Fprint(os.Stderr, ansi.Cyan("\nTo learn more about what's new in this version, please see https://docs.astronomer.io/astro/cli/release-notes\n\n"))
 		fmt.Fprintf(os.Stderr, "If you don't want to see this message again run 'astro config set -g upgrade_message false'or pass '2>/dev/null | head' to print this text to stderr\n\n")
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 
@@ -72,11 +73,11 @@ func CompareVersions(client *github.Client, owner, repo string) error {
 	// Compare the versions and print a message to the user if the current version is outdated
 	if currentSemver.LessThan(latestSemver) {
 		if runtime.GOOS == "darwin" {
-			fmt.Printf("\nA newer version of Astro CLI is available: %s\nPlease update to the latest version using 'brew upgrade astro'\n\n", latestSemver)
+			fmt.Fprintf(os.Stderr, "\nA newer version of Astro CLI is available: %s\nPlease update to the latest version using 'brew upgrade astro'\n\n", latestSemver)
 		} else {
-			fmt.Printf("\nA newer version of Astro CLI is available: %s\nPlease see https://docs.astronomer.io/astro/cli/install-cli#upgrade-the-cli for information on how to update the Astro CLI\n\n", latestSemver)
+			fmt.Fprintf(os.Stderr, "\nA newer version of Astro CLI is available: %s\nPlease see https://docs.astronomer.io/astro/cli/install-cli#upgrade-the-cli for information on how to update the Astro CLI\n\n", latestSemver)
 		}
-		fmt.Printf("If you don't want to see this message again run 'astro config set -g upgrade_message false'\n\n")
+		fmt.Fprintf(os.Stderr, "If you don't want to see this message again run 'astro config set -g upgrade_message false'\n\n")
 	}
 
 	return nil

--- a/version/version.go
+++ b/version/version.go
@@ -77,7 +77,7 @@ func CompareVersions(client *github.Client, owner, repo string) error {
 		} else {
 			fmt.Fprintf(os.Stderr, "\nA newer version of Astro CLI is available: %s\nPlease see https://docs.astronomer.io/astro/cli/install-cli#upgrade-the-cli for information on how to update the Astro CLI\n\n", latestSemver)
 		}
-		fmt.Fprintf(os.Stderr, "If you don't want to see this message again run 'astro config set -g upgrade_message false'\n\n")
+		fmt.Fprintf(os.Stderr, "If you don't want to see this message again run 'astro config set -g upgrade_message false'or pass '2>/dev/null | head' to print this text to stderr\n\n")
 	}
 
 	return nil


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Stderr upgrade notice so it doesnt mess output. If users are on an older cli version can avoid the warning notice interruption with command outputs by running the command and passing `2>/dev/null | head`

## 🎟 Issue(s)

Related #1583, #1622, #1197

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

<img width="707" alt="Screenshot 2024-04-28 at 15 01 06" src="https://github.com/astronomer/astro-cli/assets/65428224/60cdea4d-8448-4936-ab40-754ade888e46">
<img width="873" alt="Screenshot 2024-04-28 at 15 04 39" src="https://github.com/astronomer/astro-cli/assets/65428224/0d5d4bb5-b212-4331-8611-b6fbbcbc0b13">
<img width="836" alt="Screenshot 2024-04-28 at 15 04 48" src="https://github.com/astronomer/astro-cli/assets/65428224/7bba1443-63a7-4d7d-83ad-eed817db2b77">


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
