### PR TITLE
Block dbt deploys from within Astro project

### DIFF
--- a/cmd/cloud/dbt.go
+++ b/cmd/cloud/dbt.go
@@ -75,8 +75,17 @@ func deployDbt(cmd *cobra.Command, args []string) error {
 		dbtProjectPath = config.WorkingPath
 	}
 
+	// check that the dbt project path is not within an Astro project
+	withinAstroProject, err := config.IsWithinProjectDir(dbtProjectPath)
+	if err != nil {
+		return fmt.Errorf("failed to verify dbt project path is not within an Astro project: %w", err)
+	}
+	if withinAstroProject {
+		return fmt.Errorf("dbt project is within an Astro project. Use 'astro deploy' to deploy your Astro project")
+	}
+
 	// check that there is a valid dbt project at the dbt project path
-	err := validateDbtProjectExists(dbtProjectPath)
+	err = validateDbtProjectExists(dbtProjectPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/cloud/dbt_test.go
+++ b/cmd/cloud/dbt_test.go
@@ -11,6 +11,7 @@ import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	cloud "github.com/astronomer/astro-cli/cloud/deploy"
+	"github.com/astronomer/astro-cli/config"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -123,6 +124,16 @@ func (s *DbtSuite) TestDbtDeploy_CustomMountPath() {
 	assert.NoError(s.T(), err)
 
 	s.mockPlatformCoreClient.AssertExpectations(s.T())
+}
+
+func (s *DbtSuite) TestDbtDeploy_WithinAstroProject() {
+	projectDir, cleanup, err := config.CreateTempProject()
+	assert.NoError(s.T(), err)
+	defer cleanup()
+
+	err = testExecCmd(newDbtDeployCmd(), "test-deployment-id", "--project-path", projectDir)
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "dbt project is within an Astro project")
 }
 
 func (s *DbtSuite) TestDbtDelete_PickDeployment() {

--- a/config/config.go
+++ b/config/config.go
@@ -233,13 +233,13 @@ func IsProjectDir(path string) (bool, error) {
 
 // IsWithinProjectDir returns true if the path is at or within an Astro project directory
 func IsWithinProjectDir(path string) (bool, error) {
-	dbtProjectPathAbs, err := filepath.Abs(filepath.Clean(path))
+	pathAbs, err := filepath.Abs(filepath.Clean(path))
 	if err != nil {
 		return false, err
 	}
-	dbtProjectPathComponents := strings.Split(dbtProjectPathAbs, string(os.PathSeparator))
-	for i := range dbtProjectPathComponents {
-		componentAbs := strings.Join(dbtProjectPathComponents[:i+1], string(os.PathSeparator))
+	pathComponents := strings.Split(pathAbs, string(os.PathSeparator))
+	for i := range pathComponents {
+		componentAbs := strings.Join(pathComponents[:i+1], string(os.PathSeparator))
 		isProjectDir, err := IsProjectDir(componentAbs)
 		if err != nil {
 			return false, err

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/spf13/afero"
@@ -228,6 +229,26 @@ func IsProjectDir(path string) (bool, error) {
 	}
 
 	return fileutil.Exists(configFile, nil)
+}
+
+// IsWithinProjectDir returns true if the path is at or within an Astro project directory
+func IsWithinProjectDir(path string) (bool, error) {
+	dbtProjectPathAbs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return false, err
+	}
+	dbtProjectPathComponents := strings.Split(dbtProjectPathAbs, string(os.PathSeparator))
+	for i := range dbtProjectPathComponents {
+		componentAbs := strings.Join(dbtProjectPathComponents[:i+1], string(os.PathSeparator))
+		isProjectDir, err := IsProjectDir(componentAbs)
+		if err != nil {
+			return false, err
+		}
+		if isProjectDir {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // saveConfig will save the config to a file

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,34 @@ func (s *Suite) TestIsProjectDir() {
 	}
 }
 
+func (s *Suite) TestIsWithinProjectDir() {
+	projectDir, cleanupProjectDir, err := CreateTempProject()
+	s.NoError(err)
+	defer cleanupProjectDir()
+
+	anotherDir, err := os.MkdirTemp("", "")
+	s.NoError(err)
+
+	tests := []struct {
+		name string
+		in   string
+		out  bool
+	}{
+		{"not in", anotherDir, false},
+		{"at", projectDir, true},
+		{"just in", filepath.Join(projectDir, "test"), true},
+		{"deep in", filepath.Join(projectDir, "test", "test", "test"), true},
+		{"root", string(os.PathSeparator), false},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			got, err := IsWithinProjectDir(tt.in)
+			s.NoError(err)
+			s.Equal(got, tt.out)
+		})
+	}
+}
+
 func (s *Suite) TestInitHomeDefaultCase() {
 	fs := afero.NewMemMapFs()
 	initHome(fs)

--- a/config/config_test_utils.go
+++ b/config/config_test_utils.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+func CreateTempProject() (dir string, cleanup func(), err error) {
+	projectDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return "", nil, err
+	}
+	astroDirPerms := 0o755
+	err = os.Mkdir(filepath.Join(projectDir, ".astro"), fs.FileMode(astroDirPerms))
+	if err != nil {
+		return "", nil, err
+	}
+	configFile, err := os.Create(filepath.Join(projectDir, ConfigDir, ConfigFileNameWithExt))
+	if err != nil {
+		return "", nil, err
+	}
+	return projectDir, func() {
+		configFile.Close()
+		os.RemoveAll(projectDir)
+	}, nil
+}


### PR DESCRIPTION
## Description

This change blocks the `astro dbt deploy` command from deploying a dbt project that is within an Astro project. This use case is not supported because it can create unexpected behavior when the full Astro project is then deployed with `astro deploy`.

## 🧪 Functional Testing

- Unit tests added/updated
- Manually tested within and outside of an Astro project

## 📸 Screenshots

<img width="868" alt="Screenshot 2024-07-17 at 1 32 41 PM" src="https://github.com/user-attachments/assets/88cfb64d-200d-476d-ac8f-9ec5f292afa8">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
