### PR TITLE
Add JWT secret for API server auth

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -355,6 +355,7 @@ services:
 		expectedCfg := `x-common-env-vars: &common-env-vars
   AIRFLOW__API__BASE_URL: "http://localhost:8080"
   AIRFLOW__API__PORT: 8080
+  AIRFLOW__API_AUTH__JWT_SECRET: "test-project-name"
   AIRFLOW__CORE__AUTH_MANAGER: airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager
   AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS: "True"
   AIRFLOW__CORE__EXECUTION_API_SERVER_URL: "http://api-server:8080/execution/"

--- a/airflow/include/airflow3/composeyml.go.tmpl
+++ b/airflow/include/airflow3/composeyml.go.tmpl
@@ -1,6 +1,7 @@
 x-common-env-vars: &common-env-vars
   AIRFLOW__API__BASE_URL: "http://localhost:8080"
   AIRFLOW__API__PORT: 8080
+  AIRFLOW__API_AUTH__JWT_SECRET: "{{ .ProjectName }}"
   AIRFLOW__CORE__AUTH_MANAGER: airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager
   AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS: "True"
   AIRFLOW__CORE__EXECUTION_API_SERVER_URL: "http://api-server:8080/execution/"


### PR DESCRIPTION
## Description

This change adds a new env var to the Airflow 3 local dev docker-compose file, to provide a JWT secret for the Airflow containers to authenticate to the API server.

## 🧪 Functional Testing

Latest pre-release Airflow 3 image now starts up and runs DAGs.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
