### PR TITLE
Fixing flakey test by removing time asserts

### DIFF
--- a/version/version_test.go
+++ b/version/version_test.go
@@ -31,12 +31,7 @@ func (s *Suite) TestGithubAPITimeout() {
 	githubClient := github.NewClient(&http.Client{Timeout: 100 * time.Microsecond}) // client side timeout should be less than server side sleep defined above
 	githubClient.BaseURL = githubURL
 
-	start := time.Now()
 	release, err := getLatestRelease(githubClient, "test", "test")
-	elapsed := time.Since(start)
-	// assert time to get a response from the function is only slightly greater than client timeout
-	s.GreaterOrEqual(elapsed, 100*time.Microsecond)
-	s.Less(elapsed, 300*time.Microsecond)
 	// assert error returned is related to client timeout
 	s.Nil(release)
 	s.Error(err)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Fixing flakey test by removing time asserts.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
