### PR TITLE
Add extra large scheduler size option

### DIFF
--- a/astro-client-core/api.gen.go
+++ b/astro-client-core/api.gen.go
@@ -119,6 +119,7 @@ const (
 const (
 	ClusterHealthStatusValueHEALTHY   ClusterHealthStatusValue = "HEALTHY"
 	ClusterHealthStatusValueUNHEALTHY ClusterHealthStatusValue = "UNHEALTHY"
+	ClusterHealthStatusValueUNKNOWN   ClusterHealthStatusValue = "UNKNOWN"
 )
 
 // Defines values for ClusterRouteSource.
@@ -168,9 +169,10 @@ const (
 
 // Defines values for CreateDedicatedDeploymentRequestSchedulerSize.
 const (
-	CreateDedicatedDeploymentRequestSchedulerSizeLARGE  CreateDedicatedDeploymentRequestSchedulerSize = "LARGE"
-	CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM CreateDedicatedDeploymentRequestSchedulerSize = "MEDIUM"
-	CreateDedicatedDeploymentRequestSchedulerSizeSMALL  CreateDedicatedDeploymentRequestSchedulerSize = "SMALL"
+	CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE CreateDedicatedDeploymentRequestSchedulerSize = "EXTRA_LARGE"
+	CreateDedicatedDeploymentRequestSchedulerSizeLARGE      CreateDedicatedDeploymentRequestSchedulerSize = "LARGE"
+	CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM     CreateDedicatedDeploymentRequestSchedulerSize = "MEDIUM"
+	CreateDedicatedDeploymentRequestSchedulerSizeSMALL      CreateDedicatedDeploymentRequestSchedulerSize = "SMALL"
 )
 
 // Defines values for CreateDedicatedDeploymentRequestType.
@@ -257,9 +259,10 @@ const (
 
 // Defines values for CreateStandardDeploymentRequestSchedulerSize.
 const (
-	CreateStandardDeploymentRequestSchedulerSizeLARGE  CreateStandardDeploymentRequestSchedulerSize = "LARGE"
-	CreateStandardDeploymentRequestSchedulerSizeMEDIUM CreateStandardDeploymentRequestSchedulerSize = "MEDIUM"
-	CreateStandardDeploymentRequestSchedulerSizeSMALL  CreateStandardDeploymentRequestSchedulerSize = "SMALL"
+	CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE CreateStandardDeploymentRequestSchedulerSize = "EXTRA_LARGE"
+	CreateStandardDeploymentRequestSchedulerSizeLARGE      CreateStandardDeploymentRequestSchedulerSize = "LARGE"
+	CreateStandardDeploymentRequestSchedulerSizeMEDIUM     CreateStandardDeploymentRequestSchedulerSize = "MEDIUM"
+	CreateStandardDeploymentRequestSchedulerSizeSMALL      CreateStandardDeploymentRequestSchedulerSize = "SMALL"
 )
 
 // Defines values for CreateStandardDeploymentRequestType.
@@ -267,6 +270,14 @@ const (
 	CreateStandardDeploymentRequestTypeDEDICATED CreateStandardDeploymentRequestType = "DEDICATED"
 	CreateStandardDeploymentRequestTypeHYBRID    CreateStandardDeploymentRequestType = "HYBRID"
 	CreateStandardDeploymentRequestTypeSTANDARD  CreateStandardDeploymentRequestType = "STANDARD"
+)
+
+// Defines values for DAGProcessorMachineName.
+const (
+	DAGProcessorMachineNameEXTRALARGE DAGProcessorMachineName = "EXTRA_LARGE"
+	DAGProcessorMachineNameLARGE      DAGProcessorMachineName = "LARGE"
+	DAGProcessorMachineNameMEDIUM     DAGProcessorMachineName = "MEDIUM"
+	DAGProcessorMachineNameSMALL      DAGProcessorMachineName = "SMALL"
 )
 
 // Defines values for DefaultRoleScopeType.
@@ -286,9 +297,10 @@ const (
 
 // Defines values for DeployType.
 const (
-	DeployTypeBUNDLE DeployType = "BUNDLE"
-	DeployTypeDAG    DeployType = "DAG"
-	DeployTypeIMAGE  DeployType = "IMAGE"
+	DeployTypeBASEIMAGE DeployType = "BASE_IMAGE"
+	DeployTypeBUNDLE    DeployType = "BUNDLE"
+	DeployTypeDAG       DeployType = "DAG"
+	DeployTypeIMAGE     DeployType = "IMAGE"
 )
 
 // Defines values for DeployGitProvider.
@@ -319,9 +331,10 @@ const (
 
 // Defines values for DeploymentSchedulerSize.
 const (
-	DeploymentSchedulerSizeLARGE  DeploymentSchedulerSize = "LARGE"
-	DeploymentSchedulerSizeMEDIUM DeploymentSchedulerSize = "MEDIUM"
-	DeploymentSchedulerSizeSMALL  DeploymentSchedulerSize = "SMALL"
+	DeploymentSchedulerSizeEXTRALARGE DeploymentSchedulerSize = "EXTRA_LARGE"
+	DeploymentSchedulerSizeLARGE      DeploymentSchedulerSize = "LARGE"
+	DeploymentSchedulerSizeMEDIUM     DeploymentSchedulerSize = "MEDIUM"
+	DeploymentSchedulerSizeSMALL      DeploymentSchedulerSize = "SMALL"
 )
 
 // Defines values for DeploymentStatus.
@@ -356,10 +369,11 @@ const (
 
 // Defines values for DeploymentLogEntrySource.
 const (
-	DeploymentLogEntrySourceScheduler DeploymentLogEntrySource = "scheduler"
-	DeploymentLogEntrySourceTriggerer DeploymentLogEntrySource = "triggerer"
-	DeploymentLogEntrySourceWebserver DeploymentLogEntrySource = "webserver"
-	DeploymentLogEntrySourceWorker    DeploymentLogEntrySource = "worker"
+	DeploymentLogEntrySourceDagProcessor DeploymentLogEntrySource = "dag-processor"
+	DeploymentLogEntrySourceScheduler    DeploymentLogEntrySource = "scheduler"
+	DeploymentLogEntrySourceTriggerer    DeploymentLogEntrySource = "triggerer"
+	DeploymentLogEntrySourceWebserver    DeploymentLogEntrySource = "webserver"
+	DeploymentLogEntrySourceWorker       DeploymentLogEntrySource = "worker"
 )
 
 // Defines values for DeploymentRepositoryPathGitProvider.
@@ -509,9 +523,10 @@ const (
 
 // Defines values for SchedulerMachineName.
 const (
-	SchedulerMachineNameLARGE  SchedulerMachineName = "LARGE"
-	SchedulerMachineNameMEDIUM SchedulerMachineName = "MEDIUM"
-	SchedulerMachineNameSMALL  SchedulerMachineName = "SMALL"
+	SchedulerMachineNameEXTRALARGE SchedulerMachineName = "EXTRA_LARGE"
+	SchedulerMachineNameLARGE      SchedulerMachineName = "LARGE"
+	SchedulerMachineNameMEDIUM     SchedulerMachineName = "MEDIUM"
+	SchedulerMachineNameSMALL      SchedulerMachineName = "SMALL"
 )
 
 // Defines values for SelfSignupType.
@@ -594,9 +609,10 @@ const (
 
 // Defines values for UpdateHostedDeploymentRequestSchedulerSize.
 const (
-	LARGE  UpdateHostedDeploymentRequestSchedulerSize = "LARGE"
-	MEDIUM UpdateHostedDeploymentRequestSchedulerSize = "MEDIUM"
-	SMALL  UpdateHostedDeploymentRequestSchedulerSize = "SMALL"
+	UpdateHostedDeploymentRequestSchedulerSizeEXTRALARGE UpdateHostedDeploymentRequestSchedulerSize = "EXTRA_LARGE"
+	UpdateHostedDeploymentRequestSchedulerSizeLARGE      UpdateHostedDeploymentRequestSchedulerSize = "LARGE"
+	UpdateHostedDeploymentRequestSchedulerSizeMEDIUM     UpdateHostedDeploymentRequestSchedulerSize = "MEDIUM"
+	UpdateHostedDeploymentRequestSchedulerSizeSMALL      UpdateHostedDeploymentRequestSchedulerSize = "SMALL"
 )
 
 // Defines values for UpdateHostedDeploymentRequestType.
@@ -913,10 +929,11 @@ const (
 
 // Defines values for GetDeploymentLogsParamsSources.
 const (
-	GetDeploymentLogsParamsSourcesScheduler GetDeploymentLogsParamsSources = "scheduler"
-	GetDeploymentLogsParamsSourcesTriggerer GetDeploymentLogsParamsSources = "triggerer"
-	GetDeploymentLogsParamsSourcesWebserver GetDeploymentLogsParamsSources = "webserver"
-	GetDeploymentLogsParamsSourcesWorker    GetDeploymentLogsParamsSources = "worker"
+	GetDeploymentLogsParamsSourcesDagProcessor GetDeploymentLogsParamsSources = "dag-processor"
+	GetDeploymentLogsParamsSourcesScheduler    GetDeploymentLogsParamsSources = "scheduler"
+	GetDeploymentLogsParamsSourcesTriggerer    GetDeploymentLogsParamsSources = "triggerer"
+	GetDeploymentLogsParamsSourcesWebserver    GetDeploymentLogsParamsSources = "webserver"
+	GetDeploymentLogsParamsSourcesWorker       GetDeploymentLogsParamsSources = "worker"
 )
 
 // Defines values for ListDeploymentTeamsParamsSorts.
@@ -1351,6 +1368,7 @@ type ClusterHealthStatusDetail struct {
 // ClusterMetadata defines model for ClusterMetadata.
 type ClusterMetadata struct {
 	ExternalIPs   *[]string `json:"externalIPs,omitempty"`
+	KubeDnsIp     *string   `json:"kubeDnsIp,omitempty"`
 	OidcIssuerUrl *string   `json:"oidcIssuerUrl,omitempty"`
 }
 
@@ -1561,7 +1579,7 @@ type CreateDedicatedDeploymentRequest struct {
 	ResourceQuotaMemory string                        `json:"resourceQuotaMemory"`
 	ScalingSpec         *DeploymentScalingSpecRequest `json:"scalingSpec,omitempty"`
 
-	// SchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE
+	// SchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE, EXTRA_LARGE
 	SchedulerSize CreateDedicatedDeploymentRequestSchedulerSize `json:"schedulerSize"`
 
 	// Type Types of the deployment, one of: DEDICATED, HYBRID, STANDARD
@@ -1580,7 +1598,7 @@ type CreateDedicatedDeploymentRequest struct {
 // CreateDedicatedDeploymentRequestExecutor Airflow executors, supported: CELERY, KUBERNETES
 type CreateDedicatedDeploymentRequestExecutor string
 
-// CreateDedicatedDeploymentRequestSchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE
+// CreateDedicatedDeploymentRequestSchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE, EXTRA_LARGE
 type CreateDedicatedDeploymentRequestSchedulerSize string
 
 // CreateDedicatedDeploymentRequestType Types of the deployment, one of: DEDICATED, HYBRID, STANDARD
@@ -1684,6 +1702,10 @@ type CreateEnvironmentObjectMetricsExportOverridesRequest struct {
 	BasicToken   *string                                                           `json:"basicToken,omitempty"`
 	Endpoint     *string                                                           `json:"endpoint,omitempty"`
 	ExporterType *CreateEnvironmentObjectMetricsExportOverridesRequestExporterType `json:"exporterType,omitempty"`
+	Headers      *map[string]string                                                `json:"headers,omitempty"`
+	Labels       *map[string]string                                                `json:"labels,omitempty"`
+	Password     *string                                                           `json:"password,omitempty"`
+	Username     *string                                                           `json:"username,omitempty"`
 }
 
 // CreateEnvironmentObjectMetricsExportOverridesRequestExporterType defines model for CreateEnvironmentObjectMetricsExportOverridesRequest.ExporterType.
@@ -1694,6 +1716,10 @@ type CreateEnvironmentObjectMetricsExportRequest struct {
 	BasicToken   *string                                                 `json:"basicToken,omitempty"`
 	Endpoint     string                                                  `json:"endpoint"`
 	ExporterType CreateEnvironmentObjectMetricsExportRequestExporterType `json:"exporterType"`
+	Headers      *map[string]string                                      `json:"headers,omitempty"`
+	Labels       *map[string]string                                      `json:"labels,omitempty"`
+	Password     *string                                                 `json:"password,omitempty"`
+	Username     *string                                                 `json:"username,omitempty"`
 }
 
 // CreateEnvironmentObjectMetricsExportRequestExporterType defines model for CreateEnvironmentObjectMetricsExportRequest.ExporterType.
@@ -1872,7 +1898,7 @@ type CreateStandardDeploymentRequest struct {
 	ResourceQuotaMemory string                        `json:"resourceQuotaMemory"`
 	ScalingSpec         *DeploymentScalingSpecRequest `json:"scalingSpec,omitempty"`
 
-	// SchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE
+	// SchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE, EXTRA_LARGE
 	SchedulerSize CreateStandardDeploymentRequestSchedulerSize `json:"schedulerSize"`
 
 	// Type Types of the deployment, one of: DEDICATED, HYBRID, STANDARD
@@ -1894,7 +1920,7 @@ type CreateStandardDeploymentRequestCloudProvider string
 // CreateStandardDeploymentRequestExecutor Airflow executors, supported: CELERY, KUBERNETES
 type CreateStandardDeploymentRequestExecutor string
 
-// CreateStandardDeploymentRequestSchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE
+// CreateStandardDeploymentRequestSchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE, EXTRA_LARGE
 type CreateStandardDeploymentRequestSchedulerSize string
 
 // CreateStandardDeploymentRequestType Types of the deployment, one of: DEDICATED, HYBRID, STANDARD
@@ -1933,6 +1959,16 @@ type CreateWorkspaceRequest struct {
 type CronExpressionSchema struct {
 	Value string `json:"value"`
 }
+
+// DAGProcessorMachine defines model for DAGProcessorMachine.
+type DAGProcessorMachine struct {
+	// Name The name of this machine.
+	Name DAGProcessorMachineName `json:"name"`
+	Spec MachineSpec             `json:"spec"`
+}
+
+// DAGProcessorMachineName The name of this machine.
+type DAGProcessorMachineName string
 
 // DagFilters defines model for DagFilters.
 type DagFilters struct {
@@ -1993,6 +2029,7 @@ type Deploy struct {
 	RollbackFromId     *string              `json:"rollbackFromId,omitempty"`
 	RuntimeVersion     *string              `json:"runtimeVersion,omitempty"`
 	Status             DeployStatus         `json:"status"`
+	StatusReason       *string              `json:"statusReason,omitempty"`
 	Steps              *[]DeployStep        `json:"steps,omitempty"`
 	Type               DeployType           `json:"type"`
 	UpdatedAt          *time.Time           `json:"updatedAt,omitempty"`
@@ -2070,6 +2107,7 @@ type DeployStepsPaginated struct {
 // Deployment defines model for Deployment.
 type Deployment struct {
 	AirflowVersion                 string                           `json:"airflowVersion"`
+	Bundles                        *[]Bundle                        `json:"bundles,omitempty"`
 	ClusterCloudProvider           *DeploymentClusterCloudProvider  `json:"clusterCloudProvider,omitempty"`
 	ClusterId                      string                           `json:"clusterId"`
 	ClusterName                    *string                          `json:"clusterName,omitempty"`
@@ -2299,6 +2337,7 @@ type DeploymentLogEntrySource string
 
 // DeploymentOptions defines model for DeploymentOptions.
 type DeploymentOptions struct {
+	DagProcessorMachines    *[]DAGProcessorMachine    `json:"dagProcessorMachines,omitempty"`
 	DefaultValues           DefaultValueOptions       `json:"defaultValues"`
 	Executors               []string                  `json:"executors"`
 	LegacyAstro             LegacyAstroOptions        `json:"legacyAstro"`
@@ -2436,6 +2475,10 @@ type EnvironmentObjectMetricsExport struct {
 	BasicToken   *string                                    `json:"basicToken,omitempty"`
 	Endpoint     string                                     `json:"endpoint"`
 	ExporterType EnvironmentObjectMetricsExportExporterType `json:"exporterType"`
+	Headers      *map[string]string                         `json:"headers,omitempty"`
+	Labels       *map[string]string                         `json:"labels,omitempty"`
+	Password     *string                                    `json:"password,omitempty"`
+	Username     *string                                    `json:"username,omitempty"`
 }
 
 // EnvironmentObjectMetricsExportExporterType defines model for EnvironmentObjectMetricsExport.ExporterType.
@@ -2446,6 +2489,10 @@ type EnvironmentObjectMetricsExportOverrides struct {
 	BasicToken   *string                                              `json:"basicToken,omitempty"`
 	Endpoint     *string                                              `json:"endpoint,omitempty"`
 	ExporterType *EnvironmentObjectMetricsExportOverridesExporterType `json:"exporterType,omitempty"`
+	Headers      *map[string]string                                   `json:"headers,omitempty"`
+	Labels       *map[string]string                                   `json:"labels,omitempty"`
+	Password     *string                                              `json:"password,omitempty"`
+	Username     *string                                              `json:"username,omitempty"`
 }
 
 // EnvironmentObjectMetricsExportOverridesExporterType defines model for EnvironmentObjectMetricsExportOverrides.ExporterType.
@@ -3147,6 +3194,10 @@ type UpdateEnvironmentObjectMetricsExportOverridesRequest struct {
 	BasicToken   *string                                                           `json:"basicToken,omitempty"`
 	Endpoint     *string                                                           `json:"endpoint,omitempty"`
 	ExporterType *UpdateEnvironmentObjectMetricsExportOverridesRequestExporterType `json:"exporterType,omitempty"`
+	Headers      *map[string]string                                                `json:"headers,omitempty"`
+	Labels       *map[string]string                                                `json:"labels,omitempty"`
+	Password     *string                                                           `json:"password,omitempty"`
+	Username     *string                                                           `json:"username,omitempty"`
 }
 
 // UpdateEnvironmentObjectMetricsExportOverridesRequestExporterType defines model for UpdateEnvironmentObjectMetricsExportOverridesRequest.ExporterType.
@@ -3157,6 +3208,10 @@ type UpdateEnvironmentObjectMetricsExportRequest struct {
 	BasicToken   *string                                                  `json:"basicToken,omitempty"`
 	Endpoint     *string                                                  `json:"endpoint,omitempty"`
 	ExporterType *UpdateEnvironmentObjectMetricsExportRequestExporterType `json:"exporterType,omitempty"`
+	Headers      *map[string]string                                       `json:"headers,omitempty"`
+	Labels       *map[string]string                                       `json:"labels,omitempty"`
+	Password     *string                                                  `json:"password,omitempty"`
+	Username     *string                                                  `json:"username,omitempty"`
 }
 
 // UpdateEnvironmentObjectMetricsExportRequestExporterType defines model for UpdateEnvironmentObjectMetricsExportRequest.ExporterType.
@@ -3242,7 +3297,7 @@ type UpdateHostedDeploymentRequest struct {
 	ResourceQuotaMemory string                        `json:"resourceQuotaMemory"`
 	ScalingSpec         *DeploymentScalingSpecRequest `json:"scalingSpec,omitempty"`
 
-	// SchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE
+	// SchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE, EXTRA_LARGE
 	SchedulerSize UpdateHostedDeploymentRequestSchedulerSize `json:"schedulerSize"`
 	Type          UpdateHostedDeploymentRequestType          `json:"type"`
 
@@ -3255,7 +3310,7 @@ type UpdateHostedDeploymentRequest struct {
 // UpdateHostedDeploymentRequestExecutor Airflow executors, supported: CELERY, KUBERNETES
 type UpdateHostedDeploymentRequestExecutor string
 
-// UpdateHostedDeploymentRequestSchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE
+// UpdateHostedDeploymentRequestSchedulerSize Size of scheduler, one of: SMALL, MEDIUM, LARGE, EXTRA_LARGE
 type UpdateHostedDeploymentRequestSchedulerSize string
 
 // UpdateHostedDeploymentRequestType defines model for UpdateHostedDeploymentRequest.Type.

--- a/astro-client-platform-core/api.gen.go
+++ b/astro-client-platform-core/api.gen.go
@@ -55,6 +55,7 @@ const (
 const (
 	HEALTHY   ClusterHealthStatusValue = "HEALTHY"
 	UNHEALTHY ClusterHealthStatusValue = "UNHEALTHY"
+	UNKNOWN   ClusterHealthStatusValue = "UNKNOWN"
 )
 
 // Defines values for ClusterOptionsProvider.
@@ -98,9 +99,10 @@ const (
 
 // Defines values for CreateDedicatedDeploymentRequestSchedulerSize.
 const (
-	CreateDedicatedDeploymentRequestSchedulerSizeLARGE  CreateDedicatedDeploymentRequestSchedulerSize = "LARGE"
-	CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM CreateDedicatedDeploymentRequestSchedulerSize = "MEDIUM"
-	CreateDedicatedDeploymentRequestSchedulerSizeSMALL  CreateDedicatedDeploymentRequestSchedulerSize = "SMALL"
+	CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE CreateDedicatedDeploymentRequestSchedulerSize = "EXTRA_LARGE"
+	CreateDedicatedDeploymentRequestSchedulerSizeLARGE      CreateDedicatedDeploymentRequestSchedulerSize = "LARGE"
+	CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM     CreateDedicatedDeploymentRequestSchedulerSize = "MEDIUM"
+	CreateDedicatedDeploymentRequestSchedulerSizeSMALL      CreateDedicatedDeploymentRequestSchedulerSize = "SMALL"
 )
 
 // Defines values for CreateDedicatedDeploymentRequestType.
@@ -158,9 +160,10 @@ const (
 
 // Defines values for CreateStandardDeploymentRequestSchedulerSize.
 const (
-	CreateStandardDeploymentRequestSchedulerSizeLARGE  CreateStandardDeploymentRequestSchedulerSize = "LARGE"
-	CreateStandardDeploymentRequestSchedulerSizeMEDIUM CreateStandardDeploymentRequestSchedulerSize = "MEDIUM"
-	CreateStandardDeploymentRequestSchedulerSizeSMALL  CreateStandardDeploymentRequestSchedulerSize = "SMALL"
+	CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE CreateStandardDeploymentRequestSchedulerSize = "EXTRA_LARGE"
+	CreateStandardDeploymentRequestSchedulerSizeLARGE      CreateStandardDeploymentRequestSchedulerSize = "LARGE"
+	CreateStandardDeploymentRequestSchedulerSizeMEDIUM     CreateStandardDeploymentRequestSchedulerSize = "MEDIUM"
+	CreateStandardDeploymentRequestSchedulerSizeSMALL      CreateStandardDeploymentRequestSchedulerSize = "SMALL"
 )
 
 // Defines values for CreateStandardDeploymentRequestType.
@@ -199,9 +202,10 @@ const (
 
 // Defines values for DeploymentSchedulerSize.
 const (
-	DeploymentSchedulerSizeLARGE  DeploymentSchedulerSize = "LARGE"
-	DeploymentSchedulerSizeMEDIUM DeploymentSchedulerSize = "MEDIUM"
-	DeploymentSchedulerSizeSMALL  DeploymentSchedulerSize = "SMALL"
+	DeploymentSchedulerSizeEXTRALARGE DeploymentSchedulerSize = "EXTRA_LARGE"
+	DeploymentSchedulerSizeLARGE      DeploymentSchedulerSize = "LARGE"
+	DeploymentSchedulerSizeMEDIUM     DeploymentSchedulerSize = "MEDIUM"
+	DeploymentSchedulerSizeSMALL      DeploymentSchedulerSize = "SMALL"
 )
 
 // Defines values for DeploymentStatus.
@@ -273,9 +277,10 @@ const (
 
 // Defines values for SchedulerMachineName.
 const (
-	SchedulerMachineNameLARGE  SchedulerMachineName = "LARGE"
-	SchedulerMachineNameMEDIUM SchedulerMachineName = "MEDIUM"
-	SchedulerMachineNameSMALL  SchedulerMachineName = "SMALL"
+	SchedulerMachineNameEXTRALARGE SchedulerMachineName = "EXTRA_LARGE"
+	SchedulerMachineNameLARGE      SchedulerMachineName = "LARGE"
+	SchedulerMachineNameMEDIUM     SchedulerMachineName = "MEDIUM"
+	SchedulerMachineNameSMALL      SchedulerMachineName = "SMALL"
 )
 
 // Defines values for UpdateDedicatedClusterRequestClusterType.
@@ -291,9 +296,10 @@ const (
 
 // Defines values for UpdateDedicatedDeploymentRequestSchedulerSize.
 const (
-	UpdateDedicatedDeploymentRequestSchedulerSizeLARGE  UpdateDedicatedDeploymentRequestSchedulerSize = "LARGE"
-	UpdateDedicatedDeploymentRequestSchedulerSizeMEDIUM UpdateDedicatedDeploymentRequestSchedulerSize = "MEDIUM"
-	UpdateDedicatedDeploymentRequestSchedulerSizeSMALL  UpdateDedicatedDeploymentRequestSchedulerSize = "SMALL"
+	UpdateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE UpdateDedicatedDeploymentRequestSchedulerSize = "EXTRA_LARGE"
+	UpdateDedicatedDeploymentRequestSchedulerSizeLARGE      UpdateDedicatedDeploymentRequestSchedulerSize = "LARGE"
+	UpdateDedicatedDeploymentRequestSchedulerSizeMEDIUM     UpdateDedicatedDeploymentRequestSchedulerSize = "MEDIUM"
+	UpdateDedicatedDeploymentRequestSchedulerSizeSMALL      UpdateDedicatedDeploymentRequestSchedulerSize = "SMALL"
 )
 
 // Defines values for UpdateDedicatedDeploymentRequestType.
@@ -329,9 +335,10 @@ const (
 
 // Defines values for UpdateStandardDeploymentRequestSchedulerSize.
 const (
-	UpdateStandardDeploymentRequestSchedulerSizeLARGE  UpdateStandardDeploymentRequestSchedulerSize = "LARGE"
-	UpdateStandardDeploymentRequestSchedulerSizeMEDIUM UpdateStandardDeploymentRequestSchedulerSize = "MEDIUM"
-	UpdateStandardDeploymentRequestSchedulerSizeSMALL  UpdateStandardDeploymentRequestSchedulerSize = "SMALL"
+	UpdateStandardDeploymentRequestSchedulerSizeEXTRALARGE UpdateStandardDeploymentRequestSchedulerSize = "EXTRA_LARGE"
+	UpdateStandardDeploymentRequestSchedulerSizeLARGE      UpdateStandardDeploymentRequestSchedulerSize = "LARGE"
+	UpdateStandardDeploymentRequestSchedulerSizeMEDIUM     UpdateStandardDeploymentRequestSchedulerSize = "MEDIUM"
+	UpdateStandardDeploymentRequestSchedulerSizeSMALL      UpdateStandardDeploymentRequestSchedulerSize = "SMALL"
 )
 
 // Defines values for UpdateStandardDeploymentRequestType.
@@ -593,6 +600,9 @@ type ClusterK8sTag struct {
 type ClusterMetadata struct {
 	// ExternalIPs External IPs of the cluster.
 	ExternalIPs *[]string `json:"externalIPs,omitempty"`
+
+	// KubeDnsIp The IP address of the kube-dns service.
+	KubeDnsIp *string `json:"kubeDnsIp,omitempty"`
 
 	// OidcIssuerUrl OIDC issuer URL for the cluster
 	OidcIssuerUrl *string `json:"oidcIssuerUrl,omitempty"`

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -58,10 +58,6 @@ const (
 	awsCloud            = "aws"
 	azureCloud          = "azure"
 	standard            = "standard"
-	LargeScheduler      = "large"
-	MediumScheduler     = "medium"
-	SmallScheduler      = "small"
-	ExtraLargeScheduler = "extra_large"
 	disable             = "disable"
 	enable              = "enable"
 )
@@ -369,13 +365,13 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 				standardDeploymentRequest.WorkerQueues = &defautWorkerQueue
 			}
 			switch schedulerSize {
-			case SmallScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeSMALL)):
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeSMALL
-			case MediumScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM)):
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM
-			case LargeScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeLARGE)):
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeLARGE
-			case ExtraLargeScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE)):
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSize(configOption.DefaultValues.SchedulerSize)
@@ -418,13 +414,13 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 				dedicatedDeploymentRequest.WorkerQueues = &defautWorkerQueue
 			}
 			switch schedulerSize {
-			case SmallScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeSMALL)):
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeSMALL
-			case MediumScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM)):
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM
-			case LargeScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeLARGE)):
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeLARGE
-			case ExtraLargeScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE)):
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSize(configOption.DefaultValues.SchedulerSize)
@@ -941,13 +937,13 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 				DefaultTaskPodMemory: defaultTaskPodMemory,
 			}
 			switch schedulerSize {
-			case SmallScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeSMALL)):
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeSMALL
-			case MediumScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM)):
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeMEDIUM
-			case LargeScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeLARGE)):
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeLARGE
-			case ExtraLargeScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE)):
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSize(*currentDeployment.SchedulerSize)
@@ -1004,13 +1000,13 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 				WorkerQueues:         &workerQueuesRequest,
 			}
 			switch schedulerSize {
-			case SmallScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeSMALL)):
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeSMALL
-			case MediumScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM)):
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeMEDIUM
-			case LargeScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeLARGE)):
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeLARGE
-			case ExtraLargeScheduler:
+			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE)):
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSize(*currentDeployment.SchedulerSize)

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -62,10 +62,6 @@ const (
 	MediumScheduler     = "medium"
 	SmallScheduler      = "small"
 	ExtraLargeScheduler = "extra_large"
-	SMALL               = "SMALL"
-	MEDIUM              = "MEDIUM"
-	LARGE               = "LARGE"
-	EXTRA_LARGE         = "EXTRA_LARGE"
 	disable             = "disable"
 	enable              = "enable"
 )

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -61,9 +61,11 @@ const (
 	LargeScheduler      = "large"
 	MediumScheduler     = "medium"
 	SmallScheduler      = "small"
+	ExtraLargeScheduler = "extra_large"
 	SMALL               = "SMALL"
 	MEDIUM              = "MEDIUM"
 	LARGE               = "LARGE"
+	EXTRA_LARGE         = "EXTRA_LARGE"
 	disable             = "disable"
 	enable              = "enable"
 )
