### PR TITLE
Don't log spurious error when extra is empty

### DIFF
--- a/settings/settings.go
+++ b/settings/settings.go
@@ -628,6 +628,9 @@ func jsonString(conn *Connection) string {
 	case map[string]any:
 		// if some future code provides a map[string]any, we can use that directly
 		extraMap = connExtra
+	case nil:
+		// if the extra is nil, we proceed with an empty extra
+		return ""
 	default:
 		// if the extra type is something else entirely, we log a warning and proceed with an empty extra
 		fmt.Printf("Error converting extra to map for %s, found type: %T\n", conn.ConnID, conn.ConnExtra)

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -395,6 +395,12 @@ func TestJsonString(t *testing.T) {
 		res := jsonString(&conn)
 		assert.Equal(t, "", res)
 	})
+
+	t.Run("nil extra", func(t *testing.T) {
+		conn := Connection{ConnExtra: nil}
+		res := jsonString(&conn)
+		assert.Equal(t, "", res)
+	})
 }
 
 func TestWriteAirflowSettingstoYAML(t *testing.T) {


### PR DESCRIPTION
## Description

This fixes a spurious error log where if a connection is loaded into the Airflow DB, and the extra field on the connection is empty, it prints:

```
Error converting extra to map for my_conn_id, found type: <nil>
```

This does not block the connection from loading, but it is confusing, so this change removes it.

## 🧪 Functional Testing

- Added unit test
- Manually checked that the spurious error no longer appears

## 📸 Screenshots

Before:
<img width="555" alt="Screenshot 2024-05-10 at 10 19 00 AM" src="https://github.com/astronomer/astro-cli/assets/1947420/f7dbae12-2688-477a-8932-729913c5aab3">

After:
<img width="512" alt="Screenshot 2024-05-10 at 10 20 40 AM" src="https://github.com/astronomer/astro-cli/assets/1947420/4753efec-5e1f-4757-9bb3-d4781abbd73c">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
