### PR TITLE
Configure Circle CI to run Integration Test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,10 @@ jobs:
     steps:
       - test
   integration-test:
-    working_directory: /go/src/github.com/astronomer/astro-cli
-    docker:
-      - image: quay.io/astronomer/ap-dind-golang:24.0.6
+  #  working_directory: /go/src/github.com/astronomer/astro-cli
+    machine:
+      resource_class: medium
+      image: ubuntu-2204:2024.11.1
     steps:
       - integration-test
   new-tag:
@@ -107,19 +108,34 @@ commands:
     description: "Run integration tests"
     steps:
       - checkout
-      - setup_remote_docker
+      - run:
+          name: Install Go
+          command: |
+            set -e
+            cd /tmp
+            if [[ ! -f go.tar.gz ]]
+            then
+              curl -Lo go.tar.gz https://go.dev/dl/go1.23.4.linux-amd64.tar.gz
+            else
+              echo "using existing go"
+            fi
+            sudo rm -rf /usr/local/go
+            sudo tar -C /usr/local -xvf go.tar.gz
+            GOROOT=/usr/local/go go version
+            echo 'export GOROOT=/usr/local/go' >> $BASH_ENV
+      - run:
+          name: Setup python env
+          command: |
+            pyenv install --skip-existing 3.11.1
+            pyenv global 3.11.1
+            pip install poetry
       - run:
           name: Build astro cli
           command: make build
       - run:
-          name: Install Poetry
-          command: |
-            python3 --version
-            pip install poetry
-      - run:
           name: Run integration test
           command: |
-            python3 -m venv penv
+            python -m venv penv
             . penv/bin/activate
             cd integration-test && poetry install --no-root
             pytest -x -s -v dev_test.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   integration-test:
     machine:
       resource_class: medium
-      image: ubuntu-2204:2024.11.1
+      image: ubuntu-2204:current
     steps:
       - integration-test
   new-tag:
@@ -112,12 +112,7 @@ commands:
           command: |
             set -e
             cd /tmp
-            if [[ ! -f go.tar.gz ]]
-            then
-              curl -Lo go.tar.gz https://go.dev/dl/go1.23.4.linux-amd64.tar.gz
-            else
-              echo "using existing go"
-            fi
+            curl -Lo go.tar.gz https://go.dev/dl/go1.23.4.linux-amd64.tar.gz
             sudo rm -rf /usr/local/go
             sudo tar -C /usr/local -xvf go.tar.gz
             GOROOT=/usr/local/go go version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,12 @@ jobs:
       - image: quay.io/astronomer/ap-dind-golang:24.0.6
     steps:
       - test
+  integration-test:
+    working_directory: /go/src/github.com/astronomer/astro-cli
+    docker:
+      - image: quay.io/astronomer/ap-dind-golang:24.0.6
+    steps:
+      - integration-test
   new-tag:
     executor: docker-executor
     steps:
@@ -34,6 +40,13 @@ workflows:
     jobs:
       - lint
       - test
+      - approve-run-integration-tests:
+          type: approval
+      - integration-test:
+          requires:
+            - lint
+            - test
+            - approve-run-integration-tests
       - approve-release:
           requires:
             - lint
@@ -90,6 +103,21 @@ commands:
           command: |
             make test
             bash -c "bash <(curl -s https://codecov.io/bash)"
+  integration-test:
+    description: "Run integration tests"
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build astro cli
+          command: make build
+      - run:
+          name: Run integration test
+          command: |
+            python -m venv penv
+            . penv/bin/activate
+            cd integration-test && poetry install --no-root
+            pytest -x -s -v dev_test.py
   commit-next-tag:
     description: "Tag the commit to the release branch major.minor with the patch number incremented by one"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - test
   integration-test:
-  #  working_directory: /go/src/github.com/astronomer/astro-cli
     machine:
       resource_class: medium
       image: ubuntu-2204:2024.11.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,9 +112,14 @@ commands:
           name: Build astro cli
           command: make build
       - run:
+          name: Install Poetry
+          command: |
+            python3 --version
+            pip install poetry
+      - run:
           name: Run integration test
           command: |
-            python -m venv penv
+            python3 -m venv penv
             . penv/bin/activate
             cd integration-test && poetry install --no-root
             pytest -x -s -v dev_test.py

--- a/integration-test/dev_test.py
+++ b/integration-test/dev_test.py
@@ -92,7 +92,7 @@ def test_dev_init(temp_dir):
 def test_dev_start(docker_client):
     # Run `astro dev start` command
     result = subprocess.run(
-        [ASTRO, "dev", "start"],
+        [ASTRO, "dev", "start", "--no-browser"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,


### PR DESCRIPTION
## Description

Configure/Setup existing circle CI pipeline to include newly added integration tests as part of PR validations.

This new IT's CI run will require an approval to trigger the pipeline, so that we do not trigger these ITs on every push and can be triggered once changes are ready and conserve some resources.

## 🎟 Issue(s)

Related #1754 

## 🧪 Functional Testing

Tested the new integration test CI Pipeline in this PR and all test were invoked as expected. Please find the link below for reference:

https://app.circleci.com/pipelines/github/astronomer/astro-cli/6063/workflows/0ba0dc71-0501-408d-b97a-e961e3d2e9ef/jobs/12594

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
