### PR TITLE
Support Airflow 2 to 3 deployment upgrades

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -1416,7 +1416,7 @@ var CheckTriggererEnabled = func(imageLabels map[string]string) (bool, error) {
 		return false, nil
 	}
 
-	return versions.GreaterThanOrEqualTo(runtimeVersion, triggererAllowedRuntimeVersion), nil
+	return airflowversions.CompareRuntimeVersions(runtimeVersion, triggererAllowedRuntimeVersion) >= 0, nil
 }
 
 func checkServiceState(serviceState, expectedState string) bool {

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	httpContext "context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,8 +23,8 @@ import (
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
+	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/util"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
 )
 
@@ -34,18 +33,14 @@ const (
 	astroDomain            = "astronomer.io"
 	registryUsername       = "cli"
 	runtimeImageLabel      = airflow.RuntimeImageLabel
-	defaultRuntimeVersion  = "4.2.5"
 	dagParseAllowedVersion = "4.1.0"
 
 	composeImageBuildingPromptMsg     = "Building image..."
 	composeSkipImageBuildingPromptMsg = "Skipping building image..."
 	deploymentHeaderMsg               = "Authenticated to %s \n\n"
 
-	warningInvaildImageNameMsg = "WARNING! The image in your Dockerfile '%s' is not based on Astro Runtime and is not supported. Change your Dockerfile with an image that pulls from 'quay.io/astronomer/astro-runtime' to proceed.\n"
-	warningInvalidImageTagMsg  = "WARNING! You are about to push an image using the '%s' runtime tag. This is not supported.\nConsider using one of the following supported tags: %s"
+	warningInvalidImageNameMsg = "WARNING! The image in your Dockerfile '%s' is not based on Astro Runtime and is not supported. Change your Dockerfile with an image that pulls from 'quay.io/astronomer/astro-runtime' to proceed.\n"
 
-	message                  = "DAGs uploaded successfully"
-	action                   = "UPLOAD"
 	allTests                 = "all-tests"
 	parseAndPytest           = "parse-and-all-tests"
 	enableDagDeployMsg       = "DAG-only deploys are not enabled for this Deployment. Run 'astro deployment update %s --dag-deploy enable' to enable DAG-only deploys"
@@ -112,6 +107,7 @@ type InputDeploy struct {
 	DagsPath          string
 	Description       string
 	BuildSecretString string
+	ForceUpgradeToAF3 bool
 }
 
 const accessYourDeploymentFmt = `
@@ -265,7 +261,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 			}
 		}
 		if deployInput.Pytest != "" {
-			runtimeVersion, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.organizationID, deployInput.BuildSecretString, deployInfo.dagDeployEnabled, platformCoreClient)
+			runtimeVersion, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.organizationID, deployInput.BuildSecretString, deployInfo.dagDeployEnabled, deployInput.ForceUpgradeToAF3, platformCoreClient)
 			if err != nil {
 				return err
 			}
@@ -345,7 +341,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 		}
 
 		// Build our image
-		runtimeVersion, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.organizationID, deployInput.BuildSecretString, deployInfo.dagDeployEnabled, platformCoreClient)
+		runtimeVersion, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.organizationID, deployInput.BuildSecretString, deployInfo.dagDeployEnabled, deployInput.ForceUpgradeToAF3, platformCoreClient)
 		if err != nil {
 			return err
 		}
@@ -462,8 +458,8 @@ func getDeploymentInfo(
 }
 
 func parseOrPytestDAG(pytest, runtimeVersion, envFile, deployImage, namespace, buildSecretString string) error {
-	dagParseVersionCheck := versions.GreaterThanOrEqualTo(runtimeVersion, dagParseAllowedVersion)
-	if !dagParseVersionCheck {
+	validDAGParseVersion := airflowversions.CompareRuntimeVersions(runtimeVersion, dagParseAllowedVersion) >= 0
+	if !validDAGParseVersion {
 		fmt.Println("\nruntime image is earlier than 4.1.0, this deploy will skip DAG parse...")
 	}
 
@@ -473,7 +469,7 @@ func parseOrPytestDAG(pytest, runtimeVersion, envFile, deployImage, namespace, b
 	}
 
 	switch {
-	case pytest == parse && dagParseVersionCheck:
+	case pytest == parse && validDAGParseVersion:
 		// parse dags
 		fmt.Println("Testing image...")
 		err := parseDAGs(deployImage, buildSecretString, containerHandler)
@@ -637,7 +633,7 @@ func buildImageWithoutDags(path, buildSecretString string, imageHandler airflow.
 	return nil
 }
 
-func buildImage(path, currentVersion, deployImage, imageName, organizationID, buildSecretString string, dagDeployEnabled bool, platformCoreClient astroplatformcore.CoreClient) (version string, err error) {
+func buildImage(path, currentVersion, deployImage, imageName, organizationID, buildSecretString string, dagDeployEnabled, forceUpgradeToAF3 bool, platformCoreClient astroplatformcore.CoreClient) (version string, err error) {
 	imageHandler := airflowImageHandler(deployImage)
 
 	if imageName == "" {
@@ -679,14 +675,11 @@ func buildImage(path, currentVersion, deployImage, imageName, organizationID, bu
 	}
 
 	if config.CFG.ShowWarnings.GetBool() && version == "" {
-		fmt.Printf(warningInvaildImageNameMsg, DockerfileImage)
+		fmt.Printf(warningInvalidImageNameMsg, DockerfileImage)
 		fmt.Println("Canceling deploy...")
 		os.Exit(1)
 	}
 
-	if version == "" {
-		version = defaultRuntimeVersion
-	}
 	resp, err := platformCoreClient.GetDeploymentOptionsWithResponse(httpContext.Background(), organizationID, &astroplatformcore.GetDeploymentOptionsParams{})
 	if err != nil {
 		return "", err
@@ -695,30 +688,17 @@ func buildImage(path, currentVersion, deployImage, imageName, organizationID, bu
 	if err != nil {
 		return "", err
 	}
-
-	runtimeReleases := resp.JSON200.RuntimeReleases
-	runtimeVersions := []string{}
-
-	for _, runtimeRelease := range runtimeReleases {
-		runtimeVersions = append(runtimeVersions, runtimeRelease.Version)
+	deploymentOptionsRuntimeVersions := []string{}
+	for _, runtimeRelease := range resp.JSON200.RuntimeReleases {
+		deploymentOptionsRuntimeVersions = append(deploymentOptionsRuntimeVersions, runtimeRelease.Version)
 	}
 
-	isValidRuntimeVersions := ValidTags(runtimeVersions, currentVersion)
-	isUpgradeValid := IsValidUpgrade(currentVersion, version)
-
-	if !isUpgradeValid {
-		fmt.Printf("You pushed a version of Astro Runtime that is incompatible with your Deployment\nModify your Astro Runtime version to %s or higher in your Dockerfile and try again\n", currentVersion)
+	if !ValidRuntimeVersion(currentVersion, version, deploymentOptionsRuntimeVersions, forceUpgradeToAF3) {
 		fmt.Println("Canceling deploy...")
 		os.Exit(1)
 	}
 
-	isTagValid := IsValidTag(isValidRuntimeVersions, version)
-
-	CheckVersion(version, os.Stdout)
-
-	if !isTagValid {
-		fmt.Println(fmt.Sprintf(warningInvalidImageTagMsg, version, isValidRuntimeVersions))
-	}
+	WarnIfNonLatestVersion(version, httputil.NewHTTPClient())
 
 	return version, nil
 }
@@ -758,69 +738,52 @@ func createDeploy(organizationID, deploymentID string, request astroplatformcore
 	return resp.JSON200, err
 }
 
-func IsValidUpgrade(currentVersion, tag string) bool {
-	// To allow old deployments which do not have runtimeVersion tag
+func ValidRuntimeVersion(currentVersion, tag string, deploymentOptionsRuntimeVersions []string, forceUpgradeToAF3 bool) bool {
+	// Allow old deployments which do not have runtimeVersion tag
 	if currentVersion == "" {
 		return true
 	}
 
-	tagVersion := util.Coerce(tag)
-	currentTagVersion := util.Coerce(currentVersion)
-
-	if i := tagVersion.Compare(currentTagVersion); i >= 0 {
-		return true
+	// Check that the tag is not a downgrade
+	if airflowversions.CompareRuntimeVersions(tag, currentVersion) < 0 {
+		fmt.Printf("Cannot deploy a downgraded Astro Runtime version. Modify your Astro Runtime version to %s or higher in your Dockerfile\n", currentVersion)
+		return false
 	}
 
-	return false
-}
-
-func IsValidTag(runtimeVersions []string, tag string) bool {
-	tagVersion := util.Coerce(tag)
-	for _, runtimeVersion := range runtimeVersions {
-		supportedVersion := util.Coerce(runtimeVersion)
-		// i = 1 means version greater than
-		if i := supportedVersion.Compare(tagVersion); i == 0 {
-			return true
+	// Check that the tag is supported by the deployment
+	tagInDeploymentOptions := false
+	for _, runtimeVersion := range deploymentOptionsRuntimeVersions {
+		if airflowversions.CompareRuntimeVersions(tag, runtimeVersion) == 0 {
+			tagInDeploymentOptions = true
+			break
 		}
 	}
-	return false
-}
-
-func ValidTags(runtimeVersions []string, currentVersion string) []string {
-	// For old deployments which do not have runtimeVersion tag
-	if currentVersion == "" {
-		return runtimeVersions
+	if !tagInDeploymentOptions {
+		fmt.Println("Cannot deploy an unsupported Astro Runtime version. Modify your Astro Runtime version to a supported version in your Dockerfile")
+		fmt.Printf("Supported versions: %s\n", strings.Join(deploymentOptionsRuntimeVersions, ", "))
+		return false
 	}
 
-	currentTagVersion := util.Coerce(currentVersion)
-	validVersions := []string{}
-
-	for _, runtimeVersion := range runtimeVersions {
-		supportedVersion := util.Coerce(runtimeVersion)
-		// i = 1 means version greater than
-		if i := supportedVersion.Compare(currentTagVersion); i >= 0 {
-			validVersions = append(validVersions, runtimeVersion)
-		}
+	// If upgrading from Airflow 2 to Airflow 3, we require the user to force the upgrade
+	currentVersionAirflowMajorVersion := airflowversions.AirflowMajorVersionForRuntimeVersion(currentVersion)
+	tagAirflowMajorVersion := airflowversions.AirflowMajorVersionForRuntimeVersion(tag)
+	if currentVersionAirflowMajorVersion == "2" && tagAirflowMajorVersion == "3" && !forceUpgradeToAF3 {
+		fmt.Println("Cannot upgrade from Airflow 2 to Airflow 3 without the --force-upgrade-to-af3 flag")
+		return false
 	}
 
-	return validVersions
+	return true
 }
 
-func CheckVersion(version string, out io.Writer) {
-	httpClient := airflowversions.NewClient(httputil.NewHTTPClient(), false)
-	latestRuntimeVersion, _ := airflowversions.GetDefaultImageTag(httpClient, "")
-	switch {
-	case versions.LessThan(version, latestRuntimeVersion):
-		// if current runtime version is not greater than or equal to the latest runtime verion let the user know
-		fmt.Fprintf(out, "WARNING! You are currently running Astro Runtime Version %s\nConsider upgrading to the latest version, Astro Runtime %s\n", version, latestRuntimeVersion)
-	case versions.GreaterThan(version, latestRuntimeVersion):
-		i, _ := input.Confirm("WARNING! The Astro Runtime image in your Dockerfile is classified as \"Beta\" and may not be fit for pipelines in production. Are you sure you want to continue?\n")
+func WarnIfNonLatestVersion(version string, httpClient *httputil.HTTPClient) {
+	client := airflowversions.NewClient(httpClient, false)
+	latestRuntimeVersion, err := airflowversions.GetDefaultImageTag(client, "")
+	if err != nil {
+		logger.Debugf("unable to get latest runtime version: %s", err)
+		return
+	}
 
-		if !i {
-			fmt.Fprintf(out, "Canceling deploy...")
-			os.Exit(1)
-		}
-	default:
-		fmt.Fprintf(out, "Runtime Version: %s\n", version)
+	if airflowversions.CompareRuntimeVersions(version, latestRuntimeVersion) <= 0 {
+		fmt.Printf("WARNING! You are currently running Astro Runtime Version %s\nConsider upgrading to the latest version, Astro Runtime %s\n", version, latestRuntimeVersion)
 	}
 }

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/astronomer/astro-cli/airflow"
 	"github.com/astronomer/astro-cli/airflow/mocks"
-	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
@@ -90,8 +90,12 @@ var (
 		},
 		JSON200: &astroplatformcore.DeploymentOptions{
 			RuntimeReleases: []astroplatformcore.RuntimeRelease{
-				{Version: "4.0.0"},
-				{Version: "5.0.0"},
+				{Version: "12.0.0"},
+				{Version: "4.2.6"},
+				{Version: "4.2.5"},
+				{Version: "3.1-1"},
+				{Version: "3.0-3"},
+				{Version: "3.0-1"},
 			},
 		},
 	}
@@ -101,7 +105,7 @@ var (
 		},
 		JSON200: &astroplatformcore.Deployment{
 			Id:                 deploymentID,
-			RuntimeVersion:     "4.2.5",
+			RuntimeVersion:     "12.0.0",
 			Namespace:          "test-name",
 			WorkspaceId:        ws,
 			WebServerUrl:       "test-url",
@@ -115,7 +119,7 @@ var (
 		},
 		JSON200: &astroplatformcore.Deployment{
 			Id:                 deploymentID,
-			RuntimeVersion:     "4.2.5",
+			RuntimeVersion:     "12.0.0",
 			Namespace:          "test-name",
 			WorkspaceId:        ws,
 			WebServerUrl:       "test-url",
@@ -131,7 +135,7 @@ var (
 		},
 		JSON200: &astroplatformcore.Deployment{
 			Id:                       deploymentID,
-			RuntimeVersion:           "4.2.5",
+			RuntimeVersion:           "12.0.0",
 			Namespace:                "test-name",
 			WorkspaceId:              ws,
 			WebServerUrl:             "test-url",
@@ -172,7 +176,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
 	}
@@ -316,7 +320,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
 	}
@@ -452,7 +456,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
 	}
@@ -530,7 +534,7 @@ func TestImageOnlyDeploySuccess(t *testing.T) {
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
 	}
@@ -618,7 +622,7 @@ func TestDagsDeployFailed(t *testing.T) {
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("4.2.5", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
 		return mockImageHandler
 	}
 
@@ -683,7 +687,7 @@ func TestDeployFailure(t *testing.T) {
 	mockImageHandler := new(mocks.ImageHandler)
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("4.2.5", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
 		return mockImageHandler
 	}
 
@@ -778,7 +782,7 @@ func TestDeployMonitoringDAGNonHosted(t *testing.T) {
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
 		return mockImageHandler
 	}
@@ -856,7 +860,7 @@ func TestDeployNoMonitoringDAGHosted(t *testing.T) {
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
 		mockImageHandler.On("TagLocalImage", mock.Anything).Return("", nil)
 		return mockImageHandler
 	}
@@ -901,70 +905,253 @@ func TestBuildImageFailure(t *testing.T) {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(errMock).Once()
 		return mockImageHandler
 	}
-	_, err := buildImage("./testfiles/", "4.2.5", "", "", "", "", false, nil)
+	_, err := buildImage("./testfiles/", "4.2.5", "", "", "", "", false, false, mockPlatformCoreClient)
 	assert.ErrorIs(t, err, errMock)
 
 	airflowImageHandler = func(image string) airflow.ImageHandler {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("4.2.5", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
 		return mockImageHandler
 	}
 
 	// dockerfile parsing error
 	dockerfile = "Dockerfile.invalid"
-	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, nil)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, false, mockPlatformCoreClient)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse dockerfile")
 
 	// failed to get runtime releases
 	dockerfile = "Dockerfile"
 	mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentOptionsResponse, errMock).Once()
-	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, mockPlatformCoreClient)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, false, mockPlatformCoreClient)
 	assert.ErrorIs(t, err, errMock)
 	mockCoreClient.AssertExpectations(t)
 	mockPlatformCoreClient.AssertExpectations(t)
 	mockImageHandler.AssertExpectations(t)
 }
 
-func TestIsValidUpgrade(t *testing.T) {
-	resp := IsValidUpgrade("4.2.5", "4.2.6")
-	assert.True(t, resp)
+func TestValidRuntimeVersion(t *testing.T) {
+	testCases := []struct {
+		name              string
+		currentVersion    string
+		newVersion        string
+		deploymentOptions []string
+		forceUpgradeToAF3 bool
+		expected          bool
+		expectedError     string
+	}{
+		// Empty current version cases
+		{
+			name:              "empty current version allows any upgrade",
+			currentVersion:    "",
+			newVersion:        "4.2.6",
+			deploymentOptions: []string{"4.2.6"},
+			expected:          true,
+		},
 
-	resp = IsValidUpgrade("4.2.6", "4.2.5")
-	assert.False(t, resp)
+		// AF2 version upgrade cases
+		{
+			name:              "newer AF2 version is valid upgrade",
+			currentVersion:    "4.2.5",
+			newVersion:        "4.2.6",
+			deploymentOptions: []string{"4.2.6"},
+			expected:          true,
+		},
+		{
+			name:              "older AF2 version is invalid upgrade",
+			currentVersion:    "4.2.6",
+			newVersion:        "4.2.5",
+			deploymentOptions: []string{"4.2.5"},
+			expected:          false,
+			expectedError:     "Cannot deploy a downgraded Astro Runtime version",
+		},
 
-	resp = IsValidUpgrade("", "4.2.6")
-	assert.True(t, resp)
+		// AF2 to AF3 upgrade cases
+		{
+			name:              "AF2 to AF3 version with force flag is valid upgrade",
+			currentVersion:    "4.2.5",
+			newVersion:        "3.0-1",
+			deploymentOptions: []string{"3.0-1"},
+			forceUpgradeToAF3: true,
+			expected:          true,
+		},
+		{
+			name:              "AF2 to AF3 version without force flag is invalid upgrade",
+			currentVersion:    "4.2.5",
+			newVersion:        "3.0-1",
+			deploymentOptions: []string{"3.0-1"},
+			forceUpgradeToAF3: false,
+			expected:          false,
+			expectedError:     "Cannot upgrade from Airflow 2 to Airflow 3 without the --force-upgrade-to-af3 flag",
+		},
+
+		// AF3 version cases
+		{
+			name:              "newer AF3 version is valid upgrade",
+			currentVersion:    "3.0-1",
+			newVersion:        "3.1-1",
+			deploymentOptions: []string{"3.1-1"},
+			expected:          true,
+		},
+		{
+			name:              "older AF3 version is invalid upgrade",
+			currentVersion:    "3.1-1",
+			newVersion:        "3.0-3",
+			deploymentOptions: []string{"3.0-3"},
+			expected:          false,
+			expectedError:     "Cannot deploy a downgraded Astro Runtime version",
+		},
+		{
+			name:              "AF3 to AF2 is invalid upgrade",
+			currentVersion:    "3.0-1",
+			newVersion:        "4.2.6",
+			deploymentOptions: []string{"4.2.6"},
+			expected:          false,
+			expectedError:     "Cannot deploy a downgraded Astro Runtime version",
+		},
+
+		// Deployment options validation cases
+		{
+			name:              "version not in deployment options is invalid",
+			currentVersion:    "4.2.5",
+			newVersion:        "4.2.6",
+			deploymentOptions: []string{"4.2.5", "4.2.4"},
+			expected:          false,
+			expectedError:     "Cannot deploy an unsupported Astro Runtime version",
+		},
+		{
+			name:              "version in deployment options is valid",
+			currentVersion:    "4.2.5",
+			newVersion:        "4.2.6",
+			deploymentOptions: []string{"4.2.6", "4.2.5"},
+			expected:          true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Capture stdout to check error messages
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			outC := make(chan string)
+			go func() {
+				var buf bytes.Buffer
+				io.Copy(&buf, r)
+				outC <- buf.String()
+			}()
+
+			result := ValidRuntimeVersion(tc.currentVersion, tc.newVersion, tc.deploymentOptions, tc.forceUpgradeToAF3)
+
+			// Restore stdout
+			w.Close()
+			os.Stdout = oldStdout
+
+			// Check result
+			assert.Equal(t, tc.expected, result)
+
+			// Check error message if expected
+			if tc.expectedError != "" {
+				output := <-outC
+				assert.Contains(t, output, tc.expectedError)
+			}
+		})
+	}
 }
 
-func TestIsValidTag(t *testing.T) {
-	resp := IsValidTag([]string{"4.2.5", "4.2.6"}, "4.2.7")
-	assert.False(t, resp)
-
-	resp = IsValidTag([]string{"4.2.5", "4.2.6"}, "4.2.6")
-	assert.True(t, resp)
+// mockTransport implements http.RoundTripper for mocking HTTP responses
+type mockTransport struct {
+	response *http.Response
 }
 
-func TestCheckVersion(t *testing.T) {
-	httpClient := airflowversions.NewClient(httputil.NewHTTPClient(), false)
-	latestRuntimeVersion, _ := airflowversions.GetDefaultImageTag(httpClient, "")
-
-	// version that is older than newest
-	buf := new(bytes.Buffer)
-	CheckVersion("1.0.0", buf)
-	assert.Contains(t, buf.String(), "WARNING! You are currently running Astro Runtime Version")
-
-	// version that is latest
-	CheckVersion(latestRuntimeVersion, buf)
-	assert.Contains(t, buf.String(), "Runtime Version: "+latestRuntimeVersion)
+func (m *mockTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return m.response, nil
 }
 
-func TestCheckVersionBeta(t *testing.T) {
-	// version that newer than latest
-	buf := new(bytes.Buffer)
-	defer testUtil.MockUserInput(t, "y")()
-	CheckVersion("10.0.0", buf)
-	assert.Contains(t, buf.String(), "")
+func TestWarnNonLatestVersion(t *testing.T) {
+	// Create a mock HTTP client
+	mockClient := &httputil.HTTPClient{
+		HTTPClient: &http.Client{
+			Transport: &mockTransport{
+				response: &http.Response{
+					StatusCode: 200,
+					Body: io.NopCloser(strings.NewReader(`{
+						"runtimeVersions": {
+							"5.0.1": {
+								"metadata": {
+									"airflowVersion": "2.2.5",
+									"channel": "stable",
+									"releaseDate": "2024-01-01"
+								},
+								"migrations": {
+									"airflowDatabase": false
+								}
+							},
+							"5.0.2": {
+								"metadata": {
+									"airflowVersion": "2.2.6",
+									"channel": "stable",
+									"releaseDate": "2024-01-02"
+								},
+								"migrations": {
+									"airflowDatabase": false
+								}
+							}
+						}
+					}`)),
+				},
+			},
+		},
+	}
+
+	// Test cases
+	testCases := []struct {
+		name           string
+		version        string
+		expectedOutput string
+	}{
+		{
+			name:           "older version shows warning",
+			version:        "4.2.5",
+			expectedOutput: "WARNING! You are currently running Astro Runtime Version 4.2.5\nConsider upgrading to the latest version, Astro Runtime 5.0.2\n",
+		},
+		{
+			name:           "latest version shows no warning",
+			version:        "5.0.2",
+			expectedOutput: "",
+		},
+		{
+			name:           "newer version shows no warning",
+			version:        "5.0.3",
+			expectedOutput: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+			outC := make(chan string)
+			go func() {
+				var buf bytes.Buffer
+				io.Copy(&buf, r)
+				outC <- buf.String()
+			}()
+
+			// Call the function with our mock client
+			WarnIfNonLatestVersion(tc.version, mockClient)
+
+			// Restore stdout
+			w.Close()
+			os.Stdout = oldStdout
+
+			// Check output
+			output := <-outC
+			assert.Equal(t, tc.expectedOutput, output)
+		})
+	}
 }
 
 func TestCheckPyTest(t *testing.T) {

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -8,7 +8,6 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/git"
 	"github.com/astronomer/astro-cli/pkg/util"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -38,9 +37,10 @@ Menu will be presented if you do not specify a deployment ID:
   $ astro deploy
 `
 
-	DeployImage      = cloud.Deploy
-	EnsureProjectDir = utils.EnsureProjectDir
-	buildSecrets     = []string{}
+	DeployImage       = cloud.Deploy
+	EnsureProjectDir  = utils.EnsureProjectDir
+	buildSecrets      = []string{}
+	forceUpgradeToAF3 bool
 )
 
 const (
@@ -74,6 +74,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().MarkHidden("dags-path") //nolint:errcheck
 	cmd.Flags().StringVarP(&deployDescription, "description", "", "", "Add a description for more context on this deploy")
 	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().BoolVar(&forceUpgradeToAF3, "force-upgrade-to-af3", false, "Force allow upgrade from Airflow 2 to Airflow 3")
 	return cmd
 }
 
