### PR TITLE
bump up release step resource class to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
     docker:
       - image: golang:1.23
     working_directory: /go/src/github.com/astronomer/astro-cli
+    resource_class: large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Description

Bumping up the resource class to provide more memory to get past the failures seen on Circle CI during release step: https://app.circleci.com/pipelines/github/astronomer/astro-cli/6090/workflows/0c0af39a-4a1b-4ead-b608-bbace9ff436f/jobs/12670

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
