### PR TITLE
Run approval & new tag jobs only after lint & test are passing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ workflows:
       - lint
       - test
       - approve-release:
+          requires:
+            - lint
+            - test
           type: approval
           filters:
             branches:


### PR DESCRIPTION
## Description

Fix the order of jobs in CI when creating a new release. One can approve and build the release even if linting or unit tests are failing. This PR fixes that to block the release workflow if lint/test jobs are failing

Existing Workflow:
<img width="799" alt="image" src="https://github.com/user-attachments/assets/8540f9dd-8e25-4570-b255-971088dfeb7c">


## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
