### PR TITLE
Bump resource class for release job to reduce failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
     docker:
       - image: golang:1.23
     working_directory: /go/src/github.com/astronomer/astro-cli
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - setup-cross-build-libs


### PR DESCRIPTION
## Description

The current large resource class seems to be maxing out in terms of CPU and memory causing frequent build failure when releasing new CLI versions. This is due to high requirements when we try to build various platforms and arch binaries that need to cross-compile libs along with cgo enabled. 

Reference job stats: https://app.circleci.com/pipelines/github/astronomer/astro-cli/6195/workflows/549fbbc2-32bb-4f05-a8de-5c19e1a29e38/jobs/13010/resources