### PR TITLE
Add ability to switch workspaces with name

### DIFF
--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -141,7 +141,7 @@ func Switch(workspaceNameOrID string, client astrocore.CoreClient, out io.Writer
 		}
 
 		if wsID == "" {
-			return errors.Wrap(err, "workspace id/name is not valid")
+			return errors.Wrap(err, "workspace id/name could not be found")
 		}
 	}
 

--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -120,28 +120,27 @@ var GetWorkspaceSelection = func(client astrocore.CoreClient, out io.Writer) (st
 	return selected.Id, nil
 }
 
-func Switch(workspaceNameOrId string, client astrocore.CoreClient, out io.Writer) error {
-	var wsId string
-	if workspaceNameOrId == "" {
+func Switch(workspaceNameOrID string, client astrocore.CoreClient, out io.Writer) error {
+	var wsID string
+	if workspaceNameOrID == "" {
 		id, err := GetWorkspaceSelection(client, out)
 		if err != nil {
 			return err
 		}
 
-		wsId = id
+		wsID = id
 	} else {
 		ws, err := GetWorkspaces(client)
 		if err != nil {
 			return err
 		}
 		for i := range ws {
-			if ws[i].Name == workspaceNameOrId || ws[i].Id == workspaceNameOrId {
-				wsId = ws[i].Id
+			if ws[i].Name == workspaceNameOrID || ws[i].Id == workspaceNameOrID {
+				wsID = ws[i].Id
 			}
 		}
 
-		if wsId == "" {
-
+		if wsID == "" {
 			return errors.Wrap(err, "workspace id/name is not valid")
 		}
 	}
@@ -151,12 +150,12 @@ func Switch(workspaceNameOrId string, client astrocore.CoreClient, out io.Writer
 		return err
 	}
 
-	err = c.SetContextKey("workspace", wsId)
+	err = c.SetContextKey("workspace", wsID)
 	if err != nil {
 		return err
 	}
 
-	err = c.SetContextKey("last_used_workspace", wsId)
+	err = c.SetContextKey("last_used_workspace", wsID)
 	if err != nil {
 		return err
 	}

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -146,13 +146,37 @@ func TestSwitch(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
+	workspace2 := astrocore.Workspace{
+		Name:                         "test-workspace-2",
+		Description:                  &description,
+		ApiKeyOnlyDeploymentsDefault: false,
+		Id:                           "workspace-id-2",
+	}
+
+	workspaces = []astrocore.Workspace{
+		workspace1,
+		workspace2,
+	}
+
+	ListWorkspacesResponseOK = astrocore.ListWorkspacesResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &astrocore.WorkspacesPaginated{
+			Limit:      10,
+			Offset:     0,
+			TotalCount: 2,
+			Workspaces: workspaces,
+		},
+	}
+
 	t.Run("success", func(t *testing.T) {
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
 
 		buf := new(bytes.Buffer)
-		err := Switch("test-id-1", mockCoreClient, buf)
+		err := Switch("workspace-id-2", mockCoreClient, buf)
 		assert.NoError(t, err)
-		assert.Contains(t, buf.String(), "test-id-1")
+		assert.Contains(t, buf.String(), "workspace-id-2")
 		mockCoreClient.AssertExpectations(t)
 	})
 
@@ -160,13 +184,13 @@ func TestSwitch(t *testing.T) {
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errMock).Once()
 
 		buf := new(bytes.Buffer)
-		err := Switch("test-id-1", mockCoreClient, buf)
+		err := Switch("workspace-id-2", mockCoreClient, buf)
 		assert.ErrorIs(t, err, errMock)
 		mockCoreClient.AssertExpectations(t)
 	})
 
 	t.Run("success with selection", func(t *testing.T) {
-		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Twice()
+		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
 
 		// mock os.Stdin
 		input := []byte("1")

--- a/cmd/cloud/deployment_inspect.go
+++ b/cmd/cloud/deployment_inspect.go
@@ -19,8 +19,8 @@ func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "inspect",
 		Aliases: []string{"in"},
-		Short:   "Inspect a deployment",
-		Long:    "Inspect an Astro Deployment.",
+		Short:   "Inspect a deployment configuration",
+		Long:    "Inspect an Astro Deployment configuration, which can be useful if you manage deployments as code or use Deployment configuration templates. This command returns the Deployment's configuration as a YAML or JSON output, which includes information about resources, such as cluster ID, region, and Airflow API URL, as well as scheduler and worker queue configurations.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentInspect(cmd, args, out)
 		},

--- a/cmd/cloud/deployment_inspect_test.go
+++ b/cmd/cloud/deployment_inspect_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewDeploymentInspectCmd(t *testing.T) {
-	expectedHelp := "Inspect an Astro Deployment."
+	expectedHelp := "Inspect an Astro Deployment configuration, which can be useful if you manage deployments as code or use Deployment configuration templates. This command returns the Deployment's configuration as a YAML or JSON output, which includes information about resources, such as cluster ID, region, and Airflow API URL, as well as scheduler and worker queue configurations."
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 	platformCoreClient = mockPlatformCoreClient

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -598,13 +598,13 @@ func workspaceList(cmd *cobra.Command, out io.Writer) error {
 func workspaceSwitch(cmd *cobra.Command, out io.Writer, args []string) error {
 	// Silence Usage as we have now validated command input
 
-	workspaceNameOrId := ""
+	workspaceNameOrID := ""
 
 	if len(args) == 1 {
-		workspaceNameOrId = args[0]
+		workspaceNameOrID = args[0]
 	}
 	cmd.SilenceUsage = true
-	return workspace.Switch(workspaceNameOrId, astroCoreClient, out)
+	return workspace.Switch(workspaceNameOrID, astroCoreClient, out)
 }
 
 func workspaceCreate(cmd *cobra.Command, out io.Writer) error {

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -85,7 +85,7 @@ func newWorkspaceListCmd(out io.Writer) *cobra.Command {
 
 func newWorkspaceSwitchCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "switch [workspace_id]",
+		Use:     "switch [workspace name/id]",
 		Aliases: []string{"sw"},
 		Short:   "Switch to a different Astro Workspace",
 		Long:    "Switch to a different Astro Workspace",
@@ -598,13 +598,13 @@ func workspaceList(cmd *cobra.Command, out io.Writer) error {
 func workspaceSwitch(cmd *cobra.Command, out io.Writer, args []string) error {
 	// Silence Usage as we have now validated command input
 
-	id := ""
+	workspaceNameOrId := ""
 
 	if len(args) == 1 {
-		id = args[0]
+		workspaceNameOrId = args[0]
 	}
 	cmd.SilenceUsage = true
-	return workspace.Switch(id, astroCoreClient, out)
+	return workspace.Switch(workspaceNameOrId, astroCoreClient, out)
 }
 
 func workspaceCreate(cmd *cobra.Command, out io.Writer) error {

--- a/cmd/cloud/workspace_test.go
+++ b/cmd/cloud/workspace_test.go
@@ -86,7 +86,7 @@ func TestWorkspaceSwitch(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Twice()
+	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
 	astroCoreClient = mockClient
 
 	// mock os.Stdin


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Add ability to switch workspaces with name. We will save the workspaceId in the .astro/config.yaml file

## 🎟 Issue(s)

Related #1654

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

**Switch workspaces using name**
![Screenshot 2024-05-21 at 08 44 14](https://github.com/astronomer/astro-cli/assets/65428224/e2ffadb8-4e10-4a1e-a2e8-fad41b571797)

**Switch workspaces via selection**
![Screenshot 2024-05-21 at 08 44 26](https://github.com/astronomer/astro-cli/assets/65428224/79dc5eef-d34a-4b40-a570-6142888aa690)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
