### PR TITLE
Removed warnings for users if they want to use some other base image other than quay.io inside astro deploy

### DIFF
--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -244,14 +244,8 @@ func buildDockerImageFromWorkingDir(path string, imageHandler airflow.ImageHandl
 		return fmt.Errorf("failed to parse dockerfile: %s: %w", filepath.Join(path, dockerfile), err)
 	}
 
-	image, tag := docker.GetImageTagFromParsedFile(cmds)
-	if config.CFG.ShowWarnings.GetBool() && !validAirflowImageRepo(image) && !validRuntimeImageRepo(image) {
-		i, _ := input.Confirm(fmt.Sprintf(warningInvalidImageName, image))
-		if !i {
-			fmt.Println("Canceling deploy...")
-			os.Exit(1)
-		}
-	}
+	_, tag := docker.GetImageTagFromParsedFile(cmds)
+
 	// Get valid image tags for platform using Deployment Info request
 	err = validateRuntimeVersion(houstonClient, tag, deploymentInfo)
 	if err != nil {
@@ -297,29 +291,6 @@ func buildPushDockerImage(houstonClient houston.ClientInterface, c *config.Conte
 		return err
 	}
 	return pushDockerImage(byoRegistryEnabled, byoRegistryDomain, name, nextTag, cloudDomain, imageHandler, houstonClient, c, customImageName)
-}
-
-func validAirflowImageRepo(image string) bool {
-	validDockerfileBaseImages := map[string]bool{
-		"quay.io/astronomer/ap-airflow": true,
-		"astronomerinc/ap-airflow":      true,
-	}
-	result, ok := validDockerfileBaseImages[image]
-	if !ok {
-		return false
-	}
-	return result
-}
-
-func validRuntimeImageRepo(image string) bool {
-	validDockerfileBaseImages := map[string]bool{
-		"quay.io/astronomer/astro-runtime": true,
-	}
-	result, ok := validDockerfileBaseImages[image]
-	if !ok {
-		return false
-	}
-	return result
 }
 
 func getAirflowUILink(deploymentID string, deploymentURLs []houston.DeploymentURL) string {

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -91,18 +91,6 @@ func (s *Suite) TestDeploymentNameDoesntExists() {
 	s.False(deploymentExists("dev-test", deployments))
 }
 
-func (s *Suite) TestValidAirflowImageRepo() {
-	s.True(validAirflowImageRepo("quay.io/astronomer/ap-airflow"))
-	s.True(validAirflowImageRepo("astronomerinc/ap-airflow"))
-	s.False(validAirflowImageRepo("personal-repo/ap-airflow"))
-}
-
-func (s *Suite) TestValidRuntimeImageRepo() {
-	s.False(validRuntimeImageRepo("quay.io/astronomer/ap-airflow"))
-	s.True(validRuntimeImageRepo("quay.io/astronomer/astro-runtime"))
-	s.False(validRuntimeImageRepo("personal-repo/ap-airflow"))
-}
-
 func (s *Suite) SetupSuite() {
 	// Common setup logic for the test suite
 	s.fsForLocalConfig = afero.NewMemMapFs()


### PR DESCRIPTION
## Description

Removed warnings for users if they want to use some other base image other than quay.io inside astro deploy

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/6873

## 🧪 Functional Testing

Tested on local

## 📸 Screenshots
It can be seen that we didn't ask for any user confirmation for non-quay repo.

<img width="1639" alt="Screenshot 2025-03-06 at 4 27 16 PM" src="https://github.com/user-attachments/assets/ef6b3973-e67d-4f7d-88aa-cb78410bdca9" />

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
