### PR TITLE
Add `astro dbt delete` command

### DIFF
--- a/cmd/cloud/dbt.go
+++ b/cmd/cloud/dbt.go
@@ -140,7 +140,7 @@ Menu will be presented if you do not specify a deployment ID:
 `,
 	}
 
-	cmd.Flags().StringVarP(&mountPath, "mount-path", "m", "", fmt.Sprintf("Path to mount dbt project in Airflow, for reference by DAGs. Default %s{dbt project name}", dbtDefaultMountPathPrefix))
+	cmd.Flags().StringVarP(&mountPath, "mount-path", "m", "", fmt.Sprintf("Mount path of the dbt project to be deleted from the Deployment. Default %s{dbt project name}", dbtDefaultMountPathPrefix))
 	cmd.Flags().StringVarP(&dbtProjectPath, "project-path", "p", "", "Path to the dbt project to delete from the Deployment. Default current directory")
 	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Workspace for your Deployment")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the Deployment to deploy to")
@@ -162,7 +162,7 @@ func deleteDbt(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// get the deployment id to deploy the dbt project to
+	// get the deployment id to delete the dbt project
 	deploymentID, err := resolveDeploymentIDFromDbtArgsFlags(args, workspaceID, deploymentName)
 	if err != nil {
 		return err

--- a/cmd/cloud/dbt.go
+++ b/cmd/cloud/dbt.go
@@ -143,7 +143,7 @@ Menu will be presented if you do not specify a deployment ID:
 	cmd.Flags().StringVarP(&mountPath, "mount-path", "m", "", fmt.Sprintf("Mount path of the dbt project to be deleted from the Deployment. Default %s{dbt project name}", dbtDefaultMountPathPrefix))
 	cmd.Flags().StringVarP(&dbtProjectPath, "project-path", "p", "", "Path to the dbt project to delete from the Deployment. Default current directory")
 	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "Workspace for your Deployment")
-	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the Deployment to deploy to")
+	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the Deployment to delete the dbt project from")
 	cmd.Flags().StringVarP(&deployDescription, "description", "", "", "Description to store on the deploy")
 	cmd.Flags().BoolVarP(&waitForDeploy, "wait", "w", false, "Wait for the Deployment to become healthy before ending the command")
 


### PR DESCRIPTION
## Description

This change adds a new command `astro dbt delete`, to delete a dbt project bundle from a deployment. This is effectively the inverse of `astro dbt deploy`. The command effects a delete by creating a new deploy where the reported bundle tarball version is left empty, which Astro understands to mean that the bundle should be deleted from the deployment.

The dbt project to be deleted is automatically inferred from the current working directory, or the project path can be specified, or if the dbt project is not locally accessible the mount path can be provided instead.

## 🧪 Functional Testing

- Unit tests added
- Manually tested

## 📸 Screenshots

<img width="948" alt="Screenshot 2024-07-01 at 1 41 54 PM" src="https://github.com/astronomer/astro-cli/assets/1947420/a5930451-5a1d-443e-910e-7333422c40b0">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
