### PR TITLE
Fix goreleaser build for darwin with CGO enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
+      - setup-cross-build-libs
       - run:
           name: goreleaser
           command: curl -sL https://raw.githubusercontent.com/goreleaser/get/master/get | bash
@@ -159,3 +160,15 @@ commands:
             git remote set-url origin "https://astro-astronomer:${GITHUB_TOKEN}@github.com/${GIT_ORG}/${CIRCLE_PROJECT_REPONAME}.git"
             git tag $NEXT_TAG
             git push origin $NEXT_TAG
+
+  setup-cross-build-libs:
+    description: "Setup MacOS cross build libraries via osxcross"
+    steps:
+      - run:
+          name: Install cross build libraries
+          command: |
+            apt-get update && apt-get install -y clang llvm cmake libssl-dev patch zlib1g-dev xz-utils
+            git clone https://github.com/tpoechtrager/osxcross.git /osxcross
+            wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz -P /osxcross/tarballs/
+            cd /osxcross && UNATTENDED=yes ./build.sh
+            echo 'export PATH="/osxcross/target/bin:$PATH"' >> $BASH_ENV

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,18 +17,29 @@ changelog:
   sort: asc
   use: github
 builds:
-  - main: main.go
+  - id: darwin-build
+    main: main.go
     binary: astro
     env:
-      - >-
-        {{- if or (eq .Os "windows") (eq .Os "darwin") -}}
-          CGO_ENABLED=1
-        {{- else -}}
-          CGO_ENABLED=0
-        {{- end -}}
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    goos:
+      - darwin
+    goarch:
+      - 386
+      - arm64
+      - amd64
+    goarm:
+      - 7
+    ldflags: -s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }}
+  - id: linux-windows-build
+    main: main.go
+    binary: astro
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
       - windows
     goarch:
       - 386
@@ -58,7 +69,7 @@ archives:
     format_overrides:
       - goos: windows
         format: binary
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - licence*
       - LICENCE*
@@ -71,4 +82,4 @@ archives:
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"


### PR DESCRIPTION
## Description

