### PR TITLE
Incorporated newly introduced test suite in pre-existing test cases for astro deploy command

### DIFF
--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -156,7 +156,6 @@ func (s *Suite) TestDeploy() {
 		testImageName := "test-image-name" // Set the expected image name
 		err := execDeployCmd([]string{"test-deployment-id", "--image-name=" + testImageName, "--force", "--remote", "--workspace-id=" + mockWorkspace.ID}...)
 		s.ErrorIs(err, nil)
-
 		// Assert that DeployAirflowImage was NOT called
 		s.False(deployAirflowImageCalled, "DeployAirflowImage should not be called when --remote is specified")
 	})

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -156,6 +156,7 @@ func (s *Suite) TestDeploy() {
 		testImageName := "test-image-name" // Set the expected image name
 		err := execDeployCmd([]string{"test-deployment-id", "--image-name=" + testImageName, "--force", "--remote", "--workspace-id=" + mockWorkspace.ID}...)
 		s.ErrorIs(err, nil)
+
 		// Assert that DeployAirflowImage was NOT called
 		s.False(deployAirflowImageCalled, "DeployAirflowImage should not be called when --remote is specified")
 	})


### PR DESCRIPTION
## Description

Incorporated newly introduced test suite in pre-existing test cases for astro deploy command

## 🎟 Issue(s)

Related #6862

## 🧪 Functional Testing

Unit tests


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
