### PR TITLE
pull runtime images on build

### DIFF
--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -63,6 +63,46 @@ func (s *Suite) TestDockerImageBuild() {
 		s.NoError(err)
 	})
 
+	s.Run("build with no --pull", func() {
+		dockerfileContent := "FROM nginx"
+		dockerfile, _ := os.CreateTemp(os.TempDir(), "temp-Dockerfile")
+		defer os.Remove(dockerfile.Name())
+		dockerfile.WriteString(dockerfileContent)
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			s.NotContains(args, "--pull")
+			return nil
+		}
+		err = handler.Build(dockerfile.Name(), "", options)
+		s.NoError(err)
+	})
+
+	s.Run("build with no --pull with multiple images", func() {
+		dockerfileContent := `FROM nginx
+FROM quay.io/astronomer/astro-runtime:12.0.0`
+		dockerfile, _ := os.CreateTemp(os.TempDir(), "temp-Dockerfile")
+		defer os.Remove(dockerfile.Name())
+		dockerfile.WriteString(dockerfileContent)
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			s.NotContains(args, "--pull")
+			return nil
+		}
+		err = handler.Build(dockerfile.Name(), "", options)
+		s.NoError(err)
+	})
+
+	s.Run("build with --pull", func() {
+		dockerfileContent := "FROM quay.io/astronomer/astro-runtime:12.0.0"
+		dockerfile, _ := os.CreateTemp(os.TempDir(), "temp-Dockerfile")
+		defer os.Remove(dockerfile.Name())
+		dockerfile.WriteString(dockerfileContent)
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			s.Contains(args, "--pull")
+			return nil
+		}
+		err = handler.Build(dockerfile.Name(), "", options)
+		s.NoError(err)
+	})
+
 	s.Run("build --label", func() {
 		options.Labels = []string{"io.astronomer.skip.revision=true"}
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {


### PR DESCRIPTION
## Description

when building images with the CLI, if it's an astro-runtime image, instruct `docker build` to pull the image first. this will allow is to start using floating tags for astro-runtime going forward.

## 🎟 Issue(s)

Closes https://github.com/astronomer/astro-cli/issues/1407

this was implemented once and reverted, due to incompatibility with customers' pipelines using their own images that are not public. liming this to runtime images (which are public) solves that.

## 🧪 Functional Testing

unit testing covers the cases where `--pull` should and should not be added.

## 📸 Screenshots

unit tests passing is sufficient

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
