### PR TITLE
Cleanup typos and messaging for dev parse/pytest command

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -657,7 +657,7 @@ func (d *DockerCompose) pullImageFromDeployment(deploymentID string, platformCor
 }
 
 func (d *DockerCompose) conflictTest(testHomeDirectory, newImageName, newAirflowVersion string) error {
-	fmt.Println("\nChecking your 'requirments.txt' for dependency conflicts with the new version of Airflow")
+	fmt.Println("\nChecking your 'requirements.txt' for dependency conflicts with the new version of Airflow")
 	fmt.Println("\nThis may take a few minutes...")
 
 	// create files needed for conflict test
@@ -1082,7 +1082,7 @@ func (d *DockerCompose) Parse(customImageName, deployImageName, buildSecretStrin
 		return err
 	}
 
-	fmt.Println("\nChecking your DAGs for errors,\nthis might take a minute if you haven't run this command before…")
+	fmt.Println("Checking your DAGs for errors…")
 
 	pytestFile := DefaultTestPath
 	exitCode, err := d.Pytest(pytestFile, customImageName, deployImageName, "", buildSecretString)
@@ -1092,7 +1092,7 @@ func (d *DockerCompose) Parse(customImageName, deployImageName, buildSecretStrin
 		}
 		return errors.Wrap(err, "something went wrong while parsing your DAGs")
 	}
-	fmt.Println("\n" + ansi.Green("✔") + " no errors detected in your DAGs ")
+	fmt.Println(ansi.Green("✔") + " No errors detected in your DAGs ")
 	return err
 }
 

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -364,7 +364,7 @@ func newAirflowPytestCmd() *cobra.Command {
 func newAirflowParseCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "parse",
-		Short:   "parse all DAGs in your Astro project for errors",
+		Short:   "Parse all DAGs in your Astro project for errors",
 		Long:    "This command spins up a local Python environment and checks your DAGs for syntax and import errors.",
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: EnsureRuntime,
@@ -845,7 +845,7 @@ func airflowPytest(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println("Running Pytest\nThis may take a minute if you have not run this command before…")
+	fmt.Println("Running your test suite…")
 
 	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile, dockerfile, imageName)
 	if err != nil {
@@ -857,12 +857,12 @@ func airflowPytest(cmd *cobra.Command, args []string) error {
 	exitCode, err := containerHandler.Pytest(pytestFile, customImageName, "", pytestArgs, buildSecretString)
 	if err != nil {
 		if strings.Contains(exitCode, "1") { // exit code is 1 meaning tests failed
-			return errors.New("pytests failed")
+			return errors.New("pytest failed")
 		}
 		return err
 	}
 
-	fmt.Println("\n" + ansi.Green("✔") + " All Pytests passed!")
+	fmt.Println("\n" + ansi.Green("✔") + " All tests passed!")
 	return err
 }
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1131,7 +1131,7 @@ func (s *AirflowSuite) TestAirflowPytest() {
 		}
 
 		err := airflowPytest(cmd, args)
-		s.Contains(err.Error(), "pytests failed")
+		s.Contains(err.Error(), "pytest failed")
 		mockContainerHandler.AssertExpectations(s.T())
 	})
 


### PR DESCRIPTION
## Description

This is just a small cosmetic PR to clean up some output on `astro dev parse` and `astro dev pytest`.

## 🧪 Functional Testing

Run the commands locally. The changes are purely cosmetic. 

## 📸 Screenshots

## `astro dev parse`
![Screenshot 2025-01-30 at 3 13 36 PM](https://github.com/user-attachments/assets/54d90887-4d33-4c52-b403-aa67b26183a1)

## `astro dev pytest`
![Screenshot 2025-01-30 at 3 14 13 PM](https://github.com/user-attachments/assets/d3a7aa9b-ca28-47b7-bfc3-69a1908a8dbd)


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
