### PR TITLE
track github action deploys

### DIFF
--- a/astro-client-core/client.go
+++ b/astro-client-core/client.go
@@ -64,7 +64,7 @@ func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
 		req.Header.Add("x-astro-client-identifier", "deploy-action")
 		req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
 	case os.Getenv("GITHUB_ACTIONS") == "true":
-		req.Header.Add("x-astro-client-identifier", "deploy-action")
+		req.Header.Add("x-astro-client-identifier", "github-action")
 		req.Header.Add("x-astro-client-version", version.CurrVersion)
 	default:
 		req.Header.Add("x-astro-client-identifier", "cli")

--- a/astro-client-core/client.go
+++ b/astro-client-core/client.go
@@ -59,10 +59,16 @@ func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
 	}
 	req.URL = requestURL
 	req.Header.Add("authorization", currentCtx.Token)
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		req.Header.Add("x-astro-client-identifier", "github-action")
-	} else {
+	switch {
+	case os.Getenv("DEPLOY_ACTION") == "true" && os.Getenv("GITHUB_ACTIONS") == "true":
+		req.Header.Add("x-astro-client-identifier", "deploy-action")
+		req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
+	case os.Getenv("GITHUB_ACTIONS") == "true":
+		req.Header.Add("x-astro-client-identifier", "deploy-action")
+		req.Header.Add("x-astro-client-version", version.CurrVersion)
+	default:
 		req.Header.Add("x-astro-client-identifier", "cli")
+		req.Header.Add("x-astro-client-version", version.CurrVersion)
 	}
 	req.Header.Add("x-astro-client-version", version.CurrVersion)
 	req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)

--- a/astro-client-core/client.go
+++ b/astro-client-core/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 
 	"github.com/astronomer/astro-cli/context"
@@ -49,7 +50,7 @@ func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
 	if err != nil {
 		return nil
 	}
-	os := runtime.GOOS
+	operatingSystem := runtime.GOOS
 	arch := runtime.GOARCH
 	baseURL := currentCtx.GetPublicRESTAPIURL("v1alpha1")
 	requestURL, err := url.Parse(baseURL + req.URL.String())
@@ -58,9 +59,13 @@ func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
 	}
 	req.URL = requestURL
 	req.Header.Add("authorization", currentCtx.Token)
-	req.Header.Add("x-astro-client-identifier", "cli")
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		req.Header.Add("x-astro-client-identifier", "github-action")
+	} else {
+		req.Header.Add("x-astro-client-identifier", "cli")
+	}
 	req.Header.Add("x-astro-client-version", version.CurrVersion)
-	req.Header.Add("x-client-os-identifier", os+"-"+arch)
+	req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)
 	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
 	return nil
 }

--- a/astro-client-iam-core/client.go
+++ b/astro-client-iam-core/client.go
@@ -63,7 +63,7 @@ func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
 		req.Header.Add("x-astro-client-identifier", "deploy-action")
 		req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
 	case os.Getenv("GITHUB_ACTIONS") == "true":
-		req.Header.Add("x-astro-client-identifier", "deploy-action")
+		req.Header.Add("x-astro-client-identifier", "github-action")
 		req.Header.Add("x-astro-client-version", version.CurrVersion)
 	default:
 		req.Header.Add("x-astro-client-identifier", "cli")

--- a/astro-client-iam-core/client.go
+++ b/astro-client-iam-core/client.go
@@ -58,12 +58,17 @@ func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
 	}
 	req.URL = requestURL
 	req.Header.Add("authorization", currentCtx.Token)
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		req.Header.Add("x-astro-client-identifier", "github-action")
-	} else {
+	switch {
+	case os.Getenv("DEPLOY_ACTION") == "true" && os.Getenv("GITHUB_ACTIONS") == "true":
+		req.Header.Add("x-astro-client-identifier", "deploy-action")
+		req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
+	case os.Getenv("GITHUB_ACTIONS") == "true":
+		req.Header.Add("x-astro-client-identifier", "deploy-action")
+		req.Header.Add("x-astro-client-version", version.CurrVersion)
+	default:
 		req.Header.Add("x-astro-client-identifier", "cli")
+		req.Header.Add("x-astro-client-version", version.CurrVersion)
 	}
-	req.Header.Add("x-astro-client-version", version.CurrVersion)
 	req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)
 	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
 	return nil

