### PR TITLE
Fix inspecting deployment is_development_mode

### DIFF
--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -261,7 +261,7 @@ func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, pl
 		deploymentMap["is_high_availability"] = *coreDeployment.IsHighAvailability
 	}
 	if coreDeployment.IsDevelopmentMode != nil {
-		deploymentMap["is_development_mode"] = coreDeployment.IsDevelopmentMode
+		deploymentMap["is_development_mode"] = *coreDeployment.IsDevelopmentMode
 	}
 	if coreDeployment.SchedulerAu != nil {
 		deploymentMap["scheduler_au"] = *coreDeployment.SchedulerAu

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -1186,6 +1186,12 @@ func TestGetSpecificField(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, *sourceDeployment.ClusterName, actual)
 	})
+	t.Run("returns correct boolean value", func(t *testing.T) {
+		requestedField := "configuration.is_development_mode"
+		actual, err := getSpecificField(printableDeployment, requestedField)
+		assert.NoError(t, err)
+		assert.Equal(t, *sourceDeployment.IsDevelopmentMode, actual)
+	})
 	t.Run("returns error if no value is found", func(t *testing.T) {
 		requestedField := "does-not-exist"
 		actual, err := getSpecificField(printableDeployment, requestedField)


### PR DESCRIPTION
## Description

Update the deployment map to return the `is_development_mode` value instead of the pointer (address).

## 🎟 Issue(s)

```
❯ astro deployment inspect clyoma4kq000l01nt2gohsr93 --clean-output --key configuration.is_development_mode
0x1400055b23e
```

## 🧪 Functional Testing

```
❯ astro deployment inspect clyoma4kq000l01nt2gohsr93 --clean-output --key configuration.is_development_mode
false
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
