### PR TITLE
Handle no node pools for hybrid org cluster

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -434,24 +434,23 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 		}
 	}
 	// build hybrid input
-	if !IsDeploymentStandard(deploymentType) && !IsDeploymentDedicated(deploymentType) {
+	if IsDeploymentHybrid(deploymentType) {
 		cluster, err := CoreGetCluster("", clusterID, platformCoreClient)
 		if err != nil {
 			return err
 		}
-		nodePools := *cluster.NodePools
+		nodePoolID := getDefaultNodePoolID(cluster.NodePools)
 		defautWorkerQueue := []astroplatformcore.HybridWorkerQueueRequest{{
 			IsDefault:         true,
 			MaxWorkerCount:    int(configOption.WorkerQueues.MaxWorkers.Default),
 			MinWorkerCount:    int(configOption.WorkerQueues.MinWorkers.Default),
 			Name:              "default",
 			WorkerConcurrency: int(configOption.WorkerQueues.WorkerConcurrency.Default),
-			NodePoolId:        nodePools[0].Id,
+			NodePoolId:        nodePoolID,
 		}}
 		if schedulerAU == 0 {
 			schedulerAU = int(configOption.LegacyAstro.SchedulerAstroUnitRange.Default)
 		}
-
 		if schedulerReplicas == 0 {
 			schedulerReplicas = int(configOption.LegacyAstro.SchedulerReplicaRange.Default)
 		}
@@ -488,7 +487,7 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 		if strings.EqualFold(executor, CeleryExecutor) || strings.EqualFold(executor, CELERY) {
 			hybridDeploymentRequest.WorkerQueues = &defautWorkerQueue
 		} else {
-			hybridDeploymentRequest.TaskPodNodePoolId = &nodePools[0].Id
+			hybridDeploymentRequest.TaskPodNodePoolId = &nodePoolID
 		}
 		err = createDeploymentRequest.FromCreateHybridDeploymentRequest(hybridDeploymentRequest)
 		if err != nil {
@@ -518,6 +517,13 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 	}
 
 	return nil
+}
+
+func getDefaultNodePoolID(nodePools *[]astroplatformcore.NodePool) string {
+	if nodePools != nil && len(*nodePools) > 0 {
+		return (*nodePools)[0].Id
+	}
+	return ""
 }
 
 func createOutput(workspaceID string, d *astroplatformcore.Deployment) error {
@@ -1100,11 +1106,11 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		if err != nil {
 			return err
 		}
-		nodePools := *cluster.NodePools
+		nodePoolID := getDefaultNodePoolID(cluster.NodePools)
 		if hybridDeploymentRequest.Executor == astroplatformcore.UpdateHybridDeploymentRequestExecutorKUBERNETES {
 			if *currentDeployment.Executor == astroplatformcore.DeploymentExecutorCELERY {
 				confirmWithUser = true
-				hybridDeploymentRequest.TaskPodNodePoolId = &nodePools[0].Id
+				hybridDeploymentRequest.TaskPodNodePoolId = &nodePoolID
 			} else {
 				hybridDeploymentRequest.TaskPodNodePoolId = currentDeployment.TaskPodNodePoolId
 			}
@@ -1116,7 +1122,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 					MinWorkerCount:    int(configOption.WorkerQueues.MinWorkers.Default),
 					Name:              "default",
 					WorkerConcurrency: int(configOption.WorkerQueues.WorkerConcurrency.Default),
-					NodePoolId:        nodePools[0].Id,
+					NodePoolId:        nodePoolID,
 				}}
 				hybridDeploymentRequest.WorkerQueues = &workerQueuesRequest
 			} else {
@@ -1309,6 +1315,10 @@ func IsDeploymentStandard(deploymentType astroplatformcore.DeploymentType) bool 
 
 func IsDeploymentDedicated(deploymentType astroplatformcore.DeploymentType) bool {
 	return deploymentType == astroplatformcore.DeploymentTypeDEDICATED
+}
+
+func IsDeploymentHybrid(deploymentType astroplatformcore.DeploymentType) bool {
+	return deploymentType == astroplatformcore.DeploymentTypeHYBRID
 }
 
 // CoreUpdateDeploymentHibernationOverride updates a deployment hibernation override with the core API

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -245,9 +245,14 @@ const (
 )
 
 var (
-	mockPlatformCoreClient = new(astroplatformcore_mocks.ClientWithResponsesInterface)
-	mockCoreClient         = new(astrocore_mocks.ClientWithResponsesInterface)
+	mockPlatformCoreClient *astroplatformcore_mocks.ClientWithResponsesInterface
+	mockCoreClient         *astrocore_mocks.ClientWithResponsesInterface
 )
+
+func (s *Suite) SetupTest() {
+	mockPlatformCoreClient = new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockCoreClient = new(astrocore_mocks.ClientWithResponsesInterface)
+}
 
 func (s *Suite) TestList() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
@@ -934,6 +939,7 @@ func (s *Suite) TestCreate() {
 			StatusCode: 200,
 		},
 	}