Changes:
- Divide the build step for Darwin and the rest of the OS, as the if-else block from earlier wasn't working as per expectation because of the extra quotation
- Add a step in the release workflow to install the MacOS clang library, since the container is Linux-based and lacks those libraries.

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Ran build step manually from the circle ci container:
```
root@fa36124a8856:/go/src/github.com/astronomer/astro-cli# curl -sL https://raw.githubusercontent.com/goreleaser/get/master/get | bash -s - build --clean --auto-snapshot --verbose
  • verbose output enabled
  • using configuration                              path=.goreleaser.yml
  • parallelism: 8
  • git command result                               args=[-c log.showSignature=false status --porcelain] stdout=M .goreleaser.yml
?? -
?? main stderr=
  • git repository is dirty and --auto-snapshot is set, implying --snapshot
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
    • using token from  $GITHUB_TOKEN 
    • token type: github
  • getting and validating git state
    • git command result                             args=[-c log.showSignature=false rev-parse --is-inside-work-tree] stdout=true stderr=
    • git command result                             args=[-c log.showSignature=false rev-parse --is-inside-work-tree] stdout=true stderr=
    • git command result                             args=[-c log.showSignature=false rev-parse --abbrev-ref HEAD --quiet] stdout=HEAD stderr=
    • git command result                             args=[-c log.showSignature=false show --format=%h HEAD --quiet] stdout=8316556a stderr=
    • git command result                             args=[-c log.showSignature=false show --format=%H HEAD --quiet] stdout=8316556a2ac4d3c4396ca409a766f23462bee4d7 stderr=
    • git command result                             args=[-c log.showSignature=false rev-list --max-parents=0 HEAD] stdout=00b57ce52153c4674c3a6254bd3e27a52f352f95 stderr=
    • git command result                             args=[-c log.showSignature=false show --format='%ct' HEAD --quiet] stdout='1735842389' stderr=
    • git command result                             args=[-c log.showSignature=false describe --always --dirty --tags] stdout=v1.33.0-dirty stderr=
    • git command result                             args=[-c log.showSignature=false ls-remote --get-url] stdout=git@github.com:astronomer/astro-cli.git stderr=
    • git command result                             args=[-c log.showSignature=false tag --points-at HEAD --sort -version:refname] stdout=v1.33.0 stderr=
    • git command result                             args=[-c log.showSignature=false tag -l --format='%(contents:subject)' v1.33.0] stdout='Use CGO enabled for darwin and windows binaries (#1776)' stderr=
    • git command result                             args=[-c log.showSignature=false tag -l --format='%(contents)' v1.33.0] stdout='Use CGO enabled for darwin and windows binaries (#1776)

' stderr=
    • git command result                             args=[-c log.showSignature=false tag -l --format='%(contents:body)' v1.33.0] stdout='' stderr=
    • git command result                             args=[-c log.showSignature=false describe --tags --abbrev=0 tags/v1.33.0^] stdout=v1.31.0 stderr=
    • git command result                             args=[-c log.showSignature=false rev-list -n1 v1.31.0] stdout=ba53ff961abf392bbf4594d372c13cd5646604ed stderr=
    • git command result                             args=[-c log.showSignature=false tag --points-at ba53ff961abf392bbf4594d372c13cd5646604ed --sort -version:refname] stdout=v1.31.0 stderr=
    • git command result                             args=[-c log.showSignature=false status --porcelain] stdout=M .goreleaser.yml
?? -
?? main stderr=
    • git state                                      commit=8316556a2ac4d3c4396ca409a766f23462bee4d7 branch=HEAD current_tag=v1.33.0 previous_tag=v1.31.0 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
    • pre-release for tag v1.33.0 set to true
    • skipped invalid build                          target=darwin_386_sse2
    • git command result                             args=[-c log.showSignature=false config gpg.program] stdout= stderr=
    • git command result                             args=[-c log.showSignature=false config gpg.program] stdout= stderr=
  • skipped partial
  • snapshotting
    • building snapshot...                           version=SNAPSHOT-8316556a2ac4d3c4396ca409a766f23462bee4d7
  • running before hooks
    • running                                        hook=go mod download
    • running                                        cmd=[go mod download] dir=
    • running                                        hook=go mod tidy
    • running                                        cmd=[go mod tidy] dir=
  • ensuring distribution directory
    • dist doesn't exist, creating empty directory
  • setting up metadata
  • writing release metadata
    • writing                                        path=dist/metadata.json
    • added new artifact                             name=metadata.json type=Metadata path=dist/metadata.json
  • loading go mod information
  • build prerequisites
  • skipped checking go.mod
  • skipped proxying go module
  • writing effective configuration                  path=dist/config.yaml
  • building binaries
    • building                                       build={darwin-build [darwin] [386 arm64 amd64] [v1] [sse2] [7] [v8.0] [hardfloat] [power8] [rva20u64] [darwin_arm64_v8.0 darwin_amd64_v1] [] . main.go astro {[] []} go    go build  false   { [-s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }}] [] [] [] [] [CGO_ENABLED=1 CC=o64-clang CXX=o64-clang++]} []}
    • building                                       build={linux-windows-build [linux windows] [386 arm64 amd64] [v1] [sse2] [7] [v8.0] [hardfloat] [power8] [rva20u64] [linux_386_sse2 linux_arm64_v8.0 linux_amd64_v1 windows_386_sse2 windows_arm64_v8.0 windows_amd64_v1] [] . main.go astro {[] []} go    go build  false   { [-s -w -X github.com/astronomer/astro-cli/version.CurrVersion={{ .Version }}] [] [] [] [] [CGO_ENABLED=0]} []}
    • building                                       binary=dist/linux-windows-build_windows_amd64_v1/astro.exe
    • building                                       binary=dist/darwin-build_darwin_arm64_v8.0/astro
    • building                                       binary=dist/linux-windows-build_linux_arm64_v8.0/astro
    • building                                       binary=dist/linux-windows-build_windows_arm64_v8.0/astro.exe
    • building                                       binary=dist/darwin-build_darwin_amd64_v1/astro
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • env "CGO_ENABLED=1" evaluated to "CGO_ENABLED=1"
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • building                                       binary=dist/linux-windows-build_windows_386_sse2/astro.exe
    • running
    • building                                       binary=dist/linux-windows-build_linux_386_sse2/astro
    • building                                       binary=dist/linux-windows-build_linux_amd64_v1/astro
    • running
    • env "CC=o64-clang" evaluated to "CC=o64-clang"
    • env "CGO_ENABLED=1" evaluated to "CGO_ENABLED=1"
    • env "CXX=o64-clang++" evaluated to "CXX=o64-clang++"
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • env "CC=o64-clang" evaluated to "CC=o64-clang"
    • running
    • env "CXX=o64-clang++" evaluated to "CXX=o64-clang++"
    • env "CGO_ENABLED=0" evaluated to "CGO_ENABLED=0"
    • running
    • running
    • running
    • running
    • running
    • added new artifact                             name=astro type=Binary path=dist/darwin-build_darwin_amd64_v1/astro
    • added new artifact                             name=astro type=Binary path=dist/linux-windows-build_linux_386_sse2/astro
    • added new artifact                             name=astro.exe type=Binary path=dist/linux-windows-build_windows_arm64_v8.0/astro.exe
    • added new artifact                             name=astro type=Binary path=dist/linux-windows-build_linux_arm64_v8.0/astro
    • added new artifact                             name=astro type=Binary path=dist/linux-windows-build_linux_amd64_v1/astro
    • added new artifact                             name=astro.exe type=Binary path=dist/linux-windows-build_windows_386_sse2/astro.exe
    • added new artifact                             name=astro.exe type=Binary path=dist/linux-windows-build_windows_amd64_v1/astro.exe
    • added new artifact                             name=astro type=Binary path=dist/darwin-build_darwin_arm64_v8.0/astro
    • took: 14s
  • skipped universal binaries
  • skipped signing binaries
  • skipped sign & notarize macOS binaries
  • skipped upx
  • skipped size reports
  • writing artifacts metadata
    • writing                                        path=dist/artifacts.json
  • you are using deprecated options, check the output above for details
  • build succeeded after 13s
  • thanks for using GoReleaser!
root@fa36124a8856:/go/src/github.com/astronomer/astro-cli# 
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
