### PR TITLE
Update dagintegritytestdefault.py

### DIFF
--- a/airflow/include/dagintegritytestdefault.py
+++ b/airflow/include/dagintegritytestdefault.py
@@ -132,6 +132,8 @@ def test_file_imports(rel_path, rv):
     if os.path.exists(".astro/dag_integrity_exceptions.txt"):
         with open(".astro/dag_integrity_exceptions.txt", "r") as f:
             exceptions = f.readlines()
+    else:
+        exceptions = []
     print(f"Exceptions: {exceptions}")
     if (rv != "No import errors") and rel_path not in exceptions:
         # If rv is not "No import errors," consider it a failed test


### PR DESCRIPTION
## Description

The new test fails when the file ".astro/dag_integrity_exceptions.txt" does not exist because we do not handle that case in the test code. This PR fixes that issue

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Tested manually

## 📸 Screenshots
<img width="777" alt="Screenshot 2024-06-05 at 10 12 10 AM" src="https://github.com/astronomer/astro-cli/assets/63181127/8ed7be54-21e4-4806-ac12-45f2cc92235f">

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
