### PR TITLE
Add Airflow 3 ruff checks to upgrade-test command

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5" //nolint:gosec
 	"fmt"
 	"html/template"
+	"io"
 	"regexp"
 	"strings"
 	"time"
@@ -36,7 +37,7 @@ type ContainerHandler interface {
 	ComposeExport(settingsFile, composeFile string) error
 	Pytest(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString string) (string, error)
 	Parse(customImageName, deployImageName, buildSecretString string) error
-	UpgradeTest(runtimeVersion, deploymentID, newImageName, customImageName, buildSecretString string, versionTest, dagTest bool, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error
+	UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString string, versionTest, dagTest, ruffTest bool, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error
 }
 
 // RegistryHandler defines methods require to handle all operations with registry
@@ -53,10 +54,11 @@ type ImageHandler interface {
 	DoesImageExist(image string) error
 	ListLabels() (map[string]string, error)
 	TagLocalImage(localImage string) error
-	Run(dagID, envFile, settingsFile, containerName, dagFile, executionDate string, taskLogs bool) error
+	RunDAG(dagID, envFile, settingsFile, containerName, dagFile, executionDate string, taskLogs bool) error
 	Pytest(pytestFile, airflowHome, envFile, testHomeDirectory string, pytestArgs []string, htmlReport bool, config types.ImageBuildConfig) (string, error)
 	CreatePipFreeze(altImageName, pipFreezeFile string) error
 	GetImageRepoSHA(registry string) (string, error)
+	RunCommand(args []string, mountDirs map[string]string, stdout, stderr io.Writer) error
 }
 
 type DockerComposeAPI interface {

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -171,7 +171,7 @@ func DockerComposeInit(airflowHome, envFile, dockerfile, imageName string) (*Doc
 	}
 
 	imageHandler := DockerImageInit(ImageName(imageName, "latest"))
-	ruffImageHandler := DockerImageInit("ghcr.io/astral-sh/ruff:latest")
+	ruffImageHandler := DockerImageInit(config.CFG.RuffImage.GetString())
 
 	// Route output streams according to verbosity.
 	var stdout, stderr io.Writer
@@ -630,11 +630,15 @@ func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, build
 	}
 
 	if ruffTest && airflowversions.AirflowMajorVersionForRuntimeVersion(newVersion) != "3" {
-		fmt.Println("Skipping ruff Airflow 3 test because not testing upgrade to Airflow 3.x")
+		fmt.Println("")
+		fmt.Println("Skipping ruff Airflow 3 linter because not testing upgrade to Airflow 3.x")
 		ruffTest = false
 	}
 
 	if ruffTest {
+		fmt.Println("")
+		fmt.Println("Running ruff Airflow 3 linter")
+
 		ruffTestPassed, err := d.ruffTest(testHomeDirectory)
 		if err != nil {
 			return err
@@ -651,7 +655,7 @@ func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, build
 		fmt.Printf("\tDAG Parse Test HTML Report: %s\n", "dag-test-report.html")
 	}
 	if ruffTest {
-		fmt.Printf("\tRuff Test Results: %s\n", "ruff-airflow3.txt")
+		fmt.Printf("\tRuff Linter Results: %s\n", "ruff-airflow3.txt")
 	}
 	if failed {
 		return errors.New("one of the tests run above failed")

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -2,6 +2,7 @@ package airflow
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -59,6 +60,7 @@ const (
 	patch                          = "patch"
 	minor                          = "minor"
 	partsNum                       = 2
+	ruffFilePermission             = 0o600
 
 	composeCreateErrMsg      = "error creating docker-compose project"
 	composeStatusCheckErrMsg = "error checking docker-compose status"
@@ -147,13 +149,14 @@ type ComposeConfig struct {
 }
 
 type DockerCompose struct {
-	airflowHome    string
-	projectName    string
-	envFile        string
-	dockerfile     string
-	composeService DockerComposeAPI
-	cliClient      DockerCLIClient
-	imageHandler   ImageHandler
+	airflowHome      string
+	projectName      string
+	envFile          string
+	dockerfile       string
+	composeService   DockerComposeAPI
+	cliClient        DockerCLIClient
+	imageHandler     ImageHandler
+	ruffImageHandler ImageHandler
 }
 
 func DockerComposeInit(airflowHome, envFile, dockerfile, imageName string) (*DockerCompose, error) {
@@ -168,6 +171,7 @@ func DockerComposeInit(airflowHome, envFile, dockerfile, imageName string) (*Doc
 	}
 
 	imageHandler := DockerImageInit(ImageName(imageName, "latest"))
+	ruffImageHandler := DockerImageInit("ghcr.io/astral-sh/ruff:latest")
 
 	// Route output streams according to verbosity.
 	var stdout, stderr io.Writer
@@ -192,13 +196,14 @@ func DockerComposeInit(airflowHome, envFile, dockerfile, imageName string) (*Doc
 	composeService := compose.NewComposeService(dockerCli)
 
 	return &DockerCompose{
-		airflowHome:    airflowHome,
-		projectName:    projectName,
-		envFile:        envFile,
-		dockerfile:     dockerfile,
-		composeService: composeService,
-		cliClient:      dockerCli.Client(),
-		imageHandler:   imageHandler,
+		airflowHome:      airflowHome,
+		projectName:      projectName,
+		envFile:          envFile,
+		dockerfile:       dockerfile,
+		composeService:   composeService,
+		cliClient:        dockerCli.Client(),
+		imageHandler:     imageHandler,
+		ruffImageHandler: ruffImageHandler,
 	}, nil
 }
 
@@ -554,11 +559,12 @@ func (d *DockerCompose) Pytest(pytestFile, customImageName, deployImageName, pyt
 	return exitCode, errors.New("something went wrong while Pytesting your DAGs")
 }
 
-func (d *DockerCompose) UpgradeTest(newAirflowVersion, deploymentID, newImageName, customImage, buildSecretString string, versionTest, dagTest bool, astroPlatformCore astroplatformcore.CoreClient) error {
+func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, buildSecretString string, versionTest, dagTest, ruffTest bool, astroPlatformCore astroplatformcore.CoreClient) error { //nolint:gocognit,gocyclo
 	// figure out which tests to run
-	if !versionTest && !dagTest {
+	if !versionTest && !dagTest && !ruffTest {
 		versionTest = true
 		dagTest = true
+		ruffTest = true
 	}
 	var deploymentImage string
 	// if custom image is used get new Airflow version
@@ -567,7 +573,7 @@ func (d *DockerCompose) UpgradeTest(newAirflowVersion, deploymentID, newImageNam
 		if err != nil {
 			return errCustomImageDoesNotExist
 		}
-		newAirflowVersion = strings.SplitN(customImage, ":", partsNum)[1]
+		newVersion = strings.SplitN(customImage, ":", partsNum)[1]
 	}
 	// if user supplies deployment id pull down current image
 	if deploymentID != "" {
@@ -577,25 +583,27 @@ func (d *DockerCompose) UpgradeTest(newAirflowVersion, deploymentID, newImageNam
 		}
 	} else {
 		// build image for current Airflow version to get current Airflow version
-		fmt.Println("\nBuilding image for current Airflow version")
+		fmt.Println("\nBuilding image for current version")
 		imageBuildErr := d.imageHandler.Build(d.dockerfile, buildSecretString, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
 		if imageBuildErr != nil {
 			return imageBuildErr
 		}
 	}
-	// get current Airflow version
-	currentAirflowVersion, err := d.imageHandler.GetLabel(deploymentImage, RuntimeImageLabel)
+
+	// get the current version from the image labels
+	currentVersion, err := d.imageHandler.GetLabel(deploymentImage, RuntimeImageLabel)
 	if err != nil {
 		return err
 	}
-	if currentAirflowVersion == "" {
-		currentAirflowVersion, err = d.imageHandler.GetLabel(deploymentImage, AirflowImageLabel)
+	if currentVersion == "" {
+		currentVersion, err = d.imageHandler.GetLabel(deploymentImage, AirflowImageLabel)
 		if err != nil {
 			return err
 		}
 	}
+
 	// create test home directory
-	testHomeDirectory := "upgrade-test-" + currentAirflowVersion + "--" + newAirflowVersion
+	testHomeDirectory := "upgrade-test-" + currentVersion + "--" + newVersion
 
 	destFolder := filepath.Join(d.airflowHome, testHomeDirectory)
 	var filePerms fs.FileMode = 0o755
@@ -605,18 +613,35 @@ func (d *DockerCompose) UpgradeTest(newAirflowVersion, deploymentID, newImageNam
 	newDockerFile := destFolder + "/Dockerfile"
 
 	if versionTest {
-		err := d.versionTest(testHomeDirectory, currentAirflowVersion, deploymentImage, newDockerFile, newAirflowVersion, customImage, buildSecretString)
+		err := d.versionTest(testHomeDirectory, currentVersion, deploymentImage, newDockerFile, newVersion, customImage, buildSecretString)
 		if err != nil {
 			return err
 		}
 	}
-	var errorCode int
+
+	var failed bool
+
 	if dagTest {
-		errorCode, err = d.dagTest(testHomeDirectory, newAirflowVersion, newDockerFile, customImage, buildSecretString)
+		dagTestPassed, err := d.dagTest(testHomeDirectory, newVersion, newDockerFile, customImage, buildSecretString)
 		if err != nil {
 			return err
 		}
+		failed = failed || !dagTestPassed
 	}
+
+	if ruffTest && airflowversions.AirflowMajorVersionForRuntimeVersion(newVersion) != "3" {
+		fmt.Println("Skipping ruff Airflow 3 test because not testing upgrade to Airflow 3.x")
+		ruffTest = false
+	}
+
+	if ruffTest {
+		ruffTestPassed, err := d.ruffTest(testHomeDirectory)
+		if err != nil {
+			return err
+		}
+		failed = failed || !ruffTestPassed
+	}
+
 	fmt.Println("\nTest Summary:")
 	fmt.Printf("\tUpgrade Test Results Directory: %s\n", testHomeDirectory)
 	if versionTest {
@@ -625,7 +650,10 @@ func (d *DockerCompose) UpgradeTest(newAirflowVersion, deploymentID, newImageNam
 	if dagTest {
 		fmt.Printf("\tDAG Parse Test HTML Report: %s\n", "dag-test-report.html")
 	}
-	if errorCode == 1 {
+	if ruffTest {
+		fmt.Printf("\tRuff Test Results: %s\n", "ruff-airflow3.txt")
+	}
+	if failed {
 		return errors.New("one of the tests run above failed")
 	}
 
@@ -652,36 +680,36 @@ func (d *DockerCompose) pullImageFromDeployment(deploymentID string, platformCor
 	return nil
 }
 
-func (d *DockerCompose) versionTest(testHomeDirectory, currentAirflowVersion, deploymentImage, newDockerFile, newAirflowVersion, customImage, buildSecretString string) error {
+func (d *DockerCompose) versionTest(testHomeDirectory, currentVersion, deploymentImage, newDockerFile, newVersion, customImage, buildSecretString string) error {
 	fmt.Println("\nComparing dependency versions between current and upgraded environment")
 	// pip freeze old Airflow image
-	fmt.Println("\nObtaining pip freeze for current Airflow version")
-	currentAirflowPipFreezeFile := d.airflowHome + "/" + testHomeDirectory + "/pip_freeze_" + currentAirflowVersion + ".txt"
+	fmt.Println("\nObtaining pip freeze for current version")
+	currentAirflowPipFreezeFile := d.airflowHome + "/" + testHomeDirectory + "/pip_freeze_" + currentVersion + ".txt"
 	err := d.imageHandler.CreatePipFreeze(deploymentImage, currentAirflowPipFreezeFile)
 	if err != nil {
 		return err
 	}
 
 	// build image with the new airflow version
-	err = upgradeDockerfile(d.dockerfile, newDockerFile, newAirflowVersion, customImage)
+	err = upgradeDockerfile(d.dockerfile, newDockerFile, newVersion, customImage)
 	if err != nil {
 		return err
 	}
-	fmt.Println("\nBuilding image for new Airflow version")
+	fmt.Println("\nBuilding image for new version")
 	imageBuildErr := d.imageHandler.Build(newDockerFile, buildSecretString, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
 	if imageBuildErr != nil {
 		return imageBuildErr
 	}
 	// pip freeze new airflow image
-	fmt.Println("\nObtaining pip freeze for new Airflow version")
-	newAirflowPipFreezeFile := d.airflowHome + "/" + testHomeDirectory + "/pip_freeze_" + newAirflowVersion + ".txt"
+	fmt.Println("\nObtaining pip freeze for new version")
+	newAirflowPipFreezeFile := filepath.Join(d.airflowHome, testHomeDirectory, "pip_freeze_"+newVersion+".txt")
 	err = d.imageHandler.CreatePipFreeze("", newAirflowPipFreezeFile)
 	if err != nil {
 		return err
 	}
 	// compare pip freeze files
 	fmt.Println("\nComparing pip freeze files")
-	pipFreezeCompareFile := d.airflowHome + "/" + testHomeDirectory + "/dependency_compare.txt"
+	pipFreezeCompareFile := filepath.Join(d.airflowHome, testHomeDirectory, "dependency_compare.txt")
 	err = CreateVersionTestFile(currentAirflowPipFreezeFile, newAirflowPipFreezeFile, pipFreezeCompareFile)
 	if err != nil {
 		return err
@@ -690,13 +718,13 @@ func (d *DockerCompose) versionTest(testHomeDirectory, currentAirflowVersion, de
 	return nil
 }
 
-func (d *DockerCompose) dagTest(testHomeDirectory, newAirflowVersion, newDockerFile, customImage, buildSecretString string) (int, error) {
-	fmt.Printf("\nChecking the DAGs in this project for errors against the new Airflow version %s\n", newAirflowVersion)
+func (d *DockerCompose) dagTest(testHomeDirectory, newVersion, newDockerFile, customImage, buildSecretString string) (bool, error) {
+	fmt.Printf("\nChecking the DAGs in this project for errors against the new Airflow version %s\n", newVersion)
 
 	// build image with the new runtime version
-	err := upgradeDockerfile(d.dockerfile, newDockerFile, newAirflowVersion, customImage)
+	err := upgradeDockerfile(d.dockerfile, newDockerFile, newVersion, customImage)
 	if err != nil {
-		return 1, err
+		return false, err
 	}
 
 	reqFile := d.airflowHome + "/requirements.txt"
@@ -705,7 +733,7 @@ func (d *DockerCompose) dagTest(testHomeDirectory, newAirflowVersion, newDockerF
 	if err != nil {
 		fmt.Printf("Adding 'pytest-html' package to requirements.txt unsuccessful: %s\nManually add package to requirements.txt", err.Error())
 	}
-	fmt.Println("\nBuilding image for new Airflow version")
+	fmt.Println("\nBuilding image for new version")
 	imageBuildErr := d.imageHandler.Build(newDockerFile, buildSecretString, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
 
 	// remove pytest-html to the requirements
@@ -714,18 +742,18 @@ func (d *DockerCompose) dagTest(testHomeDirectory, newAirflowVersion, newDockerF
 		fmt.Printf("Removing package 'pytest-html' from requirements.txt unsuccessful: %s\n", err.Error())
 	}
 	if imageBuildErr != nil {
-		return 1, imageBuildErr
+		return false, imageBuildErr
 	}
 	// check for file
 	path := d.airflowHome + "/" + DefaultTestPath
 
 	fileExist, err := util.Exists(path)
 	if err != nil {
-		return 1, err
+		return false, err
 	}
 	if !fileExist {
 		fmt.Println("\nThe file " + path + " which is needed for the parse test does not exist. Please run `astro dev init` to create it")
-		return 1, err
+		return false, err
 	}
 	// run parse test
 	pytestFile := DefaultTestPath
@@ -737,17 +765,62 @@ func (d *DockerCompose) dagTest(testHomeDirectory, newAirflowVersion, newDockerF
 	if err != nil {
 		if strings.Contains(exitCode, "1") { // exit code is 1 meaning tests failed
 			fmt.Println("See above for errors detected in your DAGs")
-			return 1, nil
+			return false, nil
 		} else {
-			return 1, errors.Wrap(err, "something went wrong while parsing your DAGs")
+			return false, errors.Wrap(err, "something went wrong while parsing your DAGs")
 		}
 	} else {
 		fmt.Println("\n" + ansi.Green("✔") + " No errors detected in your DAGs ")
 	}
-	return 0, nil
+	return true, nil
 }
 
-func upgradeDockerfile(oldDockerfilePath, newDockerfilePath, newTag, newImage string) error { //nolint:gocognit
+func (d *DockerCompose) ruffTest(testHomeDirectory string) (bool, error) {
+	ruffRules := `[lint]
+preview = true
+extend-select = ["AIR"]`
+
+	tempFile, err := os.CreateTemp("", "ruff-airflow3-*.toml")
+	if err != nil {
+		return false, fmt.Errorf("failed to create temporary ruff config file: %w", err)
+	}
+	defer os.Remove(tempFile.Name())
+	err = os.WriteFile(tempFile.Name(), []byte(ruffRules), ruffFilePermission)
+	if err != nil {
+		return false, fmt.Errorf("failed to write to temporary ruff config file: %w", err)
+	}
+
+	// Mount the dags directory and the ruff config file
+	mountDirs := map[string]string{
+		filepath.Join(config.WorkingPath, "dags"): "/app/dags",
+		tempFile.Name(): "/app/ruff-airflow3.toml",
+	}
+
+	// Run ruff with the config file and the dags directory
+	ruffArgs := []string{"check", "--config", "/app/ruff-airflow3.toml", "/app/dags"}
+	var buf bytes.Buffer
+	bufWriter := io.MultiWriter(os.Stdout, &buf)
+	ruffErr := d.ruffImageHandler.RunCommand(ruffArgs, mountDirs, bufWriter, bufWriter)
+
+	// Write the ruff output to a results file in the test directory
+	resultsFile := filepath.Join(d.airflowHome, testHomeDirectory, "ruff-airflow3.txt")
+	resultsErr := os.WriteFile(resultsFile, buf.Bytes(), ruffFilePermission)
+	if resultsErr != nil {
+		return false, fmt.Errorf("failed to write ruff output to file: %w", resultsErr)
+	}
+
+	return ruffErr == nil, nil
+}
+
+func upgradeDockerfile(oldDockerfilePath, newDockerfilePath, newTag, customImage string) error { //nolint:gocognit
+	var newImage string
+	switch airflowversions.AirflowMajorVersionForRuntimeVersion(newTag) {
+	case "3":
+		newImage = "air.astronomer.io/runtime"
+	case "2":
+		newImage = "quay.io/astronomer/astro-runtime"
+	}
+
 	// Read the content of the old Dockerfile
 	content, err := os.ReadFile(oldDockerfilePath)
 	if err != nil {
@@ -756,13 +829,18 @@ func upgradeDockerfile(oldDockerfilePath, newDockerfilePath, newTag, newImage st
 
 	lines := strings.Split(string(content), "\n")
 	var newContent strings.Builder
-	if newImage == "" {
+	if customImage == "" {
 		for _, line := range lines {
-			if strings.HasPrefix(strings.TrimSpace(line), "FROM quay.io/astronomer/astro-runtime:") {
-				// Replace the tag on the matching line
-				parts := strings.SplitN(line, ":", partsNum)
-				if len(parts) == partsNum {
-					line = parts[0] + ":" + newTag
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "FROM quay.io/astronomer/astro-runtime") ||
+				strings.HasPrefix(line, "FROM air.astronomer.io/runtime") {
+				if strings.HasPrefix(line, fmt.Sprintf("FROM %s", newImage)) {
+					parts := strings.SplitN(line, ":", partsNum)
+					if len(parts) == partsNum {
+						line = parts[0] + ":" + newTag
+					}
+				} else {
+					line = fmt.Sprintf("FROM %s:%s", newImage, newTag)
 				}
 			}
 			if strings.HasPrefix(strings.TrimSpace(line), "FROM quay.io/astronomer/ap-airflow:") {
@@ -792,7 +870,7 @@ func upgradeDockerfile(oldDockerfilePath, newDockerfilePath, newTag, newImage st
 				// Replace the tag on the matching line
 				parts := strings.SplitN(line, " ", partsNum)
 				if len(parts) == partsNum {
-					line = parts[0] + " " + newImage
+					line = parts[0] + " " + customImage
 				}
 			}
 			newContent.WriteString(line + "\n") // Add a newline after each line
@@ -1219,7 +1297,7 @@ func (d *DockerCompose) RunDAG(dagID, settingsFile, dagFile, executionDate strin
 		for i := range psInfo {
 			if checkServiceState(psInfo[i].State, dockerStateUp) {
 				if strings.Contains(psInfo[i].Name, SchedulerDockerContainerName) {
-					err = d.imageHandler.Run(dagID, d.envFile, settingsFile, psInfo[i].Name, dagFile, executionDate, taskLogs)
+					err = d.imageHandler.RunDAG(dagID, d.envFile, settingsFile, psInfo[i].Name, dagFile, executionDate, taskLogs)
 					if err != nil {
 						return err
 					}
@@ -1257,7 +1335,7 @@ func (d *DockerCompose) RunDAG(dagID, settingsFile, dagFile, executionDate strin
 		return err
 	}
 
-	err = d.imageHandler.Run(dagID, d.envFile, settingsFile, "", dagFile, executionDate, taskLogs)
+	err = d.imageHandler.RunDAG(dagID, d.envFile, settingsFile, "", dagFile, executionDate, taskLogs)
 	if err != nil {
 		return err
 	}

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -727,7 +727,7 @@ func (s *Suite) TestDockerImageRun() {
 			return nil
 		}
 
-		err = handler.Run("", "./testfiles/airflow_settings.yaml", "", "", "", "", true)
+		err = handler.RunDAG("", "./testfiles/airflow_settings.yaml", "", "", "", "", true)
 		s.NoError(err)
 	})
 
@@ -736,7 +736,7 @@ func (s *Suite) TestDockerImageRun() {
 			return nil
 		}
 
-		err = handler.Run("", "./testfiles/airflow_settings_invalid.yaml", "", "test-container", "", "", true)
+		err = handler.RunDAG("", "./testfiles/airflow_settings_invalid.yaml", "", "test-container", "", "", true)
 		s.NoError(err)
 	})
 
@@ -745,7 +745,7 @@ func (s *Suite) TestDockerImageRun() {
 			return errExecMock
 		}
 
-		err = handler.Run("", "./testfiles/airflow_settings.yaml", "", "", "", "", true)
+		err = handler.RunDAG("", "./testfiles/airflow_settings.yaml", "", "", "", "", true)
 		s.Contains(err.Error(), errExecMock.Error())
 	})
 }

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1233,7 +1233,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", "", false, false, nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
@@ -1253,7 +1253,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", "", false, false, mockPlatformCoreClient)
+		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", false, false, false, mockPlatformCoreClient)
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
@@ -1265,7 +1265,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1277,7 +1277,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1289,7 +1289,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1302,7 +1302,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1316,7 +1316,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1331,7 +1331,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1346,7 +1346,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1358,7 +1358,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetDeploymentsResponse, nil).Once()
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", "", false, false, mockPlatformCoreClient)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, mockPlatformCoreClient)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1372,7 +1372,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", "", false, false, mockPlatformCoreClient)
+		err = mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", false, false, false, mockPlatformCoreClient)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1386,7 +1386,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", "", false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "", "", "", false, false, false, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1395,8 +1395,62 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		err := config.ResetCurrentContext()
 		s.NoError(err)
 
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", "", false, false, nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, nil)
 		s.Error(err)
+	})
+
+	s.Run("success with ruff test", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
+
+		ruffImageHandler := new(mocks.ImageHandler)
+		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff-airflow3.toml", "/app/dags"}, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+		mockDockerCompose.imageHandler = imageHandler
+		mockDockerCompose.ruffImageHandler = ruffImageHandler
+
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, nil)
+		s.NoError(err)
+
+		imageHandler.AssertExpectations(s.T())
+		ruffImageHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("ruff test failure", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
+
+		ruffImageHandler := new(mocks.ImageHandler)
+		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff-airflow3.toml", "/app/dags"}, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
+
+		mockDockerCompose.imageHandler = imageHandler
+		mockDockerCompose.ruffImageHandler = ruffImageHandler
+
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, nil)
+		s.Error(err)
+		s.Contains(err.Error(), "one of the tests run above failed")
+
+		imageHandler.AssertExpectations(s.T())
+		ruffImageHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("ruff test skipped for airflow 2", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
+
+		ruffImageHandler := new(mocks.ImageHandler)
+
+		mockDockerCompose.imageHandler = imageHandler
+		mockDockerCompose.ruffImageHandler = ruffImageHandler
+
+		err := mockDockerCompose.UpgradeTest("2.0.0", "", "", "", false, false, true, nil)
+		s.NoError(err)
+
+		imageHandler.AssertExpectations(s.T())
+		ruffImageHandler.AssertExpectations(s.T())
 	})
 }
 
@@ -1739,7 +1793,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 	s.Run("success with container", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		imageHandler.On("RunDAG", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-scheduler-id", State: "running", Name: "test-scheduler"}}, nil).Once()
@@ -1757,7 +1811,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 	s.Run("error with container", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
+		imageHandler.On("RunDAG", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-scheduler-id", State: "running", Name: "test-scheduler"}}, nil).Once()
@@ -1776,7 +1830,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
-		imageHandler.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		imageHandler.On("RunDAG", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Once()
@@ -1795,7 +1849,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
-		imageHandler.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
+		imageHandler.On("RunDAG", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Once()
@@ -1891,14 +1945,14 @@ func (s *Suite) TestUpgradeDockerfile() {
 	s.Run("update Dockerfile with new tag", func() {
 		// Create a temporary old Dockerfile
 		oldDockerfilePath := "test_old_Dockerfile"
-		oldContent := "FROM quay.io/astronomer/astro-runtime:old-tag\n"
+		oldContent := "FROM quay.io/astronomer/astro-runtime:12.0.0\n"
 		err := os.WriteFile(oldDockerfilePath, []byte(oldContent), 0o644)
 		s.NoError(err)
 		defer os.Remove(oldDockerfilePath)
 
 		// Define test data
 		newDockerfilePath := "test_new_Dockerfile"
-		newTag := "new-tag"
+		newTag := "13.0.0"
 
 		// Call the function
 		err = upgradeDockerfile(oldDockerfilePath, newDockerfilePath, newTag, "")
@@ -1910,7 +1964,32 @@ func (s *Suite) TestUpgradeDockerfile() {
 		// Read the new Dockerfile and check its content
 		newContent, err := os.ReadFile(newDockerfilePath)
 		s.NoError(err)
-		s.Contains(string(newContent), "FROM quay.io/astronomer/astro-runtime:new-tag")
+		s.Contains(string(newContent), "FROM quay.io/astronomer/astro-runtime:13.0.0")
+	})
+
+	s.Run("update Dockerfile with new major version", func() {
+		// Create a temporary old Dockerfile
+		oldDockerfilePath := "test_old_Dockerfile"
+		oldContent := "FROM quay.io/astronomer/astro-runtime:12.0.0\n"
+		err := os.WriteFile(oldDockerfilePath, []byte(oldContent), 0o644)
+		s.NoError(err)
+		defer os.Remove(oldDockerfilePath)
+
+		// Define test data
+		newDockerfilePath := "test_new_Dockerfile"
+		newTag := "3.0-1"
+
+		// Call the function
+		err = upgradeDockerfile(oldDockerfilePath, newDockerfilePath, newTag, "")
+		defer os.Remove(newDockerfilePath)
+
+		// Check for errors
+		s.NoError(err)
+
+		// Read the new Dockerfile and check its content
+		newContent, err := os.ReadFile(newDockerfilePath)
+		s.NoError(err)
+		s.Contains(string(newContent), "FROM air.astronomer.io/runtime:3.0-1")
 	})
 
 	s.Run("update Dockerfile with new image", func() {

--- a/airflow/include/airflow3/exampledag.py
+++ b/airflow/include/airflow3/exampledag.py
@@ -53,7 +53,7 @@ def example_astronauts():
             r.raise_for_status()
             number_of_people_in_space = r.json()["number"]
             list_of_people_in_space = r.json()["people"]
-        except:
+        except Exception:
             print("API currently not available, using hardcoded data instead.")
             number_of_people_in_space = 12
             list_of_people_in_space = [

--- a/airflow/mocks/ContainerHandler.go
+++ b/airflow/mocks/ContainerHandler.go
@@ -267,17 +267,17 @@ func (_m *ContainerHandler) Stop(waitForExit bool) error {
 	return r0
 }
 
-// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, newImageName, customImageName, buildSecretString, versionTest, dagTest, astroPlatformCore
-func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, newImageName string, customImageName string, buildSecretString string, versionTest bool, dagTest bool, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error {
-	ret := _m.Called(runtimeVersion, deploymentID, newImageName, customImageName, buildSecretString, versionTest, dagTest, astroPlatformCore)
+// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, ruffTest, astroPlatformCore
+func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, customImageName string, buildSecretString string, versionTest bool, dagTest bool, ruffTest bool, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error {
+	ret := _m.Called(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, ruffTest, astroPlatformCore)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpgradeTest")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, string, bool, bool, astroplatformcore.ClientWithResponsesInterface) error); ok {
-		r0 = rf(runtimeVersion, deploymentID, newImageName, customImageName, buildSecretString, versionTest, dagTest, astroPlatformCore)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, bool, astroplatformcore.ClientWithResponsesInterface) error); ok {
+		r0 = rf(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, ruffTest, astroPlatformCore)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/airflow/mocks/ImageHandler.go
+++ b/airflow/mocks/ImageHandler.go
@@ -3,6 +3,8 @@
 package mocks
 
 import (
+	io "io"
+
 	types "github.com/astronomer/astro-cli/airflow/types"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -226,12 +228,30 @@ func (_m *ImageHandler) Pytest(pytestFile string, airflowHome string, envFile st
 	return r0, r1
 }
 
-// Run provides a mock function with given fields: dagID, envFile, settingsFile, containerName, dagFile, executionDate, taskLogs
-func (_m *ImageHandler) Run(dagID string, envFile string, settingsFile string, containerName string, dagFile string, executionDate string, taskLogs bool) error {
+// RunCommand provides a mock function with given fields: args, mountDirs, stdout, stderr
+func (_m *ImageHandler) RunCommand(args []string, mountDirs map[string]string, stdout io.Writer, stderr io.Writer) error {
+	ret := _m.Called(args, mountDirs, stdout, stderr)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RunCommand")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string, map[string]string, io.Writer, io.Writer) error); ok {
+		r0 = rf(args, mountDirs, stdout, stderr)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// RunDAG provides a mock function with given fields: dagID, envFile, settingsFile, containerName, dagFile, executionDate, taskLogs
+func (_m *ImageHandler) RunDAG(dagID string, envFile string, settingsFile string, containerName string, dagFile string, executionDate string, taskLogs bool) error {
 	ret := _m.Called(dagID, envFile, settingsFile, containerName, dagFile, executionDate, taskLogs)
 
 	if len(ret) == 0 {
-		panic("no return value specified for Run")
+		panic("no return value specified for RunDAG")
 	}
 
 	var r0 error

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -808,7 +808,11 @@ func ValidTags(runtimeVersions []string, currentVersion string) []string {
 
 func CheckVersion(version string, out io.Writer) {
 	httpClient := airflowversions.NewClient(httputil.NewHTTPClient(), false)
-	latestRuntimeVersion, _ := airflowversions.GetDefaultImageTag(httpClient, "")
+	latestRuntimeVersion, err := airflowversions.GetDefaultImageTag(httpClient, "")
+	if err != nil {
+		fmt.Fprintf(out, "Could not check for latest Astro Runtime version: %s", err)
+		os.Exit(1)
+	}
 	switch {
 	case versions.LessThan(version, latestRuntimeVersion):
 		// if current runtime version is not greater than or equal to the latest runtime verion let the user know

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/astronomer/astro-cli/airflow"
 	"github.com/astronomer/astro-cli/airflow/mocks"
-	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	coreMocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
 	"github.com/astronomer/astro-cli/config"
@@ -1485,22 +1484,5 @@ func (s *AirflowSuite) TestAirflowObjectExport() {
 
 		err := airflowSettingsExport(cmd, args)
 		s.ErrorIs(err, errMock)
-	})
-}
-
-func (s *AirflowSuite) TestPrepareDefaultAirflowImageTag() {
-	getDefaultImageTag = func(httpClient *airflowversions.Client, airflowVersion string) (string, error) {
-		return "", nil
-	}
-	s.Run("default airflow version", func() {
-		useAstronomerCertified = true
-		resp := prepareDefaultAirflowImageTag("", nil)
-		s.Equal(airflowversions.DefaultAirflowVersion, resp)
-	})
-
-	s.Run("default runtime version", func() {
-		useAstronomerCertified = false
-		resp := prepareDefaultAirflowImageTag("", nil)
-		s.Equal(airflowversions.DefaultRuntimeVersion, resp)
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ var (
 		MachineCPU:            newCfg("machine.cpu", "2"),
 		MachineMemory:         newCfg("machine.memory", "4096"),
 		ShaAsTag:              newCfg("sha_as_tag", "false"),
+		RuffImage:             newCfg("ruff.image", "ghcr.io/astral-sh/ruff:latest"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/types.go
+++ b/config/types.go
@@ -49,6 +49,7 @@ type cfgs struct {
 	MachineCPU            cfg
 	MachineMemory         cfg
 	ShaAsTag              cfg
+	RuffImage             cfg
 }
 
 // Creates a new cfg struct


### PR DESCRIPTION
## Description

This change adds support to the `astro dev upgrade-test` command so that when upgrading to Airflow 3 (including within Airflow 3 releases) the command will run ruff checks to validate the DAGs in the `dags` directory of the project.

The ruff checks are run [as a container](https://docs.astral.sh/ruff/installation/) using the `ghcr.io/astral-sh/ruff:latest` image. The Airflow 3 rules are available [as part of ruff](https://docs.astral.sh/ruff/rules/#airflow-air) itself. As new rules are added to ruff they will be automatically available to the CLI via the latest tag reference.

## 🧪 Functional Testing

- Unit tests added/updated

## 📸 Screenshots

ruff check failures:
<img width="981" alt="Screenshot 2025-03-28 at 2 28 47 PM" src="https://github.com/user-attachments/assets/925e9a0e-717b-4fb4-a5ec-4106bdbcb598" />

ruff check pass:
<img width="977" alt="Screenshot 2025-03-28 at 2 29 27 PM" src="https://github.com/user-attachments/assets/4a1ac7d5-0815-4339-ac72-cfc50b97f1d1" />

Not run for Airflow 2:
<img width="759" alt="Screenshot 2025-03-28 at 2 30 06 PM" src="https://github.com/user-attachments/assets/a5ef6797-e701-49f8-ad63-d7fb09562640" />

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
