### PR TITLE
Added the support for --image-name flag in the astro deploy command

### DIFF
--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -454,5 +454,6 @@ func UpdateDeploymentImage(houstonClient houston.ClientInterface, deploymentID, 
 		return fmt.Errorf("failed to get deployment info: %w", err)
 	}
 	_, err = updateDeploymentImageAPICall(houstonClient, imageName, deploymentInfo.ReleaseName, "", runtimeVersion)
+	fmt.Println("Image successfully updated")
 	return err
 }

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -920,5 +920,4 @@ func (s *Suite) TestUpdateDeploymentImage() {
 		houstonMock.AssertExpectations(s.T())
 		s.ErrorIs(err, nil)
 	})
-
 }


### PR DESCRIPTION
## Description

Added the support for --image-name flag in the astro deploy command. Internally, it will call the updateDeploymentImage API. No image will be pushed to the registry. The command will be like this -
astro deploy --image-name IMAGE_URL --runtime-version IMAGE_RUNTIME_VERSION

## 🎟 Issue(s)

Related https://github.com/astronomer/issues/issues/6828

## 🧪 Functional Testing

Tested locally

## 📸 Screenshots

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
