### PR TITLE
update description on dag server

### DIFF
--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -91,17 +91,6 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Fetch the description flag value from the command flags
-	desc, err := cmd.Flags().GetString("description")
-	if err != nil {
-		return err
-	}
-
-	// If the description is not set, use GetDefaultDeployDescription to get the default
-	if desc == "" {
-		desc = utils.GetDefaultDeployDescription(cmd, args)
-	}
-
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
@@ -129,7 +118,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true, desc)
+	err = DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true, description)
 	// Don't throw the error if dag-deploy itself is disabled
 	if errors.Is(err, deploy.ErrDagOnlyDeployDisabledInConfig) || errors.Is(err, deploy.ErrDagOnlyDeployNotEnabledForDeployment) {
 		return nil

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -91,6 +91,17 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Fetch the description flag value from the command flags
+	desc, err := cmd.Flags().GetString("description")
+	if err != nil {
+		return err
+	}
+
+	// If the description is not set, use GetDefaultDeployDescription to get the default
+	if desc == "" {
+		desc = utils.GetDefaultDeployDescription(cmd, args)
+	}
+	
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
@@ -104,18 +115,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if isDagOnlyDeploy {
-		return DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true)
-	}
-
-	// Fetch the description flag value from the command flags
-	desc, err := cmd.Flags().GetString("description")
-	if err != nil {
-		return err
-	}
-
-	// If the description is not set, use GetDefaultDeployDescription to get the default
-	if desc == "" {
-		desc = utils.GetDefaultDeployDescription(cmd, args)
+		return DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true, desc)
 	}
 
 	// Since we prompt the user to enter the deploymentID in come cases for DeployAirflowImage, reusing the same  deploymentID for DagsOnlyDeploy
@@ -124,7 +124,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true)
+	err = DagsOnlyDeploy(houstonClient, appConfig, ws, deploymentID, config.WorkingPath, nil, true, desc)
 	// Don't throw the error if dag-deploy itself is disabled
 	if errors.Is(err, deploy.ErrDagOnlyDeployDisabledInConfig) || errors.Is(err, deploy.ErrDagOnlyDeployNotEnabledForDeployment) {
 		return nil

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -101,7 +101,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 	if desc == "" {
 		desc = utils.GetDefaultDeployDescription(cmd, args)
 	}
-	
+
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -29,7 +29,7 @@ func (s *Suite) TestDeploy() {
 		return deploymentID, nil
 	}
 
-	DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
+	DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, desc string) error {
 		return nil
 	}
 
@@ -58,7 +58,7 @@ func (s *Suite) TestDeploy() {
 	})
 
 	s.Run("error should be returned for astro deploy, if dags deploy throws error and the feature is enabled", func() {
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, desc string) error {
 			return deploy.ErrNoWorkspaceID
 		}
 		err := execDeployCmd([]string{"-f"}...)
@@ -83,7 +83,7 @@ func (s *Suite) TestDeploy() {
 				BYORegistryEnabled: true,
 			},
 		}
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, desc string) error {
 			return deploy.ErrNoWorkspaceID
 		}
 		err := execDeployCmd([]string{"-f"}...)

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -34,7 +34,7 @@ func (s *Suite) TestDeploy() {
 		return deploymentID, nil
 	}
 
-	DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, desc string) error {
+	DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 		return nil
 	}
 
@@ -80,7 +80,7 @@ func (s *Suite) TestDeploy() {
 	})
 
 	s.Run("error should be returned for astro deploy, if dags deploy throws error and the feature is enabled", func() {
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, desc string) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 			return deploy.ErrNoWorkspaceID
 		}
 		err := execDeployCmd([]string{"-f"}...)
@@ -105,7 +105,7 @@ func (s *Suite) TestDeploy() {
 				BYORegistryEnabled: true,
 			},
 		}
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, desc string) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 			return deploy.ErrNoWorkspaceID
 		}
 		err := execDeployCmd([]string{"-f"}...)

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -335,12 +335,12 @@ func validateIfDagDeployURLCanBeConstructed(deploymentInfo *houston.Deployment) 
 	return nil
 }
 
