### PR TITLE
Error should be returned if BYORegistryEnabled is true but BYORegistryDomain is empty

### DIFF
--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -96,6 +96,9 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 	if appConfig != nil && appConfig.Flags.BYORegistryEnabled {
 		byoRegistryEnabled = true
 		byoRegistryDomain = appConfig.BYORegistryDomain
+		if byoRegistryDomain == "" {
+			return deploy.ErrBYORegistryDomainNotSet
+		}
 	}
 	if isDagOnlyDeploy {
 		return DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true)

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -79,4 +79,19 @@ func TestDeploy(t *testing.T) {
 		err := execDeployCmd([]string{"test-deployment-id", "--dags", "--force"}...)
 		assert.ErrorIs(t, err, deploy.ErrDagOnlyDeployDisabledInConfig)
 	})
+
+	t.Run("error should be returned if BYORegistryEnabled is true but BYORegistryDomain is empty", func(t *testing.T) {
+		appConfig = &houston.AppConfig{
+			BYORegistryDomain: "",
+			Flags: houston.FeatureFlags{
+				BYORegistryEnabled: true,
+			},
+		}
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
+			return deploy.ErrNoWorkspaceID
+		}
+		err := execDeployCmd([]string{"-f"}...)
+		assert.ErrorIs(t, err, deploy.ErrBYORegistryDomainNotSet)
+		DagsOnlyDeploy = deploy.DagsOnlyDeploy
+	})
 }

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -41,7 +41,7 @@ var (
 	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in your Astronomer cluster")
 	ErrDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the Deployment type to 'dag_deploy' via the UI or the API or the CLI")
 	ErrEmptyDagFolderUserCancelledOperation = errors.New("no DAGs found in the dags folder. User canceled the operation")
-	ErrBYORegistryDomainNotSet              = errors.New("Custom registry host is not set in config. It can be set at astronomer.houston.config.deployments.registry.protectedCustomRegistry.updateRegistry.host")
+	ErrBYORegistryDomainNotSet              = errors.New("Custom registry host is not set in config. It can be set at astronomer.houston.config.deployments.registry.protectedCustomRegistry.updateRegistry.host") //nolint
 )
 
 const (

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -41,6 +41,7 @@ var (
 	ErrDagOnlyDeployDisabledInConfig        = errors.New("to perform this operation, set both deployments.dagOnlyDeployment and deployments.configureDagDeployment to true in your Astronomer cluster")
 	ErrDagOnlyDeployNotEnabledForDeployment = errors.New("to perform this operation, first set the Deployment type to 'dag_deploy' via the UI or the API or the CLI")
 	ErrEmptyDagFolderUserCancelledOperation = errors.New("no DAGs found in the dags folder. User canceled the operation")
+	ErrBYORegistryDomainNotSet              = errors.New("Custom registry host is not set in config. It can be set at astronomer.houston.config.deployments.registry.protectedCustomRegistry.updateRegistry.host")
 )
 
 const (


### PR DESCRIPTION
## Description

Error should be returned if BYORegistryEnabled is true but BYORegistryDomain is empty
## 🎟 Issue(s)

Related https://github.com/astronomer/issues/issues/6100

## 🧪 Functional Testing

Tested locally

## 📸 Screenshots
<img width="681" alt="Screenshot 2024-05-02 at 5 49 58 PM" src="https://github.com/astronomer/astro-cli/assets/95576577/889564a8-dc3b-4846-bc9e-5b0c0dccdbf4">

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
