### PR TITLE
Add support to fetch workload identity

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -182,7 +182,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 	if jsonOutput {
 		outputFormat = jsonFormat
 	}
-	return inspect.Inspect(workspaceID, "", existingDeployment.Id, outputFormat, astroPlatformCore, coreClient, out, "", false)
+	return inspect.Inspect(workspaceID, "", existingDeployment.Id, outputFormat, astroPlatformCore, coreClient, out, "", false, true)
 }
 
 // createOrUpdateDeployment transforms an inspect.FormattedDeployment into astroplateformcore CreateDeploymentInput or

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -307,10 +307,7 @@ func ReturnSpecifiedValue(wsID, deploymentName, deploymentID string, astroPlatfo
 		return nil, err
 	}
 
-	showWorkloadIdentity := false
-	if strings.Contains(requestedField, "workload_identity") { // if the caller has requested for workload_identity, we set the flag to true to fetch the deployment workload_identity
-		showWorkloadIdentity = true
-	}
+	showWorkloadIdentity := strings.Contains(requestedField, "workload_identity") // if the caller has requested for workload_identity, we set the flag to true to fetch the deployment workload_identity
 
 	// create a map for deployment.information
 	deploymentInfoMap, err = getDeploymentInfo(requestedDeployment)

--- a/cloud/deployment/inspect/inspect.go
+++ b/cloud/deployment/inspect/inspect.go
@@ -112,7 +112,7 @@ const (
 	notApplicable = "N/A"
 )
 
-func Inspect(wsID, deploymentName, deploymentID, outputFormat string, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, out io.Writer, requestedField string, template bool) error {
+func Inspect(wsID, deploymentName, deploymentID, outputFormat string, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, out io.Writer, requestedField string, template, showWorkloadIdentity bool) error {
 	var (
 		requestedDeployment                                                        astroplatformcore.Deployment
 		err                                                                        error
@@ -135,7 +135,7 @@ func Inspect(wsID, deploymentName, deploymentID, outputFormat string, platformCo
 		return err
 	}
 	// create a map for deployment.configuration
-	deploymentConfigMap, err = getDeploymentConfig(&requestedDeployment, platformCoreClient)
+	deploymentConfigMap, err = getDeploymentConfig(&requestedDeployment, platformCoreClient, showWorkloadIdentity)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func getDeploymentInfo(coreDeployment astroplatformcore.Deployment) (map[string]
 	return metadata, nil
 }
 
-func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, platformCoreClient astroplatformcore.CoreClient) (map[string]interface{}, error) {
+func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, platformCoreClient astroplatformcore.CoreClient, showWorkloadIdentity bool) (map[string]interface{}, error) {
 	var clusterName string
 	var defaultWorkerType string
 	var err error
@@ -272,6 +272,9 @@ func getDeploymentConfig(coreDeploymentPointer *astroplatformcore.Deployment, pl
 	if coreDeployment.Region != nil {
 		deploymentMap["region"] = *coreDeployment.Region
 	}
+	if showWorkloadIdentity && coreDeployment.WorkloadIdentity != nil {
+		deploymentMap["workload_identity"] = *coreDeployment.WorkloadIdentity
+	}
 	return deploymentMap, nil
 }
 
@@ -304,13 +307,18 @@ func ReturnSpecifiedValue(wsID, deploymentName, deploymentID string, astroPlatfo
 		return nil, err
 	}
 
+	showWorkloadIdentity := false
+	if strings.Contains(requestedField, "workload_identity") { // if the caller has requested for workload_identity, we set the flag to true to fetch the deployment workload_identity
+		showWorkloadIdentity = true
+	}
+
 	// create a map for deployment.information
 	deploymentInfoMap, err = getDeploymentInfo(requestedDeployment)
 	if err != nil {
 		return nil, err
 	}
 	// create a map for deployment.configuration
-	deploymentConfigMap, err = getDeploymentConfig(&requestedDeployment, astroPlatformCore)
+	deploymentConfigMap, err = getDeploymentConfig(&requestedDeployment, astroPlatformCore, showWorkloadIdentity)
 	if err != nil {
 		return nil, err
 	}

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -193,6 +193,7 @@ var (
 		SchedulerSize:          &schedulerTestSize,
 		CloudProvider:          &cloudProvider,
 		IsDevelopmentMode:      &isDevelopmentMode,
+		WorkloadIdentity:       &workloadIdentity,
 		ScalingSpec: &astroplatformcore.DeploymentScalingSpec{
 			HibernationSpec: &astroplatformcore.DeploymentHibernationSpec{
 				Override:  &hibernationOverride,
@@ -251,7 +252,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentResponse.Namespace)
 		assert.Contains(t, out.String(), deploymentName)
@@ -265,7 +266,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", true)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", true, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentResponse.RuntimeVersion)
 		assert.NotContains(t, out.String(), deploymentResponse.Namespace)
@@ -279,7 +280,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "json", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "json", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentResponse.Namespace)
 		assert.Contains(t, out.String(), deploymentName)
@@ -293,7 +294,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "json", mockPlatformCoreClient, mockCoreClient, out, "", true)
+		err := Inspect(workspaceID, "", deploymentID, "json", mockPlatformCoreClient, mockCoreClient, out, "", true, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentResponse.RuntimeVersion)
 		assert.NotContains(t, out.String(), deploymentResponse.Namespace)
@@ -307,7 +308,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "configuration.cluster_name", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "configuration.cluster_name", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), *deploymentResponse.ClusterName)
 		mockCoreClient.AssertExpectations(t)