+
 	s.Run("success with Celery Executor", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -954,6 +960,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("success with Celery Executor and differen schedulers", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(3)
@@ -982,6 +989,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("success with enabling ci-cd enforcement", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1001,6 +1009,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("success with enabling development mode", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1019,6 +1028,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("success with cloud provider and region", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1097,6 +1107,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("success with region selection", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1115,6 +1126,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("success with Kube Executor", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1135,6 +1147,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("success and wait for status with Dedicated Deployment", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1159,6 +1172,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("returns an error when creating a Hybrid deployment fails", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1189,6 +1203,7 @@ func (s *Suite) TestCreate() {
 		s.ErrorIs(err, errMock)
 		mockCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("failed to get default options", func() {
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, errMock).Once()
 
@@ -1196,6 +1211,7 @@ func (s *Suite) TestCreate() {
 		s.ErrorIs(err, errMock)
 		mockCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("returns an error if cluster choice is not valid", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1214,6 +1230,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("invalid hybrid resources", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1230,6 +1247,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
+
 	s.Run("invalid workspace failure", func() {
 		// Set up mock responses and expectations
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
@@ -1238,6 +1256,26 @@ func (s *Suite) TestCreate() {
 		err := Create("test-name", "wrong-workspace", "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.ErrorContains(err, "no Workspace with id")
 		mockCoreClient.AssertExpectations(s.T())
+	})
+
+	s.Run("no node pools on hybrid cluster", func() {
+		mockGetClusterResponseWithNoNodePools := mockGetClusterResponse
+		mockGetClusterResponseWithNoNodePools.JSON200.NodePools = nil
+
+		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
+		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
+		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
+		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponseWithNoNodePools, nil).Once()
+
+		defer testUtil.MockUserInput(s.T(), "test-name")()
+
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		s.NoError(err)
+
+		// Assert expectations
+		mockCoreClient.AssertExpectations(s.T())
+		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
 }
 
@@ -1721,6 +1759,31 @@ func (s *Suite) TestUpdate() { //nolint
 
 		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		s.NoError(err)
+		mockCoreClient.AssertExpectations(s.T())
+		mockPlatformCoreClient.AssertExpectations(s.T())
+	})
+
+	s.Run("no node pools on hybrid cluster", func() {
+		mockGetClusterResponseWithNoNodePools := astroplatformcore.GetClusterResponse{
+			HTTPResponse: &http.Response{
+				StatusCode: 200,
+			},
+			JSON200: &astroplatformcore.Cluster{
+				Id:        "test-cluster-id",
+				Name:      "test-cluster",
+				NodePools: nil,
+			},
+		}
+
+		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil)
+		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil)
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil)
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponseWithNoNodePools, nil)
+
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
+		s.NoError(err)
+
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})


### PR DESCRIPTION
## Description

This change avoids a panic when there are no node pools being returned for a cluster of a hybrid organization when creating/updating a deployment, by falling back to an empty node pool id.

## 🎟 Issue(s)

Fixes #1691 

## 🧪 Functional Testing

- Unit tested

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
