### PR TITLE
Switch Project Dockerfiles from Quay to Azure ACR

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -787,14 +787,14 @@ func upgradeDockerfile(oldDockerfilePath, newDockerfilePath, newTag, newImage st
 	var newContent strings.Builder
 	if newImage == "" {
 		for _, line := range lines {
-			if strings.HasPrefix(strings.TrimSpace(line), "FROM quay.io/astronomer/astro-runtime:") {
+			if strings.HasPrefix(strings.TrimSpace(line), "FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:") {
 				// Replace the tag on the matching line
 				parts := strings.SplitN(line, ":", partsNum)
 				if len(parts) == partsNum {
 					line = parts[0] + ":" + newTag
 				}
 			}
-			if strings.HasPrefix(strings.TrimSpace(line), "FROM quay.io/astronomer/ap-airflow:") {
+			if strings.HasPrefix(strings.TrimSpace(line), "FROM astrocrpublic.azurecr.io/astronomer/ap-airflow:") {
 				isRuntime, err := isRuntimeVersion(newTag)
 				if err != nil {
 					logger.Debug(err)

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1708,7 +1708,7 @@ func (s *Suite) TestUpgradeDockerfile() {
 	s.Run("update Dockerfile with new tag", func() {
 		// Create a temporary old Dockerfile
 		oldDockerfilePath := "test_old_Dockerfile"
-		oldContent := "FROM quay.io/astronomer/astro-runtime:old-tag\n"
+		oldContent := "FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:old-tag\n"
 		err := os.WriteFile(oldDockerfilePath, []byte(oldContent), 0o644)
 		s.NoError(err)
 		defer os.Remove(oldDockerfilePath)
@@ -1727,13 +1727,13 @@ func (s *Suite) TestUpgradeDockerfile() {
 		// Read the new Dockerfile and check its content
 		newContent, err := os.ReadFile(newDockerfilePath)
 		s.NoError(err)
-		s.Contains(string(newContent), "FROM quay.io/astronomer/astro-runtime:new-tag")
+		s.Contains(string(newContent), "FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:new-tag")
 	})
 
 	s.Run("update Dockerfile with new image", func() {
 		// Create a temporary old Dockerfile
 		oldDockerfilePath := "test_old_Dockerfile"
-		oldContent := "FROM quay.io/astronomer/astro-runtime:old-tag\n"
+		oldContent := "FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:old-tag\n"
 		err := os.WriteFile(oldDockerfilePath, []byte(oldContent), 0o644)
 		s.NoError(err)
 		defer os.Remove(oldDockerfilePath)
@@ -1758,7 +1758,7 @@ func (s *Suite) TestUpgradeDockerfile() {
 	s.Run("update Dockerfile for ap-airflow with runtime version", func() {
 		// Create a temporary old Dockerfile with a line matching the pattern
 		oldDockerfilePath := "test_old_Dockerfile"
-		oldContent := "FROM quay.io/astronomer/ap-airflow:old-tag"
+		oldContent := "FROM astrocrpublic.azurecr.io/astronomer/ap-airflow:old-tag"
 		err := os.WriteFile(oldDockerfilePath, []byte(oldContent), 0o644)
 		s.NoError(err)
 		defer os.Remove(oldDockerfilePath)
@@ -1777,13 +1777,13 @@ func (s *Suite) TestUpgradeDockerfile() {
 		// Read the new Dockerfile and check its content
 		newContent, err := os.ReadFile(newDockerfilePath)
 		s.NoError(err)
-		s.Contains(string(newContent), "FROM quay.io/astronomer/astro-runtime:5.0.0\n")
+		s.Contains(string(newContent), "FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:5.0.0\n")
 	})
 
 	s.Run("update Dockerfile for ap-airflow with non-runtime version", func() {
 		// Create a temporary old Dockerfile with a line matching the pattern
 		oldDockerfilePath := "test_old_Dockerfile"
-		oldContent := "FROM quay.io/astronomer/ap-airflow:old-tag\n"
+		oldContent := "FROM astrocrpublic.azurecr.io/astronomer/ap-airflow:old-tag\n"
 		err := os.WriteFile(oldDockerfilePath, []byte(oldContent), 0o644)
 		s.NoError(err)
 		defer os.Remove(oldDockerfilePath)
@@ -1802,7 +1802,7 @@ func (s *Suite) TestUpgradeDockerfile() {
 		// Read the new Dockerfile and check its content
 		newContent, err := os.ReadFile(newDockerfilePath)
 		s.NoError(err)
-		s.Contains(string(newContent), "FROM quay.io/astronomer/ap-airflow:new-tag")
+		s.Contains(string(newContent), "FROM astrocrpublic.azurecr.io/astronomer/ap-airflow:new-tag")
 	})
 
 	s.Run("error reading old Dockerfile", func() {

--- a/airflow/include/dockerfile
+++ b/airflow/include/dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/%s:%s
+FROM astrocrpublic.azurecr.io/astronomer/%s:%s

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -194,7 +194,7 @@ func (s *AirflowSuite) Test_airflowInitNonEmptyDir() {
 
 		b, _ := os.ReadFile(filepath.Join(s.tempDir, "Dockerfile"))
 		dockerfileContents := string(b)
-		s.True(strings.Contains(dockerfileContents, "FROM quay.io/astronomer/astro-runtime:"))
+		s.True(strings.Contains(dockerfileContents, "FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:"))
 	})
 }
 
@@ -210,7 +210,7 @@ func (s *AirflowSuite) Test_airflowInitNoDefaultImageTag() {
 		// assert contents of Dockerfile
 		b, _ := os.ReadFile(filepath.Join(s.tempDir, "Dockerfile"))
 		dockerfileContents := string(b)
-		s.True(strings.Contains(dockerfileContents, "FROM quay.io/astronomer/astro-runtime:"))
+		s.True(strings.Contains(dockerfileContents, "FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:"))
 	})
 }
 
@@ -317,7 +317,7 @@ func (s *AirflowSuite) TestAirflowInit() {
 
 		b, _ := os.ReadFile(filepath.Join(s.tempDir, "Dockerfile"))
 		dockerfileContents := string(b)
-		s.True(strings.Contains(dockerfileContents, "FROM quay.io/astronomer/astro-runtime:"))
+		s.True(strings.Contains(dockerfileContents, "FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:"))
 	})
 
 	s.Run("invalid project name", func() {


### PR DESCRIPTION
## Description

Noticed we still scaffold out quay.io for our astro-runtime image in the `Dockerfile`. @jedcunningham mentioned AF3 will only be pushed to ACR only, so seems like this needs to happen soon-ish anyway.

@jeremybeard @jedcunningham @melugoyal @jpweber any reason not to do this?

## 🎟 Issue(s)

No issue here, unless there's one on the AF3 board somewhere.

## 🧪 Functional Testing

`astro dev start` and friends build the image as normal.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
