### PR TITLE
Reset the file pointer to the beginning of the file on each retry to send dags to dag server

### DIFF
--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -338,6 +338,11 @@ func UploadFile(args *UploadFileArguments) error {
 		if i < args.MaxTries {
 			retryDelayInMS = backOff(retryDelayInMS, args.BackoffFactor)
 		}
+		// Reset the file pointer to the beginning of the file
+		_, err = file.Seek(0, io.SeekStart)
+		if err != nil {
+			return fmt.Errorf("error seeking file: %w", err)
+		}
 	}
 	return currentUploadError
 }


### PR DESCRIPTION
## Description

Reset the file pointer to the beginning of the file on each retry to send dags to dag server

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/6390

## 🧪 Functional Testing

Locally

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