@@ -320,7 +321,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", "", "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", "", "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), deploymentName)
 		mockCoreClient.AssertExpectations(t)
@@ -331,7 +332,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, errGetDeployment).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.ErrorIs(t, err, errGetDeployment)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -340,7 +341,7 @@ func TestInspect(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, errGetDeployment).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.ErrorIs(t, err, errGetDeployment)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -351,7 +352,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "no-exist-information", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "no-exist-information", false, false)
 		assert.ErrorIs(t, err, errKeyNotFound)
 		assert.Equal(t, "", out.String())
 		mockCoreClient.AssertExpectations(t)
@@ -366,7 +367,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.ErrorIs(t, err, errMarshal)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -375,7 +376,7 @@ func TestInspect(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.ErrorReturningContext)
 		out := new(bytes.Buffer)
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.ErrorContains(t, err, "no context set, have you authenticated to Astro or Astronomer Software? Run astro login and try again")
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -391,7 +392,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err = Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err = Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), "N/A")
 		assert.Contains(t, out.String(), deploymentName)
@@ -404,8 +405,34 @@ func TestInspect(t *testing.T) {
 	t.Run("when no deployments in workspace", func(t *testing.T) {
 		out := new(bytes.Buffer)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&emptyListDeploymentsResponse, nil).Once()
-		err := Inspect(workspaceID, "", "", "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false)
+		err := Inspect(workspaceID, "", "", "yaml", mockPlatformCoreClient, mockCoreClient, out, "", false, false)
 		assert.NoError(t, err)
+		mockCoreClient.AssertExpectations(t)
+		mockPlatformCoreClient.AssertExpectations(t)
+	})
+
+	t.Run("returns an error when trying to fetch the workload identity field with flag set to false", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
+
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "configuration.workload_identity", false, false)
+		assert.ErrorIs(t, err, errKeyNotFound)
+		assert.Equal(t, out.String(), "")
+		mockCoreClient.AssertExpectations(t)
+		mockPlatformCoreClient.AssertExpectations(t)
+	})
+
+	t.Run("returns actual workload identity when the flag is set to true", func(t *testing.T) {
+		out := new(bytes.Buffer)
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
+
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "configuration.workload_identity", false, true)
+		assert.NoError(t, err)
+		assert.Contains(t, out.String(), workloadIdentity)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
@@ -478,7 +505,7 @@ func TestGetDeploymentConfig(t *testing.T) {
 			CloudProvider:     string(*sourceDeployment.CloudProvider),
 			IsDevelopmentMode: *sourceDeployment.IsDevelopmentMode,
 		}
-		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		err = decodeToStruct(rawDeploymentConfig, &actualDeploymentConfig)
 		assert.NoError(t, err)
@@ -515,7 +542,7 @@ func TestGetDeploymentConfig(t *testing.T) {
 			ResourceQuotaMemory:  *sourceDeployment.ResourceQuotaMemory,
 			IsDevelopmentMode:    *sourceDeployment.IsDevelopmentMode,
 		}
-		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		rawDeploymentConfig, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		err = decodeToStruct(rawDeploymentConfig, &actualDeploymentConfig)
 		assert.NoError(t, err)
@@ -532,7 +559,7 @@ func TestGetPrintableDeployment(t *testing.T) {
 	t.Run("returns a deployment map", func(t *testing.T) {
 		info, _ := getDeploymentInfo(sourceDeployment)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		expectedDeployment := map[string]interface{}{
@@ -625,7 +652,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 
 	t.Run("returns a yaml formatted printable deployment", func(t *testing.T) {
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 
@@ -720,7 +747,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		sourceDeployment2.Region = &empty
 
 		info, _ := getDeploymentInfo(sourceDeployment2)
-		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment2, nodePools)
 
@@ -809,7 +836,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		sourceDeployment2.ScalingSpec.HibernationSpec.Override.OverrideUntil = &overrideUntil
 
 		info, _ := getDeploymentInfo(sourceDeployment2)
-		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment2, nodePools)
 
@@ -907,7 +934,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		sourceDeployment2.Region = &empty
 
 		info, _ := getDeploymentInfo(sourceDeployment2)
-		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment2, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment2, nodePools)
 		printableDeployment := map[string]interface{}{
@@ -1015,7 +1042,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		sourceDeployment.Region = &empty
 
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		printableDeployment := map[string]interface{}{
@@ -1085,7 +1112,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		decodeToStruct = errorReturningDecode
 		defer restoreDecode(originalDecode)
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		expectedPrintableDeployment = []byte{}
@@ -1098,7 +1125,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		yamlMarshal = errReturningYAMLMarshal
 		defer restoreYAMLMarshal(originalMarshal)
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		expectedPrintableDeployment = []byte{}
@@ -1111,7 +1138,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
 		jsonMarshal = errReturningJSONMarshal
 		defer restoreJSONMarshal(originalMarshal)
 		info, _ := getDeploymentInfo(sourceDeployment)
-		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+		config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 		assert.NoError(t, err)
 		additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 		expectedPrintableDeployment = []byte{}
@@ -1125,7 +1152,7 @@ func TestGetSpecificField(t *testing.T) {
 	sourceDeployment.Status = "UNHEALTHY"
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	info, _ := getDeploymentInfo(sourceDeployment)
-	config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+	config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 	assert.NoError(t, err)
 	additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 	printableDeployment := map[string]interface{}{
@@ -1241,7 +1268,7 @@ func TestGetTemplate(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 
 	info, _ := getDeploymentInfo(sourceDeployment)
-	config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient)
+	config, err := getDeploymentConfig(&sourceDeployment, mockPlatformCoreClient, false)
 	assert.NoError(t, err)
 	additional := getAdditionalNullableFields(&sourceDeployment, nodePools)
 

--- a/cmd/cloud/deployment_inspect.go
+++ b/cmd/cloud/deployment_inspect.go
@@ -13,6 +13,7 @@ var (
 	outputFormat, requestedField string
 	template                     bool
 	cleanOutput                  bool
+	showWorkloadIdentity         bool
 )
 
 func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
@@ -30,6 +31,7 @@ func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVarP(&template, "template", "t", false, "Create a template from the deployment being inspected.")
 	cmd.Flags().StringVarP(&requestedField, "key", "k", "", "A specific key for the deployment. Use --key configuration.cluster_id to get a deployment's cluster id.")
 	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "c", false, "clean output to only include inspect yaml or json file in any situation.")
+	cmd.Flags().BoolVarP(&showWorkloadIdentity, "show-workload-identity", "", false, "Include the workload identity configured for the deployment in the output.")
 	return cmd
 }
 
@@ -48,5 +50,5 @@ func deploymentInspect(cmd *cobra.Command, args []string, out io.Writer) error {
 	// clean output
 	deployment.CleanOutput = cleanOutput
 
-	return inspect.Inspect(wsID, deploymentName, deploymentID, outputFormat, platformCoreClient, astroCoreClient, out, requestedField, template)
+	return inspect.Inspect(wsID, deploymentName, deploymentID, outputFormat, platformCoreClient, astroCoreClient, out, requestedField, template, showWorkloadIdentity)
 }

--- a/cmd/cloud/deployment_inspect_test.go
+++ b/cmd/cloud/deployment_inspect_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"fmt"
 	"testing"
 
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
@@ -64,6 +65,26 @@ func TestNewDeploymentInspectCmd(t *testing.T) {
 		cmdArgs := []string{"inspect", "-n", "test", "-k", "metadata.cluster_id"}
 		_, err := execDeploymentCmd(cmdArgs...)
 		assert.NoError(t, err)
+		mockPlatformCoreClient.AssertExpectations(t)
+	})
+	t.Run("returns empty workload identity when show-workload-identity flag is not passed", func(t *testing.T) {
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
+		cmdArgs := []string{"inspect", "-n", "test"}
+		out, err := execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, out, `workload_identity: ""`)
+		mockPlatformCoreClient.AssertExpectations(t)
+	})
+	t.Run("returns workload identity when show-workload-identity flag is passed", func(t *testing.T) {
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
+		cmdArgs := []string{"inspect", "-n", "test", "--show-workload-identity"}
+		out, err := execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.Contains(t, out, fmt.Sprintf(`workload_identity: %s`, mockWorkloadIdentity))
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 	t.Run("returns an error when getting workspace fails", func(t *testing.T) {

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -118,6 +118,7 @@ var (
 			DefaultTaskPodCpu:      &defaultTaskPodCPU,
 			DefaultTaskPodMemory:   &defaultTaskPodMemory,
 			WebServerAirflowApiUrl: "airflow-url",
+			WorkloadIdentity:       &mockWorkloadIdentity,
 			WorkerQueues:           &[]astroplatformcore.WorkerQueue{},
 		},
 	}


### PR DESCRIPTION
## Description

Changes:
- Adds `--show-workload-identity` boolean flag for `astro deployment inspect` command to fetch the workload identity value set for the deployment
- Returns the workload identity set for the deployment when running `astro deployment create --deployment-file <deployment-file>`. In this case, the field value would be populated without any new flag exposed for the `astro deployment create` command.

## 🎟 Issue(s)

Related #1571

## 🧪 Functional Testing

- Test the `astro deployment inspect` command (with and without the `show-workload-identity` flag) against a deployment using the default workload identity
<img width="1197" alt="Screenshot 2024-10-30 at 11 03 08 AM" src="https://github.com/user-attachments/assets/a9e74d2f-e25c-4c7d-8ed0-c6de7613cbc2">

- Test the `astro deployment inspect` command (with and without the `show-workload-identity` flag) against a deployment using custom workload identity
<img width="1185" alt="Screenshot 2024-10-30 at 11 07 00 AM" src="https://github.com/user-attachments/assets/0934652f-7e02-472a-8057-00330a569037">

- Test the `astro deployment create --deployment-file` command with a deployment file containing custom workload identity.
<img width="893" alt="Screenshot 2024-10-30 at 11 09 21 AM" src="https://github.com/user-attachments/assets/4e08e8dc-2fc3-4e8d-ad6f-b1c8b6a37257">

- Test the `astro deployment create --deployment-file` command with a deployment file containing an empty string as workload identity.
<img width="833" alt="Screenshot 2024-10-30 at 11 12 48 AM" src="https://github.com/user-attachments/assets/4c762c31-e7ff-40b5-8aec-1c048849bd33">

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