@@ -153,6 +154,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		DagsPath:          dagsPath,
 		Description:       deployDescription,
 		BuildSecretString: BuildSecretString,
+		ForceUpgradeToAF3: forceUpgradeToAF3,
 	}
 
 	return DeployImage(deployInput, platformCoreClient, astroCoreClient)


### PR DESCRIPTION
## Description

This change supports upgrading Astro deployments from Airflow 2 to 3. This involves updating the version comparison logic to take into account the new runtime versioning scheme for Airflow 3 images.

Note that for the initial period of Airflow 3 availability, to upgrade a deployment from Airflow 2 to 3 will require setting the `--force-upgrade-to-af3` flag on the `astro deploy` command.

Resolves #1815 

## 🧪 Functional Testing

- Unit tests added/updated
- Ran `astro deploy` for an AF3 project on an AF2 deployment, hit expected error on missing flag
- Ran `astro deploy --force-upgrade-to-af3` for an AF3 project on an AF2 deployment, deploy proceeded

## 📸 Screenshots

Without flag:
<img width="1009" alt="Screenshot 2025-03-26 at 3 43 23 PM" src="https://github.com/user-attachments/assets/4a60b4e4-9983-4e1d-b946-3397c74ccec5" />

With flag:
<img width="998" alt="Screenshot 2025-03-26 at 3 45 01 PM" src="https://github.com/user-attachments/assets/d52e5b12-d82f-409a-b0f9-76583efa817b" />

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