--- a/astro-client-iam-core/client.go
+++ b/astro-client-iam-core/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 
 	"github.com/astronomer/astro-cli/context"
@@ -48,7 +49,7 @@ func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
 	if err != nil {
 		return nil
 	}
-	os := runtime.GOOS
+	operatingSystem := runtime.GOOS
 	arch := runtime.GOARCH
 	baseURL := currentCtx.GetPublicRESTAPIURL("iam/v1beta1")
 	requestURL, err := url.Parse(baseURL + req.URL.String())
@@ -57,9 +58,13 @@ func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
 	}
 	req.URL = requestURL
 	req.Header.Add("authorization", currentCtx.Token)
-	req.Header.Add("x-astro-client-identifier", "cli")
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		req.Header.Add("x-astro-client-identifier", "github-action")
+	} else {
+		req.Header.Add("x-astro-client-identifier", "cli")
+	}
 	req.Header.Add("x-astro-client-version", version.CurrVersion)
-	req.Header.Add("x-client-os-identifier", os+"-"+arch)
+	req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)
 	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
 	return nil
 }

--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -47,13 +47,17 @@ func requestEditor(ctx httpContext.Context, req *http.Request) error {
 	}
 	req.URL = requestURL
 	req.Header.Add("authorization", currentCtx.Token)
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		req.Header.Add("x-astro-client-identifier", "github-action")
-	} else {
+	switch {
+	case os.Getenv("DEPLOY_ACTION") == "true" && os.Getenv("GITHUB_ACTIONS") == "true":
+		req.Header.Add("x-astro-client-identifier", "deploy-action")
+		req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
+	case os.Getenv("GITHUB_ACTIONS") == "true":
+		req.Header.Add("x-astro-client-identifier", "deploy-action")
+		req.Header.Add("x-astro-client-version", version.CurrVersion)
+	default:
 		req.Header.Add("x-astro-client-identifier", "cli")
+		req.Header.Add("x-astro-client-version", version.CurrVersion)
 	}
-
-	req.Header.Add("x-astro-client-version", version.CurrVersion)
 	req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)
 	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
 	return nil

--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -52,7 +52,7 @@ func requestEditor(ctx httpContext.Context, req *http.Request) error {
 		req.Header.Add("x-astro-client-identifier", "deploy-action")
 		req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
 	case os.Getenv("GITHUB_ACTIONS") == "true":
-		req.Header.Add("x-astro-client-identifier", "deploy-action")
+		req.Header.Add("x-astro-client-identifier", "github-action")
 		req.Header.Add("x-astro-client-version", version.CurrVersion)
 	default:
 		req.Header.Add("x-astro-client-identifier", "cli")

--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 
 	"github.com/astronomer/astro-cli/context"
@@ -37,7 +38,7 @@ func requestEditor(ctx httpContext.Context, req *http.Request) error {
 	if err != nil {
 		return nil
 	}
-	os := runtime.GOOS
+	operatingSystem := runtime.GOOS
 	arch := runtime.GOARCH
 	baseURL := currentCtx.GetPublicRESTAPIURL("platform/v1beta1")
 	requestURL, err := url.Parse(baseURL + req.URL.String())
@@ -46,10 +47,14 @@ func requestEditor(ctx httpContext.Context, req *http.Request) error {
 	}
 	req.URL = requestURL
 	req.Header.Add("authorization", currentCtx.Token)
-	req.Header.Add("x-astro-client-identifier", "cli")
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		req.Header.Add("x-astro-client-identifier", "github-action")
+	} else {
+		req.Header.Add("x-astro-client-identifier", "cli")
+	}
 
 	req.Header.Add("x-astro-client-version", version.CurrVersion)
-	req.Header.Add("x-client-os-identifier", os+"-"+arch)
+	req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)
 	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
 	return nil
 }


### PR DESCRIPTION
## Description

This change will make the header for client `github-action` for all requests the CLI makes within a github action workflow. This will help us see how many customers are using github actions to deploy

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
