### PR TITLE
Adds Ability to Chain Cobra RunE Commands

### DIFF
--- a/cmd/root_hooks.go
+++ b/cmd/root_hooks.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	astrocore "github.com/astronomer/astro-cli/astro-client-core"
+	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	cloudCmd "github.com/astronomer/astro-cli/cmd/cloud"
+	softwareCmd "github.com/astronomer/astro-cli/cmd/software"
+	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/version"
+	"github.com/google/go-github/v48/github"
+	"github.com/spf13/cobra"
+)
+
+// SetupLoggingPersistentPreRunE is a pre-run hook shared between software & cloud
+// setting up log verbosity.
+func SetupLoggingPersistentPreRunE(_ *cobra.Command, _ []string) error {
+	return softwareCmd.SetUpLogs(os.Stdout, verboseLevel)
+}
+
+// CreateRootPersistentPreRunE takes clients as arguments and returns a cobra
+// pre-run hook that sets up the context and checks for the latest version.
+func CreateRootPersistentPreRunE(astroCoreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// Check for latest version
+		if config.CFG.UpgradeMessage.GetBool() {
+			// create github client with 3 second timeout, setting an aggressive timeout since its not mandatory to get a response in each command execution
+			githubClient := github.NewClient(&http.Client{Timeout: 3 * time.Second})
+			// compare current version to latest
+			err := version.CompareVersions(githubClient, "astronomer", "astro-cli")
+			if err != nil {
+				softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error comparing CLI versions: "+err.Error())
+			}
+		}
+		if context.IsCloudContext() {
+			err := cloudCmd.Setup(cmd, platformCoreClient, astroCoreClient)
+			if err != nil {
+				if strings.Contains(err.Error(), "token is invalid or malformed") {
+					return errors.New("API Token is invalid or malformed") //nolint
+				}
+				if strings.Contains(err.Error(), "the API token given has expired") {
+					return errors.New("API Token is expired") //nolint
+				}
+				softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error during cmd setup: "+err.Error())
+			}
+		}
+		softwareCmd.PrintDebugLogs()
+		return nil
+	}
+}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -7,6 +7,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type RunE func(cmd *cobra.Command, args []string) error
+
+// ChainRunEs chains multiple RunE functions together for cleaner composition.
+func ChainRunEs(runEs ...RunE) RunE {
+	return func(cmd *cobra.Command, args []string) error {
+		for _, runE := range runEs {
+			if err := runE(cmd, args); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
 func EnsureProjectDir(cmd *cobra.Command, args []string) error {
 	isProjectDir, err := config.IsProjectDir(config.WorkingPath)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR just adds a new utility to chain multiple cobra `RunE` type functions. This PR actually changes nothing functionally, but I'll be building upon this in a future PR to fix the logging of the `astro dev` commands.

Hat tip to @jeremybeard for the original concept [here](https://github.com/astronomer/astro-cli/compare/main...fix-conns-wo-settings-file). 

## Motivation

At the moment, the logging setup in our root `PersistentPreRunE` never actually runs for the `astro dev` commands because we clobber this function property with a separate one. This setup allows us to separate out logic and share composable RunE functions when clobbering a `RunE` command is necessary. 

## 🎟 Issue(s)

Related to https://github.com/astronomer/astro/issues/26133

## 🧪 Functional Testing

Commands still run as expected and all tests pass. New tests added for chain functionality. 

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
