### PR TITLE
Add workload identity to hosted deployment

### DIFF
--- a/astro-client-core/api.gen.go
+++ b/astro-client-core/api.gen.go
@@ -50,10 +50,11 @@ const (
 
 // Defines values for ClusterCohort.
 const (
-	ClusterCohortCRITICAL ClusterCohort = "CRITICAL"
-	ClusterCohortDEFAULT  ClusterCohort = "DEFAULT"
-	ClusterCohortINTERNAL ClusterCohort = "INTERNAL"
-	ClusterCohortSTABLE   ClusterCohort = "STABLE"
+	ClusterCohortCRITICAL   ClusterCohort = "CRITICAL"
+	ClusterCohortDEFAULT    ClusterCohort = "DEFAULT"
+	ClusterCohortINTERNAL   ClusterCohort = "INTERNAL"
+	ClusterCohortPREDEFAULT ClusterCohort = "PRE_DEFAULT"
+	ClusterCohortSTABLE     ClusterCohort = "STABLE"
 )
 
 // Defines values for ClusterStatus.
@@ -87,10 +88,11 @@ const (
 
 // Defines values for ClusterDetailedCohort.
 const (
-	ClusterDetailedCohortCRITICAL ClusterDetailedCohort = "CRITICAL"
-	ClusterDetailedCohortDEFAULT  ClusterDetailedCohort = "DEFAULT"
-	ClusterDetailedCohortINTERNAL ClusterDetailedCohort = "INTERNAL"
-	ClusterDetailedCohortSTABLE   ClusterDetailedCohort = "STABLE"
+	ClusterDetailedCohortCRITICAL   ClusterDetailedCohort = "CRITICAL"
+	ClusterDetailedCohortDEFAULT    ClusterDetailedCohort = "DEFAULT"
+	ClusterDetailedCohortINTERNAL   ClusterDetailedCohort = "INTERNAL"
+	ClusterDetailedCohortPREDEFAULT ClusterDetailedCohort = "PRE_DEFAULT"
+	ClusterDetailedCohortSTABLE     ClusterDetailedCohort = "STABLE"
 )
 
 // Defines values for ClusterDetailedStatus.
@@ -544,10 +546,11 @@ const (
 
 // Defines values for SharedClusterCohort.
 const (
-	SharedClusterCohortCRITICAL SharedClusterCohort = "CRITICAL"
-	SharedClusterCohortDEFAULT  SharedClusterCohort = "DEFAULT"
-	SharedClusterCohortINTERNAL SharedClusterCohort = "INTERNAL"
-	SharedClusterCohortSTABLE   SharedClusterCohort = "STABLE"
+	SharedClusterCohortCRITICAL   SharedClusterCohort = "CRITICAL"
+	SharedClusterCohortDEFAULT    SharedClusterCohort = "DEFAULT"
+	SharedClusterCohortINTERNAL   SharedClusterCohort = "INTERNAL"
+	SharedClusterCohortPREDEFAULT SharedClusterCohort = "PRE_DEFAULT"
+	SharedClusterCohortSTABLE     SharedClusterCohort = "STABLE"
 )
 
 // Defines values for SharedClusterStatus.
@@ -1243,6 +1246,7 @@ type Bundle struct {
 type Cluster struct {
 	AppliedHarmonyVersion  *string              `json:"appliedHarmonyVersion,omitempty"`
 	AppliedTemplateVersion string               `json:"appliedTemplateVersion"`
+	BlockInternetAccess    *bool                `json:"blockInternetAccess,omitempty"`
 	CloudProvider          ClusterCloudProvider `json:"cloudProvider"`
 	Cohort                 *ClusterCohort       `json:"cohort,omitempty"`
 	CreatedAt              time.Time            `json:"createdAt"`
@@ -1293,6 +1297,7 @@ type ClusterType string
 type ClusterDetailed struct {
 	AppliedHarmonyVersion         *string                      `json:"appliedHarmonyVersion,omitempty"`
 	AppliedTemplateVersion        string                       `json:"appliedTemplateVersion"`
+	BlockInternetAccess           *bool                        `json:"blockInternetAccess,omitempty"`
 	CloudProvider                 ClusterDetailedCloudProvider `json:"cloudProvider"`
 	Cohort                        *ClusterDetailedCohort       `json:"cohort,omitempty"`
 	CreatedAt                     time.Time                    `json:"createdAt"`
@@ -1461,6 +1466,7 @@ type ConnectionAuthTypeParameter struct {
 
 // CreateAwsClusterRequest defines model for CreateAwsClusterRequest.
 type CreateAwsClusterRequest struct {
+	BlockInternetAccess           *bool                       `json:"blockInternetAccess,omitempty"`
 	DbInstanceType                string                      `json:"dbInstanceType"`
 	DisableHarmonyVersionUpgrades *bool                       `json:"disableHarmonyVersionUpgrades,omitempty"`
 	HarmonyVersion                *string                     `json:"harmonyVersion,omitempty"`
@@ -1480,6 +1486,7 @@ type CreateAwsClusterRequestType string
 
 // CreateAzureClusterRequest defines model for CreateAzureClusterRequest.
 type CreateAzureClusterRequest struct {
+	BlockInternetAccess           *bool                         `json:"blockInternetAccess,omitempty"`
 	DbInstanceType                string                        `json:"dbInstanceType"`
 	DisableHarmonyVersionUpgrades *bool                         `json:"disableHarmonyVersionUpgrades,omitempty"`
 	HarmonyVersion                *string                       `json:"harmonyVersion,omitempty"`
@@ -1753,6 +1760,7 @@ type CreateEnvironmentObjectRequestScope string
 
 // CreateGcpClusterRequest defines model for CreateGcpClusterRequest.
 type CreateGcpClusterRequest struct {
+	BlockInternetAccess           *bool                       `json:"blockInternetAccess,omitempty"`
 	DbInstanceType                string                      `json:"dbInstanceType"`
 	DisableHarmonyVersionUpgrades *bool                       `json:"disableHarmonyVersionUpgrades,omitempty"`
 	HarmonyVersion                *string                     `json:"harmonyVersion,omitempty"`
@@ -2968,6 +2976,7 @@ type SelfSignupType string
 
 // SharedCluster defines model for SharedCluster.
 type SharedCluster struct {
+	BlockInternetAccess *bool                      `json:"blockInternetAccess,omitempty"`
 	CloudProvider       SharedClusterCloudProvider `json:"cloudProvider"`
 	Cohort              *SharedClusterCohort       `json:"cohort,omitempty"`
 	CreatedAt           time.Time                  `json:"createdAt"`
@@ -3095,6 +3104,7 @@ type TriggerGitDeployRequestDeployType string
 
 // UpdateAwsClusterRequest defines model for UpdateAwsClusterRequest.
 type UpdateAwsClusterRequest struct {
+	BlockInternetAccess           *bool                   `json:"blockInternetAccess,omitempty"`
 	DbInstanceType                string                  `json:"dbInstanceType"`
 	DbInstanceVersion             *string                 `json:"dbInstanceVersion,omitempty"`
 	DisableHarmonyVersionUpgrades *bool                   `json:"disableHarmonyVersionUpgrades,omitempty"`
@@ -3107,6 +3117,7 @@ type UpdateAwsClusterRequest struct {
 
 // UpdateAzureClusterRequest defines model for UpdateAzureClusterRequest.
 type UpdateAzureClusterRequest struct {
+	BlockInternetAccess           *bool                   `json:"blockInternetAccess,omitempty"`
 	DbInstanceType                string                  `json:"dbInstanceType"`
 	DbInstanceVersion             *string                 `json:"dbInstanceVersion,omitempty"`
 	DisableHarmonyVersionUpgrades *bool                   `json:"disableHarmonyVersionUpgrades,omitempty"`
@@ -3245,6 +3256,7 @@ type UpdateEnvironmentObjectRequestScope string
 
 // UpdateGcpClusterRequest defines model for UpdateGcpClusterRequest.
 type UpdateGcpClusterRequest struct {
+	BlockInternetAccess           *bool                   `json:"blockInternetAccess,omitempty"`
 	DbInstanceType                string                  `json:"dbInstanceType"`
 	DbInstanceVersion             *string                 `json:"dbInstanceVersion,omitempty"`
 	DisableHarmonyVersionUpgrades *bool                   `json:"disableHarmonyVersionUpgrades,omitempty"`

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -134,6 +134,7 @@ func List(ws string, fromAllWorkspaces bool, platformCoreClient astroplatformcor
 	return nil
 }
 
+// TODO (https://github.com/astronomer/astro-cli/issues/1709): move these input arguments to a struct, and drop the nolint
 func Logs(deploymentID, ws, deploymentName, keyword string, logWebserver, logScheduler, logTriggerer, logWorkers, warnLogs, errorLogs, infoLogs bool, logCount int, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
 	var logLevel string
 	var i int
@@ -211,7 +212,7 @@ func Logs(deploymentID, ws, deploymentName, keyword string, logWebserver, logSch
 	return nil
 }
 
-// TODO: move these input arguments to a struct, and drop the nolint
+// TODO (https://github.com/astronomer/astro-cli/issues/1709): move these input arguments to a struct, and drop the nolint
 func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy, executor, cloudProvider, region, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string, deploymentType astroplatformcore.DeploymentType, schedulerAU, schedulerReplicas int, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, waitForStatus bool) error { //nolint
 	var organizationID string
 	var currentWorkspace astrocore.Workspace
@@ -744,7 +745,7 @@ func HealthPoll(deploymentID, ws string, sleepTime, tickNum, timeoutNum int, pla
 	}
 }
 
-// TODO: move these input arguments to a struct, and drop the nolint
+// TODO (https://github.com/astronomer/astro-cli/issues/1709): move these input arguments to a struct, and drop the nolint
 func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string, schedulerAU, schedulerReplicas int, wQueueList []astroplatformcore.WorkerQueueRequest, hybridQueueList []astroplatformcore.HybridWorkerQueueRequest, newEnvironmentVariables []astroplatformcore.DeploymentEnvironmentVariableRequest, force bool, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient) error { //nolint
 	var queueCreateUpdate, confirmWithUser bool
 	// get deployment

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -211,7 +211,7 @@ func Logs(deploymentID, ws, deploymentName, keyword string, logWebserver, logSch
 	return nil
 }
 
-// TODO: move these input arguements to a struct, and drop the nolint
+// TODO: move these input arguments to a struct, and drop the nolint
 func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy, executor, cloudProvider, region, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string, deploymentType astroplatformcore.DeploymentType, schedulerAU, schedulerReplicas int, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, waitForStatus bool) error { //nolint
 	var organizationID string
 	var currentWorkspace astrocore.Workspace
@@ -744,7 +744,7 @@ func HealthPoll(deploymentID, ws string, sleepTime, tickNum, timeoutNum int, pla
 	}
 }
 
-// TODO: move these input arguements to a struct, and drop the nolint
+// TODO: move these input arguments to a struct, and drop the nolint
 func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string, schedulerAU, schedulerReplicas int, wQueueList []astroplatformcore.WorkerQueueRequest, hybridQueueList []astroplatformcore.HybridWorkerQueueRequest, newEnvironmentVariables []astroplatformcore.DeploymentEnvironmentVariableRequest, force bool, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient) error { //nolint
 	var queueCreateUpdate, confirmWithUser bool
 	// get deployment

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1895,7 +1895,7 @@ func (s *Suite) TestUpdate() { //nolint
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
 
-		// Call the Create function with a non-empty workload ID
+		// Call the Update function with a non-empty workload ID
 		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "small", "enable", "", "disable", "", "", "", "", mockWorkloadIdentity, 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, true, mockCoreClient, mockPlatformCoreClient)
 		s.NoError(err)
 	})

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -337,6 +337,11 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				schedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 
+			var deplWorkloadIdentity *string
+			if deploymentFromFile.Deployment.Configuration.WorkloadIdentity != "" {
+				deplWorkloadIdentity = &deploymentFromFile.Deployment.Configuration.WorkloadIdentity
+			}
+
 			standardDeploymentRequest := astroplatformcore.CreateStandardDeploymentRequest{
 				AstroRuntimeVersion:  deploymentFromFile.Deployment.Configuration.RunTimeVersion,
 				CloudProvider:        &requestedCloudProvider,
@@ -356,6 +361,7 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				ResourceQuotaMemory:  deploymentFromFile.Deployment.Configuration.ResourceQuotaMemory,
 				WorkerQueues:         &listQueuesRequest,
 				SchedulerSize:        schedulerSize,
+				WorkloadIdentity:     deplWorkloadIdentity,
 			}
 			if standardDeploymentRequest.IsDevelopmentMode != nil && *standardDeploymentRequest.IsDevelopmentMode {
 				hibernationSchedules := ToDeploymentHibernationSchedules(deploymentFromFile.Deployment.HibernationSchedules)
@@ -391,6 +397,11 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				schedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			}
 
+			var deplWorkloadIdentity *string
+			if deploymentFromFile.Deployment.Configuration.WorkloadIdentity != "" {
+				deplWorkloadIdentity = &deploymentFromFile.Deployment.Configuration.WorkloadIdentity
+			}
+
 			dedicatedDeploymentRequest := astroplatformcore.CreateDedicatedDeploymentRequest{
 				AstroRuntimeVersion:  deploymentFromFile.Deployment.Configuration.RunTimeVersion,
 				Description:          &deploymentFromFile.Deployment.Configuration.Description,
@@ -409,6 +420,7 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				ResourceQuotaMemory:  deploymentFromFile.Deployment.Configuration.ResourceQuotaMemory,
 				WorkerQueues:         &listQueuesRequest,
 				SchedulerSize:        schedulerSize,
+				WorkloadIdentity:     deplWorkloadIdentity,
 			}
 			if dedicatedDeploymentRequest.IsDevelopmentMode != nil && *dedicatedDeploymentRequest.IsDevelopmentMode {
 				hibernationSchedules := ToDeploymentHibernationSchedules(deploymentFromFile.Deployment.HibernationSchedules)
@@ -511,6 +523,11 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				deploymentFromFile.Deployment.Configuration.ResourceQuotaMemory = *existingDeployment.ResourceQuotaMemory
 			}
 
+			var deplWorkloadIdentity *string
+			if deploymentFromFile.Deployment.Configuration.WorkloadIdentity != "" {
+				deplWorkloadIdentity = &deploymentFromFile.Deployment.Configuration.WorkloadIdentity
+			}
+
 			standardDeploymentRequest := astroplatformcore.UpdateStandardDeploymentRequest{
 				Description:          &deploymentFromFile.Deployment.Configuration.Description,
 				Name:                 deploymentFromFile.Deployment.Configuration.Name,
@@ -528,6 +545,7 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				SchedulerSize:        schedulerSize,
 				ContactEmails:        &deploymentFromFile.Deployment.AlertEmails,
 				EnvironmentVariables: envVars,
+				WorkloadIdentity:     deplWorkloadIdentity,
 			}
 			if existingDeployment.IsDevelopmentMode != nil && *existingDeployment.IsDevelopmentMode {
 				hibernationSchedules := ToDeploymentHibernationSchedules(deploymentFromFile.Deployment.HibernationSchedules)
@@ -575,6 +593,11 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				deploymentFromFile.Deployment.Configuration.ResourceQuotaMemory = *existingDeployment.ResourceQuotaMemory
 			}
 
+			var deplWorkloadIdentity *string
+			if deploymentFromFile.Deployment.Configuration.WorkloadIdentity != "" {
+				deplWorkloadIdentity = &deploymentFromFile.Deployment.Configuration.WorkloadIdentity
+			}
+
 			dedicatedDeploymentRequest := astroplatformcore.UpdateDedicatedDeploymentRequest{
 				Description:          &deploymentFromFile.Deployment.Configuration.Description,
 				Name:                 deploymentFromFile.Deployment.Configuration.Name,
@@ -592,6 +615,7 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				SchedulerSize:        schedulerSize,
 				ContactEmails:        &deploymentFromFile.Deployment.AlertEmails,
 				EnvironmentVariables: envVars,
+				WorkloadIdentity:     deplWorkloadIdentity,
 			}
 			if existingDeployment.IsDevelopmentMode != nil && *existingDeployment.IsDevelopmentMode {
 				hibernationSchedules := ToDeploymentHibernationSchedules(deploymentFromFile.Deployment.HibernationSchedules)

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -1258,7 +1258,8 @@ deployment:
 			"deployment_type": "STANDARD",
 			"region": "test-region",
 			"cloud_provider": "aws",
-			"is_development_mode": true
+			"is_development_mode": true,
+			"workload_identity": "test-workload-identity"
         },
         "worker_queues": [
             {
@@ -1307,7 +1308,14 @@ deployment:
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(2)
-		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
+		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.MatchedBy(
+			func(input astroplatformcore.CreateDeploymentRequest) bool {
+				request, err := input.AsCreateStandardDeploymentRequest()
+				s.NoError(err)
+				return request.WorkloadIdentity != nil && *request.WorkloadIdentity == "test-workload-identity" &&
+					request.Type == astroplatformcore.CreateStandardDeploymentRequestTypeSTANDARD
+			},
+		)).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out)
@@ -1767,6 +1775,7 @@ deployment:
     scheduler_size: medium
     workspace_name: test-workspace
     deployment_type: STANDARD
+    workload_identity: test-workload-identity
   worker_queues:
     - name: default
       is_default: true
@@ -1809,7 +1818,14 @@ deployment:
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(3)
-		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
+		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(
+			func(input astroplatformcore.UpdateDeploymentRequest) bool {
+				request, err := input.AsUpdateStandardDeploymentRequest()
+				s.NoError(err)
+				return request.WorkloadIdentity != nil && *request.WorkloadIdentity == "test-workload-identity" &&
+					request.Type == astroplatformcore.UpdateStandardDeploymentRequestTypeSTANDARD
+			},
+		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 
 		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out)
@@ -1853,6 +1869,7 @@ deployment:
     scheduler_size: medium
     workspace_name: test-workspace
     deployment_type: DEDICATED
+    workload_identity: test-workload-identity
   worker_queues:
     - name: default
       is_default: true
@@ -1885,7 +1902,14 @@ deployment:
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(3)
-		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
+		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(
+			func(input astroplatformcore.UpdateDeploymentRequest) bool {
+				request, err := input.AsUpdateDedicatedDeploymentRequest()
+				s.NoError(err)
+				return request.WorkloadIdentity != nil && *request.WorkloadIdentity == "test-workload-identity" &&
+					request.Type == astroplatformcore.UpdateDedicatedDeploymentRequestTypeDEDICATED
+			},
+		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -272,9 +272,6 @@ func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, pl
 	if coreDeployment.Region != nil {
 		deploymentMap["region"] = *coreDeployment.Region
 	}
-	if coreDeployment.WorkloadIdentity != nil {
-		deploymentMap["workload_identity"] = *coreDeployment.WorkloadIdentity
-	}
 	return deploymentMap, nil
 }
 

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -272,7 +272,9 @@ func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, pl
 	if coreDeployment.Region != nil {
 		deploymentMap["region"] = *coreDeployment.Region
 	}
-
+	if coreDeployment.WorkloadIdentity != nil {
+		deploymentMap["workload_identity"] = *coreDeployment.WorkloadIdentity
+	}
 	return deploymentMap, nil
 }
 

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -458,17 +458,10 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 func TestGetDeploymentConfig(t *testing.T) {
 	t.Run("returns deployment config for the requested cloud deployment", func(t *testing.T) {
 		sourceDeployment.Type = &hybridType
+		sourceDeployment.WorkloadIdentity = &workloadIdentity
 		cloudProvider := astroplatformcore.DeploymentCloudProviderAWS
 		sourceDeployment.CloudProvider = &cloudProvider
 		var actualDeploymentConfig deploymentConfig
-		sourceDeployment.WorkloadIdentity = &workloadIdentity
-
-		// TODO: use test suite and have setup and teardown functions to make the tests stateless
-		defer func() {
-			// clear workload identity
-			sourceDeployment.WorkloadIdentity = nil
-		}()
-
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		expectedDeploymentConfig := deploymentConfig{
 			Name:              sourceDeployment.Name,
@@ -484,13 +477,15 @@ func TestGetDeploymentConfig(t *testing.T) {
 			DeploymentType:    string(*sourceDeployment.Type),
 			CloudProvider:     string(*sourceDeployment.CloudProvider),
 			IsDevelopmentMode: *sourceDeployment.IsDevelopmentMode,
-			WorkloadIdentity:  workloadIdentity,
 		}
 		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		err = decodeToStruct(rawDeploymentConfig, &actualDeploymentConfig)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedDeploymentConfig, actualDeploymentConfig)
+
+		// clear workload identity
+		sourceDeployment.WorkloadIdentity = nil
 	})
 
 	t.Run("returns deployment config for the requested cloud standard deployment", func(t *testing.T) {

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -458,10 +458,17 @@ func TestGetDeploymentInspectInfo(t *testing.T) {
 func TestGetDeploymentConfig(t *testing.T) {
 	t.Run("returns deployment config for the requested cloud deployment", func(t *testing.T) {
 		sourceDeployment.Type = &hybridType
-		sourceDeployment.WorkloadIdentity = &workloadIdentity
 		cloudProvider := astroplatformcore.DeploymentCloudProviderAWS
 		sourceDeployment.CloudProvider = &cloudProvider
 		var actualDeploymentConfig deploymentConfig
+		sourceDeployment.WorkloadIdentity = &workloadIdentity
+
+		// TODO: use test suite and have setup and teardown functions to make the tests stateless
+		defer func() {
+			// clear workload identity
+			sourceDeployment.WorkloadIdentity = nil
+		}()
+
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		expectedDeploymentConfig := deploymentConfig{
 			Name:              sourceDeployment.Name,
@@ -477,15 +484,13 @@ func TestGetDeploymentConfig(t *testing.T) {
 			DeploymentType:    string(*sourceDeployment.Type),
 			CloudProvider:     string(*sourceDeployment.CloudProvider),
 			IsDevelopmentMode: *sourceDeployment.IsDevelopmentMode,
+			WorkloadIdentity:  workloadIdentity,
 		}
 		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
 		assert.NoError(t, err)
 		err = decodeToStruct(rawDeploymentConfig, &actualDeploymentConfig)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedDeploymentConfig, actualDeploymentConfig)
-
-		// clear workload identity
-		sourceDeployment.WorkloadIdentity = nil
 	})
 
 	t.Run("returns deployment config for the requested cloud standard deployment", func(t *testing.T) {

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -395,6 +395,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&inputFile, "deployment-file", "", "", "Location of file containing the Deployment to create. File can be in either JSON or YAML format.")
 	cmd.Flags().BoolVarP(&waitForStatus, "wait", "i", false, "Wait for the Deployment to become healthy before ending the command")
 	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "", false, "clean output to only include inspect yaml or json file in any situation.")
+	cmd.Flags().StringVarP(&workloadIdentity, "workload-identity", "", "", "The Workload Identity to use for the Deployment")
 	if organization.IsOrgHosted() {
 		cmd.Flags().StringVarP(&deploymentType, "cluster-type", "", standard, "The Cluster Type to use for the Deployment. Possible values can be standard or dedicated. This flag has been deprecated for the --type flag.")
 		err := cmd.Flags().MarkDeprecated("cluster-type", "use --type instead")
@@ -414,7 +415,6 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	} else {
 		cmd.Flags().IntVarP(&schedulerAU, "scheduler-au", "s", 0, "The Deployment's scheduler resources in AUs")
 		cmd.Flags().IntVarP(&schedulerReplicas, "scheduler-replicas", "r", 0, "The number of scheduler replicas for the Deployment")
-		cmd.Flags().StringVarP(&workloadIdentity, "workload-identity", "", "", "The Workload Identity to use for the Deployment")
 	}
 	cmd.Flags().StringVarP(&clusterID, "cluster-id", "c", "", "Cluster to create the Deployment in")
 	return cmd
@@ -445,6 +445,7 @@ func newDeploymentUpdateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment to update")
 	cmd.Flags().StringVarP(&dagDeploy, "dag-deploy", "", "", "Enables DAG-only deploys for the deployment")
 	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "c", false, "clean output to only include inspect yaml or json file in any situation.")
+	cmd.Flags().StringVarP(&workloadIdentity, "workload-identity", "", "", "The Workload Identity to use for the Deployment")
 	if organization.IsOrgHosted() {
 		cmd.Flags().StringVarP(&schedulerSize, "scheduler-size", "", "", "The size of Scheduler for the Deployment. Possible values can be small, medium, large, extra_large")
 		cmd.Flags().StringVarP(&highAvailability, "high-availability", "a", "", "Enables High Availability for the Deployment")
@@ -456,7 +457,6 @@ func newDeploymentUpdateCmd(out io.Writer) *cobra.Command {
 	} else {
 		cmd.Flags().IntVarP(&updateSchedulerAU, "scheduler-au", "s", 0, "The Deployment's Scheduler resources in AUs.")
 		cmd.Flags().IntVarP(&updateSchedulerReplicas, "scheduler-replicas", "r", 0, "The number of Scheduler replicas for the Deployment.")
-		cmd.Flags().StringVarP(&workloadIdentity, "workload-identity", "", "", "The Workload Identity to use for the Deployment")
 	}
 	return cmd
 }


### PR DESCRIPTION
## Description
Changes:
- Add workload identity flag for `astro deployment create` and `astro deployment update` commands for dedicated and standard deployments
- Add workload identity field in the file-based deployment operation, i.e. `astro deployment --deployment-file` for dedicated and standard deployments
- Fix update deployment unit tests to make it stateless, until now a lot of state is shared/global, which makes adding any new unit test extremely tedious.

## 🎟 Issue(s)

Related #1704

## 🧪 Functional Testing

- `astro deployment create` case with workload identity flag
<img width="1736" alt="Screenshot 2024-08-23 at 7 42 23 PM" src="https://github.com/user-attachments/assets/5b89f798-9eec-4051-a103-cce3d2805535">
<img width="2067" alt="Screenshot 2024-08-23 at 7 41 21 PM" src="https://github.com/user-attachments/assets/76214af5-9743-41c7-b653-928387e64b7c">

- `astro deployment update` case with workload identity flag
<img width="1726" alt="Screenshot 2024-08-23 at 7 42 29 PM" src="https://github.com/user-attachments/assets/32881553-01ea-47ea-893e-a1a5e0f27711">
<img width="2064" alt="Screenshot 2024-08-23 at 7 41 40 PM" src="https://github.com/user-attachments/assets/f7ba8444-43e8-4ca8-afec-f88cf135669a">

- `astro deployment` case for deployments running on azure/gcp 
<img width="1396" alt="Screenshot 2024-08-23 at 7 42 36 PM" src="https://github.com/user-attachments/assets/43dd8ede-5d6f-4242-beda-b1d03651b37e">
<img width="1427" alt="Screenshot 2024-08-23 at 7 43 22 PM" src="https://github.com/user-attachments/assets/7f3e9dd9-37d2-4099-aa1b-008a0fc21340">

- `astro deployment create` case using a deployment yaml file
<img width="1010" alt="Screenshot 2024-08-23 at 8 12 22 PM" src="https://github.com/user-attachments/assets/058e0328-a73d-4780-a34a-aa6a517f3e5c">
<img width="2061" alt="Screenshot 2024-08-23 at 8 13 28 PM" src="https://github.com/user-attachments/assets/7cc6225c-3404-4962-a958-52e116f9a768">

- `astro deployment update` case using a deployment yaml file
<img width="1018" alt="Screenshot 2024-08-23 at 8 11 25 PM" src="https://github.com/user-attachments/assets/cedcc1a7-60c7-4044-b8be-049418ccb8b9">
<img width="2069" alt="Screenshot 2024-08-23 at 8 11 35 PM" src="https://github.com/user-attachments/assets/81bf9225-77b0-4f8d-abb0-43552129fb69">

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
