### PR TITLE
Add support for azure deployment creation

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -604,6 +604,9 @@ func ListClusterOptions(cloudProvider string, coreClient astrocore.CoreClient) (
 	if cloudProvider == awsCloud {
 		provider = astrocore.GetClusterOptionsParamsProvider(astrocore.GetClusterOptionsParamsProviderAws) //nolint
 	}
+	if cloudProvider == azureCloud {
+		provider = astrocore.GetClusterOptionsParamsProvider(astrocore.GetClusterOptionsParamsProviderAzure) //nolint
+	}
 	optionsParams := &astrocore.GetClusterOptionsParams{
 		Provider: &provider,
 		Type:     astrocore.GetClusterOptionsParamsType(astrocore.GetClusterOptionsParamsTypeSHARED), //nolint

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -1734,7 +1734,7 @@ func deploymentSelectionProcess(ws string, deployments []astroplatformcore.Deplo
 			coreDeploymentType = astroplatformcore.DeploymentTypeSTANDARD
 			dagDeploy = enable
 		}
-		err = createDeployment("", ws, "", "", runtimeVersion, dagDeploy, CeleryExecutor, "gcp", "", "", "", "disable", cicdEnforcement, "", "", "", "", "", coreDeploymentType, 0, 0, platformCoreClient, coreClient, false)
+		err = createDeployment("", ws, "", "", runtimeVersion, dagDeploy, CeleryExecutor, "azure", "", "", "", "disable", cicdEnforcement, "", "", "", "", "", coreDeploymentType, 0, 0, platformCoreClient, coreClient, false)
 		if err != nil {
 			return astroplatformcore.Deployment{}, err
 		}

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -99,7 +99,7 @@ var (
 	httpClient              = httputil.NewHTTPClient()
 	errFlag                 = errors.New("--deployment-file can not be used with other arguments")
 	errInvalidExecutor      = errors.New("not a valid executor")
-	errInvalidCloudProvider = errors.New("not a valid cloud provider. It can only be gcp or aws")
+	errInvalidCloudProvider = errors.New("not a valid cloud provider. It can only be gcp, azure or aws")
 )
 
 func newDeploymentRootCmd(out io.Writer) *cobra.Command {
@@ -407,7 +407,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 		cmd.Flags().StringVarP(&defaultTaskPodMemory, "default-task-pod-memory", "", "", "The default task pod memory to use for the Deployment. Example value: 0.5Gi")
 		cmd.Flags().StringVarP(&resourceQuotaCPU, "resource-quota-cpu", "", "", "The Deployment's CPU resource quota. Example value: 10")
 		cmd.Flags().StringVarP(&resourceQuotaMemory, "resource-quota-memory", "", "", "The Deployment's memory resource quota. Example value: 20Gi")
-		cmd.Flags().StringVarP(&cloudProvider, "cloud-provider", "p", "gcp", "The Cloud Provider to use for the Deployment. Possible values can be gcp, aws.")
+		cmd.Flags().StringVarP(&cloudProvider, "cloud-provider", "p", "azure", "The Cloud Provider to use for the Deployment. Possible values can be gcp, aws, azure.")
 		cmd.Flags().StringVarP(&region, "region", "", "", "The Cloud Provider region to use for the Deployment.")
 		cmd.Flags().StringVarP(&schedulerSize, "scheduler-size", "", "", "The size of scheduler for the Deployment. Possible values can be small, medium, large, extra_large")
 		cmd.Flags().StringVarP(&highAvailability, "high-availability", "a", "disable", "Enables High Availability for the Deployment")
@@ -869,7 +869,7 @@ func isValidExecutor(executor string) bool {
 
 // isValidCloudProvider returns true for valid CloudProvider values and false if not.
 func isValidCloudProvider(cloudProvider astrocore.SharedClusterCloudProvider) bool {
-	return cloudProvider == astrocore.SharedClusterCloudProviderGcp || cloudProvider == astrocore.SharedClusterCloudProviderAws
+	return cloudProvider == astrocore.SharedClusterCloudProviderGcp || cloudProvider == astrocore.SharedClusterCloudProviderAws || cloudProvider == astrocore.SharedClusterCloudProviderAzure
 }
 
 func addDeploymentUser(cmd *cobra.Command, args []string, out io.Writer) error {

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -703,10 +703,10 @@ deployment:
 		ctx.SetContextKey("workspace", ws)
 		cmdArgs := []string{
 			"create", "--name", "test-name", "--workspace-id", ws, "--dag-deploy", "disable",
-			"--executor", "KubernetesExecutor", "--cloud-provider", "azure",
+			"--executor", "KubernetesExecutor", "--cloud-provider", "ibm",
 		}
 		_, err = execDeploymentCmd(cmdArgs...)
-		assert.ErrorContains(t, err, "azure is not a valid cloud provider. It can only be gcp")
+		assert.ErrorContains(t, err, "ibm is not a valid cloud provider. It can only be gcp")
 	})
 	t.Run("creates a hosted dedicated deployment", func(t *testing.T) {
 		ctx, err := context.GetCurrentContext()
@@ -1445,8 +1445,12 @@ func TestIsValidCloudProvider(t *testing.T) {
 		actual := isValidCloudProvider("aws")
 		assert.True(t, actual)
 	})
-	t.Run("returns false if cloudProvider is not gcp", func(t *testing.T) {
+	t.Run("returns true if cloudProvider is azure", func(t *testing.T) {
 		actual := isValidCloudProvider("azure")
+		assert.True(t, actual)
+	})
+	t.Run("returns false if cloudProvider is not gcp,aws or azure", func(t *testing.T) {
+		actual := isValidCloudProvider("ibm")
 		assert.False(t, actual)
 	})
 }


### PR DESCRIPTION
## Description

As we have changed the default cloud provider to Azure for deployments on standard cluster. We would also like to have same behaviour on Astro-cli end. Currently, we have default cloud-provider set to `gcp` in Astro-cli. As part of this PR changes, we are updating  default cloud-provider to `azure` to be in sync with UI.
 
## 🎟 Issue(s)

closes https://github.com/astronomer/astro-cli/issues/1707

## 🧪 Functional Testing

Tested the changes by creating default deployment on PR-preview environment using Astro-CLI build with these changes:

```
./astro deployment create
                                                                         
Current Workspace: Sample Workspace 2

Please specify a name for your Deployment

Deployment name: test-cli

Please select a Region for your Deployment:
 #     REGION         
 1     eastus2        
 2     westeurope     
 3     westus2        

> 2
 NAME         NAMESPACE                     CLUSTER     CLOUD PROVIDER     REGION         DEPLOYMENT ID                 RUNTIME VERSION                      DAG DEPLOY ENABLED     CI-CD ENFORCEMENT     DEPLOYMENT TYPE     
 test-cli     asteroidal-telemetry-9312     N/A         AZURE              westeurope     cm0zkgbag00a401nhf2is3wus     12.1.0 (based on Airflow 2.10.1)     true                   false                 STANDARD            

 Successfully created Deployment: test-cli
 Deployment can be accessed at the following URLs 

 Deployment Dashboard: cloud.astronomer-dev.io/cm0wad7pq0108f7j2he7990qn/deployments/cm0zkgbag00a401nhf2is3wus/overview
 Airflow Dashboard: sampleorgpr23859-pr23859.astronomer-dev.run/d2is3wus?orgId=org_TpYkP1OnRzcNzN8r
```

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/c2c4ca99-0f92-4c77-84b0-e5bc62e4c0cc)

![image](https://github.com/user-attachments/assets/11f079ee-1579-4988-9364-307e55269cf6)

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
