### PR TITLE
Fix: Strip newline characters from dag_integrity_exceptions.txt entries

### DIFF
--- a/airflow/include/dagintegritytestdefault.py
+++ b/airflow/include/dagintegritytestdefault.py
@@ -131,7 +131,7 @@ def test_file_imports(rel_path, rv):
     """Test for import errors on a file"""
     if os.path.exists(".astro/dag_integrity_exceptions.txt"):
         with open(".astro/dag_integrity_exceptions.txt", "r") as f:
-            exceptions = f.readlines()
+            exceptions = [line.rstrip() for line in f]
     print(f"Exceptions: {exceptions}")
     if (rv != "No import errors") and rel_path not in exceptions:
         # If rv is not "No import errors," consider it a failed test


### PR DESCRIPTION
## Description

By stripping the output, we ensure that DAG names are correctly matched as defined in dag_integrity_exceptions.txt.

**Example output before fix:**

`Exceptions: ['# Add dag files to exempt from parse test below. ex: dags/<test-file>\n', 'dags/dag_example1\n', 'dags/dag_example2.py']`


## 🎟 Issue(s)

> The readlines module does not strip newline characters (\n) from the output, causing entries in dag_integrity_exceptions.txt to include them. This leads to incorrect comparisons and breaks the logic.


## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.
Before change:
![image](https://github.com/user-attachments/assets/83562e68-e638-4417-95f8-4ef8120a445d)

After change:
![image](https://github.com/user-attachments/assets/ffd41641-4f1f-4e6d-bba4-040715e81c2d)


## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
