### PR TITLE
Use commit message for bundle deploy description

### DIFF
--- a/cloud/deploy/bundle_test.go
+++ b/cloud/deploy/bundle_test.go
@@ -13,6 +13,7 @@ import (
 	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
+	"github.com/astronomer/astro-cli/pkg/git"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -121,11 +122,12 @@ func (s *BundleSuite) TestBundleDeploy_GitMetadataRetrieved() {
 	mockGetDeployment(s.mockPlatformCoreClient, true, false)
 
 	expectedAuthorName := "Test"
+	expectedDescription := strings.Repeat("a", git.MaxCommitMessageLineLength)
 	expectedDeploy := &astrocore.CreateDeployRequest{
 		Type:            astrocore.CreateDeployRequestTypeBUNDLE,
 		BundleType:      &input.BundleType,
 		BundleMountPath: &input.MountPath,
-		Description:     &input.Description,
+		Description:     &expectedDescription,
 		Git: &astrocore.CreateDeployGitRequest{
 			Provider:   astrocore.CreateDeployGitRequestProviderGITHUB,
 			Account:    "account",
@@ -280,7 +282,8 @@ func (s *BundleSuite) createTestGitRepository(withUncommittedFile bool) (sha, pa
 	err = exec.Command("git", "-C", dir, "config", "user.name", "Test").Run()
 	require.NoError(s.T(), err)
 
-	err = exec.Command("git", "-C", dir, "commit", "--allow-empty", "-m", "Initial commit").Run()
+	commitMessage := strings.Repeat("a", git.MaxCommitMessageLineLength+1) + "\n" + strings.Repeat("b", git.MaxCommitMessageLineLength+1)
+	err = exec.Command("git", "-C", dir, "commit", "--allow-empty", "-m", commitMessage).Run()
 	require.NoError(s.T(), err)
 
 	err = exec.Command("git", "-C", dir, "remote", "add", "origin", "https://github.com/account/repo.git").Run()


### PR DESCRIPTION
## Description

This change uses the local Git checkout commit message as the default description for bundle deploys, such as for `astro dbt deploy`. If there is no found local Git checkout the default description is left blank.

## 🧪 Functional Testing

- Unit test added
- Manually tested

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
