### PR TITLE
Add flag to inspect workload identity

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -182,7 +182,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 	if jsonOutput {
 		outputFormat = jsonFormat
 	}
-	return inspect.Inspect(workspaceID, "", existingDeployment.Id, outputFormat, astroPlatformCore, coreClient, out, "", false)
+	return inspect.Inspect(workspaceID, "", existingDeployment.Id, outputFormat, astroPlatformCore, coreClient, out, "", false, true)
 }
 
 // createOrUpdateDeployment transforms an inspect.FormattedDeployment into astroplateformcore CreateDeploymentInput or

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -251,7 +251,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentResponse.Namespace)
 		assert.Contains(t, out.String(), deploymentName)
@@ -265,7 +265,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", true)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", true, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentResponse.RuntimeVersion)
 		assert.NotContains(t, out.String(), deploymentResponse.Namespace)
@@ -279,7 +279,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "json", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentResponse.Namespace)
 		assert.Contains(t, out.String(), deploymentName)
@@ -293,7 +293,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "json", mockPlatformCoreClient, mockCoreClient, out, "", true)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", true, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentResponse.RuntimeVersion)
 		assert.NotContains(t, out.String(), deploymentResponse.Namespace)
@@ -307,7 +307,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "configuration.cluster_name", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "configuration.cluster_name", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), *deploymentResponse.ClusterName)
 		mockCoreClient.AssertExpectations(t)
@@ -320,7 +320,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", "", "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", "", "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentName)
 		mockCoreClient.AssertExpectations(t)
@@ -331,7 +331,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, errGetDeployment).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.ErrorIs(t, err, errGetDeployment)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -340,7 +340,7 @@ func TestInspect(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, errGetDeployment).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.ErrorIs(t, err, errGetDeployment)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -351,7 +351,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "no-exist-information", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "no-exist-information", false, false)
 		assert.ErrorIs(t, err, errKeyNotFound)
 		assert.Equal(t, "", out.String())
 		mockCoreClient.AssertExpectations(t)
@@ -366,7 +366,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.ErrorIs(t, err, errMarshal)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -375,7 +375,7 @@ func TestInspect(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.ErrorReturningContext)
 		out := new(bytes.Buffer)
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.ErrorContains(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -391,7 +391,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err = Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err = Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), "N/A")
 		assert.Contains(t, out.String(), deploymentName)
