### PR TITLE
update golang version to 1.23 for release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - commit-next-tag
   release:
     docker:
-      - image: golang:1.21.6
+      - image: golang:1.23
     working_directory: /go/src/github.com/astronomer/astro-cli
     steps:
       - checkout


### PR DESCRIPTION
## Description

The goreleaser pipeline seems to be failing because of outdated golang version: https://app.circleci.com/pipelines/github/astronomer/astro-cli/6085/workflows/a3e8c53e-726f-448b-ad22-4c8c73c841e4/jobs/12653

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
