### PR TITLE
Remove additional output when initializing project

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -103,7 +103,6 @@ astro dev init --from-template
 
 	configReinitProjectConfigMsg = "Reinitialized existing Astro project in %s\n"
 	configInitProjectConfigMsg   = "Initialized empty Astro project in %s\n"
-	changeDirectoryMsg           = "To begin developing, change to your project directory with `cd %s`\n"
 
 	// this is used to monkey patch the function in order to write unit test cases
 	containerHandlerInit = airflow.ContainerHandlerInit
@@ -460,12 +459,6 @@ func airflowInit(cmd *cobra.Command, args []string) error {
 	}
 	projectName = name
 
-	// Save the directory we are in when the init command is run.
-	initialDir, err := fileutil.GetWorkingDir()
-	if err != nil {
-		return err
-	}
-
 	if fromTemplate == "select-template" {
 		selectedTemplate, err := selectedTemplate()
 		if err != nil {
@@ -552,13 +545,6 @@ func airflowInit(cmd *cobra.Command, args []string) error {
 		fmt.Printf(configInitProjectConfigMsg, config.WorkingPath)
 	}
 
-	// If we started in a different directory, that means the positional argument for projectName was used.
-	// This means the users shell pwd is not the project directory, so we print a message
-	// to cd into the project directory.
-	if initialDir != config.WorkingPath {
-		fmt.Printf(changeDirectoryMsg, projectName)
-	}
-
 	return nil
 }
 
@@ -580,7 +566,7 @@ func ensureProjectDirectory(args []string, workingPath, projectName string) (str
 
 	// If the project directory does not exist, create it.
 	if !projectDirExists {
-		err := os.Mkdir(newProjectPath, os.FileMode(directoryPermissions))
+		err := os.Mkdir(newProjectPath, os.FileMode(directoryPermissions)) //nolint:gosec
 		if err != nil {
 			return "", err
 		}

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -481,16 +480,14 @@ func (s *AirflowSuite) TestAirflowInit() {
 
 		orgStdout := os.Stdout
 		defer func() { os.Stdout = orgStdout }()
-		r, w, _ := os.Pipe()
+		_, w, _ := os.Pipe()
 		os.Stdout = w
 
 		err := airflowInit(cmd, args)
 
 		w.Close()
-		out, _ := io.ReadAll(r)
 
 		s.NoError(err)
-		s.Contains(string(out), fmt.Sprintf(changeDirectoryMsg, args[0]))
 	})
 
 	s.Run("specify flag and positional argument for project name, resulting in error", func() {


### PR DESCRIPTION
## Description

This PR just removes the extra help text we recently added to the CLI. It's redundant with our onboarding commands.

In our onboarding flows, we'll be specifying the `init` and the `cd` commands in a single line that can be pasted. It's confusing and redundant to tell the user to `cd` into the project directory when we've already done it.

**Before:**
![before](https://github.com/user-attachments/assets/9625daf7-9638-425b-b7c8-d689dc34bb8f)

**After:**
![after_combo](https://github.com/user-attachments/assets/acd43b26-b3dd-4c5c-ac85-bf72ace0931c)

**After, without the `cd` command:**
![after](https://github.com/user-attachments/assets/a143f21a-674a-4c52-acd4-6ac70b225f3d)


## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