@@ -404,7 +404,7 @@ func TestInspect(t *testing.T) {
 	t.Run("when no deployments in workspace", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&emptyListDeploymentsResponse, nil).Once()
-		err := Inspect(workspaceID, "", "", "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", "", "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -478,7 +478,7 @@ func TestGetDeploymentConfig(t *testing.T) {
 			CloudProvider:     string(*sourceDeployment.CloudProvider),
 			IsDevelopmentMode: *sourceDeployment.IsDevelopmentMode,
 		}
-		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		err = decodeToStruct(rawDeploymentConfig, &actualDeploymentConfig)
 		assert.NoError(t, err)
@@ -515,7 +515,7 @@ func TestGetDeploymentConfig(t *testing.T) {
 			ResourceQuotaMemory:  *sourceDeployment.ResourceQuotaMemory,
 			IsDevelopmentMode:    *sourceDeployment.IsDevelopmentMode,
 		}
-		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		err = decodeToStruct(rawDeploymentConfig, &actualDeploymentConfig)
 		assert.NoError(t, err)
@@ -532,7 +532,7 @@ func TestGetPrintableDeployment(t *testing.T) {
 	t.Run("returns a deployment map", func(t *testing.T) {
 		info, _ := getDeploymentInfo(sourceDeployment)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		expectedDeployment := map[string]interface{}{
@@ -625,7 +625,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 
 	t.Run("returns a yaml formatted printable deployment", func(t *testing.T) {
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 
@@ -720,7 +720,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		sourceDeployment2.Region = &empty
 
 		info, _ := getDeploymentInfo(sourceDeployment2)
-		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment2, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment2, nodePools)
 
@@ -809,7 +809,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		sourceDeployment2.ScalingSpec.HibernationSpec.Override.OverrideUntil = &overrideUntil
 
 		info, _ := getDeploymentInfo(sourceDeployment2)
-		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment2, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment2, nodePools)
 
@@ -907,7 +907,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		sourceDeployment2.Region = &empty
 
 		info, _ := getDeploymentInfo(sourceDeployment2)
-		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment2, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment2, nodePools)
 		printableDeployment := map[string]interface{}{
@@ -1015,7 +1015,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		sourceDeployment.Region = &empty
 
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		printableDeployment := map[string]interface{}{
@@ -1085,7 +1085,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		decodeToStruct = errorReturningDecode
 		defer restoreDecode(originalDecode)
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		expectedPrintableDeployment = []byte{}
@@ -1098,7 +1098,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		yamlMarshal = errReturningYAMLMarshal
 		defer restoreYAMLMarshal(originalMarshal)
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		expectedPrintableDeployment = []byte{}
@@ -1111,7 +1111,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		jsonMarshal = errReturningJSONMarshal
 		defer restoreJSONMarshal(originalMarshal)
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		expectedPrintableDeployment = []byte{}
@@ -1125,7 +1125,7 @@ func TestGetSpecificField(t *testing.T) {
 	sourceDeployment.Status = "UNHEALTHY"
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	info, _ := getDeploymentInfo(sourceDeployment)
-	config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+	config, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 	assert.NoError(t, err)
 	additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 	printableDeployment := map[string]interface{}{
@@ -1241,7 +1241,7 @@ func TestGetTemplate(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 
 	info, _ := getDeploymentInfo(sourceDeployment)
-	config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+	config, err := getDeploymentConfig(&sourceDeployment, false, mockPlatformCoreClient)
 	assert.NoError(t, err)
 	additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 

--- a/cmd/cloud/deployment_inspect.go
+++ b/cmd/cloud/deployment_inspect.go
@@ -13,6 +13,7 @@ var (
 	outputFormat, requestedField string
 	template                     bool
 	cleanOutput                  bool
+	includeWorkloadIdentity      bool
 )
 
 func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
@@ -30,6 +31,7 @@ func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&template, "template", "t", false, "Create a template from the deployment being inspected.")
 	cmd.Flags().StringVarP(&requestedField, "key", "k", "", "A specific key for the deployment. Use --key configuration.cluster_id to get a deployment's cluster id.")
 	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "c", false, "clean output to only include inspect yaml or json file in any situation.")
+	cmd.Flags().BoolVarP(&includeWorkloadIdentity, "include-workload-identity", "", false, "Include Workload Identity configuration in the output.")
 	return cmd
 }
 
@@ -48,5 +50,5 @@ func deploymentInspect(cmd *cobra.Command, args []string, out io.Writer) error {
 	// clean output
 	deployment.CleanOutput = cleanOutput
 
-	return inspect.Inspect(wsID, deploymentName, deploymentID, outputFormat, platformCoreClient, astroCoreClient, out, requestedField, template)
+	return inspect.Inspect(wsID, deploymentName, deploymentID, outputFormat, platformCoreClient, astroCoreClient, out, requestedField, template, includeWorkloadIdentity)
 }

--- a/cmd/cloud/deployment_inspect_test.go
+++ b/cmd/cloud/deployment_inspect_test.go
@@ -66,6 +66,16 @@ func TestNewDeploymentInspectCmd(t *testing.T) {
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
+	t.Run("includes workload identity", func(t *testing.T) {
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
+		cmdArgs := []string{"inspect", "-n", "test", "--include-workload-identity"}
+		resp, err := execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, resp, mockWorkloadIdentity)
+		mockPlatformCoreClient.AssertExpectations(t)
+	})
 	t.Run("returns an error when getting workspace fails", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.Initial)
 		expectedOut := "Usage:\n"

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -119,6 +119,7 @@ var (
 			DefaultTaskPodMemory:   &defaultTaskPodMemory,
 			WebServerAirflowApiUrl: "airflow-url",
 			WorkerQueues:           &[]astroplatformcore.WorkerQueue{},
+			WorkloadIdentity:       &mockWorkloadIdentity,
 		},
 	}
 	mockListDeploymentsResponse = astroplatformcore.ListDeploymentsResponse{


### PR DESCRIPTION
## Description

This change adds a flag `--include-workload-identity` for the command `astro deployment inspect`.

Currently the workload identity is not included because it is generally not applicable to a new deployment that clones from the inspect output. This flag will allow the workload identity to be included if it is needed for other reasons.

## 🎟 Issue(s)

Fixes #1571 

## 🧪 Functional Testing

- Unit tests
- Manually tested on deployment

## 📸 Screenshots

<img width="1079" alt="Screenshot 2024-07-30 at 2 18 42 PM" src="https://github.com/user-attachments/assets/a462e01a-b8be-480c-b3c2-9524dd4c1330">
<img width="1067" alt="Screenshot 2024-07-30 at 2 18 53 PM" src="https://github.com/user-attachments/assets/cc5f60c6-5355-4c51-ab74-320a6d8c94fb">
<img width="907" alt="Screenshot 2024-07-30 at 2 19 00 PM" src="https://github.com/user-attachments/assets/73946b0e-1e8a-432a-ae8c-7171c8550c35">

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
