### PR TITLE
Implement gzip for dag bundle compression for cloud deploys

### DIFF
--- a/cloud/deploy/bundle.go
+++ b/cloud/deploy/bundle.go
@@ -142,11 +142,15 @@ func DeleteBundle(input *DeleteBundleInput) error {
 
 func uploadBundle(tarDirPath, bundlePath, uploadURL string, prependBaseDir bool) (string, error) {
 	tarFilePath := filepath.Join(tarDirPath, "bundle.tar")
+	tarGzFilePath := tarFilePath + ".gz"
 	defer func() {
-		err := os.Remove(tarFilePath)
-		if err != nil {
-			fmt.Println("\nFailed to delete tar file: ", err.Error())
-			fmt.Println("\nPlease delete the tar file manually from path: " + tarFilePath)
+		tarFiles := []string{tarFilePath, tarGzFilePath}
+		for _, file := range tarFiles {
+			err := os.Remove(file)
+			if err != nil {
+				fmt.Println("\nFailed to delete archived file: ", err.Error())
+				fmt.Println("\nPlease delete the archived file manually from path: " + file)
+			}
 		}
 	}()
 
@@ -156,13 +160,19 @@ func uploadBundle(tarDirPath, bundlePath, uploadURL string, prependBaseDir bool)
 		return "", err
 	}
 
-	tarFile, err := os.Open(tarFilePath)
+	// Gzip the tar
+	err = fileutil.GzipFile(tarFilePath, tarGzFilePath)
 	if err != nil {
 		return "", err
 	}
-	defer tarFile.Close()
 
-	versionID, err := azureUploader(uploadURL, tarFile)
+	tarGzFile, err := os.Open(tarGzFilePath)
+	if err != nil {
+		return "", err
+	}
+	defer tarGzFile.Close()
+
+	versionID, err := azureUploader(uploadURL, tarGzFile)
 	if err != nil {
 		return "", err
 	}

--- a/cloud/deploy/bundle.go
+++ b/cloud/deploy/bundle.go
@@ -148,6 +148,9 @@ func uploadBundle(tarDirPath, bundlePath, uploadURL string, prependBaseDir bool)
 		for _, file := range tarFiles {
 			err := os.Remove(file)
 			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
 				fmt.Println("\nFailed to delete archived file: ", err.Error())
 				fmt.Println("\nPlease delete the archived file manually from path: " + file)
 			}


### PR DESCRIPTION
## Description

This PR implements gzip compression for tar dag bundles for cloud based dag only deployments.

This is part of long term solutions that were discussed as part of nova `#nova-20241227-devoid-mass` where it was observed that dag deployment for large dag bundles could take up to 20-30 mins to initiate astro dag only deploy.

Links for reference:

https://astronomer.slack.com/archives/C08671SHPUP/p1735582286325009

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Tested these changes on dev deployment. Please find below details for reference:

- Created a deployment on dev cluster. Deployment Id: cm5gr26z504ir01ocmbepukg7
- Created Astro project with 630 Mb dags directory size.
- Created sample tar bundle manually in order to compare the compression and could see that tar bundle turns out to be of 440 Mb

```
ls -ltr                                    
drwxr-xr-x pritt staff  64 B  Fri Jan  3 18:35:31 2025  plugins
drwxr-xr-x pritt staff  64 B  Fri Jan  3 18:35:31 2025  include
drwxr-xr-x pritt staff  96 B  Fri Jan  3 18:35:31 2025  tests
.rw-r--r-- pritt staff  45 B  Fri Jan  3 18:35:31 2025  Dockerfile
.rw-r--r-- pritt staff 866 B  Fri Jan  3 18:35:31 2025  airflow_settings.yaml
.rw-r--r-- pritt staff 155 B  Fri Jan  3 18:35:31 2025  requirements.txt
.rw-r--r-- pritt staff 3.3 KB Fri Jan  3 18:35:31 2025  README.md
.rw-r--r-- pritt staff   0 B  Fri Jan  3 18:35:31 2025  packages.txt
drwxr-xr-x pritt staff 192 B  Fri Jan  3 18:43:51 2025  dags
.rw-r--r-- pritt staff 440 MB Fri Jan  3 18:53:32 2025  bundle.tar

```

- Pushed the dags via astro cli dag deploy functionality to above created deployment. Took around 30-40 sec.

```
/Users/pritt/go/src/github.com/astronomer/astro-cli/astro deploy -d
Authenticated to astronomer-dev.io 

Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME                      DEPLOYMENT ID                 DAG DEPLOY ENABLED     
 1     neel-test-1_DND     ultraviolet-blueshift-6057        cm5cfqhag02dn01nq2zncpnn2     true                   
 2     pritt-test          mathematical-exploration-7116     cm5gr26z504ir01ocmbepukg7     true                   

> 2
Initiating DAG deploy for: cm5gr26z504ir01ocmbepukg7
Deployed DAG bundle:  2025-01-03T13:28:41.2286129Z
Deployed Image Tag:  12.6.0

Successfully uploaded DAGs with version 2025-01-03T13:28:41.2286129Z to Astro. Navigate to the Airflow UI to confirm that your deploy was successful. The Airflow UI takes about 1 minute to update.

 Access your Deployment:

 Deployment View: cloud.astronomer-dev.io/clm7hapoz009a01ok5jn619kt/deployments/cm5gr26z504ir01ocmbepukg7/overview
 Airflow UI: neel-test-hosted.astronomer-dev.run/dbepukg7?orgId=org_bQTPWyCrWrv7QA4M

```

- Validated the bundle size in azure storage account and could see that bundle was compressed successfully and size of bundle was reduced to 2.3Mb

![image](https://github.com/user-attachments/assets/85c050a9-6ef5-4bf5-ab8d-a880229ae63d)


- Validated that dags are deployed successfully.

![image](https://github.com/user-attachments/assets/4729f90c-2056-4110-b55a-0de706c3f532)

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
