### PR TITLE
Only exclude .git for bundles, not all hidden paths

### DIFF
--- a/cloud/deploy/bundle.go
+++ b/cloud/deploy/bundle.go
@@ -151,7 +151,7 @@ func uploadBundle(tarDirPath, bundlePath, uploadURL string, prependBaseDir bool)
 	}()
 
 	// Generate the bundle tar
-	err := fileutil.Tar(bundlePath, tarFilePath, prependBaseDir)
+	err := fileutil.Tar(bundlePath, tarFilePath, prependBaseDir, []string{".git/"})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -160,16 +160,13 @@ func (s *Suite) TestTar() {
 	testSourceDirPath := filepath.Join(testDirPath, testSourceDirName)
 	defer afero.NewOsFs().Remove(testSourceDirPath)
 
-	// create a test file, and a symlink to it, and a hidden test file
+	// create a test file, and a symlink to it
 	testFileName := "test.txt"
 	testFilePath := filepath.Join(testSourceDirPath, testFileName)
 	WriteStringToFile(testFilePath, "testing")
 	symlinkFileName := "symlink"
 	symlinkFilePath := filepath.Join(testSourceDirPath, symlinkFileName)
 	os.Symlink(testFilePath, symlinkFilePath)
-	hiddenTestFileName := ".hidden_test.txt"
-	hiddenTestFilePath := filepath.Join(testSourceDirPath, hiddenTestFileName)
-	WriteStringToFile(hiddenTestFilePath, "testing")
 
 	// create test file in a sub-directory
 	testSubDirFileName := "test_subdir.txt"
@@ -183,6 +180,7 @@ func (s *Suite) TestTar() {
 		source         string
 		target         string
 		prependBaseDir bool
+		excludePaths   []string
 	}
 	tests := []struct {
 		name         string
@@ -202,7 +200,6 @@ func (s *Suite) TestTar() {
 				testFileName,
 				symlinkFileName,
 				filepath.Join(testSubDirName, testSubDirFileName),
-				// no hidden file
 			},
 		},
 		{
@@ -217,7 +214,21 @@ func (s *Suite) TestTar() {
 				filepath.Join(testSourceDirName, testFileName),
 				filepath.Join(testSourceDirName, symlinkFileName),
 				filepath.Join(testSourceDirName, testSubDirName, testSubDirFileName),
-				// no hidden file
+			},
+		},
+		{
+			name: "exclude paths",
+			args: args{
+				source:         testSourceDirPath,
+				target:         filepath.Join(testDirPath, "test_exclude.tar"),
+				prependBaseDir: false,
+				excludePaths:   []string{testSubDirPath},
+			},
+			errAssertion: assert.NoError,
+			expectPaths: []string{
+				testFileName,
+				symlinkFileName,
+				// testSubDirFileName excluded
 			},
 		},
 	}
@@ -225,7 +236,7 @@ func (s *Suite) TestTar() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			// check that the tar operation was successful
-			assert.True(s.T(), tt.errAssertion(s.T(), Tar(tt.args.source, tt.args.target, tt.args.prependBaseDir)))
+			assert.True(s.T(), tt.errAssertion(s.T(), Tar(tt.args.source, tt.args.target, tt.args.prependBaseDir, tt.args.excludePaths)))
 
 			// check that all the files are in the tar at the correct paths
 			file, err := os.Open(tt.args.target)

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -222,7 +222,7 @@ func (s *Suite) TestTar() {
 				source:         testSourceDirPath,
 				target:         filepath.Join(testDirPath, "test_exclude.tar"),
 				prependBaseDir: false,
-				excludePaths:   []string{testSubDirPath},
+				excludePaths:   []string{testSubDirName},
 			},
 			errAssertion: assert.NoError,
 			expectPaths: []string{

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -384,7 +384,7 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.Ap
 	}
 
 	// Generate the dags tar
-	err = fileutil.Tar(dagsPath, dagsTarPath, true)
+	err = fileutil.Tar(dagsPath, dagsTarPath, true, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This change fixes a bug where all hidden files were being removed from the DAG bundle, which excluded important files such as `.airflowignore`. Instead, only the `.git` directory is excluded, which was the intention behind the original hidden files change.

## 🧪 Functional Testing

- Unit tests updated
- Manually tested with `--verbosity debug` which shows `.airflowignore` being included and `.git` files being excluded.

## 📸 Screenshots

<img width="910" alt="Screenshot 2024-07-25 at 10 36 21 AM" src="https://github.com/user-attachments/assets/d49b845b-9798-4bb5-9eba-b40b5772ebee">

<img width="918" alt="Screenshot 2024-07-25 at 10 35 58 AM" src="https://github.com/user-attachments/assets/1e654e96-1eab-40b8-b6ae-c6f760a57036">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