-func getDagDeployURL(deploymentInfo *houston.Deployment) string {
+func getDagDeployURL(deploymentInfo *houston.Deployment, description string) string {
 	c, _ := config.GetCurrentContext()
-	return fmt.Sprintf("https://deployments.%s/%s/dags/upload", c.Domain, deploymentInfo.ReleaseName)
+	return fmt.Sprintf("https://deployments.%s/%s/dags/upload?description=%s", c.Domain, deploymentInfo.ReleaseName, description)
 }
 
-func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool) error {
+func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.AppConfig, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 	// Throw error if the feature is disabled at Houston level
 	if !isDagOnlyDeploymentEnabled(appConfig) {
 		return ErrDagOnlyDeployDisabledInConfig
@@ -372,7 +372,7 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, appConfig *houston.Ap
 		if err != nil {
 			return err
 		}
-		uploadURL = getDagDeployURL(deploymentInfo)
+		uploadURL = getDagDeployURL(deploymentInfo, description)
 	} else {
 		uploadURL = *dagDeployURL
 	}

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -379,7 +379,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 		houstonMock := new(houston_mocks.ClientInterface)
 
-		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, ErrDagOnlyDeployDisabledInConfig)
 		houstonMock.AssertExpectations(s.T())
 	})
@@ -396,7 +396,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 		houstonMock := new(houston_mocks.ClientInterface)
 
-		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, errDeploymentNotFound)
 		houstonMock.AssertExpectations(s.T())
 	})
@@ -414,7 +414,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		houstonMock := new(houston_mocks.ClientInterface)
 		houstonMock.On("GetDeployment", mock.Anything).Return(nil, errMockHouston).Once()
 
-		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorContains(err, "failed to get deployment info: some houston error")
 		houstonMock.AssertExpectations(s.T())
 	})
@@ -437,7 +437,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 			DagDeployment: *dagDeployment,
 		}
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
-		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, ErrDagOnlyDeployNotEnabledForDeployment)
 		houstonMock.AssertExpectations(s.T())
 	})
@@ -462,7 +462,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
 		config.ResetCurrentContext()
 
-		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.EqualError(err, "could not get current context! Error: no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 		houstonMock.AssertExpectations(s.T())
 		context.Switch("localhost")
@@ -487,7 +487,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 			DagDeployment: *dagDeployment,
 		}
 		houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
-		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false)
+		err := DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, config.WorkingPath, nil, false, description)
 		houstonMock.AssertExpectations(s.T())
 		s.ErrorIs(err, errInvalidDeploymentID)
 	})
@@ -530,7 +530,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		s.NoError(err)
 		defer os.RemoveAll("dags")
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", nil, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", nil, false, description)
 		s.EqualError(err, ErrEmptyDagFolderUserCancelledOperation.Error())
 
 		// assert that no tar or gz file exists
@@ -592,7 +592,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}))
 		defer server.Close()
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", &server.URL, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", &server.URL, false, description)
 		s.NoError(err)
 		houstonMock.AssertExpectations(s.T())
 
@@ -642,7 +642,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		os.Stdin = r
 		defer testUtil.MockUserInput(s.T(), "y")()
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, "./dags", nil, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, "./dags", nil, false, description)
 		s.EqualError(err, "open dags/dags.tar: no such file or directory")
 		houstonMock.AssertExpectations(s.T())
 
@@ -688,7 +688,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 			return gzipMockError
 		}
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, deploymentID, wsID, ".", nil, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, deploymentID, wsID, ".", nil, false, description)
 		s.ErrorIs(err, gzipMockError)
 		houstonMock.AssertExpectations(s.T())
 
@@ -749,7 +749,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}))
 		defer server.Close()
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", &server.URL, false)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", &server.URL, false, description)
 		s.NoError(err)
 		houstonMock.AssertExpectations(s.T())
 
@@ -809,7 +809,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}))
 		defer server.Close()
 
-		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", &server.URL, true)
+		err = DagsOnlyDeploy(houstonMock, appConfig, wsID, deploymentID, ".", &server.URL, true, description)
 		s.NoError(err)
 		houstonMock.AssertExpectations(s.T())
 


### PR DESCRIPTION
## Description

This PR introduces functionality to support custom deployment revision descriptions during the `astro deploy --dags` command to the dag server. It adds a mechanism to capture and assign meaningful descriptions for deployment revisions, enhancing traceability and clarity in the deployment process.

This is a continuation of astronomer/astro-cli/pull/1713

## 🎟 Issue(s)

Related astronomer/issues#6437

## 🧪 Functional Testing

- testing with dag server

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
