### PR TITLE
Add `include_deferred` to `airflow_settings.yaml`

### DIFF
--- a/settings/settings.go
+++ b/settings/settings.go
@@ -293,6 +293,9 @@ func AddPools(id string, version uint64) {
 				} else {
 					airflowCommand += "''"
 				}
+				if pool.PoolIncludeDeferred {
+					airflowCommand += "--include-deferred"
+				}
 				fmt.Println(airflowCommand)
 				out := execAirflowCommand(id, airflowCommand)
 				logrus.Debugf("Adding pool logs:\n" + out)
@@ -593,7 +596,7 @@ func ExportPools(id string) error {
 			}
 		}
 		fmt.Println("Exporting Pool: " + pools[i].PoolName)
-		newPools := Pools{{pools[i].PoolName, slot, pools[i].PoolDescription}}
+		newPools := Pools{{pools[i].PoolName, slot, pools[i].PoolDescription, pools[i].PoolIncludeDeferred}}
 		settings.Airflow.Pools = append(settings.Airflow.Pools, newPools...)
 	}
 	// write pools to the airflow settings file

--- a/settings/types.go
+++ b/settings/types.go
@@ -18,9 +18,10 @@ type Connection struct {
 
 // Pools contains structure of airflow pools
 type Pools []struct {
-	PoolName        string `mapstructure:"pool_name" yaml:"pool_name"`
-	PoolSlot        int    `mapstructure:"pool_slot" yaml:"pool_slot"`
-	PoolDescription string `mapstructure:"pool_description" yaml:"pool_description"`
+	PoolName            string `mapstructure:"pool_name" yaml:"pool_name"`
+	PoolSlot            int    `mapstructure:"pool_slot" yaml:"pool_slot"`
+	PoolDescription     string `mapstructure:"pool_description" yaml:"pool_description"`
+	PoolIncludeDeferred bool   `mapstructure:"pool_include_deferred" yaml:"pool_include_deferred"`
 }
 
 // Variables contains structure of airflow variables
@@ -56,9 +57,10 @@ type AirflowConnection struct {
 }
 
 type AirflowPools []struct {
-	PoolName        string `yaml:"pool"`
-	PoolSlot        string `yaml:"slots"`
-	PoolDescription string `yaml:"description"`
+	PoolName            string `yaml:"pool"`
+	PoolSlot            string `yaml:"slots"`
+	PoolDescription     string `yaml:"description"`
+	PoolIncludeDeferred bool   `yaml:"include_deferred"`
 }
 
 // types for creating variables and connections yaml files


### PR DESCRIPTION
## Description
Pools in airflow have a new `include_deferrred` setting
https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html#set

This adds this in so it can be passed through via `airflow_settings.yaml`.
Basic tests pass, but would love assistance doing more thorough testing with this. 

Uncertain if it'd cause any issues with older versions of Airflow that don't have that property - I imagine you just need to not set that property in `airflow_settings.yaml`, if that's the case?

## 🎟 Issue(s)

https://apache-airflow.slack.com/archives/C03T0AVNA6A/p1725917969468329

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
