### PR TITLE
Fix error output

### DIFF
--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -44,7 +44,7 @@ func GetCurrentWorkspace() (string, error) {
 	}
 
 	if c.Workspace == "" {
-		return "", errors.New("current workspace context not set, you can switch to a workspace with \n\astro workspace switch WORKSPACEID")
+		return "", errors.New("current workspace context not set, you can switch to a workspace with \n\tastro workspace switch WORKSPACEID")
 	}
 
 	return c.Workspace, nil

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -256,7 +256,7 @@ func (s *Suite) TestGetCurrentWorkspace() {
 	s.NoError(err)
 
 	_, err = GetCurrentWorkspace()
-	s.EqualError(err, "current workspace context not set, you can switch to a workspace with \n\astro workspace switch WORKSPACEID")
+	s.EqualError(err, "current workspace context not set, you can switch to a workspace with \n\tastro workspace switch WORKSPACEID")
 
 	config.ResetCurrentContext()
 	_, err = GetCurrentWorkspace()


### PR DESCRIPTION
Fixes the following output where the `a` in the output is accidentally escaped:

![image](https://github.com/user-attachments/assets/4e648d17-bc25-473a-b6c4-f6feb6d3ec87)
