### PR TITLE
Introduction of sha_as_tag=True config in astro cli which will be used during Astro deploy

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -46,7 +46,7 @@ type RegistryHandler interface {
 // ImageHandler defines methods require to handle all operations on/for container images
 type ImageHandler interface {
 	Build(dockerfile, buildSecretString string, config types.ImageBuildConfig) error
-	Push(remoteImage, username, token string) error
+	Push(remoteImage, username, token string, getRemoteShaTag bool) (string, error)
 	Pull(remoteImage, username, token string) error
 	GetLabel(altImageName, labelName string) (string, error)
 	DoesImageExist(image string) error

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -350,19 +350,19 @@ func (d *DockerImage) CreatePipFreeze(altImageName, pipFreezeFile string) error 
 	return nil
 }
 
-func (d *DockerImage) Push(remoteImage, username, token string) error {
+func (d *DockerImage) Push(remoteImage, username, token string, getRemoteShaTag bool) (string, error) {
 	containerRuntime, err := runtimes.GetContainerRuntimeBinary()
 	if err != nil {
-		return err
+		return "", err
 	}
 	err = cmdExec(containerRuntime, nil, nil, "tag", d.imageName, remoteImage)
 	if err != nil {
-		return fmt.Errorf("command '%s tag %s %s' failed: %w", containerRuntime, d.imageName, remoteImage, err)
+		return "", fmt.Errorf("command '%s tag %s %s' failed: %w", containerRuntime, d.imageName, remoteImage, err)
 	}
 
 	registry, err := d.getRegistryToAuth(remoteImage)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Push image to registry
@@ -373,7 +373,7 @@ func (d *DockerImage) Push(remoteImage, username, token string) error {
 	authConfig, err := configFile.GetAuthConfig(registry)
 	if err != nil {
 		log.Debugf("Error reading credentials: %v", err)
-		return fmt.Errorf("error reading credentials: %w", err)
+		return "", fmt.Errorf("error reading credentials: %w", err)
 	}
 
 	if username == "" && token == "" {
@@ -398,16 +398,34 @@ func (d *DockerImage) Push(remoteImage, username, token string) error {
 		// if it does not work with the go library use bash to run docker commands. Support for (old?) versions of Colima
 		err = pushWithBash(&authConfig, remoteImage)
 		if err != nil {
-			return err
+			return "", err
+		}
+	}
+
+	// Get the digest of the pushed image
+	remoteDigest := ""
+	if getRemoteShaTag {
+		out := &bytes.Buffer{}
+		err = cmdExec(containerRuntime, out, nil, "inspect", "--format={{index .RepoDigests 0}}", remoteImage)
+		if err != nil {
+			return remoteDigest, fmt.Errorf("failed to get digest for image %s: %w", remoteImage, err)
+		}
+		// Parse and clean the output
+		digestOutput := strings.TrimSpace(out.String())
+		if digestOutput != "" {
+			parts := strings.Split(digestOutput, "@")
+			if len(parts) == 2 {
+				remoteDigest = parts[1] // Extract the digest part (after '@')
+			}
 		}
 	}
 
 	// Delete the image tags we just generated
 	err = cmdExec(containerRuntime, nil, nil, "rmi", remoteImage)
 	if err != nil {
-		return fmt.Errorf("command '%s rmi %s' failed: %w", containerRuntime, remoteImage, err)
+		return remoteDigest, fmt.Errorf("command '%s rmi %s' failed: %w", containerRuntime, remoteImage, err)
 	}
-	return nil
+	return remoteDigest, nil
 }
 
 func (d *DockerImage) pushWithClient(authConfig *cliTypes.AuthConfig, remoteImage string) error {

--- a/airflow/mocks/ImageHandler.go
+++ b/airflow/mocks/ImageHandler.go
@@ -142,18 +142,28 @@ func (_m *ImageHandler) Pull(remoteImage string, username string, token string) 
 	return r0
 }
 
-// Push provides a mock function with given fields: remoteImage, username, token
-func (_m *ImageHandler) Push(remoteImage string, username string, token string) error {
-	ret := _m.Called(remoteImage, username, token)
+// Push provides a mock function with given fields: remoteImage, username, token, getRemoteShaTag
+func (_m *ImageHandler) Push(remoteImage string, username string, token string, getRemoteShaTag bool) (string, error) {
+	ret := _m.Called(remoteImage, username, token, getRemoteShaTag)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = rf(remoteImage, username, token)
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string, string, bool) (string, error)); ok {
+		return rf(remoteImage, username, token, getRemoteShaTag)
+	}
+	if rf, ok := ret.Get(0).(func(string, string, string, bool) string); ok {
+		r0 = rf(remoteImage, username, token, getRemoteShaTag)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(string)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(string, string, string, bool) error); ok {
+		r1 = rf(remoteImage, username, token, getRemoteShaTag)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Pytest provides a mock function with given fields: pytestFile, airflowHome, envFile, testHomeDirectory, pytestArgs, htmlReport, config

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -364,7 +364,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 		remoteImage := fmt.Sprintf("%s:%s", repository, nextTag)
 
 		imageHandler := airflowImageHandler(deployInfo.deployImage)
-		err = imageHandler.Push(remoteImage, registryUsername, c.Token)
+		_, err = imageHandler.Push(remoteImage, registryUsername, c.Token, false)
 		if err != nil {
 			return err
 		}

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -171,7 +171,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
@@ -315,7 +315,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
@@ -451,7 +451,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
@@ -529,7 +529,7 @@ func TestImageOnlyDeploySuccess(t *testing.T) {
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
@@ -777,7 +777,7 @@ func TestDeployMonitoringDAGNonHosted(t *testing.T) {
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
@@ -855,7 +855,7 @@ func TestDeployNoMonitoringDAGHosted(t *testing.T) {
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler

--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,7 @@ var (
 		DisableAstroRun:       newCfg("disable_astro_run", "false"),
 		DisableEnvObjects:     newCfg("disable_env_objects", "false"),
 		AutoSelect:            newCfg("auto_select", "false"),
+		ShaAsTag:              newCfg("sha_as_tag", "false"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/types.go
+++ b/config/types.go
@@ -45,6 +45,7 @@ type cfgs struct {
 	DisableAstroRun       cfg
 	DisableEnvObjects     cfg
 	AutoSelect            cfg
+	ShaAsTag              cfg
 }
 
 // Creates a new cfg struct

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -111,7 +111,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithTagWarning() {
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockImageHandler
 	}
 
@@ -142,7 +142,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithImageRepoWarning() {
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockImageHandler
 	}
 
@@ -187,7 +187,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithBYORegistry() {
 			return false
 		})).Return(nil).Once()
 
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		mockImageHandler.On("GetLabel", "", runtimeImageLabel).Return("", nil).Once()
 		mockImageHandler.On("GetLabel", "", airflowImageLabel).Return("1.10.12", nil).Once()
 
@@ -249,7 +249,7 @@ func (s *Suite) TestBuildPushDockerImageFailure() {
 	mockImageHandler = new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errSomeContainerIssue)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errSomeContainerIssue)
 		return mockImageHandler
 	}
 
@@ -363,7 +363,7 @@ func (s *Suite) TestAirflowSuccess() {
 	mockImageHandler := new(mocks.ImageHandler)
 	imageHandlerInit = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 		return mockImageHandler
 	}
 


### PR DESCRIPTION
## Description

Introduction of sha_as_tag=True config in astro cli which will be used during Astro deploy.
1. Option to set sha_as_tag true in config.
2. During `astro deploy`, using the sha digest when we make a call to the updateDeploymentImage endpoint in Houston, instead of the runtime version tag.

## 🎟 Issue(s)
Related #6836

## 🧪 Functional Testing

Testing locally and on staging cluster too.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
