### PR TITLE
Update goreleaser.yaml to version 2.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,10 +33,10 @@ builds:
       - 7
     ldflags: -s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }}
 brews:
-  - tap:
+  - repository:
       owner: astronomer
       name: homebrew-tap
-    folder: Formula
+    directory: Formula
     # Setting this will prevent goreleaser to actually try to commit the updated
     # formula - instead, the formula file will be stored on the dist folder only,
     # leaving the responsibility of publishing it to the user.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 project_name: astro
+version: 2
 before:
   hooks:
     # You may remove this if you don't use go modules.


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Update goreleaser.yaml to version 2.0. The new go releaser version requires this configuration

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
