### PR TITLE
Fix dbt delete without project path

### DIFF
--- a/cmd/cloud/dbt.go
+++ b/cmd/cloud/dbt.go
@@ -171,15 +171,21 @@ func deleteDbt(cmd *cobra.Command, args []string) error {
 
 	// if the mount path is not provided, derive it from the dbt project name
 	if mountPath == "" {
+		// if the dbt project path is not provided, use the current directory
+		if dbtProjectPath == "" {
+			dbtProjectPath = config.WorkingPath
+		}
+
+		// check that there is a valid dbt project at the dbt project path
+		err := validateDbtProjectExists(dbtProjectPath)
+		if err != nil {
+			return err
+		}
+
 		// extract the dbt project's name
 		dbtProjectName, err := extractDbtProjectName(dbtProjectPath)
 		if err != nil {
 			return fmt.Errorf("dbt project name not found in %s: %w", dbtProjectPath, err)
-		}
-
-		// if the dbt project path is not provided, use the current directory
-		if dbtProjectPath == "" {
-			dbtProjectPath = config.WorkingPath
 		}
 
 		mountPath = dbtDefaultMountPathPrefix + dbtProjectName


### PR DESCRIPTION
## Description

This change fixes a bug in `astro dbt delete` where if the project path is not specified then it does not correctly look at the current working directory for the dbt project.

## 🧪 Functional Testing

- Unit tests
- Manually tested

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
