### PR TITLE
Add `astro dbt deploy` command

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,22 +106,8 @@ linters:
     - unparam
     - unused
     - whitespace
-    - goerr113
     - prealloc
     - gocognit
-
-  # don't enable:
-  # - asciicheck
-  # - scopelint
-  # - gochecknoglobals
-  # - godot
-  # - godox
-  # - goerr113
-  # - interfacer
-  # - maligned
-  # - testpackage
-  # - revive
-  # - wsl
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
@@ -136,7 +122,6 @@ issues:
         - typecheck
         - revive
         - unused
-        - goerr113
   exclude:
     - "shadow: declaration of .err. shadows declaration"
     - "sloppyTestFuncName: function cleanUpInitFiles should be of form"

--- a/airflow-client/airflow-client.go
+++ b/airflow-client/airflow-client.go
@@ -221,7 +221,6 @@ func (c *HTTPClient) DoAirflowClient(doOpts *httputil.DoOptions) (*Response, err
 
 	// Check the response status code
 	if response.StatusCode != http.StatusOK {
-		//nolint:goerr113
 		return nil, fmt.Errorf("unexpected response status code: %d", response.StatusCode)
 	}
 

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -1382,7 +1382,7 @@ var checkWebserverHealth = func(settingsFile string, envConns map[string]astroco
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				fmt.Printf("\n")
-				return fmt.Errorf("there might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out", timeout) //nolint:goerr113
+				return fmt.Errorf("there might be a problem with your project starting up. The webserver health check timed out after %s but your project will continue trying to start. Run 'astro dev logs --webserver | --scheduler' for details.\n\nTry again or use the --wait flag to increase the time out", timeout)
 			}
 			if !errors.Is(err, errComposeProjectRunning) {
 				return err

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -398,7 +398,7 @@ func (d *DockerImage) getRegistryToAuth(imageName string) (string, error) {
 	parts := strings.SplitN(imageName, "/", 2)
 	if len(parts) != 2 || !strings.Contains(parts[1], "/") {
 		// This _should_ be impossible for users to hit
-		return "", fmt.Errorf("internal logic error: unsure how to get registry from image name %q", imageName) //nolint:goerr113
+		return "", fmt.Errorf("internal logic error: unsure how to get registry from image name %q", imageName)
 	}
 	return parts[0], nil
 }

--- a/astro-client-core/api.gen.go
+++ b/astro-client-core/api.gen.go
@@ -48,17 +48,27 @@ const (
 	ClusterCloudProviderGcp   ClusterCloudProvider = "gcp"
 )
 
+// Defines values for ClusterCohort.
+const (
+	ClusterCohortCRITICAL ClusterCohort = "CRITICAL"
+	ClusterCohortDEFAULT  ClusterCohort = "DEFAULT"
+	ClusterCohortINTERNAL ClusterCohort = "INTERNAL"
+	ClusterCohortSTABLE   ClusterCohort = "STABLE"
+)
+
 // Defines values for ClusterStatus.
 const (
-	ClusterStatusCREATED      ClusterStatus = "CREATED"
-	ClusterStatusCREATEFAILED ClusterStatus = "CREATE_FAILED"
-	ClusterStatusCREATING     ClusterStatus = "CREATING"
-	ClusterStatusDELETED      ClusterStatus = "DELETED"
-	ClusterStatusDELETEFAILED ClusterStatus = "DELETE_FAILED"
-	ClusterStatusDELETING     ClusterStatus = "DELETING"
-	ClusterStatusFORCEDELETED ClusterStatus = "FORCE_DELETED"
-	ClusterStatusUPDATEFAILED ClusterStatus = "UPDATE_FAILED"
-	ClusterStatusUPDATING     ClusterStatus = "UPDATING"
+	ClusterStatusACCESSDENIED   ClusterStatus = "ACCESS_DENIED"
+	ClusterStatusCREATED        ClusterStatus = "CREATED"
+	ClusterStatusCREATEFAILED   ClusterStatus = "CREATE_FAILED"
+	ClusterStatusCREATING       ClusterStatus = "CREATING"
+	ClusterStatusDELETED        ClusterStatus = "DELETED"
+	ClusterStatusDELETEFAILED   ClusterStatus = "DELETE_FAILED"
+	ClusterStatusDELETING       ClusterStatus = "DELETING"
+	ClusterStatusFORCEDELETED   ClusterStatus = "FORCE_DELETED"
+	ClusterStatusUPDATEFAILED   ClusterStatus = "UPDATE_FAILED"
+	ClusterStatusUPDATING       ClusterStatus = "UPDATING"
+	ClusterStatusUPGRADEPENDING ClusterStatus = "UPGRADE_PENDING"
 )
 
 // Defines values for ClusterType.
@@ -75,17 +85,27 @@ const (
 	ClusterDetailedCloudProviderGcp   ClusterDetailedCloudProvider = "gcp"
 )
 
+// Defines values for ClusterDetailedCohort.
+const (
+	ClusterDetailedCohortCRITICAL ClusterDetailedCohort = "CRITICAL"
+	ClusterDetailedCohortDEFAULT  ClusterDetailedCohort = "DEFAULT"
+	ClusterDetailedCohortINTERNAL ClusterDetailedCohort = "INTERNAL"
+	ClusterDetailedCohortSTABLE   ClusterDetailedCohort = "STABLE"
+)
+
 // Defines values for ClusterDetailedStatus.
 const (
-	ClusterDetailedStatusCREATED      ClusterDetailedStatus = "CREATED"
-	ClusterDetailedStatusCREATEFAILED ClusterDetailedStatus = "CREATE_FAILED"
-	ClusterDetailedStatusCREATING     ClusterDetailedStatus = "CREATING"
-	ClusterDetailedStatusDELETED      ClusterDetailedStatus = "DELETED"
-	ClusterDetailedStatusDELETEFAILED ClusterDetailedStatus = "DELETE_FAILED"
-	ClusterDetailedStatusDELETING     ClusterDetailedStatus = "DELETING"
-	ClusterDetailedStatusFORCEDELETED ClusterDetailedStatus = "FORCE_DELETED"
-	ClusterDetailedStatusUPDATEFAILED ClusterDetailedStatus = "UPDATE_FAILED"
-	ClusterDetailedStatusUPDATING     ClusterDetailedStatus = "UPDATING"
+	ClusterDetailedStatusACCESSDENIED   ClusterDetailedStatus = "ACCESS_DENIED"
+	ClusterDetailedStatusCREATED        ClusterDetailedStatus = "CREATED"
+	ClusterDetailedStatusCREATEFAILED   ClusterDetailedStatus = "CREATE_FAILED"
+	ClusterDetailedStatusCREATING       ClusterDetailedStatus = "CREATING"
+	ClusterDetailedStatusDELETED        ClusterDetailedStatus = "DELETED"
+	ClusterDetailedStatusDELETEFAILED   ClusterDetailedStatus = "DELETE_FAILED"
+	ClusterDetailedStatusDELETING       ClusterDetailedStatus = "DELETING"
+	ClusterDetailedStatusFORCEDELETED   ClusterDetailedStatus = "FORCE_DELETED"
+	ClusterDetailedStatusUPDATEFAILED   ClusterDetailedStatus = "UPDATE_FAILED"
+	ClusterDetailedStatusUPDATING       ClusterDetailedStatus = "UPDATING"
+	ClusterDetailedStatusUPGRADEPENDING ClusterDetailedStatus = "UPGRADE_PENDING"
 )
 
 // Defines values for ClusterDetailedType.
@@ -93,6 +113,12 @@ const (
 	ClusterDetailedTypeBRINGYOUROWNCLOUD ClusterDetailedType = "BRING_YOUR_OWN_CLOUD"
 	ClusterDetailedTypeHOSTED            ClusterDetailedType = "HOSTED"
 	ClusterDetailedTypeSHARED            ClusterDetailedType = "SHARED"
+)
+
+// Defines values for ClusterHealthStatusValue.
+const (
+	ClusterHealthStatusValueHEALTHY   ClusterHealthStatusValue = "HEALTHY"
+	ClusterHealthStatusValueUNHEALTHY ClusterHealthStatusValue = "UNHEALTHY"
 )
 
 // Defines values for ClusterRouteSource.
@@ -154,10 +180,16 @@ const (
 	CreateDedicatedDeploymentRequestTypeSTANDARD  CreateDedicatedDeploymentRequestType = "STANDARD"
 )
 
+// Defines values for CreateDeployGitRequestProvider.
+const (
+	CreateDeployGitRequestProviderGITHUB CreateDeployGitRequestProvider = "GITHUB"
+)
+
 // Defines values for CreateDeployRequestType.
 const (
-	CreateDeployRequestTypeDAG   CreateDeployRequestType = "DAG"
-	CreateDeployRequestTypeIMAGE CreateDeployRequestType = "IMAGE"
+	CreateDeployRequestTypeBUNDLE CreateDeployRequestType = "BUNDLE"
+	CreateDeployRequestTypeDAG    CreateDeployRequestType = "DAG"
+	CreateDeployRequestTypeIMAGE  CreateDeployRequestType = "IMAGE"
 )
 
 // Defines values for CreateEnvironmentObjectLinkRequestScope.
@@ -254,8 +286,9 @@ const (
 
 // Defines values for DeployType.
 const (
-	DeployTypeDAG   DeployType = "DAG"
-	DeployTypeIMAGE DeployType = "IMAGE"
+	DeployTypeBUNDLE DeployType = "BUNDLE"
+	DeployTypeDAG    DeployType = "DAG"
+	DeployTypeIMAGE  DeployType = "IMAGE"
 )
 
 // Defines values for DeployGitProvider.
@@ -338,6 +371,7 @@ const (
 const (
 	EntitlementRequiredPlanAZUREMANAGEDPREVIEW EntitlementRequiredPlan = "AZURE_MANAGED_PREVIEW"
 	EntitlementRequiredPlanBASIC               EntitlementRequiredPlan = "BASIC"
+	EntitlementRequiredPlanBASICPAYGO          EntitlementRequiredPlan = "BASIC_PAYGO"
 	EntitlementRequiredPlanBUSINESS            EntitlementRequiredPlan = "BUSINESS"
 	EntitlementRequiredPlanBUSINESSCRITICAL    EntitlementRequiredPlan = "BUSINESS_CRITICAL"
 	EntitlementRequiredPlanENTERPRISE          EntitlementRequiredPlan = "ENTERPRISE"
@@ -493,17 +527,33 @@ const (
 	SharedClusterCloudProviderGcp   SharedClusterCloudProvider = "gcp"
 )
 
+// Defines values for SharedClusterCohort.
+const (
+	SharedClusterCohortCRITICAL SharedClusterCohort = "CRITICAL"
+	SharedClusterCohortDEFAULT  SharedClusterCohort = "DEFAULT"
+	SharedClusterCohortINTERNAL SharedClusterCohort = "INTERNAL"
+	SharedClusterCohortSTABLE   SharedClusterCohort = "STABLE"
+)
+
 // Defines values for SharedClusterStatus.
 const (
-	SharedClusterStatusCREATED      SharedClusterStatus = "CREATED"
-	SharedClusterStatusCREATEFAILED SharedClusterStatus = "CREATE_FAILED"
-	SharedClusterStatusCREATING     SharedClusterStatus = "CREATING"
-	SharedClusterStatusDELETED      SharedClusterStatus = "DELETED"
-	SharedClusterStatusDELETEFAILED SharedClusterStatus = "DELETE_FAILED"
-	SharedClusterStatusDELETING     SharedClusterStatus = "DELETING"
-	SharedClusterStatusFORCEDELETED SharedClusterStatus = "FORCE_DELETED"
-	SharedClusterStatusUPDATEFAILED SharedClusterStatus = "UPDATE_FAILED"
-	SharedClusterStatusUPDATING     SharedClusterStatus = "UPDATING"
+	SharedClusterStatusACCESSDENIED   SharedClusterStatus = "ACCESS_DENIED"
+	SharedClusterStatusCREATED        SharedClusterStatus = "CREATED"
+	SharedClusterStatusCREATEFAILED   SharedClusterStatus = "CREATE_FAILED"
+	SharedClusterStatusCREATING       SharedClusterStatus = "CREATING"
+	SharedClusterStatusDELETED        SharedClusterStatus = "DELETED"
+	SharedClusterStatusDELETEFAILED   SharedClusterStatus = "DELETE_FAILED"
+	SharedClusterStatusDELETING       SharedClusterStatus = "DELETING"
+	SharedClusterStatusFORCEDELETED   SharedClusterStatus = "FORCE_DELETED"
+	SharedClusterStatusUPDATEFAILED   SharedClusterStatus = "UPDATE_FAILED"
+	SharedClusterStatusUPDATING       SharedClusterStatus = "UPDATING"
+	SharedClusterStatusUPGRADEPENDING SharedClusterStatus = "UPGRADE_PENDING"
+)
+
+// Defines values for TriggerGitDeployRequestDeployType.
+const (
+	DAG   TriggerGitDeployRequestDeployType = "DAG"
+	IMAGE TriggerGitDeployRequestDeployType = "IMAGE"
 )
 
 // Defines values for UpdateEnvironmentObjectLinkRequestScope.
@@ -680,6 +730,27 @@ const (
 	ListOrganizationApiTokensParamsSortsUpdatedByIdDesc  ListOrganizationApiTokensParamsSorts = "updatedById:desc"
 )
 
+// Defines values for ListAssignableRolesParamsScopeType.
+const (
+	ListAssignableRolesParamsScopeTypeDEPLOYMENT   ListAssignableRolesParamsScopeType = "DEPLOYMENT"
+	ListAssignableRolesParamsScopeTypeORGANIZATION ListAssignableRolesParamsScopeType = "ORGANIZATION"
+	ListAssignableRolesParamsScopeTypeWORKSPACE    ListAssignableRolesParamsScopeType = "WORKSPACE"
+)
+
+// Defines values for ListAssignableRolesParamsSorts.
+const (
+	ListAssignableRolesParamsSortsCreatedAtAsc    ListAssignableRolesParamsSorts = "createdAt:asc"
+	ListAssignableRolesParamsSortsCreatedAtDesc   ListAssignableRolesParamsSorts = "createdAt:desc"
+	ListAssignableRolesParamsSortsDescriptionAsc  ListAssignableRolesParamsSorts = "description:asc"
+	ListAssignableRolesParamsSortsDescriptionDesc ListAssignableRolesParamsSorts = "description:desc"
+	ListAssignableRolesParamsSortsNameAsc         ListAssignableRolesParamsSorts = "name:asc"
+	ListAssignableRolesParamsSortsNameDesc        ListAssignableRolesParamsSorts = "name:desc"
+	ListAssignableRolesParamsSortsScopeTypeAsc    ListAssignableRolesParamsSorts = "scopeType:asc"
+	ListAssignableRolesParamsSortsScopeTypeDesc   ListAssignableRolesParamsSorts = "scopeType:desc"
+	ListAssignableRolesParamsSortsUpdatedAtAsc    ListAssignableRolesParamsSorts = "updatedAt:asc"
+	ListAssignableRolesParamsSortsUpdatedAtDesc   ListAssignableRolesParamsSorts = "updatedAt:desc"
+)
+
 // Defines values for ListClustersParamsProvider.
 const (
 	ListClustersParamsProviderAws   ListClustersParamsProvider = "aws"
@@ -696,15 +767,17 @@ const (
 
 // Defines values for ListClustersParamsStatuses.
 const (
-	CREATED      ListClustersParamsStatuses = "CREATED"
-	CREATEFAILED ListClustersParamsStatuses = "CREATE_FAILED"
-	CREATING     ListClustersParamsStatuses = "CREATING"
-	DELETED      ListClustersParamsStatuses = "DELETED"
-	DELETEFAILED ListClustersParamsStatuses = "DELETE_FAILED"
-	DELETING     ListClustersParamsStatuses = "DELETING"
-	FORCEDELETED ListClustersParamsStatuses = "FORCE_DELETED"
-	UPDATEFAILED ListClustersParamsStatuses = "UPDATE_FAILED"
-	UPDATING     ListClustersParamsStatuses = "UPDATING"
+	ListClustersParamsStatusesACCESSDENIED   ListClustersParamsStatuses = "ACCESS_DENIED"
+	ListClustersParamsStatusesCREATED        ListClustersParamsStatuses = "CREATED"
+	ListClustersParamsStatusesCREATEFAILED   ListClustersParamsStatuses = "CREATE_FAILED"
+	ListClustersParamsStatusesCREATING       ListClustersParamsStatuses = "CREATING"
+	ListClustersParamsStatusesDELETED        ListClustersParamsStatuses = "DELETED"
+	ListClustersParamsStatusesDELETEFAILED   ListClustersParamsStatuses = "DELETE_FAILED"
+	ListClustersParamsStatusesDELETING       ListClustersParamsStatuses = "DELETING"
+	ListClustersParamsStatusesFORCEDELETED   ListClustersParamsStatuses = "FORCE_DELETED"
+	ListClustersParamsStatusesUPDATEFAILED   ListClustersParamsStatuses = "UPDATE_FAILED"
+	ListClustersParamsStatusesUPDATING       ListClustersParamsStatuses = "UPDATING"
+	ListClustersParamsStatusesUPGRADEPENDING ListClustersParamsStatuses = "UPGRADE_PENDING"
 )
 
 // Defines values for ListClustersParamsSorts.
@@ -753,9 +826,9 @@ const (
 
 // Defines values for GetDeploymentOptionsParamsDeploymentType.
 const (
-	GetDeploymentOptionsParamsDeploymentTypeDEDICATED GetDeploymentOptionsParamsDeploymentType = "DEDICATED"
-	GetDeploymentOptionsParamsDeploymentTypeHYBRID    GetDeploymentOptionsParamsDeploymentType = "HYBRID"
-	GetDeploymentOptionsParamsDeploymentTypeSTANDARD  GetDeploymentOptionsParamsDeploymentType = "STANDARD"
+	DEDICATED GetDeploymentOptionsParamsDeploymentType = "DEDICATED"
+	HYBRID    GetDeploymentOptionsParamsDeploymentType = "HYBRID"
+	STANDARD  GetDeploymentOptionsParamsDeploymentType = "STANDARD"
 )
 
 // Defines values for GetDeploymentOptionsParamsExecutor.
@@ -992,8 +1065,8 @@ const (
 
 // Defines values for ListWorkspaceApiTokensParamsTokenTypes.
 const (
-	ORGANIZATION ListWorkspaceApiTokensParamsTokenTypes = "ORGANIZATION"
-	WORKSPACE    ListWorkspaceApiTokensParamsTokenTypes = "WORKSPACE"
+	ListWorkspaceApiTokensParamsTokenTypesORGANIZATION ListWorkspaceApiTokensParamsTokenTypes = "ORGANIZATION"
+	ListWorkspaceApiTokensParamsTokenTypesWORKSPACE    ListWorkspaceApiTokensParamsTokenTypes = "WORKSPACE"
 )
 
 // Defines values for ListWorkspaceApiTokensParamsSorts.
@@ -1034,18 +1107,18 @@ const (
 
 // Defines values for ListWorkspaceUsersParamsSorts.
 const (
-	ListWorkspaceUsersParamsSortsCreatedAtAsc      ListWorkspaceUsersParamsSorts = "createdAt:asc"
-	ListWorkspaceUsersParamsSortsCreatedAtDesc     ListWorkspaceUsersParamsSorts = "createdAt:desc"
-	ListWorkspaceUsersParamsSortsFullNameAsc       ListWorkspaceUsersParamsSorts = "fullName:asc"
-	ListWorkspaceUsersParamsSortsFullNameDesc      ListWorkspaceUsersParamsSorts = "fullName:desc"
-	ListWorkspaceUsersParamsSortsStatusAsc         ListWorkspaceUsersParamsSorts = "status:asc"
-	ListWorkspaceUsersParamsSortsStatusDesc        ListWorkspaceUsersParamsSorts = "status:desc"
-	ListWorkspaceUsersParamsSortsUpdatedAtAsc      ListWorkspaceUsersParamsSorts = "updatedAt:asc"
-	ListWorkspaceUsersParamsSortsUpdatedAtDesc     ListWorkspaceUsersParamsSorts = "updatedAt:desc"
-	ListWorkspaceUsersParamsSortsUsernameAsc       ListWorkspaceUsersParamsSorts = "username:asc"
-	ListWorkspaceUsersParamsSortsUsernameDesc      ListWorkspaceUsersParamsSorts = "username:desc"
-	ListWorkspaceUsersParamsSortsWorkspaceRoleAsc  ListWorkspaceUsersParamsSorts = "workspaceRole:asc"
-	ListWorkspaceUsersParamsSortsWorkspaceRoleDesc ListWorkspaceUsersParamsSorts = "workspaceRole:desc"
+	CreatedAtAsc      ListWorkspaceUsersParamsSorts = "createdAt:asc"
+	CreatedAtDesc     ListWorkspaceUsersParamsSorts = "createdAt:desc"
+	FullNameAsc       ListWorkspaceUsersParamsSorts = "fullName:asc"
+	FullNameDesc      ListWorkspaceUsersParamsSorts = "fullName:desc"
+	StatusAsc         ListWorkspaceUsersParamsSorts = "status:asc"
+	StatusDesc        ListWorkspaceUsersParamsSorts = "status:desc"
+	UpdatedAtAsc      ListWorkspaceUsersParamsSorts = "updatedAt:asc"
+	UpdatedAtDesc     ListWorkspaceUsersParamsSorts = "updatedAt:desc"
+	UsernameAsc       ListWorkspaceUsersParamsSorts = "username:asc"
+	UsernameDesc      ListWorkspaceUsersParamsSorts = "username:desc"
+	WorkspaceRoleAsc  ListWorkspaceUsersParamsSorts = "workspaceRole:asc"
+	WorkspaceRoleDesc ListWorkspaceUsersParamsSorts = "workspaceRole:desc"
 )
 
 // Defines values for ListSelfUserGitAccountsParamsGitProvider.
@@ -1070,7 +1143,7 @@ const (
 
 // Defines values for GetSelfUserGitAppInstallationParamsGitProvider.
 const (
-	GITHUB GetSelfUserGitAppInstallationParamsGitProvider = "GITHUB"
+	GetSelfUserGitAppInstallationParamsGitProviderGITHUB GetSelfUserGitAppInstallationParamsGitProvider = "GITHUB"
 )
 
 // AddTeamMembersRequest defines model for AddTeamMembersRequest.
@@ -1140,17 +1213,27 @@ type BasicSubjectProfile struct {
 // BasicSubjectProfileSubjectType defines model for BasicSubjectProfile.SubjectType.
 type BasicSubjectProfileSubjectType string
 
+// Bundle defines model for Bundle.
+type Bundle struct {
+	BundleType     *string `json:"bundleType,omitempty"`
+	CurrentVersion *string `json:"currentVersion,omitempty"`
+	DeployId       *string `json:"deployId,omitempty"`
+	DesiredVersion *string `json:"desiredVersion,omitempty"`
+	MountPath      *string `json:"mountPath,omitempty"`
+}
+
 // Cluster defines model for Cluster.
 type Cluster struct {
 	AppliedHarmonyVersion  *string              `json:"appliedHarmonyVersion,omitempty"`
 	AppliedTemplateVersion string               `json:"appliedTemplateVersion"`
 	CloudProvider          ClusterCloudProvider `json:"cloudProvider"`
-	Cohort                 *string              `json:"cohort,omitempty"`
+	Cohort                 *ClusterCohort       `json:"cohort,omitempty"`
 	CreatedAt              time.Time            `json:"createdAt"`
 	DbInstanceType         string               `json:"dbInstanceType"`
 	DbInstanceVersion      string               `json:"dbInstanceVersion"`
 	DeletedAt              *string              `json:"deletedAt,omitempty"`
-	HarmonyVersion         *string              `json:"harmonyVersion,omitempty"`
+	HarmonyVersion         string               `json:"harmonyVersion"`
+	HealthStatus           *ClusterHealthStatus `json:"healthStatus,omitempty"`
 	Id                     string               `json:"id"`
 	IsCordoned             *bool                `json:"isCordoned,omitempty"`
 	IsDryRun               bool                 `json:"isDryRun"`
@@ -1180,6 +1263,9 @@ type Cluster struct {
 // ClusterCloudProvider defines model for Cluster.CloudProvider.
 type ClusterCloudProvider string
 
+// ClusterCohort defines model for Cluster.Cohort.
+type ClusterCohort string
+
 // ClusterStatus defines model for Cluster.Status.
 type ClusterStatus string
 
@@ -1188,24 +1274,26 @@ type ClusterType string
 
 // ClusterDetailed defines model for ClusterDetailed.
 type ClusterDetailed struct {
-	AppliedHarmonyVersion  *string                      `json:"appliedHarmonyVersion,omitempty"`
-	AppliedTemplateVersion string                       `json:"appliedTemplateVersion"`
-	CloudProvider          ClusterDetailedCloudProvider `json:"cloudProvider"`
-	Cohort                 *string                      `json:"cohort,omitempty"`
-	CreatedAt              time.Time                    `json:"createdAt"`
-	CreatedBy              BasicSubjectProfile          `json:"createdBy"`
-	DbInstanceType         string                       `json:"dbInstanceType"`
-	DbInstanceVersion      string                       `json:"dbInstanceVersion"`
-	DeletedAt              *string                      `json:"deletedAt,omitempty"`
-	HarmonyVersion         *string                      `json:"harmonyVersion,omitempty"`
-	Id                     string                       `json:"id"`
-	IsCordoned             *bool                        `json:"isCordoned,omitempty"`
-	IsDryRun               bool                         `json:"isDryRun"`
-	IsLimited              bool                         `json:"isLimited"`
-	K8sTags                []ClusterTag                 `json:"k8sTags"`
-	Metadata               ClusterMetadata              `json:"metadata"`
-	Name                   string                       `json:"name"`
-	NodePools              []NodePool                   `json:"nodePools"`
+	AppliedHarmonyVersion         *string                      `json:"appliedHarmonyVersion,omitempty"`
+	AppliedTemplateVersion        string                       `json:"appliedTemplateVersion"`
+	CloudProvider                 ClusterDetailedCloudProvider `json:"cloudProvider"`
+	Cohort                        *ClusterDetailedCohort       `json:"cohort,omitempty"`
+	CreatedAt                     time.Time                    `json:"createdAt"`
+	CreatedBy                     BasicSubjectProfile          `json:"createdBy"`
+	DbInstanceType                string                       `json:"dbInstanceType"`
+	DbInstanceVersion             string                       `json:"dbInstanceVersion"`
+	DeletedAt                     *string                      `json:"deletedAt,omitempty"`
+	DisableHarmonyVersionUpgrades *bool                        `json:"disableHarmonyVersionUpgrades,omitempty"`
+	HarmonyVersion                string                       `json:"harmonyVersion"`
+	HealthStatus                  *ClusterHealthStatus         `json:"healthStatus,omitempty"`
+	Id                            string                       `json:"id"`
+	IsCordoned                    *bool                        `json:"isCordoned,omitempty"`
+	IsDryRun                      bool                         `json:"isDryRun"`
+	IsLimited                     bool                         `json:"isLimited"`
+	K8sTags                       []ClusterTag                 `json:"k8sTags"`
+	Metadata                      ClusterMetadata              `json:"metadata"`
+	Name                          string                       `json:"name"`
+	NodePools                     []NodePool                   `json:"nodePools"`
 
 	// OrgShortName Deprecated: orgShortName has been replaced with organizationShortName
 	OrgShortName               *string               `json:"orgShortName,omitempty"`
@@ -1235,11 +1323,30 @@ type ClusterDetailed struct {
 // ClusterDetailedCloudProvider defines model for ClusterDetailed.CloudProvider.
 type ClusterDetailedCloudProvider string
 
+// ClusterDetailedCohort defines model for ClusterDetailed.Cohort.
+type ClusterDetailedCohort string
+
 // ClusterDetailedStatus defines model for ClusterDetailed.Status.
 type ClusterDetailedStatus string
 
 // ClusterDetailedType defines model for ClusterDetailed.Type.
 type ClusterDetailedType string
+
+// ClusterHealthStatus defines model for ClusterHealthStatus.
+type ClusterHealthStatus struct {
+	Details *[]ClusterHealthStatusDetail `json:"details,omitempty"`
+	Value   ClusterHealthStatusValue     `json:"value"`
+}
+
+// ClusterHealthStatusValue defines model for ClusterHealthStatus.Value.
+type ClusterHealthStatusValue string
+
+// ClusterHealthStatusDetail defines model for ClusterHealthStatusDetail.
+type ClusterHealthStatusDetail struct {
+	Code        string `json:"code"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+}
 
 // ClusterMetadata defines model for ClusterMetadata.
 type ClusterMetadata struct {
@@ -1479,11 +1586,32 @@ type CreateDedicatedDeploymentRequestSchedulerSize string
 // CreateDedicatedDeploymentRequestType Types of the deployment, one of: DEDICATED, HYBRID, STANDARD
 type CreateDedicatedDeploymentRequestType string
 
+// CreateDeployGitRequest defines model for CreateDeployGitRequest.
+type CreateDeployGitRequest struct {
+	Account         string                         `json:"account"`
+	AuthorName      *string                        `json:"authorName,omitempty"`
+	AuthorUrl       *string                        `json:"authorUrl,omitempty"`
+	AuthorUsername  *string                        `json:"authorUsername,omitempty"`
+	BeforeCommitSha *string                        `json:"beforeCommitSha,omitempty"`
+	Branch          string                         `json:"branch"`
+	CommitSha       string                         `json:"commitSha"`
+	CommitUrl       string                         `json:"commitUrl"`
+	Path            *string                        `json:"path,omitempty"`
+	Provider        CreateDeployGitRequestProvider `json:"provider"`
+	Repo            string                         `json:"repo"`
+}
+
+// CreateDeployGitRequestProvider defines model for CreateDeployGitRequest.Provider.
+type CreateDeployGitRequestProvider string
+
 // CreateDeployRequest defines model for CreateDeployRequest.
 type CreateDeployRequest struct {
-	Description *string                 `json:"description,omitempty"`
-	ImageTag    *string                 `json:"imageTag,omitempty"`
-	Type        CreateDeployRequestType `json:"type"`
+	BundleMountPath *string                 `json:"bundleMountPath,omitempty"`
+	BundleType      *string                 `json:"bundleType,omitempty"`
+	Description     *string                 `json:"description,omitempty"`
+	Git             *CreateDeployGitRequest `json:"git,omitempty"`
+	ImageTag        *string                 `json:"imageTag,omitempty"`
+	Type            CreateDeployRequestType `json:"type"`
 }
 
 // CreateDeployRequestType defines model for CreateDeployRequest.Type.
@@ -1563,7 +1691,7 @@ type CreateEnvironmentObjectMetricsExportOverridesRequestExporterType string
 
 // CreateEnvironmentObjectMetricsExportRequest defines model for CreateEnvironmentObjectMetricsExportRequest.
 type CreateEnvironmentObjectMetricsExportRequest struct {
-	BasicToken   string                                                  `json:"basicToken"`
+	BasicToken   *string                                                 `json:"basicToken,omitempty"`
 	Endpoint     string                                                  `json:"endpoint"`
 	ExporterType CreateEnvironmentObjectMetricsExportRequestExporterType `json:"exporterType"`
 }
@@ -1848,6 +1976,9 @@ type DefaultValueOptions struct {
 // Deploy defines model for Deploy.
 type Deploy struct {
 	AirflowVersion     *string              `json:"airflowVersion,omitempty"`
+	BundleMountPath    *string              `json:"bundleMountPath,omitempty"`
+	BundleUploadUrl    *string              `json:"bundleUploadUrl,omitempty"`
+	Bundles            *[]Bundle            `json:"bundles,omitempty"`
 	CreatedAt          time.Time            `json:"createdAt"`
 	CreatedBySubject   *BasicSubjectProfile `json:"createdBySubject,omitempty"`
 	DagTarballVersion  *string              `json:"dagTarballVersion,omitempty"`
@@ -1876,16 +2007,17 @@ type DeployType string
 
 // DeployGit defines model for DeployGit.
 type DeployGit struct {
-	Account        string            `json:"account"`
-	AuthorName     string            `json:"authorName"`
-	AuthorUrl      string            `json:"authorUrl"`
-	AuthorUsername string            `json:"authorUsername"`
-	Branch         string            `json:"branch"`
-	CommitSha      string            `json:"commitSha"`
-	CommitUrl      string            `json:"commitUrl"`
-	Path           *string           `json:"path,omitempty"`
-	Provider       DeployGitProvider `json:"provider"`
-	Repo           string            `json:"repo"`
+	Account         string            `json:"account"`
+	AuthorName      *string           `json:"authorName,omitempty"`
+	AuthorUrl       *string           `json:"authorUrl,omitempty"`
+	AuthorUsername  *string           `json:"authorUsername,omitempty"`
+	BeforeCommitSha *string           `json:"beforeCommitSha,omitempty"`
+	Branch          string            `json:"branch"`
+	CommitSha       string            `json:"commitSha"`
+	CommitUrl       string            `json:"commitUrl"`
+	Path            *string           `json:"path,omitempty"`
+	Provider        DeployGitProvider `json:"provider"`
+	Repo            string            `json:"repo"`
 }
 
 // DeployGitProvider defines model for DeployGit.Provider.
@@ -2311,9 +2443,9 @@ type EnvironmentObjectMetricsExportExporterType string
 
 // EnvironmentObjectMetricsExportOverrides defines model for EnvironmentObjectMetricsExportOverrides.
 type EnvironmentObjectMetricsExportOverrides struct {
-	BasicToken   *string                                             `json:"basicToken,omitempty"`
-	Endpoint     string                                              `json:"endpoint"`
-	ExporterType EnvironmentObjectMetricsExportOverridesExporterType `json:"exporterType"`
+	BasicToken   *string                                              `json:"basicToken,omitempty"`
+	Endpoint     *string                                              `json:"endpoint,omitempty"`
+	ExporterType *EnvironmentObjectMetricsExportOverridesExporterType `json:"exporterType,omitempty"`
 }
 
 // EnvironmentObjectMetricsExportOverridesExporterType defines model for EnvironmentObjectMetricsExportOverrides.ExporterType.
@@ -2632,7 +2764,10 @@ type RepositoriesPaginated struct {
 
 // RepositoryBranch defines model for RepositoryBranch.
 type RepositoryBranch struct {
-	Name string `json:"name"`
+	CommitMessage string `json:"commitMessage"`
+	CommitSha     string `json:"commitSha"`
+	CommitUrl     string `json:"commitUrl"`
+	Name          string `json:"name"`
 }
 
 // ResourceOption defines model for ResourceOption.
@@ -2787,10 +2922,11 @@ type SelfSignupType string
 // SharedCluster defines model for SharedCluster.
 type SharedCluster struct {
 	CloudProvider       SharedClusterCloudProvider `json:"cloudProvider"`
-	Cohort              *string                    `json:"cohort,omitempty"`
+	Cohort              *SharedClusterCohort       `json:"cohort,omitempty"`
 	CreatedAt           time.Time                  `json:"createdAt"`
 	DbInstanceType      string                     `json:"dbInstanceType"`
 	DbInstanceVersion   string                     `json:"dbInstanceVersion"`
+	HealthStatus        *ClusterHealthStatus       `json:"healthStatus,omitempty"`
 	Id                  string                     `json:"id"`
 	IsCordoned          *bool                      `json:"isCordoned,omitempty"`
 	IsDryRun            bool                       `json:"isDryRun"`
@@ -2808,6 +2944,9 @@ type SharedCluster struct {
 
 // SharedClusterCloudProvider defines model for SharedCluster.CloudProvider.
 type SharedClusterCloudProvider string
+
+// SharedClusterCohort defines model for SharedCluster.Cohort.
+type SharedClusterCohort string
 
 // SharedClusterStatus defines model for SharedCluster.Status.
 type SharedClusterStatus string
@@ -2892,6 +3031,21 @@ type TransferDeploymentRequest struct {
 	TargetWorkspaceId string `json:"targetWorkspaceId"`
 }
 
+// TriggerGitDeployRequest defines model for TriggerGitDeployRequest.
+type TriggerGitDeployRequest struct {
+	// BeforeSha The commit before the deploy commit for inferring the deploy type. Can be multiple commits prior to the deploy commit. If not provided uses the parent commit where there is exactly one, otherwise infers an image deploy.
+	BeforeSha *string `json:"beforeSha,omitempty"`
+
+	// DeployType The type of deploy to trigger. If omitted then the deploy type will be inferred
+	DeployType *TriggerGitDeployRequestDeployType `json:"deployType,omitempty"`
+
+	// Sha The commit of the deployment's repository to deploy. If not provided uses the most recent commit on the deployment's branch
+	Sha *string `json:"sha,omitempty"`
+}
+
+// TriggerGitDeployRequestDeployType The type of deploy to trigger. If omitted then the deploy type will be inferred
+type TriggerGitDeployRequestDeployType string
+
 // UpdateAwsClusterRequest defines model for UpdateAwsClusterRequest.
 type UpdateAwsClusterRequest struct {
 	DbInstanceType                string                  `json:"dbInstanceType"`
@@ -2926,7 +3080,10 @@ type UpdateCustomRoleRequest struct {
 
 // UpdateDeployRequest defines model for UpdateDeployRequest.
 type UpdateDeployRequest struct {
-	// DagTarballVersion Required if DAG deploy is enabled on the deployment
+	// BundleTarballVersion Required if DAG deploy is enabled on the deployment and deploy type is BUNDLE.
+	BundleTarballVersion *string `json:"bundleTarballVersion,omitempty"`
+
+	// DagTarballVersion Required if DAG deploy is enabled on the deployment and deploy type is either IMAGE or DAG.
 	DagTarballVersion *string `json:"dagTarballVersion,omitempty"`
 }
 
@@ -3458,6 +3615,30 @@ type ListOrganizationApiTokensParams struct {
 
 // ListOrganizationApiTokensParamsSorts defines parameters for ListOrganizationApiTokens.
 type ListOrganizationApiTokensParamsSorts string
+
+// ListAssignableRolesParams defines parameters for ListAssignableRoles.
+type ListAssignableRolesParams struct {
+	// ScopeId scope ID
+	ScopeId *string `form:"scopeId,omitempty" json:"scopeId,omitempty"`
+
+	// ScopeType scope Type
+	ScopeType *ListAssignableRolesParamsScopeType `form:"scopeType,omitempty" json:"scopeType,omitempty"`
+
+	// Offset offset for pagination
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// Limit limit for pagination
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Sorts sorting criteria, each criterion should conform to format 'fieldName:asc' or 'fieldName:desc'
+	Sorts *[]ListAssignableRolesParamsSorts `form:"sorts,omitempty" json:"sorts,omitempty"`
+}
+
+// ListAssignableRolesParamsScopeType defines parameters for ListAssignableRoles.
+type ListAssignableRolesParamsScopeType string
+
+// ListAssignableRolesParamsSorts defines parameters for ListAssignableRoles.
+type ListAssignableRolesParamsSorts string
 
 // GetOrganizationAuditLogsParams defines parameters for GetOrganizationAuditLogs.
 type GetOrganizationAuditLogsParams struct {
@@ -4062,6 +4243,9 @@ type CreateDeploymentApiTokenJSONRequestBody = CreateDeploymentApiTokenRequest
 // UpdateDeploymentApiTokenJSONRequestBody defines body for UpdateDeploymentApiToken for application/json ContentType.
 type UpdateDeploymentApiTokenJSONRequestBody = UpdateDeploymentApiTokenRequest
 
+// TriggerGitDeployJSONRequestBody defines body for TriggerGitDeploy for application/json ContentType.
+type TriggerGitDeployJSONRequestBody = TriggerGitDeployRequest
+
 // DeployRollbackJSONRequestBody defines body for DeployRollback for application/json ContentType.
 type DeployRollbackJSONRequestBody = DeployRollbackRequest
 
@@ -4463,6 +4647,9 @@ type ClientInterface interface {
 	// RotateOrganizationApiToken request
 	RotateOrganizationApiToken(ctx context.Context, organizationId string, apiTokenId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListAssignableRoles request
+	ListAssignableRoles(ctx context.Context, organizationId string, params *ListAssignableRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetOrganizationAuditLogs request
 	GetOrganizationAuditLogs(ctx context.Context, organizationId string, params *GetOrganizationAuditLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4559,6 +4746,11 @@ type ClientInterface interface {
 
 	// RotateDeploymentApiToken request
 	RotateDeploymentApiToken(ctx context.Context, organizationId string, deploymentId string, apiTokenId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// TriggerGitDeploy request with any body
+	TriggerGitDeployWithBody(ctx context.Context, organizationId string, deploymentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	TriggerGitDeploy(ctx context.Context, organizationId string, deploymentId string, body TriggerGitDeployJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeployRollback request with any body
 	DeployRollbackWithBody(ctx context.Context, organizationId string, deploymentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5015,6 +5207,18 @@ func (c *Client) RotateOrganizationApiToken(ctx context.Context, organizationId 
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListAssignableRoles(ctx context.Context, organizationId string, params *ListAssignableRolesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAssignableRolesRequest(c.Server, organizationId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetOrganizationAuditLogs(ctx context.Context, organizationId string, params *GetOrganizationAuditLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetOrganizationAuditLogsRequest(c.Server, organizationId, params)
 	if err != nil {
@@ -5437,6 +5641,30 @@ func (c *Client) UpdateDeploymentApiToken(ctx context.Context, organizationId st
 
 func (c *Client) RotateDeploymentApiToken(ctx context.Context, organizationId string, deploymentId string, apiTokenId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRotateDeploymentApiTokenRequest(c.Server, organizationId, deploymentId, apiTokenId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) TriggerGitDeployWithBody(ctx context.Context, organizationId string, deploymentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewTriggerGitDeployRequestWithBody(c.Server, organizationId, deploymentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) TriggerGitDeploy(ctx context.Context, organizationId string, deploymentId string, body TriggerGitDeployJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewTriggerGitDeployRequest(c.Server, organizationId, deploymentId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7249,6 +7477,124 @@ func NewRotateOrganizationApiTokenRequest(server string, organizationId string, 
 	return req, nil
 }
 
+// NewListAssignableRolesRequest generates requests for ListAssignableRoles
+func NewListAssignableRolesRequest(server string, organizationId string, params *ListAssignableRolesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/organizations/%s/assignable-roles", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.ScopeId != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "scopeId", runtime.ParamLocationQuery, *params.ScopeId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.ScopeType != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "scopeType", runtime.ParamLocationQuery, *params.ScopeType); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Offset != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "offset", runtime.ParamLocationQuery, *params.Offset); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Limit != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Sorts != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sorts", runtime.ParamLocationQuery, *params.Sorts); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetOrganizationAuditLogsRequest generates requests for GetOrganizationAuditLogs
 func NewGetOrganizationAuditLogsRequest(server string, organizationId string, params *GetOrganizationAuditLogsParams) (*http.Request, error) {
 	var err error
@@ -8832,6 +9178,60 @@ func NewRotateDeploymentApiTokenRequest(server string, organizationId string, de
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewTriggerGitDeployRequest calls the generic TriggerGitDeploy builder with application/json body
+func NewTriggerGitDeployRequest(server string, organizationId string, deploymentId string, body TriggerGitDeployJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewTriggerGitDeployRequestWithBody(server, organizationId, deploymentId, "application/json", bodyReader)
+}
+
+// NewTriggerGitDeployRequestWithBody generates requests for TriggerGitDeploy with any type of body
+func NewTriggerGitDeployRequestWithBody(server string, organizationId string, deploymentId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "organizationId", runtime.ParamLocationPath, organizationId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "deploymentId", runtime.ParamLocationPath, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/organizations/%s/deployments/%s/deploy-git", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -13697,6 +14097,9 @@ type ClientWithResponsesInterface interface {
 	// RotateOrganizationApiToken request
 	RotateOrganizationApiTokenWithResponse(ctx context.Context, organizationId string, apiTokenId string, reqEditors ...RequestEditorFn) (*RotateOrganizationApiTokenResponse, error)
 
+	// ListAssignableRoles request
+	ListAssignableRolesWithResponse(ctx context.Context, organizationId string, params *ListAssignableRolesParams, reqEditors ...RequestEditorFn) (*ListAssignableRolesResponse, error)
+
 	// GetOrganizationAuditLogs request
 	GetOrganizationAuditLogsWithResponse(ctx context.Context, organizationId string, params *GetOrganizationAuditLogsParams, reqEditors ...RequestEditorFn) (*GetOrganizationAuditLogsResponse, error)
 
@@ -13793,6 +14196,11 @@ type ClientWithResponsesInterface interface {
 
 	// RotateDeploymentApiToken request
 	RotateDeploymentApiTokenWithResponse(ctx context.Context, organizationId string, deploymentId string, apiTokenId string, reqEditors ...RequestEditorFn) (*RotateDeploymentApiTokenResponse, error)
+
+	// TriggerGitDeploy request with any body
+	TriggerGitDeployWithBodyWithResponse(ctx context.Context, organizationId string, deploymentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TriggerGitDeployResponse, error)
+
+	TriggerGitDeployWithResponse(ctx context.Context, organizationId string, deploymentId string, body TriggerGitDeployJSONRequestBody, reqEditors ...RequestEditorFn) (*TriggerGitDeployResponse, error)
 
 	// DeployRollback request with any body
 	DeployRollbackWithBodyWithResponse(ctx context.Context, organizationId string, deploymentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeployRollbackResponse, error)
@@ -14388,6 +14796,33 @@ func (r RotateOrganizationApiTokenResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RotateOrganizationApiTokenResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListAssignableRolesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *RolesPaginated
+	JSON400      *Error
+	JSON401      *Error
+	JSON403      *Error
+	JSON404      *Error
+	JSON500      *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAssignableRolesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAssignableRolesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -15057,6 +15492,32 @@ func (r RotateDeploymentApiTokenResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RotateDeploymentApiTokenResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type TriggerGitDeployResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *Error
+	JSON401      *Error
+	JSON403      *Error
+	JSON404      *Error
+	JSON500      *Error
+}
+
+// Status returns HTTPResponse.Status
+func (r TriggerGitDeployResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r TriggerGitDeployResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -17027,6 +17488,15 @@ func (c *ClientWithResponses) RotateOrganizationApiTokenWithResponse(ctx context
 	return ParseRotateOrganizationApiTokenResponse(rsp)
 }
 
+// ListAssignableRolesWithResponse request returning *ListAssignableRolesResponse
+func (c *ClientWithResponses) ListAssignableRolesWithResponse(ctx context.Context, organizationId string, params *ListAssignableRolesParams, reqEditors ...RequestEditorFn) (*ListAssignableRolesResponse, error) {
+	rsp, err := c.ListAssignableRoles(ctx, organizationId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAssignableRolesResponse(rsp)
+}
+
 // GetOrganizationAuditLogsWithResponse request returning *GetOrganizationAuditLogsResponse
 func (c *ClientWithResponses) GetOrganizationAuditLogsWithResponse(ctx context.Context, organizationId string, params *GetOrganizationAuditLogsParams, reqEditors ...RequestEditorFn) (*GetOrganizationAuditLogsResponse, error) {
 	rsp, err := c.GetOrganizationAuditLogs(ctx, organizationId, params, reqEditors...)
@@ -17338,6 +17808,23 @@ func (c *ClientWithResponses) RotateDeploymentApiTokenWithResponse(ctx context.C
 		return nil, err
 	}
 	return ParseRotateDeploymentApiTokenResponse(rsp)
+}
+
+// TriggerGitDeployWithBodyWithResponse request with arbitrary body returning *TriggerGitDeployResponse
+func (c *ClientWithResponses) TriggerGitDeployWithBodyWithResponse(ctx context.Context, organizationId string, deploymentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TriggerGitDeployResponse, error) {
+	rsp, err := c.TriggerGitDeployWithBody(ctx, organizationId, deploymentId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTriggerGitDeployResponse(rsp)
+}
+
+func (c *ClientWithResponses) TriggerGitDeployWithResponse(ctx context.Context, organizationId string, deploymentId string, body TriggerGitDeployJSONRequestBody, reqEditors ...RequestEditorFn) (*TriggerGitDeployResponse, error) {
+	rsp, err := c.TriggerGitDeploy(ctx, organizationId, deploymentId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTriggerGitDeployResponse(rsp)
 }
 
 // DeployRollbackWithBodyWithResponse request with arbitrary body returning *DeployRollbackResponse
@@ -18915,6 +19402,67 @@ func ParseRotateOrganizationApiTokenResponse(rsp *http.Response) (*RotateOrganiz
 	return response, nil
 }
 
+// ParseListAssignableRolesResponse parses an HTTP response from a ListAssignableRolesWithResponse call
+func ParseListAssignableRolesResponse(rsp *http.Response) (*ListAssignableRolesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAssignableRolesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RolesPaginated
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetOrganizationAuditLogsResponse parses an HTTP response from a GetOrganizationAuditLogsWithResponse call
 func ParseGetOrganizationAuditLogsResponse(rsp *http.Response) (*GetOrganizationAuditLogsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -20358,6 +20906,60 @@ func ParseRotateDeploymentApiTokenResponse(rsp *http.Response) (*RotateDeploymen
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseTriggerGitDeployResponse parses an HTTP response from a TriggerGitDeployWithResponse call
+func ParseTriggerGitDeployResponse(rsp *http.Response) (*TriggerGitDeployResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &TriggerGitDeployResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
 		var dest Error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/astro-client-core/client.go
+++ b/astro-client-core/client.go
@@ -39,7 +39,7 @@ func NormalizeAPIError(httpResp *http.Response, body []byte) error {
 		if err != nil {
 			return fmt.Errorf("%w, status %d", ErrorRequest, httpResp.StatusCode)
 		}
-		return errors.New(decode.Message) //nolint:goerr113
+		return errors.New(decode.Message)
 	}
 	return nil
 }

--- a/astro-client-core/mocks/client.go
+++ b/astro-client-core/mocks/client.go
@@ -2426,6 +2426,39 @@ func (_m *ClientWithResponsesInterface) GetWorkspaceWithResponse(ctx context.Con
 	return r0, r1
 }
 
+// ListAssignableRolesWithResponse provides a mock function with given fields: ctx, organizationId, params, reqEditors
+func (_m *ClientWithResponsesInterface) ListAssignableRolesWithResponse(ctx context.Context, organizationId string, params *astrocore.ListAssignableRolesParams, reqEditors ...astrocore.RequestEditorFn) (*astrocore.ListAssignableRolesResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, organizationId, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *astrocore.ListAssignableRolesResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *astrocore.ListAssignableRolesParams, ...astrocore.RequestEditorFn) (*astrocore.ListAssignableRolesResponse, error)); ok {
+		return rf(ctx, organizationId, params, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *astrocore.ListAssignableRolesParams, ...astrocore.RequestEditorFn) *astrocore.ListAssignableRolesResponse); ok {
+		r0 = rf(ctx, organizationId, params, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*astrocore.ListAssignableRolesResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *astrocore.ListAssignableRolesParams, ...astrocore.RequestEditorFn) error); ok {
+		r1 = rf(ctx, organizationId, params, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListClusterRoutesWithResponse provides a mock function with given fields: ctx, organizationId, clusterId, params, reqEditors
 func (_m *ClientWithResponsesInterface) ListClusterRoutesWithResponse(ctx context.Context, organizationId string, clusterId string, params *astrocore.ListClusterRoutesParams, reqEditors ...astrocore.RequestEditorFn) (*astrocore.ListClusterRoutesResponse, error) {
 	_va := make([]interface{}, len(reqEditors))
@@ -3838,6 +3871,72 @@ func (_m *ClientWithResponsesInterface) TransferDeploymentWithResponse(ctx conte
 
 	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, astrocore.TransferDeploymentRequest, ...astrocore.RequestEditorFn) error); ok {
 		r1 = rf(ctx, organizationId, workspaceId, deploymentId, body, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// TriggerGitDeployWithBodyWithResponse provides a mock function with given fields: ctx, organizationId, deploymentId, contentType, body, reqEditors
+func (_m *ClientWithResponsesInterface) TriggerGitDeployWithBodyWithResponse(ctx context.Context, organizationId string, deploymentId string, contentType string, body io.Reader, reqEditors ...astrocore.RequestEditorFn) (*astrocore.TriggerGitDeployResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, organizationId, deploymentId, contentType, body)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *astrocore.TriggerGitDeployResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, io.Reader, ...astrocore.RequestEditorFn) (*astrocore.TriggerGitDeployResponse, error)); ok {
+		return rf(ctx, organizationId, deploymentId, contentType, body, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, io.Reader, ...astrocore.RequestEditorFn) *astrocore.TriggerGitDeployResponse); ok {
+		r0 = rf(ctx, organizationId, deploymentId, contentType, body, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*astrocore.TriggerGitDeployResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, io.Reader, ...astrocore.RequestEditorFn) error); ok {
+		r1 = rf(ctx, organizationId, deploymentId, contentType, body, reqEditors...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// TriggerGitDeployWithResponse provides a mock function with given fields: ctx, organizationId, deploymentId, body, reqEditors
+func (_m *ClientWithResponsesInterface) TriggerGitDeployWithResponse(ctx context.Context, organizationId string, deploymentId string, body astrocore.TriggerGitDeployRequest, reqEditors ...astrocore.RequestEditorFn) (*astrocore.TriggerGitDeployResponse, error) {
+	_va := make([]interface{}, len(reqEditors))
+	for _i := range reqEditors {
+		_va[_i] = reqEditors[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, organizationId, deploymentId, body)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *astrocore.TriggerGitDeployResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, astrocore.TriggerGitDeployRequest, ...astrocore.RequestEditorFn) (*astrocore.TriggerGitDeployResponse, error)); ok {
+		return rf(ctx, organizationId, deploymentId, body, reqEditors...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, astrocore.TriggerGitDeployRequest, ...astrocore.RequestEditorFn) *astrocore.TriggerGitDeployResponse); ok {
+		r0 = rf(ctx, organizationId, deploymentId, body, reqEditors...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*astrocore.TriggerGitDeployResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, astrocore.TriggerGitDeployRequest, ...astrocore.RequestEditorFn) error); ok {
+		r1 = rf(ctx, organizationId, deploymentId, body, reqEditors...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/astro-client-iam-core/client.go
+++ b/astro-client-iam-core/client.go
@@ -38,7 +38,7 @@ func NormalizeAPIError(httpResp *http.Response, body []byte) error {
 		if err != nil {
 			return fmt.Errorf("%w, status %d", ErrorRequest, httpResp.StatusCode)
 		}
-		return errors.New(decode.Message) //nolint:goerr113
+		return errors.New(decode.Message)
 	}
 	return nil
 }

--- a/astro-client-platform-core/api.gen.go
+++ b/astro-client-platform-core/api.gen.go
@@ -36,17 +36,25 @@ const (
 
 // Defines values for ClusterStatus.
 const (
-	ClusterStatusCREATED      ClusterStatus = "CREATED"
-	ClusterStatusCREATEFAILED ClusterStatus = "CREATE_FAILED"
-	ClusterStatusCREATING     ClusterStatus = "CREATING"
-	ClusterStatusUPDATEFAILED ClusterStatus = "UPDATE_FAILED"
-	ClusterStatusUPDATING     ClusterStatus = "UPDATING"
+	ClusterStatusACCESSDENIED   ClusterStatus = "ACCESS_DENIED"
+	ClusterStatusCREATED        ClusterStatus = "CREATED"
+	ClusterStatusCREATEFAILED   ClusterStatus = "CREATE_FAILED"
+	ClusterStatusCREATING       ClusterStatus = "CREATING"
+	ClusterStatusUPDATEFAILED   ClusterStatus = "UPDATE_FAILED"
+	ClusterStatusUPDATING       ClusterStatus = "UPDATING"
+	ClusterStatusUPGRADEPENDING ClusterStatus = "UPGRADE_PENDING"
 )
 
 // Defines values for ClusterType.
 const (
 	ClusterTypeDEDICATED ClusterType = "DEDICATED"
 	ClusterTypeHYBRID    ClusterType = "HYBRID"
+)
+
+// Defines values for ClusterHealthStatusValue.
+const (
+	HEALTHY   ClusterHealthStatusValue = "HEALTHY"
+	UNHEALTHY ClusterHealthStatusValue = "UNHEALTHY"
 )
 
 // Defines values for ClusterOptionsProvider.
@@ -483,7 +491,8 @@ type Cluster struct {
 	CreatedAt time.Time `json:"createdAt"`
 
 	// DbInstanceType The type of database instance that is used for the cluster.
-	DbInstanceType string `json:"dbInstanceType"`
+	DbInstanceType string               `json:"dbInstanceType"`
+	HealthStatus   *ClusterHealthStatus `json:"healthStatus,omitempty"`
 
 	// Id The cluster's ID.
 	Id string `json:"id"`
@@ -546,6 +555,30 @@ type ClusterStatus string
 
 // ClusterType The type of the cluster.
 type ClusterType string
+
+// ClusterHealthStatus defines model for ClusterHealthStatus.
+type ClusterHealthStatus struct {
+	// Details List of details supporting health assessment.
+	Details *[]ClusterHealthStatusDetail `json:"details,omitempty"`
+
+	// Value Overall health state (HEALTHY or UNHEALTHY).
+	Value ClusterHealthStatusValue `json:"value"`
+}
+
+// ClusterHealthStatusValue Overall health state (HEALTHY or UNHEALTHY).
+type ClusterHealthStatusValue string
+
+// ClusterHealthStatusDetail defines model for ClusterHealthStatusDetail.
+type ClusterHealthStatusDetail struct {
+	// Code The health status for a specific component.
+	Code string `json:"code"`
+
+	// Description A description of the component that was assessed.
+	Description string `json:"description"`
+
+	// Severity The weight this component is given in overall cluster health assessment.
+	Severity string `json:"severity"`
+}
 
 // ClusterK8sTag defines model for ClusterK8sTag.
 type ClusterK8sTag struct {
@@ -783,14 +816,14 @@ type CreateDedicatedDeploymentRequestType string
 
 // CreateDeployRequest defines model for CreateDeployRequest.
 type CreateDeployRequest struct {
-	// Description The Deploy's description.
+	// Description The deploy's description.
 	Description *string `json:"description,omitempty"`
 
-	// Type The type of the Deploy.
+	// Type The type of the deploy.
 	Type CreateDeployRequestType `json:"type"`
 }
 
-// CreateDeployRequestType The type of the Deploy.
+// CreateDeployRequestType The type of the deploy.
 type CreateDeployRequestType string
 
 // CreateDeploymentRequest defines model for CreateDeploymentRequest.
@@ -1009,58 +1042,58 @@ type CreateWorkspaceRequest struct {
 
 // Deploy defines model for Deploy.
 type Deploy struct {
-	// AirflowVersion The Deploy's Airflow version.
+	// AirflowVersion The deploy's Airflow version.
 	AirflowVersion *string `json:"airflowVersion,omitempty"`
 
-	// AstroRuntimeVersion The Deploy's Astro Runtime version.
+	// AstroRuntimeVersion The deploy's Astro Runtime version.
 	AstroRuntimeVersion *string `json:"astroRuntimeVersion,omitempty"`
 
-	// CreatedAt The time when the Deploy was created in UTC, formatted as `YYYY-MM-DDTHH:MM:SSZ`.
+	// CreatedAt The time when the deploy was created in UTC, formatted as `YYYY-MM-DDTHH:MM:SSZ`.
 	CreatedAt        time.Time            `json:"createdAt"`
 	CreatedBySubject *BasicSubjectProfile `json:"createdBySubject,omitempty"`
 
-	// DagTarballVersion The Deploy's DAG tarball version, also known as the Bundle Version in the Astro UI.
+	// DagTarballVersion The deploy's DAG tarball version, also known as the Bundle Version in the Astro UI.
 	DagTarballVersion *string `json:"dagTarballVersion,omitempty"`
 
-	// DagsUploadUrl The Deploy's upload URL to upload DAG bundles. Appears only if dag deploy is enabled on the Deployment.
+	// DagsUploadUrl The deploy's upload URL to upload DAG bundles. Appears only if dag deploys are enabled on the Deployment.
 	DagsUploadUrl *string `json:"dagsUploadUrl,omitempty"`
 
 	// DeploymentId The Deployment's ID.
 	DeploymentId string `json:"deploymentId"`
 
-	// Description The Deploy's description.
+	// Description The deploy's description.
 	Description *string `json:"description,omitempty"`
 
-	// Id The Deploy's ID.
+	// Id The deploy's ID.
 	Id string `json:"id"`
 
-	// ImageRepository The URL of the Deploy's image repository.
+	// ImageRepository The URL of the deploy's image repository.
 	ImageRepository string `json:"imageRepository"`
 
-	// ImageTag The Deploy's image tag. Appears only if specified in the most recent deploy.
+	// ImageTag The deploy's image tag. Appears only if specified in the most recent deploy.
 	ImageTag string `json:"imageTag"`
 
-	// IsDagDeployEnabled Whether the Deploy has DAG deploys enabled.
+	// IsDagDeployEnabled Whether the deploy was triggered on a Deployment with DAG deploys enabled.
 	IsDagDeployEnabled bool `json:"isDagDeployEnabled"`
 
-	// RollbackFromId The Deploy's ID which was Rollback from. Appears only if a rollback as been performed.
+	// RollbackFromId The ID of the deploy that you completed a rollback on. Appears only if a rollback has been performed.
 	RollbackFromId *string `json:"rollbackFromId,omitempty"`
 
-	// Status The status of the Deploy.
+	// Status The status of the deploy.
 	Status DeployStatus `json:"status"`
 
-	// Type The type of Deploy.
+	// Type The type of deploy.
 	Type DeployType `json:"type"`
 
-	// UpdatedAt The time when the Deploy was last updated in UTC, formatted as `YYYY-MM-DDTHH:MM:SSZ`.
+	// UpdatedAt The time when the deploy was last updated in UTC, formatted as `YYYY-MM-DDTHH:MM:SSZ`.
 	UpdatedAt        *time.Time           `json:"updatedAt,omitempty"`
 	UpdatedBySubject *BasicSubjectProfile `json:"updatedBySubject,omitempty"`
 }
 
-// DeployStatus The status of the Deploy.
+// DeployStatus The status of the deploy.
 type DeployStatus string
 
-// DeployType The type of Deploy.
+// DeployType The type of deploy.
 type DeployType string
 
 // DeployRollbackRequest defines model for DeployRollbackRequest.
@@ -1401,16 +1434,16 @@ type DeploymentsPaginated struct {
 
 // DeploysPaginated defines model for DeploysPaginated.
 type DeploysPaginated struct {
-	// Deploys A list of Deploys in the current page.
+	// Deploys A list of deploys in the current page.
 	Deploys []Deploy `json:"deploys"`
 
-	// Limit The maximum number of Deploys in one page.
+	// Limit The maximum number of deploys in one page.
 	Limit int `json:"limit"`
 
-	// Offset The offset of the current page of Deploys.
+	// Offset The offset of the current page of deploys.
 	Offset int `json:"offset"`
 
-	// TotalCount The total number of Deploys.
+	// TotalCount The total number of deploys.
 	TotalCount int `json:"totalCount"`
 }
 
@@ -1423,7 +1456,7 @@ type Error struct {
 
 // FinalizeDeployRequest defines model for FinalizeDeployRequest.
 type FinalizeDeployRequest struct {
-	// DagTarballVersion The Deploy's DAG tarball version, also known as the Bundle Version in the Astro UI. Required if DAG deploy is enabled on the deployment and deploy type is IMAGE_AND_DAG or DAG_ONLY
+	// DagTarballVersion The deploy's DAG tarball version, also known as the Bundle Version in the Astro UI. Required if DAG deploys are enabled on the Deployment, and deploy type is either IMAGE_AND_DAG or DAG_ONLY.
 	DagTarballVersion *string `json:"dagTarballVersion,omitempty"`
 }
 
@@ -1795,7 +1828,7 @@ type UpdateDedicatedDeploymentRequestType string
 
 // UpdateDeployRequest defines model for UpdateDeployRequest.
 type UpdateDeployRequest struct {
-	// Description The Deploy's description.
+	// Description The deploy's description.
 	Description *string `json:"description,omitempty"`
 }
 

--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -61,7 +61,7 @@ func NormalizeAPIError(httpResp *http.Response, body []byte) error {
 		if err != nil {
 			return fmt.Errorf("%w, status %d", ErrorRequest, httpResp.StatusCode)
 		}
-		return errors.New(decode.Message) //nolint:goerr113
+		return errors.New(decode.Message)
 	}
 	return nil
 }

--- a/cloud/deploy/bundle.go
+++ b/cloud/deploy/bundle.go
@@ -1,0 +1,247 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	astrocore "github.com/astronomer/astro-cli/astro-client-core"
+	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	"github.com/astronomer/astro-cli/cloud/deployment"
+	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/git"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type DeployBundleInput struct {
+	BundlePath   string
+	MountPath    string
+	DeploymentID string
+	BundleType   string
+	Description  string
+	Wait         bool
+}
+
+func DeployBundle(input *DeployBundleInput, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+	c, err := config.GetCurrentContext()
+	if err != nil {
+		return err
+	}
+
+	// get the current deployment so we can check the deploy is valid
+	currentDeployment, err := getDeployment(c.Organization, input.DeploymentID, platformCoreClient)
+	if err != nil {
+		return err
+	}
+
+	// if CI/CD is enforced, check the subject can deploy
+	if currentDeployment.IsCicdEnforced && !canCiCdDeploy(c.Token) {
+		return fmt.Errorf(errCiCdEnforcementUpdate, currentDeployment.Name) //nolint
+	}
+
+	// check the deployment is enabled for DAG deploys
+	if !currentDeployment.IsDagDeployEnabled {
+		return fmt.Errorf(enableDagDeployMsg, input.DeploymentID) //nolint
+	}
+
+	// retrieve metadata about the local Git checkout. returns nil if not available
+	gitMetadata := retrieveLocalGitMetadata(input.BundlePath)
+
+	// initialize the deploy
+	deploy, err := createBundleDeploy(c.Organization, input, gitMetadata, coreClient)
+	if err != nil {
+		return err
+	}
+
+	// check we received an upload URL
+	if deploy.BundleUploadUrl == nil {
+		return errors.New("No bundle upload URL received from Astro")
+	}
+
+	// upload the bundle
+	tarballVersion, err := uploadBundle(config.WorkingPath, input.BundlePath, *deploy.BundleUploadUrl, false)
+	if err != nil {
+		return err
+	}
+
+	// finalize the deploy
+	_, err = finalizeBundleDeploy(c.Organization, deploy.Id, tarballVersion, input, coreClient)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Successfully uploaded bundle with version " + tarballVersion + " to Astro.")
+
+	// if requested, wait for the deploy to finish by polling the deployment until it is healthy
+	if input.Wait {
+		err = deployment.HealthPoll(currentDeployment.Id, currentDeployment.WorkspaceId, dagOnlyDeploySleepTime, tickNum, timeoutNum, platformCoreClient)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func uploadBundle(tarDirPath, bundlePath, uploadURL string, prependBaseDir bool) (string, error) {
+	tarFilePath := filepath.Join(tarDirPath, "bundle.tar")
+	defer func() {
+		err := os.Remove(tarFilePath)
+		if err != nil {
+			fmt.Println("\nFailed to delete tar file: ", err.Error())
+			fmt.Println("\nPlease delete the tar file manually from path: " + tarFilePath)
+		}
+	}()
+
+	// Generate the bundle tar
+	err := fileutil.Tar(bundlePath, tarFilePath, prependBaseDir)
+	if err != nil {
+		return "", err
+	}
+
+	tarFile, err := os.Open(tarFilePath)
+	if err != nil {
+		return "", err
+	}
+	defer tarFile.Close()
+
+	versionID, err := azureUploader(uploadURL, tarFile)
+	if err != nil {
+		return "", err
+	}
+
+	return versionID, nil
+}
+
+func getDeployment(organizationID, deploymentID string, platformCoreClient astroplatformcore.CoreClient) (*astroplatformcore.Deployment, error) {
+	resp, err := platformCoreClient.GetDeploymentWithResponse(context.Background(), organizationID, deploymentID)
+	if err != nil {
+		return nil, err
+	}
+	err = astrocore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.JSON200, nil
+}
+
+func createBundleDeploy(organizationID string, input *DeployBundleInput, deployGit *astrocore.DeployGit, coreClient astrocore.CoreClient) (*astrocore.Deploy, error) {
+	request := astrocore.CreateDeployRequest{
+		Description:     &input.Description,
+		Type:            astrocore.CreateDeployRequestTypeBUNDLE,
+		BundleMountPath: &input.MountPath,
+		BundleType:      &input.BundleType,
+	}
+	if deployGit != nil {
+		request.Git = &astrocore.CreateDeployGitRequest{
+			Provider:   astrocore.CreateDeployGitRequestProvider(deployGit.Provider),
+			Repo:       deployGit.Repo,
+			Account:    deployGit.Account,
+			Path:       deployGit.Path,
+			Branch:     deployGit.Branch,
+			CommitSha:  deployGit.CommitSha,
+			CommitUrl:  fmt.Sprintf("https://github.com/%s/%s/commit/%s", deployGit.Account, deployGit.Repo, deployGit.CommitSha),
+			AuthorName: deployGit.AuthorName,
+		}
+	}
+	resp, err := coreClient.CreateDeployWithResponse(context.Background(), organizationID, input.DeploymentID, request)
+	if err != nil {
+		return nil, err
+	}
+	err = astrocore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return resp.JSON200, nil
+}
+
+func finalizeBundleDeploy(organizationID, deployID, tarballVersion string, input *DeployBundleInput, coreClient astrocore.CoreClient) (*astrocore.UpdateDeployResponse, error) {
+	request := astrocore.UpdateDeployRequest{
+		BundleTarballVersion: &tarballVersion,
+	}
+	resp, err := coreClient.UpdateDeployWithResponse(context.Background(), organizationID, input.DeploymentID, deployID, request)
+	if err != nil {
+		return nil, err
+	}
+	err = astrocore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func retrieveLocalGitMetadata(bundlePath string) *astrocore.DeployGit {
+	if git.HasUncommittedChanges() {
+		logrus.Warn("Local repository has uncommitted changes, skipping Git metadata retrieval")
+		return nil
+	}
+
+	gitMetadata := &astrocore.DeployGit{}
+
+	// get the remote repository details, assume the remote is named "origin"
+	host, account, repo, err := git.GetRemoteRepository("origin")
+	if err != nil {
+		logrus.Debugf("Failed to retrieve remote repository details, skipping Git metadata retrieval: %s", err)
+		return nil
+	}
+	switch host {
+	case "github.com":
+		gitMetadata.Provider = astrocore.DeployGitProviderGITHUB
+	default:
+		logrus.Debugf("Unsupported Git provider, skipping Git metadata retrieval: %s", host)
+		return nil
+	}
+	gitMetadata.Account = account
+	gitMetadata.Repo = repo
+
+	// get the path of the bundle within the repository
+	path, err := git.GetLocalRepositoryPathPrefix(bundlePath)
+	if err != nil {
+		logrus.Debugf("Failed to retrieve local repository path prefix, skipping Git metadata retrieval: %s", err)
+		return nil
+	}
+	if path != "" {
+		gitMetadata.Path = &path
+	}
+
+	// get the branch of the local commit
+	branch, err := git.GetBranch()
+	if err != nil {
+		logrus.Debugf("Failed to retrieve branch name, skipping Git metadata retrieval: %s", err)
+		return nil
+	}
+	gitMetadata.Branch = branch
+
+	// get the SHA of the local commit
+	sha, err := git.GetHeadCommitSHA()
+	if err != nil {
+		logrus.Debugf("Failed to retrieve commit SHA, skipping Git metadata retrieval: %s", err)
+		return nil
+	}
+	gitMetadata.CommitSha = sha
+
+	// derive the remote URL of the local commit
+	commitURL, err := git.GetCommitURL(host, account, repo, sha)
+	if err != nil {
+		logrus.Debugf("Failed to derive commit URL, skipping Git metadata retrieval: %s", err)
+		return nil
+	}
+	gitMetadata.CommitUrl = commitURL
+
+	// get the author name of the local commit
+	authorName, _, err := git.GetHeadCommitAuthor()
+	if err != nil {
+		logrus.Debugf("Failed to retrieve commit author, skipping Git metadata retrieval: %s", err)
+		return nil
+	}
+	if authorName != "" {
+		gitMetadata.AuthorName = &authorName
+	}
+
+	logrus.Debugf("Retrieved Git metadata: %+v", gitMetadata)
+
+	return gitMetadata
+}

--- a/cloud/deploy/bundle_test.go
+++ b/cloud/deploy/bundle_test.go
@@ -1,0 +1,278 @@
+package deploy
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	astrocore "github.com/astronomer/astro-cli/astro-client-core"
+	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
+	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
+	"github.com/astronomer/astro-cli/pkg/git"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleDeploy_Success(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	canCiCdDeploy = func(token string) bool {
+		return true
+	}
+
+	input := &DeployBundleInput{
+		BundlePath:   "test-bundle-path",
+		MountPath:    "test-mount-path",
+		DeploymentID: "test-deployment-id",
+		BundleType:   "test-bundle-type",
+		Description:  "test-description",
+	}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockGetDeployment(mockPlatformCoreClient, true, true)
+
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+	expectedDeploy := &astrocore.CreateDeployRequest{
+		Type:            astrocore.CreateDeployRequestTypeBUNDLE,
+		BundleType:      &input.BundleType,
+		BundleMountPath: &input.MountPath,
+		Description:     &input.Description,
+	}
+	mockCreateDeploy(mockCoreClient, "http://bundle-upload-url", expectedDeploy)
+	mockUpdateDeploy(mockCoreClient)
+
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	err := DeployBundle(input, mockPlatformCoreClient, mockCoreClient)
+	assert.NoError(t, err)
+
+	mockCoreClient.AssertExpectations(t)
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func TestBundleDeploy_CiCdIncompatible(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	canCiCdDeploy = func(token string) bool {
+		return false
+	}
+
+	input := &DeployBundleInput{
+		DeploymentID: "test-deployment-id",
+	}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockGetDeployment(mockPlatformCoreClient, true, true)
+
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+
+	err := DeployBundle(input, mockPlatformCoreClient, mockCoreClient)
+	assert.Error(t, err)
+
+	mockCoreClient.AssertExpectations(t)
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func TestBundleDeploy_DagDeployDisabled(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	input := &DeployBundleInput{}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockGetDeployment(mockPlatformCoreClient, false, false)
+
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+
+	err := DeployBundle(input, mockPlatformCoreClient, mockCoreClient)
+	assert.Error(t, err)
+
+	mockCoreClient.AssertExpectations(t)
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func TestBundleDeploy_GitMetadataRetrieved(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	sha, cleanupGit := createTestGitRepository(t, false)
+	defer cleanupGit()
+
+	input := &DeployBundleInput{}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockGetDeployment(mockPlatformCoreClient, true, false)
+
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+	expectedAuthorName := "Test"
+	expectedDeploy := &astrocore.CreateDeployRequest{
+		Type:            astrocore.CreateDeployRequestTypeBUNDLE,
+		BundleType:      &input.BundleType,
+		BundleMountPath: &input.MountPath,
+		Description:     &input.Description,
+		Git: &astrocore.CreateDeployGitRequest{
+			Provider:   astrocore.CreateDeployGitRequestProviderGITHUB,
+			Account:    "account",
+			Repo:       "repo",
+			Branch:     "main",
+			CommitSha:  sha,
+			CommitUrl:  "https://github.com/account/repo/commit/" + sha,
+			AuthorName: &expectedAuthorName,
+		},
+	}
+	mockCreateDeploy(mockCoreClient, "http://bundle-upload-url", expectedDeploy)
+	mockUpdateDeploy(mockCoreClient)
+
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	err := DeployBundle(input, mockPlatformCoreClient, mockCoreClient)
+	assert.NoError(t, err)
+
+	mockCoreClient.AssertExpectations(t)
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func TestBundleDeploy_GitHasUncommittedChanges(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	_, cleanupGit := createTestGitRepository(t, true)
+	defer cleanupGit()
+
+	input := &DeployBundleInput{}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockGetDeployment(mockPlatformCoreClient, true, false)
+
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+	expectedDeploy := &astrocore.CreateDeployRequest{
+		Type:            astrocore.CreateDeployRequestTypeBUNDLE,
+		BundleType:      &input.BundleType,
+		BundleMountPath: &input.MountPath,
+		Description:     &input.Description,
+		Git:             nil,
+	}
+	mockCreateDeploy(mockCoreClient, "http://bundle-upload-url", expectedDeploy)
+	mockUpdateDeploy(mockCoreClient)
+
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	err := DeployBundle(input, mockPlatformCoreClient, mockCoreClient)
+	assert.NoError(t, err)
+
+	mockCoreClient.AssertExpectations(t)
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func TestBundleDeploy_BundleUploadUrlMissing(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	input := &DeployBundleInput{}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockGetDeployment(mockPlatformCoreClient, true, false)
+
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+	mockCreateDeploy(mockCoreClient, "", nil)
+
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	err := DeployBundle(input, mockPlatformCoreClient, mockCoreClient)
+	assert.Error(t, err)
+
+	mockCoreClient.AssertExpectations(t)
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func mockCreateDeploy(client *astrocore_mocks.ClientWithResponsesInterface, bundleUploadURL string, expectedDeploy *astrocore.CreateDeployRequest) {
+	var request any
+	if expectedDeploy != nil {
+		request = *expectedDeploy
+	} else {
+		request = mock.Anything
+	}
+	response := &astrocore.CreateDeployResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: astrocore.HTTPStatus200,
+		},
+		JSON200: &astrocore.Deploy{
+			Id: "test-deploy-id",
+		},
+	}
+	if bundleUploadURL != "" {
+		response.JSON200.BundleUploadUrl = &bundleUploadURL
+	}
+	client.On("CreateDeployWithResponse", mock.Anything, mock.Anything, mock.Anything, request).Return(response, nil)
+}
+
+func mockUpdateDeploy(client *astrocore_mocks.ClientWithResponsesInterface) {
+	client.On("UpdateDeployWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&astrocore.UpdateDeployResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: astrocore.HTTPStatus200,
+		},
+	}, nil)
+}
+
+func mockGetDeployment(client *astroplatformcore_mocks.ClientWithResponsesInterface, isDagDeployEnabled, isCicdEnforced bool) {
+	client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.GetDeploymentResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: astrocore.HTTPStatus200,
+		},
+		JSON200: &astroplatformcore.Deployment{
+			Id:                 "test-deployment-id",
+			IsDagDeployEnabled: isDagDeployEnabled,
+			IsCicdEnforced:     isCicdEnforced,
+		},
+	}, nil)
+}
+
+func createTestGitRepository(t *testing.T, withUncommittedFile bool) (sha string, cleanup func()) {
+	dir, err := os.MkdirTemp("", "test-git-repo")
+	require.NoError(t, err)
+	git.Path = dir
+	logrus.Warnf("git.Path: %s", git.Path)
+
+	err = exec.Command("git", "-C", dir, "init", "-b", "main").Run()
+	require.NoError(t, err)
+
+	err = exec.Command("git", "-C", dir, "config", "user.email", "test@test.com").Run()
+	require.NoError(t, err)
+
+	err = exec.Command("git", "-C", dir, "config", "user.name", "Test").Run()
+	require.NoError(t, err)
+
+	err = exec.Command("git", "-C", dir, "commit", "--allow-empty", "-m", "Initial commit").Run()
+	require.NoError(t, err)
+
+	err = exec.Command("git", "-C", dir, "remote", "add", "origin", "https://github.com/account/repo.git").Run()
+	require.NoError(t, err)
+
+	shaBytes, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	require.NoError(t, err)
+
+	if withUncommittedFile {
+		err = os.WriteFile(filepath.Join(dir, "uncommitted-file"), []byte("uncommitted"), 0o644)
+		require.NoError(t, err)
+
+		err = exec.Command("git", "-C", dir, "add", "uncommitted-file").Run()
+		require.NoError(t, err)
+	}
+
+	return strings.TrimSpace(string(shaBytes)), func() {
+		os.RemoveAll(dir)
+		git.Path = ""
+	}
+}

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -48,7 +48,7 @@ const (
 	action                   = "UPLOAD"
 	allTests                 = "all-tests"
 	parseAndPytest           = "parse-and-all-tests"
-	enableDagDeployMsg       = "DAG-only deploys are not enabled for this Deployment. Run 'astro deployment update %s --dag-deploy enable' to enable DAG-only deploys."
+	enableDagDeployMsg       = "DAG-only deploys are not enabled for this Deployment. Run 'astro deployment update %s --dag-deploy enable' to enable DAG-only deploys"
 	dagDeployDisabled        = "dag deploy is not enabled for deployment"
 	invalidWorkspaceID       = "Invalid workspace id %s was provided through the --workspace-id flag\n"
 	errCiCdEnforcementUpdate = "cannot deploy since ci/cd enforcement is enabled for the deployment %s. Please use API Tokens instead"
@@ -228,18 +228,29 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 	if err != nil {
 		return err
 	}
-	resp, err := createDeploy(deployInfo.organizationID, deployInfo.deploymentID, deployInput.Description, deployInput.Dags, deployInput.Image, platformCoreClient)
+	createDeployRequest := astroplatformcore.CreateDeployRequest{
+		Description: &deployInput.Description,
+	}
+	switch {
+	case deployInput.Dags:
+		createDeployRequest.Type = astroplatformcore.CreateDeployRequestTypeDAGONLY
+	case deployInput.Image:
+		createDeployRequest.Type = astroplatformcore.CreateDeployRequestTypeIMAGEONLY
+	default:
+		createDeployRequest.Type = astroplatformcore.CreateDeployRequestTypeIMAGEANDDAG
+	}
+	deploy, err := createDeploy(deployInfo.organizationID, deployInfo.deploymentID, createDeployRequest, platformCoreClient)
 	if err != nil {
 		return err
 	}
-	deployID := resp.JSON200.Id
-	if resp.JSON200.DagsUploadUrl != nil {
-		dagsUploadURL = *resp.JSON200.DagsUploadUrl
+	deployID := deploy.Id
+	if deploy.DagsUploadUrl != nil {
+		dagsUploadURL = *deploy.DagsUploadUrl
 	} else {
 		dagsUploadURL = ""
 	}
-	if resp.JSON200.ImageTag != "" {
-		nextTag = resp.JSON200.ImageTag
+	if deploy.ImageTag != "" {
+		nextTag = deploy.ImageTag
 	} else {
 		nextTag = ""
 	}
@@ -348,7 +359,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 			fmt.Println("No DAGs found. Skipping testing...")
 		}
 
-		repository := resp.JSON200.ImageRepository
+		repository := deploy.ImageRepository
 		// TODO: Resolve the edge case where two people push the same nextTag at the same time
 		remoteImage := fmt.Sprintf("%s:%s", repository, nextTag)
 
@@ -736,29 +747,16 @@ func finalizeDeploy(deployID, deploymentID, organizationID, dagTarballVersion st
 	return nil
 }
 
-// create deploy
-func createDeploy(organizationID, deploymentID, description string, dagDeploy, imageOnlyDeploy bool, platformCoreClient astroplatformcore.CoreClient) (astroplatformcore.CreateDeployResponse, error) {
-	createDeployRequest := astroplatformcore.CreateDeployRequest{
-		Description: &description,
-	}
-	switch {
-	case dagDeploy:
-		createDeployRequest.Type = astroplatformcore.CreateDeployRequestTypeDAGONLY
-	case imageOnlyDeploy:
-		createDeployRequest.Type = astroplatformcore.CreateDeployRequestTypeIMAGEONLY
-	default:
-		createDeployRequest.Type = astroplatformcore.CreateDeployRequestTypeIMAGEANDDAG
-	}
-
-	resp, err := platformCoreClient.CreateDeployWithResponse(httpContext.Background(), organizationID, deploymentID, createDeployRequest)
+func createDeploy(organizationID, deploymentID string, request astroplatformcore.CreateDeployRequest, platformCoreClient astroplatformcore.CoreClient) (*astroplatformcore.Deploy, error) {
+	resp, err := platformCoreClient.CreateDeployWithResponse(httpContext.Background(), organizationID, deploymentID, request)
 	if err != nil {
-		return astroplatformcore.CreateDeployResponse{}, err
+		return nil, err
 	}
 	err = astrocore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
 	if err != nil {
-		return astroplatformcore.CreateDeployResponse{}, err
+		return nil, err
 	}
-	return *resp, err
+	return resp.JSON200, err
 }
 
 func IsValidUpgrade(currentVersion, tag string) bool {

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -613,7 +613,7 @@ func TestDagsDeployFailed(t *testing.T) {
 
 	defer testUtil.MockUserInput(t, "y")()
 	err := Deploy(deployInput, mockPlatformCoreClient, mockCoreClient)
-	assert.Equal(t, err.Error(), "DAG-only deploys are not enabled for this Deployment. Run 'astro deployment update test-deployment-id --dag-deploy enable' to enable DAG-only deploys.")
+	assert.Equal(t, err.Error(), "DAG-only deploys are not enabled for this Deployment. Run 'astro deployment update test-deployment-id --dag-deploy enable' to enable DAG-only deploys")
 
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -257,7 +257,7 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 	}
 
 	if organizationID == "" {
-		return fmt.Errorf(noWorkspaceMsg, workspaceID) //nolint:goerr113
+		return fmt.Errorf(noWorkspaceMsg, workspaceID)
 	}
 	fmt.Printf("Current Workspace: %s\n\n", currentWorkspace.Name)
 
@@ -725,7 +725,7 @@ func HealthPoll(deploymentID, ws string, sleepTime, tickNum, timeoutNum int, pla
 				return err
 			}
 
-			if currentDeployment.Status == "HEALTHY" {
+			if currentDeployment.Status == astroplatformcore.DeploymentStatusHEALTHY {
 				fmt.Printf("Deployment %s is now healthy\n", currentDeployment.Name)
 				return nil
 			}
@@ -1684,7 +1684,7 @@ func deploymentSelectionProcess(ws string, deployments []astroplatformcore.Deplo
 		deployments = util.Filter(deployments, deploymentFilter)
 	}
 	if len(deployments) == 0 && disableCreateFlow {
-		return astroplatformcore.Deployment{}, fmt.Errorf("%s %s", NoDeploymentInWSMsg, ws) //nolint:goerr113
+		return astroplatformcore.Deployment{}, fmt.Errorf("%s %s", NoDeploymentInWSMsg, ws)
 	}
 	currentDeployment, err := SelectDeployment(deployments, "Select a Deployment")
 	if err != nil {

--- a/cmd/cloud/dbt.go
+++ b/cmd/cloud/dbt.go
@@ -1,0 +1,154 @@
+package cloud
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	cloud "github.com/astronomer/astro-cli/cloud/deploy"
+	"github.com/astronomer/astro-cli/cloud/deployment"
+	"github.com/astronomer/astro-cli/config"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	mountPath      string
+	dbtProjectPath string
+
+	DeployBundle = cloud.DeployBundle
+)
+
+const (
+	dbtDeployExample = `
+Specify the ID of the Deployment on Astronomer you would like to deploy this dbt project to:
+
+  $ astro dbt deploy <deployment ID>
+
+Menu will be presented if you do not specify a deployment ID:
+
+  $ astro dbt deploy
+`
+
+	dbtDefaultMountPathPrefix = "/usr/local/airflow/dbt/"
+	dbtProjectYmlFilename     = "dbt_project.yml"
+	dbtBundleType             = "dbt"
+)
+
+func newDbtCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dbt",
+		Short: "Manage your dbt projects deployed to Deployments running on Astronomer",
+	}
+	cmd.AddCommand(
+		newDbtDeployCmd(),
+	)
+	return cmd
+}
+
+func newDbtDeployCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "deploy DEPLOYMENT-ID",
+		Short:   "Deploy your dbt project to a Deployment on Astro",
+		Long:    "Deploy your dbt project to a Deployment on Astro. This command bundles your dbt project files and uploads it to your Deployment.",
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    deployDbt,
+		Example: dbtDeployExample,
+	}
+
+	cmd.Flags().StringVarP(&mountPath, "mount-path", "m", "", "Path to mount dbt project in Airflow, for reference by DAGs. Default /usr/local/dbt/{dbt project name}")
+	cmd.Flags().StringVarP(&dbtProjectPath, "project-path", "b", "", "Path to the dbt project to deploy. Default current directory")
+	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Workspace for your Deployment")
+	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the Deployment to deploy to")
+	cmd.Flags().StringVarP(&deployDescription, "description", "", "", "Description to store on the deploy")
+	cmd.Flags().BoolVarP(&waitForDeploy, "wait", "w", false, "Wait for the Deployment to become healthy before ending the command")
+
+	return cmd
+}
+
+func deployDbt(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
+	// if the dbt project path is not provided, use the current directory
+	if dbtProjectPath == "" {
+		dbtProjectPath = config.WorkingPath
+	}
+
+	// check that there is a valid dbt project at the dbt project path
+	dbtProjectYamlPath := filepath.Join(dbtProjectPath, dbtProjectYmlFilename)
+	if _, err := os.Stat(dbtProjectYamlPath); os.IsNotExist(err) {
+		return fmt.Errorf("dbt project not found in %s. Please run this command in the root of your dbt project, or use --project-path to specify the dbt project path.", dbtProjectYamlPath) //nolint
+	}
+	dbtProjectName, err := extractDbtProjectName(dbtProjectYamlPath)
+	if err != nil {
+		return fmt.Errorf("dbt project name not found in %s", dbtProjectYamlPath) //nolint
+	}
+
+	// if the workspace ID is not provided, try to find a valid workspace
+	if workspaceID == "" {
+		var err error
+		workspaceID, err = coalesceWorkspace()
+		if err != nil {
+			return errors.Wrap(err, "failed to find a valid workspace")
+		}
+	}
+
+	// get the deployment to deploy the dbt project to
+	var deploymentID string
+	if len(args) > 0 {
+		// if provided, use the deployment ID from the command argument
+		deploymentID = args[0]
+	} else {
+		// otherwise, prompt the user to select a deployment
+		selectedDeployment, err := deployment.GetDeployment(workspaceID, "", deploymentName, false, nil, platformCoreClient, astroCoreClient)
+		if err != nil {
+			return err
+		}
+		deploymentID = selectedDeployment.Id
+	}
+	fmt.Println("Initiating dbt deploy for deployment ID: " + deploymentID)
+
+	// if the mount path is not provided, derive it from the dbt project name
+	if mountPath == "" {
+		mountPath = dbtDefaultMountPathPrefix + dbtProjectName
+		fmt.Printf("Generated mount path from dbt project name: %s\n", mountPath)
+	}
+
+	// deploy the dbt project as a bundle
+	deployBundleInput := &cloud.DeployBundleInput{
+		BundlePath:   dbtProjectPath,
+		MountPath:    mountPath,
+		DeploymentID: deploymentID,
+		BundleType:   dbtBundleType,
+		Description:  deployDescription,
+		Wait:         waitForDeploy,
+	}
+	err = DeployBundle(deployBundleInput, platformCoreClient, astroCoreClient)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func extractDbtProjectName(dbtProjectYamlPath string) (string, error) {
+	var dbtProject map[string]interface{}
+	file, err := os.Open(dbtProjectYamlPath)
+	if err != nil {
+		return "", fmt.Errorf("could not open %s: %w", dbtProjectYamlPath, err)
+	}
+	defer file.Close()
+	decoder := yaml.NewDecoder(file)
+	err = decoder.Decode(&dbtProject)
+	if err != nil {
+		return "", fmt.Errorf("could not decode %s: %w", dbtProjectYamlPath, err)
+	}
+
+	dbtProjectName, ok := dbtProject["name"].(string)
+	if !ok || dbtProjectName == "" {
+		return "", errors.New("invalid dbt project name")
+	}
+
+	return dbtProjectName, nil
+}

--- a/cmd/cloud/dbt_test.go
+++ b/cmd/cloud/dbt_test.go
@@ -1,0 +1,154 @@
+package cloud
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	astrocore "github.com/astronomer/astro-cli/astro-client-core"
+	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
+	cloud "github.com/astronomer/astro-cli/cloud/deploy"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDbtDeploy_PickDeployment(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	defer createDbtProjectFile(t, "dbt_project.yml")()
+
+	DeployBundle = func(deployInput *cloud.DeployBundleInput, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+		return nil
+	}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockListTestDeployments(mockPlatformCoreClient)
+	mockGetTestDeployment(mockPlatformCoreClient)
+	defer setPlatformCoreClient(mockPlatformCoreClient)()
+
+	defer testUtil.MockUserInput(t, "1")()
+	err := execDbtDeployCmd()
+	assert.NoError(t, err)
+
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func TestDbtDeploy_ProvidedDeploymentId(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	defer createDbtProjectFile(t, "dbt_project.yml")()
+
+	DeployBundle = func(deployInput *cloud.DeployBundleInput, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+		return nil
+	}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	defer setPlatformCoreClient(mockPlatformCoreClient)()
+
+	err := execDbtDeployCmd("test-deployment-id")
+	assert.NoError(t, err)
+
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func TestDbtDeploy_CustomProjectPath(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	projectPath := "/tmp/test_dbt_project"
+	err := os.MkdirAll(projectPath, os.ModePerm)
+	assert.NoError(t, err)
+	defer os.RemoveAll(projectPath)
+	createDbtProjectFile(t, filepath.Join(projectPath, "dbt_project.yml"))
+
+	DeployBundle = func(deployInput *cloud.DeployBundleInput, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+		if deployInput.BundlePath != projectPath {
+			return assert.AnError
+		}
+		return nil
+	}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	defer setPlatformCoreClient(mockPlatformCoreClient)()
+
+	defer testUtil.MockUserInput(t, "1")()
+	err = execDbtDeployCmd("test-deployment-id", "--project-path", "/tmp/test_dbt_project")
+	assert.NoError(t, err)
+
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func TestDbtDeploy_CustomMountPath(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	defer createDbtProjectFile(t, "dbt_project.yml")()
+
+	DeployBundle = func(deployInput *cloud.DeployBundleInput, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+		if deployInput.MountPath != dbtDefaultMountPathPrefix+"test_dbt_project" {
+			return assert.AnError
+		}
+		return nil
+	}
+
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	defer setPlatformCoreClient(mockPlatformCoreClient)()
+
+	defer testUtil.MockUserInput(t, "1")()
+	err := execDbtDeployCmd("test-deployment-id", "--mount-path", dbtDefaultMountPathPrefix+"test_dbt_project")
+	assert.NoError(t, err)
+
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
+func execDbtDeployCmd(args ...string) error {
+	if len(args) == 0 {
+		args = []string{}
+	}
+	testUtil.SetupOSArgsForGinkgo()
+	cmd := newDbtDeployCmd()
+	cmd.SetArgs(args)
+	_, err := cmd.ExecuteC()
+	return err
+}
+
+func createDbtProjectFile(t *testing.T, path string) func() {
+	file, err := os.Create(path)
+	assert.NoError(t, err)
+	defer file.Close()
+	_, err = file.WriteString("name: test_dbt_project")
+	assert.NoError(t, err)
+	return func() { os.Remove(path) }
+}
+
+func mockListTestDeployments(client *astroplatformcore_mocks.ClientWithResponsesInterface) {
+	client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.ListDeploymentsResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: astrocore.HTTPStatus200,
+		},
+		JSON200: &astroplatformcore.DeploymentsPaginated{
+			Deployments: []astroplatformcore.Deployment{
+				{
+					Id: "test-deployment-id",
+				},
+			},
+		},
+	}, nil)
+}
+
+func mockGetTestDeployment(client *astroplatformcore_mocks.ClientWithResponsesInterface) {
+	client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.GetDeploymentResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: astrocore.HTTPStatus200,
+		},
+		JSON200: &astroplatformcore.Deployment{
+			Id: "test-deployment-id",
+		},
+	}, nil)
+}
+
+func setPlatformCoreClient(client astroplatformcore.CoreClient) func() {
+	platformCoreClient = client
+	return func() { platformCoreClient = nil }
+}

--- a/cmd/cloud/dbt_test.go
+++ b/cmd/cloud/dbt_test.go
@@ -72,7 +72,7 @@ func (s *Suite) TestDbtDeploy_ProvidedDeploymentId() {
 		return nil
 	}
 
-	err := execDbtDeployCmd("--deployment-id", "test-deployment-id")
+	err := execDbtDeployCmd("test-deployment-id")
 	assert.NoError(s.T(), err)
 
 	s.mockPlatformCoreClient.AssertExpectations(s.T())
@@ -94,7 +94,7 @@ func (s *Suite) TestDbtDeploy_CustomProjectPath() {
 	}
 
 	defer testUtil.MockUserInput(s.T(), "1")()
-	err = execDbtDeployCmd("--deployment-id", "test-deployment-id", "--project-path", projectPath)
+	err = execDbtDeployCmd("test-deployment-id", "--project-path", projectPath)
 	assert.NoError(s.T(), err)
 
 	s.mockPlatformCoreClient.AssertExpectations(s.T())
@@ -112,7 +112,7 @@ func (s *Suite) TestDbtDeploy_CustomMountPath() {
 	}
 
 	defer testUtil.MockUserInput(s.T(), "1")()
-	err := execDbtDeployCmd("--deployment-id", "test-deployment-id", "--mount-path", dbtDefaultMountPathPrefix+"test_dbt_project")
+	err := execDbtDeployCmd("test-deployment-id", "--mount-path", dbtDefaultMountPathPrefix+"test_dbt_project")
 	assert.NoError(s.T(), err)
 
 	s.mockPlatformCoreClient.AssertExpectations(s.T())

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -94,7 +94,7 @@ func deployTests(parse, pytest, forceDeploy bool, pytestFile string) string {
 }
 
 func deploy(cmd *cobra.Command, args []string) error {
-	deploymentID := ""
+	deploymentID = ""
 
 	// Get deploymentId from args, if passed
 	if len(args) > 0 {
@@ -121,7 +121,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if git.HasUncommittedChanges() && !forceDeploy {
+	if git.HasUncommittedChanges("") && !forceDeploy {
 		fmt.Println(registryUncommitedChangesMsg)
 		return nil
 	}

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -30,39 +30,39 @@ func TestDeployImage(t *testing.T) {
 		return nil
 	}
 
-	err := execDeployCmd([]string{"-f"}...)
+	err := execDeployCmd("-f")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"test-deployment-id", "-f", "--wait"}...)
+	err = execDeployCmd("test-deployment-id", "-f", "--wait")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"test-deployment-id", "--save"}...)
+	err = execDeployCmd("test-deployment-id", "--save")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"-f", "test-deployment-id", "--pytest"}...)
+	err = execDeployCmd("-f", "test-deployment-id", "--pytest")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"-f", "test-deployment-id", "--parse"}...)
+	err = execDeployCmd("-f", "test-deployment-id", "--parse")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"-f", "test-deployment-id", "--parse", "--pytest"}...)
+	err = execDeployCmd("-f", "test-deployment-id", "--parse", "--pytest")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"test-deployment-id", "--parse", "--pytest"}...)
+	err = execDeployCmd("test-deployment-id", "--parse", "--pytest")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"test-deployment-id", "--dags"}...)
+	err = execDeployCmd("test-deployment-id", "--dags")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"test-deployment-id", "--dags", "--wait"}...)
+	err = execDeployCmd("test-deployment-id", "--dags", "--wait")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"-f", "test-deployment-id", "--dags", "--pytest"}...)
+	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--pytest")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"-f", "test-deployment-id", "--dags", "--parse"}...)
+	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--parse")
 	assert.NoError(t, err)
 
-	err = execDeployCmd([]string{"-f", "test-deployment-id", "--dags", "--parse", "--pytest"}...)
+	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--parse", "--pytest")
 	assert.NoError(t, err)
 }

--- a/cmd/cloud/deployment_workerqueue_test.go
+++ b/cmd/cloud/deployment_workerqueue_test.go
@@ -15,10 +15,8 @@ import (
 )
 
 var (
-	mockPlatformCoreClient = new(astroplatformcore_mocks.ClientWithResponsesInterface)
-	mockCoreClient         = new(astrocore_mocks.ClientWithResponsesInterface)
-	testPoolID             = "test-pool-id"
-	testPoolID1            = "test-pool-id-1"
+	testPoolID  = "test-pool-id"
+	testPoolID1 = "test-pool-id-1"
 )
 
 func TestNewDeploymentWorkerQueueRootCmd(t *testing.T) {
@@ -45,6 +43,8 @@ func TestNewDeploymentWorkerQueueRootCmd(t *testing.T) {
 func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 	expectedHelp := "Create a worker queue for an Astro Deployment"
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	platformCoreClient = mockPlatformCoreClient
 	astroCoreClient = mockCoreClient
 	t.Run("-h prints worker-queue help", func(t *testing.T) {
@@ -139,6 +139,8 @@ func TestNewDeploymentWorkerQueueCreateCmd(t *testing.T) {
 func TestNewDeploymentWorkerQueueDeleteCmd(t *testing.T) {
 	expectedHelp := "Delete a worker queue from an Astro Deployment"
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	platformCoreClient = mockPlatformCoreClient
 	astroCoreClient = mockCoreClient
 
@@ -208,6 +210,8 @@ func TestNewDeploymentWorkerQueueDeleteCmd(t *testing.T) {
 func TestNewDeploymentWorkerQueueUpdateCmd(t *testing.T) {
 	expectedHelp := "Update a worker queue for an Astro Deployment"
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	platformCoreClient = mockPlatformCoreClient
 	astroCoreClient = mockCoreClient
 

--- a/cmd/cloud/root.go
+++ b/cmd/cloud/root.go
@@ -7,6 +7,7 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroiamcore "github.com/astronomer/astro-cli/astro-client-iam-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	"github.com/astronomer/astro-cli/config"
 	"github.com/spf13/cobra"
 )
 
@@ -23,10 +24,14 @@ func AddCmds(astroPlatformCoreClient astroplatformcore.CoreClient, coreClient as
 	platformCoreClient = astroPlatformCoreClient
 	astroCoreIamClient = iamCoreClient
 	airflowAPIClient = airflowClient
-	return []*cobra.Command{
+	cmds := []*cobra.Command{
 		NewDeployCmd(),
 		newDeploymentRootCmd(out),
 		newWorkspaceCmd(out),
 		newOrganizationCmd(out),
 	}
+	if config.CFG.DbtDeploysEnabled.GetBool() {
+		cmds = append(cmds, newDbtCmd())
+	}
+	return cmds
 }

--- a/cmd/cloud/root.go
+++ b/cmd/cloud/root.go
@@ -7,7 +7,6 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroiamcore "github.com/astronomer/astro-cli/astro-client-iam-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
-	"github.com/astronomer/astro-cli/config"
 	"github.com/spf13/cobra"
 )
 
@@ -24,14 +23,11 @@ func AddCmds(astroPlatformCoreClient astroplatformcore.CoreClient, coreClient as
 	platformCoreClient = astroPlatformCoreClient
 	astroCoreIamClient = iamCoreClient
 	airflowAPIClient = airflowClient
-	cmds := []*cobra.Command{
+	return []*cobra.Command{
 		NewDeployCmd(),
 		newDeploymentRootCmd(out),
 		newWorkspaceCmd(out),
 		newOrganizationCmd(out),
+		newDbtCmd(),
 	}
-	if config.CFG.DbtDeploysEnabled.GetBool() {
-		cmds = append(cmds, newDbtCmd())
-	}
-	return cmds
 }

--- a/cmd/cloud/root_test.go
+++ b/cmd/cloud/root_test.go
@@ -11,6 +11,6 @@ func TestAddCmds(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmds := AddCmds(nil, nil, nil, nil, buf)
 	for cmdIdx := range cmds {
-		assert.Contains(t, []string{"deployment", "deploy DEPLOYMENT-ID", "workspace", "user", "organization"}, cmds[cmdIdx].Use)
+		assert.Contains(t, []string{"deployment", "deploy DEPLOYMENT-ID", "workspace", "user", "organization", "dbt"}, cmds[cmdIdx].Use)
 	}
 }

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/util"
 	"github.com/golang-jwt/jwt/v4"
@@ -30,6 +31,8 @@ var (
 
 func TestSetup(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 
 	t.Run("login cmd", func(t *testing.T) {
 		cmd := &cobra.Command{Use: "login"}
@@ -345,6 +348,8 @@ func TestSetup(t *testing.T) {
 
 func TestCheckAPIKeys(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 	t.Run("test context switch", func(t *testing.T) {
 		mockOrgsResponse := astroplatformcore.ListOrganizationsResponse{
 			HTTPResponse: &http.Response{
@@ -401,6 +406,7 @@ func TestCheckAPIKeys(t *testing.T) {
 
 func TestCheckToken(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 	t.Run("test check token", func(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
@@ -455,6 +461,7 @@ func TestCheckAPIToken(t *testing.T) {
 			ID:        "test-id",
 		},
 	}
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 
 	t.Run("test context switch", func(t *testing.T) {
 		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -84,7 +84,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if git.HasUncommittedChanges() && !forceDeploy {
+	if git.HasUncommittedChanges("") && !forceDeploy {
 		fmt.Println(registryUncommittedChanges)
 		return nil
 	}

--- a/cmd/software/validation.go
+++ b/cmd/software/validation.go
@@ -69,7 +69,7 @@ func validateWorkspaceRole(role string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("please use one of: %s", strings.Join(validRoles, ", ")) //nolint:goerr113
+	return fmt.Errorf("please use one of: %s", strings.Join(validRoles, ", "))
 }
 
 func validateDeploymentRole(role string) error {
@@ -80,7 +80,7 @@ func validateDeploymentRole(role string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("please use one of: %s", strings.Join(validRoles, ", ")) //nolint:goerr113
+	return fmt.Errorf("please use one of: %s", strings.Join(validRoles, ", "))
 }
 
 func validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL string, acceptEmptyArgs bool) error {

--- a/config/cloud.go
+++ b/config/cloud.go
@@ -65,7 +65,7 @@ func (c *Context) GetPublicGraphQLAPIURL() string {
 // GetPublicRESTAPIURL returns full core API Url for the provided Context
 func (c *Context) GetPublicRESTAPIURL(version string) string {
 	if c.Domain == localhostDomain || c.Domain == astrohubDomain {
-		return CFG.LocalCore.GetString()
+		return CFG.LocalCore.GetString() + "/" + version
 	}
 
 	domain := domainutil.FormatDomain(c.Domain)

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ var (
 		Contexts:              newCfg("contexts", ""),
 		DockerCommand:         newCfg("container.binary", "docker"),
 		LocalAstro:            newCfg("local.astrohub", "http://localhost:8871/v1"),
-		LocalCore:             newCfg("local.core", "http://localhost:8888/v1alpha1"),
+		LocalCore:             newCfg("local.core", "http://localhost:8888"),
 		LocalPublicAstro:      newCfg("local.public_astrohub", "http://localhost:8871/graphql"),
 		LocalRegistry:         newCfg("local.registry", "localhost:5555"),
 		LocalHouston:          newCfg("local.houston", ""),
@@ -85,6 +85,7 @@ var (
 		DisableAstroRun:       newCfg("disable_astro_run", "false"),
 		DisableEnvObjects:     newCfg("disable_env_objects", "false"),
 		AutoSelect:            newCfg("auto_select", "false"),
+		DbtDeploysEnabled:     newCfg("dbt_deploys_enabled", "false"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/config.go
+++ b/config/config.go
@@ -85,7 +85,6 @@ var (
 		DisableAstroRun:       newCfg("disable_astro_run", "false"),
 		DisableEnvObjects:     newCfg("disable_env_objects", "false"),
 		AutoSelect:            newCfg("auto_select", "false"),
-		DbtDeploysEnabled:     newCfg("dbt_deploys_enabled", "false"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/types.go
+++ b/config/types.go
@@ -15,7 +15,6 @@ type cfgs struct {
 	Context               cfg
 	Contexts              cfg
 	DockerCommand         cfg
-	LocalEnabled          cfg
 	LocalAstro            cfg
 	LocalCore             cfg
 	LocalPublicAstro      cfg
@@ -46,6 +45,7 @@ type cfgs struct {
 	DisableAstroRun       cfg
 	DisableEnvObjects     cfg
 	AutoSelect            cfg
+	DbtDeploysEnabled     cfg
 }
 
 // Creates a new cfg struct

--- a/config/types.go
+++ b/config/types.go
@@ -45,7 +45,6 @@ type cfgs struct {
 	DisableAstroRun       cfg
 	DisableEnvObjects     cfg
 	AutoSelect            cfg
-	DbtDeploysEnabled     cfg
 }
 
 // Creates a new cfg struct

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -214,7 +214,7 @@ func (c *Client) DoWithContext(doOpts *httputil.DoOptions, ctx *config.Context) 
 		if errMsg == errInaptPermissionsMsg || errMsg == errAuthTokenRefreshFailedMsg {
 			return nil, ErrVerboseInaptPermissions
 		}
-		return nil, fmt.Errorf("%s", decode.Errors[0].Message) //nolint:goerr113
+		return nil, fmt.Errorf("%s", decode.Errors[0].Message)
 	}
 
 	return &decode, nil

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,25 +1,104 @@
 package git
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/url"
 	"os/exec"
+	"strings"
 )
 
-// IsGitRepository checks if current directory is a git repository
-func IsGitRepository() bool {
-	_, err := exec.Command("git", "rev-parse", "--is-inside-working-tree").Output()
-	return err == nil
-}
+var Path = ""
 
 // HasUncommittedChanges checks repository for uncommitted changes
 func HasUncommittedChanges() bool {
-	if IsGitRepository() {
-		// There is no system independent way to get exit code
-		// so we treat all exit codes the same, this works as long as we check IsGitRepository first
-		_, err := exec.Command("git", "diff", "--quiet", "HEAD").Output()
-		if err != nil {
-			return true
-		}
+	if !IsGitRepository() {
+		return false
 	}
 
-	return false
+	_, err := runGitCommand("diff", "--quiet", "HEAD")
+	return err != nil
+}
+
+// IsGitRepository checks if current directory is a git repository
+func IsGitRepository() bool {
+	_, err := runGitCommand("rev-parse", "--is-inside-working-tree")
+	return err == nil
+}
+
+func GetRemoteRepository(remote string) (host, account, repo string, err error) {
+	remoteURLStr, err := runGitCommand("remote", "get-url", remote)
+	if err != nil {
+		return "", "", "", err
+	}
+	remoteURL, err := url.Parse(remoteURLStr)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	host = remoteURL.Hostname()
+	accountRepo := strings.Split(remoteURL.Path, "/")
+	if len(accountRepo) != 3 || accountRepo[0] != "" {
+		return "", "", "", fmt.Errorf("failed to parse remote URL: %s", remoteURLStr)
+	}
+	account = accountRepo[1]
+	repo = strings.TrimSuffix(accountRepo[2], ".git")
+
+	return host, account, repo, nil
+}
+
+func GetLocalRepositoryPathPrefix(dir string) (string, error) {
+	path, err := runGitCommand("-C", dir, "rev-parse", "--show-prefix")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(path, "/"), nil
+}
+
+func GetBranch() (string, error) {
+	return runGitCommand("rev-parse", "--abbrev-ref", "HEAD")
+}
+
+func GetHeadCommitSHA() (string, error) {
+	return runGitCommand("rev-parse", "HEAD")
+}
+
+func GetHeadCommitAuthor() (name, email string, err error) {
+	authorJSON, err := runGitCommand("log", "-1", `--pretty=format:{"name":"%an","email":"%ae"}`, "HEAD")
+	if err != nil {
+		return "", "", err
+	}
+
+	// parse the author JSON
+	// e.g. {"name":"Jane Doe","email":"jane@doe.com"}
+	author := struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	}{}
+	err = json.Unmarshal([]byte(authorJSON), &author)
+	if err != nil {
+		return "", "", err
+	}
+
+	return author.Name, author.Email, nil
+}
+
+func GetCommitURL(host, account, repo, sha string) (string, error) {
+	switch host {
+	case "github.com":
+		return fmt.Sprintf("https://%s/%s/%s/commit/%s", host, account, repo, sha), nil
+	default:
+		return "", fmt.Errorf("unsupported Git provider: %s", host)
+	}
+}
+
+func runGitCommand(args ...string) (string, error) {
+	if Path != "" {
+		args = append([]string{"-C", Path}, args...)
+	}
+	out, err := exec.Command("git", args...).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -18,7 +18,68 @@ func TestIsGitRepository(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, IsGitRepository())
+			assert.Equal(t, tt.want, IsGitRepository(""))
+		})
+	}
+}
+
+func TestParseGitURL(t *testing.T) {
+	tests := []struct {
+		urlStr     string
+		wantScheme string
+		wantHost   string
+		wantPath   string
+	}{
+		{
+			urlStr:     "http://example.com/foo/bar",
+			wantScheme: "http",
+			wantHost:   "example.com",
+			wantPath:   "/foo/bar",
+		},
+		{
+			urlStr:     "http://example.com/foo/bar.git",
+			wantScheme: "http",
+			wantHost:   "example.com",
+			wantPath:   "/foo/bar",
+		},
+		{
+			urlStr:     "https://user@example.com/foo/bar",
+			wantScheme: "https",
+			wantHost:   "example.com",
+			wantPath:   "/foo/bar",
+		},
+		{
+			urlStr:     "host:foo/bar",
+			wantScheme: "ssh",
+			wantHost:   "host",
+			wantPath:   "foo/bar",
+		},
+		{
+			urlStr:     "host:/foo/bar",
+			wantScheme: "ssh",
+			wantHost:   "host",
+			wantPath:   "/foo/bar",
+		},
+		{
+			urlStr:     "user@host:/foo/bar",
+			wantScheme: "ssh",
+			wantHost:   "host",
+			wantPath:   "/foo/bar",
+		},
+		{
+			urlStr:     "user@host:/foo/bar.git",
+			wantScheme: "ssh",
+			wantHost:   "host",
+			wantPath:   "/foo/bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.urlStr, func(t *testing.T) {
+			got, err := parseGitURL(tt.urlStr)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantScheme, got.Scheme)
+			assert.Equal(t, tt.wantHost, got.Host)
+			assert.Equal(t, tt.wantPath, got.Path)
 		})
 	}
 }

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -371,6 +371,8 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.Ap
 	}
 
 	dagsPath := filepath.Join(dagsParentPath, "dags")
+	dagsTarPath := filepath.Join(dagsParentPath, "dags.tar")
+	dagsTarGzPath := dagsTarPath + ".gz"
 	dagFiles := fileutil.GetFilesWithSpecificExtension(dagsPath, ".py")
 
 	// Alert the user if dags folder is empty
@@ -382,21 +384,21 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.Ap
 	}
 
 	// Generate the dags tar
-	err = fileutil.Tar(dagsPath, dagsParentPath)
+	err = fileutil.Tar(dagsPath, dagsTarPath, true)
 	if err != nil {
 		return err
 	}
 	if cleanUpFiles {
-		defer os.Remove(dagsParentPath + "/dags.tar")
+		defer os.Remove(dagsTarPath)
 	}
 
 	// Gzip the tar
-	err = gzipFile(dagsParentPath+"/dags.tar", dagsParentPath+"/dags.tar.gz")
+	err = gzipFile(dagsTarPath, dagsTarGzPath)
 	if err != nil {
 		return err
 	}
 	if cleanUpFiles {
-		defer os.Remove(dagsParentPath + "/dags.tar.gz")
+		defer os.Remove(dagsTarGzPath)
 	}
 
 	c, _ := config.GetCurrentContext()
@@ -406,7 +408,7 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.Ap
 	}
 
 	uploadFileArgs := fileutil.UploadFileArguments{
-		FilePath:            dagsParentPath + "/dags.tar.gz",
+		FilePath:            dagsTarGzPath,
 		TargetURL:           uploadURL,
 		FormFileFieldName:   "file",
 		Headers:             headers,

--- a/software/deployment/deployment_test.go
+++ b/software/deployment/deployment_test.go
@@ -1290,7 +1290,7 @@ To cancel, run:
 	})
 
 	s.Run("upgrade runtime get deployment error", func() {
-		mockError := errors.New("get deployment error") //nolint:goerr113
+		mockError := errors.New("get deployment error")
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(nil, mockError)
 
@@ -1301,7 +1301,7 @@ To cancel, run:
 	})
 
 	s.Run("upgrade runtime update deployment error", func() {
-		mockError := errors.New("update deployment error") //nolint:goerr113
+		mockError := errors.New("update deployment error")
 		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": mockDeployment.DesiredRuntimeVersion}
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
@@ -1388,7 +1388,7 @@ Runtime upgrade process has been successfully canceled. Your Deployment was not 
 	})
 
 	s.Run("upgrade cancel get deployment error", func() {
-		mockError := errors.New("get deployment error") //nolint:goerr113
+		mockError := errors.New("get deployment error")
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(nil, mockError)
 
@@ -1399,7 +1399,7 @@ Runtime upgrade process has been successfully canceled. Your Deployment was not 
 	})
 
 	s.Run("upgrade cancel error", func() {
-		mockError := errors.New("update deployment error") //nolint:goerr113
+		mockError := errors.New("update deployment error")
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
 		api.On("CancelUpdateDeploymentRuntime", expectedVars).Return(nil, mockError)
@@ -1450,7 +1450,7 @@ To cancel, run:
 	})
 
 	s.Run("migrate runtime get deployment error", func() {
-		mockError := errors.New("get deployment error") //nolint:goerr113
+		mockError := errors.New("get deployment error")
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(nil, mockError)
 
@@ -1474,7 +1474,7 @@ To cancel, run:
 	})
 
 	s.Run("migrate runtime get runtime releases error", func() {
-		mockError := errors.New("get runtime releases error") //nolint:goerr113
+		mockError := errors.New("get runtime releases error")
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
 		api.On("GetRuntimeReleases", mockDeployment.AirflowVersion).Return(houston.RuntimeReleases{}, mockError)
@@ -1497,7 +1497,7 @@ To cancel, run:
 	})
 
 	s.Run("migrate runtime update deployment error", func() {
-		mockError := errors.New("update deployment error") //nolint:goerr113
+		mockError := errors.New("update deployment error")
 		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": "4.2.4"}
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
@@ -1544,7 +1544,7 @@ Runtime migrate process has been successfully canceled. Your Deployment was not 
 	})
 
 	s.Run("migrate cancel get deployment error", func() {
-		mockError := errors.New("get deployment error") //nolint:goerr113
+		mockError := errors.New("get deployment error")
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(nil, mockError)
 
@@ -1555,7 +1555,7 @@ Runtime migrate process has been successfully canceled. Your Deployment was not 
 	})
 
 	s.Run("migrate cancel error", func() {
-		mockError := errors.New("update deployment error") //nolint:goerr113
+		mockError := errors.New("update deployment error")
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(mockDeployment, nil)
 		api.On("CancelUpdateDeploymentRuntime", expectedVars).Return(nil, mockError)

--- a/software/teams/teams.go
+++ b/software/teams/teams.go
@@ -171,7 +171,7 @@ func PaginatedList(client houston.ClientInterface, out io.Writer, pageSize, page
 // Update will update the system role associated with the team
 func Update(teamID, role string, client houston.ClientInterface, out io.Writer) error {
 	if !isValidSystemLevelRole(role) {
-		return fmt.Errorf("invalid role: %s, should be one of: %s, %s, %s or %s", role, houston.SystemAdminRole, houston.SystemEditorRole, houston.SystemViewerRole, houston.NoneRole) //nolint:goerr113
+		return fmt.Errorf("invalid role: %s, should be one of: %s, %s, %s or %s", role, houston.SystemAdminRole, houston.SystemEditorRole, houston.SystemViewerRole, houston.NoneRole)
 	}
 
 	if role == houston.NoneRole {


### PR DESCRIPTION
## Description

This change adds a new command `astro dbt deploy` for deploying a dbt project to a deployment independently of the Astro project of the deployment. This uses the new bundle deploy type, where arbitrary files can be mounted on the Airflow containers at a selected mount path.

The selection of the deployment is in line with `astro deploy`, where a deployment id argument can be provided, or one can be selected from a list.

By default the dbt project will be mounted on the Airflow containers at `/usr/local/airflow/dbt/{dbt project name}`, where the project name is extracted from the dbt project's `dbt_project.yml` file. This mount path can be overridden with `--mount-path`.

The command is currently hidden behind the CLI config `dbt_deploys_enabled` until the feature is GA.

The `goerr113` lint rule is also removed because it was repeatedly being overridden, and doesn't seem to add a lot of value.

## 🧪 Functional Testing

- Unit tests added and updated
- Ran `astro dbt deploy` and manually downloaded the bundle to confirm its contents
- Ran `astro deploy --dags` to confirm DAG deploys are not impacted

## 📸 Screenshots

<img width="768" alt="Screenshot 2024-06-24 at 3 35 28 PM" src="https://github.com/astronomer/astro-cli/assets/1947420/fe3ad5c5-a613-48e8-b4f3-0483b1697247">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
