### PR TITLE
Use CGO enabled for darwin and windows binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,12 @@ builds:
   - main: main.go
     binary: astro
     env:
-      - CGO_ENABLED=0
+      - >-
+        {{- if or (eq .Os "windows") (eq .Os "darwin") -}}
+          CGO_ENABLED=1
+        {{- else -}}
+          CGO_ENABLED=0
+        {{- end -}}
     goos:
       - linux
       - darwin


### PR DESCRIPTION
## Description

Enabled CGO for windows and darwin CLI binaries to get past failing build step in the release: https://app.circleci.com/pipelines/github/astronomer/astro-cli/6094/workflows/7df0c652-c8a7-43bb-ac7c-33bfdd29b22e/jobs/12683

For context we recently upgraded the `fsevents` indirect dependent library for docker compose lib, and as a result build is failing for darwin if we are using CGO disabled.

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