@@ -377,6 +379,8 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM
 			case LargeScheduler:
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeLARGE
+			case ExtraLargeScheduler:
+				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSize(configOption.DefaultValues.SchedulerSize)
 			}
@@ -424,6 +428,8 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM
 			case LargeScheduler:
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeLARGE
+			case ExtraLargeScheduler:
+				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSize(configOption.DefaultValues.SchedulerSize)
 			}
@@ -945,6 +951,8 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeMEDIUM
 			case LargeScheduler:
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeLARGE
+			case ExtraLargeScheduler:
+				standardDeploymentRequest.SchedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSize(*currentDeployment.SchedulerSize)
 			}
@@ -1006,6 +1014,8 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeMEDIUM
 			case LargeScheduler:
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeLARGE
+			case ExtraLargeScheduler:
+				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSize(*currentDeployment.SchedulerSize)
 			}

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -954,13 +954,13 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
-	s.Run("success with Celery Executor and differen schedulers", func() {
+	s.Run("success with Celery Executor and different schedulers", func() {
 		// Set up mock responses and expectations
-		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(3)
-		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Times(3)
-		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(3)
-		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(3)
-		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(3)
+		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(4)
+		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Times(4)
+		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(4)
+		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(4)
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(4)
 
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "test-name")()
@@ -976,6 +976,10 @@ func (s *Suite) TestCreate() {
 
 		// Call the Create function
 		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", LargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		s.NoError(err)
+
+		// Call the Create function
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", ExtraLargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1065,10 +1069,10 @@ func (s *Suite) TestCreate() {
 
 	s.Run("success with standard/dedicated type different scheduler sizes", func() {
 		// Set up mock responses and expectations
-		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(6)
-		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(6)
-		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Times(6)
-		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(3)
+		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(8)
+		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(8)
+		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Times(8)
+		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(4)
 
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "test-name")()
@@ -1083,6 +1087,10 @@ func (s *Suite) TestCreate() {
 			"us-west-2", LargeScheduler, "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KUBERNETES, gcpCloud,
+			"us-west-2", ExtraLargeScheduler, "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		s.NoError(err)
+
 		// Call the Create function with deployment type as DEDICATED, cloud provider, and region set
 		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", SmallScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
@@ -1091,6 +1099,9 @@ func (s *Suite) TestCreate() {
 		s.NoError(err)
 
 		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", LargeScheduler, "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		s.NoError(err)
+
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", ExtraLargeScheduler, "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1440,10 +1451,10 @@ func (s *Suite) TestUpdate() { //nolint
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
 	s.Run("successfully update schedulerSize and highAvailability and CICDEnforement", func() {
-		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(4)
-		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(4)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(4)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(4)
+		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(6)
+		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(6)
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(6)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(6)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(2)
 
 		// mock os.Stdin
@@ -1468,6 +1479,14 @@ func (s *Suite) TestUpdate() { //nolint
 
 		// success with dedicated type
 		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
+		s.NoError(err)
+
+		// success with large scheduler size
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, LargeScheduler, "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
+		s.NoError(err)
+
+		// success with extra large scheduler size
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, ExtraLargeScheduler, "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		s.NoError(err)
 
 		// success with hybrid type with id

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1292,8 +1292,8 @@ func (s *Suite) TestCreate() {
 
 		// Call the Create function
 		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "extra_large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
-    s.NoError(err)
-  
+		s.NoError(err)
+
 		// Assert expectations
 		mockCoreClient.AssertExpectations(s.T())
 		mockPlatformCoreClient.AssertExpectations(s.T())

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -966,19 +966,19 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// Call the Create function
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", SmallScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", MediumScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", LargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", ExtraLargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "extra_large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1076,31 +1076,31 @@ func (s *Suite) TestCreate() {
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 		// Call the Create function with deployment type as STANDARD, cloud provider, and region set
-		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", SmallScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, azureCloud, "us-west-2", MediumScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
-		s.NoError(err)
-
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KUBERNETES, gcpCloud,
-			"us-west-2", LargeScheduler, "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KUBERNETES, gcpCloud,
-			"us-west-2", ExtraLargeScheduler, "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+			"us-west-2", "large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		s.NoError(err)
+
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KUBERNETES, gcpCloud,
+			"us-west-2", "extra_large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function with deployment type as DEDICATED, cloud provider, and region set
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", SmallScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CELERY, azureCloud, "us-west-2", MediumScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CELERY, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", LargeScheduler, "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", "large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", ExtraLargeScheduler, "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", "extra_large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1260,19 +1260,19 @@ func (s *Suite) TestCreate() {
 		// defer testUtil.MockUserInput(s.T(), "1")()
 
 		// Call the Create function
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", SmallScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", MediumScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", LargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", ExtraLargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "extra_large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1511,11 +1511,11 @@ func (s *Suite) TestUpdate() { //nolint
 		s.NoError(err)
 
 		// success with large scheduler size
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, LargeScheduler, "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		s.NoError(err)
 
 		// success with extra large scheduler size
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, ExtraLargeScheduler, "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "extra_large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, false, mockCoreClient, mockPlatformCoreClient)
 		s.NoError(err)
 
 		// success with hybrid type with id

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1249,6 +1249,36 @@ func (s *Suite) TestCreate() {
 		s.ErrorContains(err, "no Workspace with id")
 		mockCoreClient.AssertExpectations(s.T())
 	})
+	s.Run("success for standard deployment with Celery Executor and different scheduler sizes", func() {
+		// Set up mock responses and expectations
+		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(4)
+		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Times(4)
+		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(4)
+
+		// Mock user input for deployment name
+		// defer testUtil.MockUserInput(s.T(), "test-name")()
+		// defer testUtil.MockUserInput(s.T(), "1")()
+
+		// Call the Create function
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", SmallScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		s.NoError(err)
+
+		// Call the Create function
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", MediumScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		s.NoError(err)
+
+		// Call the Create function
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", LargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		s.NoError(err)
+
+		// Call the Create function
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", ExtraLargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		s.NoError(err)
+
+		// Assert expectations
+		mockCoreClient.AssertExpectations(s.T())
+		mockPlatformCoreClient.AssertExpectations(s.T())
+	})
 }
 
 func (s *Suite) TestSelectCluster() {

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -960,26 +960,25 @@ func (s *Suite) TestCreate() {
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Times(4)
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(4)
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Times(4)
-		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(4)
 
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// Call the Create function
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", SmallScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", SmallScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", MediumScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", MediumScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", LargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", LargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", ExtraLargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", ExtraLargeScheduler, "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, mockPlatformCoreClient, mockCoreClient, false)
 		s.NoError(err)
 
 		// Assert expectations

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -333,6 +333,8 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				schedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM
 			case deployment.LARGE:
 				schedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeLARGE
+			case deployment.EXTRA_LARGE:
+				schedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 
 			standardDeploymentRequest := astroplatformcore.CreateStandardDeploymentRequest{
@@ -385,6 +387,8 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				schedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM
 			case deployment.LARGE:
 				schedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeLARGE
+			case deployment.EXTRA_LARGE:
+				schedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 
 			dedicatedDeploymentRequest := astroplatformcore.CreateDedicatedDeploymentRequest{
@@ -490,6 +494,8 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				schedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeMEDIUM
 			case deployment.LARGE:
 				schedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeLARGE
+			case deployment.EXTRA_LARGE:
+				schedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 
 			if deploymentFromFile.Deployment.Configuration.DefaultTaskPodMemory == "" {
@@ -553,6 +559,8 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				schedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeMEDIUM
 			case deployment.LARGE:
 				schedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeLARGE
+			case deployment.EXTRA_LARGE:
+				schedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 			if deploymentFromFile.Deployment.Configuration.DefaultTaskPodCPU == "" {
 				deploymentFromFile.Deployment.Configuration.DefaultTaskPodCPU = *existingDeployment.DefaultTaskPodCpu

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -327,13 +327,13 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 
 			var schedulerSize astroplatformcore.CreateStandardDeploymentRequestSchedulerSize
 			switch strings.ToUpper(deploymentFromFile.Deployment.Configuration.SchedulerSize) {
-			case deployment.SMALL:
+			case string(astrocore.CreateStandardDeploymentRequestSchedulerSizeSMALL):
 				schedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeSMALL
-			case deployment.MEDIUM:
+			case string(astrocore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM):
 				schedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM
-			case deployment.LARGE:
+			case string(astrocore.CreateStandardDeploymentRequestSchedulerSizeLARGE):
 				schedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeLARGE
-			case deployment.EXTRA_LARGE:
+			case string(astrocore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE):
 				schedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 
@@ -381,13 +381,13 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 
 			var schedulerSize astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSize
 			switch strings.ToUpper(deploymentFromFile.Deployment.Configuration.SchedulerSize) {
-			case deployment.SMALL:
+			case string(astrocore.CreateDedicatedDeploymentRequestSchedulerSizeSMALL):
 				schedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeSMALL
-			case deployment.MEDIUM:
+			case string(astrocore.CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM):
 				schedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM
-			case deployment.LARGE:
+			case string(astrocore.CreateDedicatedDeploymentRequestSchedulerSizeLARGE):
 				schedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeLARGE
-			case deployment.EXTRA_LARGE:
+			case string(astrocore.CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE):
 				schedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 
@@ -488,13 +488,13 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 
 			var schedulerSize astroplatformcore.UpdateStandardDeploymentRequestSchedulerSize
 			switch strings.ToUpper(deploymentFromFile.Deployment.Configuration.SchedulerSize) {
-			case deployment.SMALL:
+			case string(astrocore.CreateStandardDeploymentRequestSchedulerSizeSMALL):
 				schedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeSMALL
-			case deployment.MEDIUM:
+			case string(astrocore.CreateStandardDeploymentRequestSchedulerSizeMEDIUM):
 				schedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeMEDIUM
-			case deployment.LARGE:
+			case string(astrocore.CreateStandardDeploymentRequestSchedulerSizeLARGE):
 				schedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeLARGE
-			case deployment.EXTRA_LARGE:
+			case string(astrocore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE):
 				schedulerSize = astroplatformcore.UpdateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 
@@ -553,13 +553,13 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 
 			var schedulerSize astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSize
 			switch strings.ToUpper(deploymentFromFile.Deployment.Configuration.SchedulerSize) {
-			case deployment.SMALL:
+			case string(astrocore.CreateDedicatedDeploymentRequestSchedulerSizeSMALL):
 				schedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeSMALL
-			case deployment.MEDIUM:
+			case string(astrocore.CreateDedicatedDeploymentRequestSchedulerSizeMEDIUM):
 				schedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeMEDIUM
-			case deployment.LARGE:
+			case string(astrocore.CreateDedicatedDeploymentRequestSchedulerSizeLARGE):
 				schedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeLARGE
-			case deployment.EXTRA_LARGE:
+			case string(astrocore.CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE):
 				schedulerSize = astroplatformcore.UpdateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 			if deploymentFromFile.Deployment.Configuration.DefaultTaskPodCPU == "" {

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -408,7 +408,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 		cmd.Flags().StringVarP(&resourceQuotaMemory, "resource-quota-memory", "", "", "The Deployment's memory resource quota. Example value: 20Gi")
 		cmd.Flags().StringVarP(&cloudProvider, "cloud-provider", "p", "gcp", "The Cloud Provider to use for the Deployment. Possible values can be gcp, aws.")
 		cmd.Flags().StringVarP(&region, "region", "", "", "The Cloud Provider region to use for the Deployment.")
-		cmd.Flags().StringVarP(&schedulerSize, "scheduler-size", "", "", "The size of scheduler for the Deployment. Possible values can be small, medium, large")
+		cmd.Flags().StringVarP(&schedulerSize, "scheduler-size", "", "", "The size of scheduler for the Deployment. Possible values can be small, medium, large, extra_large")
 		cmd.Flags().StringVarP(&highAvailability, "high-availability", "a", "disable", "Enables High Availability for the Deployment")
 		cmd.Flags().StringVarP(&developmentMode, "development-mode", "m", "disable", "Set to 'enable' to enable development-only features such as hibernation. When enabled, the Deployment will not have guaranteed uptime SLAs.'")
 	} else {
@@ -446,7 +446,7 @@ func newDeploymentUpdateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "", "Enables DAG-only deploys for the deployment")
 	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "c", false, "clean output to only include inspect yaml or json file in any situation.")
 	if organization.IsOrgHosted() {
-		cmd.Flags().StringVarP(&schedulerSize, "scheduler-size", "", "", "The size of Scheduler for the Deployment. Possible values can be small, medium, large")
+		cmd.Flags().StringVarP(&schedulerSize, "scheduler-size", "", "", "The size of Scheduler for the Deployment. Possible values can be small, medium, large, extra_large")
 		cmd.Flags().StringVarP(&highAvailability, "high-availability", "a", "", "Enables High Availability for the Deployment")
 		cmd.Flags().StringVarP(&defaultTaskPodCPU, "default-task-pod-cpu", "", "", "The Default Task Pod CPU to use for the Deployment. Example value: 0.25")
 		cmd.Flags().StringVarP(&defaultTaskPodMemory, "default-task-pod-memory", "", "", "The Default Taks Pod Memory to use for the Deployment. Example value: 0.5Gi")

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -121,6 +121,38 @@ var (
 			WorkerQueues:           &[]astroplatformcore.WorkerQueue{},
 		},
 	}
+	hostedDeploymentResponse = astroplatformcore.GetDeploymentResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &astroplatformcore.Deployment{
+			Id:                     "test-id-1",
+			RuntimeVersion:         "4.2.5",
+			Namespace:              "test-name",
+			WorkspaceId:            "workspace-id",
+			WebServerUrl:           "test-url",
+			IsDagDeployEnabled:     false,
+			Description:            &description,
+			Name:                   "test-deployment-label",
+			Status:                 "HEALTHY",
+			Type:                   &standardType,
+			ClusterId:              &csID,
+			ClusterName:            &testCluster,
+			Executor:               &executorCelery,
+			IsHighAvailability:     &highAvailabilityTest,
+			IsDevelopmentMode:      &developmentModeTest,
+			ResourceQuotaCpu:       &resourceQuotaCPU,
+			ResourceQuotaMemory:    &ResourceQuotaMemory,
+			SchedulerSize:          &schedulerTestSize,
+			Region:                 &region,
+			WorkspaceName:          &workspaceName,
+			CloudProvider:          (*astroplatformcore.DeploymentCloudProvider)(&cloudProvider),
+			DefaultTaskPodCpu:      &defaultTaskPodCPU,
+			DefaultTaskPodMemory:   &defaultTaskPodMemory,
+			WebServerAirflowApiUrl: "airflow-url",
+			WorkerQueues:           &[]astroplatformcore.WorkerQueue{},
+		},
+	}
 	mockListDeploymentsResponse = astroplatformcore.ListDeploymentsResponse{
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
@@ -933,8 +965,7 @@ deployment:
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseAlphaOK, nil).Times(1)
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&hostedDeploymentResponse, nil).Times(1)
 
 		cmdArgs := []string{"update", "test-id-1", "--name", "test-name", "--workspace-id", ws, "--scheduler-size", "small", "--force"}
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -998,8 +1029,7 @@ deployment:
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseAlphaOK, nil).Times(1)
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&hostedDeploymentResponse, nil).Times(1)
 
 		cmdArgs := []string{"update", "test-id-1", "--name", "test-name", "--workspace-id", ws, "--scheduler-size", "extra_large", "--force"}
 		_, err = execDeploymentCmd(cmdArgs...)
@@ -1183,7 +1213,7 @@ func TestDeploymentHibernateAndWakeUp(t *testing.T) {
 			}
 
 			mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
-			mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+			mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&hostedDeploymentResponse, nil).Once()
 			mockPlatformCoreClient.On("UpdateDeploymentHibernationOverrideWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockResponse, nil).Once()
 
 			defer testUtil.MockUserInput(t, "1")()
@@ -1214,7 +1244,7 @@ func TestDeploymentHibernateAndWakeUp(t *testing.T) {
 			}
 
 			mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
-			mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+			mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&hostedDeploymentResponse, nil).Once()
 			mockPlatformCoreClient.On("UpdateDeploymentHibernationOverrideWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockResponse, nil).Once()
 
 			cmdArgs := []string{tt.command, "test-id-1", "--until", until, "--force"}
@@ -1252,7 +1282,7 @@ func TestDeploymentHibernateAndWakeUp(t *testing.T) {
 			}
 
 			mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
-			mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+			mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&hostedDeploymentResponse, nil).Once()
 			mockPlatformCoreClient.On("UpdateDeploymentHibernationOverrideWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockResponse, nil).Once()
 
 			cmdArgs := []string{tt.command, "test-id-1", "--for", forDuration, "--force"}
@@ -1280,7 +1310,7 @@ func TestDeploymentHibernateAndWakeUp(t *testing.T) {
 			}
 
 			mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
-			mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+			mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&hostedDeploymentResponse, nil).Once()
 			mockPlatformCoreClient.On("DeleteDeploymentHibernationOverrideWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockResponse, nil).Once()
 
 			cmdArgs := []string{tt.command, "test-id-1", "--remove-override", "--force"}

--- a/go.mod
+++ b/go.mod
@@ -308,7 +308,7 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.22.5 // indirect
 	k8s.io/client-go v0.22.5 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect


### PR DESCRIPTION
## Description

This PR contains changes to allow the user to pass `extra_large` as a scheduler size option when creating/updating Hosted deployments either via CLI command or via YAML file

## 🎟 Issue(s)

Related #22568

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

Tested Extra Large deployment creation and update via CLI command and via YAML file, attached screenshot for reference

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

<img width="1337" alt="Screenshot 2024-07-31 at 4 15 16 PM" src="https://github.com/user-attachments/assets/9528cf8f-255f-4fcf-9c7d-ed29fa82b44f">
<img width="1359" alt="Screenshot 2024-07-31 at 4 18 50 PM" src="https://github.com/user-attachments/assets/73a84097-7537-4772-a25e-a047e75579d6">
<img width="950" alt="Screenshot 2024-07-31 at 4 20 29 PM" src="https://github.com/user-attachments/assets/1a208ca9-f8be-408c-a52e-ea2aedcc178a">
<img width="1028" alt="Screenshot 2024-07-31 at 4 22 43 PM" src="https://github.com/user-attachments/assets/bdf54888-319f-4e5b-b7c5-7de5206aaca1">
<img width="838" alt="Screenshot 2024-07-31 at 4 23 53 PM" src="https://github.com/user-attachments/assets/9118d286-1c71-4bb2-b99c-47be127b5956">


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
