### PR TITLE
Block unsupported Airflow 3 commands

### DIFF
--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -25,7 +25,7 @@ func (e ErrNoTagAvailable) Error() string {
 }
 
 // GetDefaultImageTag returns default airflow image tag
-func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, error) {
+func GetDefaultImageTag(httpClient *Client, airflowVersion string, excludeAirflow3 bool) (string, error) {
 	r := Request{}
 
 	resp, err := r.DoWithClient(httpClient)
@@ -35,6 +35,10 @@ func GetDefaultImageTag(httpClient *Client, airflowVersion string) (string, erro
 
 	if httpClient.useAstronomerCertified {
 		return getAstronomerCertifiedTag(resp.AvailableReleases, airflowVersion)
+	}
+
+	if excludeAirflow3 {
+		return getAstroRuntimeTag(resp.RuntimeVersions, nil, airflowVersion)
 	}
 
 	return getAstroRuntimeTag(resp.RuntimeVersions, resp.RuntimeVersionsV3, airflowVersion)

--- a/airflow_versions/airflow_versions_test.go
+++ b/airflow_versions/airflow_versions_test.go
@@ -279,7 +279,7 @@ func (s *Suite) TestGetDefaultImageTag() {
 		})
 		httpClient := NewClient(client, true)
 
-		defaultImageTag, err := GetDefaultImageTag(httpClient, "")
+		defaultImageTag, err := GetDefaultImageTag(httpClient, "", false)
 		s.NoError(err)
 		s.Equal("2.2.0-onbuild", defaultImageTag)
 	})
@@ -349,7 +349,7 @@ func (s *Suite) TestGetDefaultImageTag() {
 		})
 		httpClient := NewClient(client, false)
 
-		defaultImageTag, err := GetDefaultImageTag(httpClient, "")
+		defaultImageTag, err := GetDefaultImageTag(httpClient, "", false)
 		s.NoError(err)
 		s.Equal("4.0.0", defaultImageTag)
 	})
@@ -367,7 +367,7 @@ func (s *Suite) TestGetDefaultImageTagError() {
 	})
 	httpClient := NewClient(client, true)
 
-	defaultImageTag, err := GetDefaultImageTag(httpClient, "")
+	defaultImageTag, err := GetDefaultImageTag(httpClient, "", false)
 	s.Error(err)
 	s.Equal("", defaultImageTag)
 }

--- a/airflow_versions/runtime_versions.go
+++ b/airflow_versions/runtime_versions.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 )
 
@@ -149,4 +150,13 @@ func AirflowMajorVersionForRuntimeVersion(runtimeVersion string) string {
 		return ""
 	}
 	return RuntimeVersionMajor(runtimeVersion)
+}
+
+// ValidateNoAirflow3Support checks if the runtime version is for Airflow 3
+// and returns an error if it is since Airflow 3 is not yet supported for the command
+func ValidateNoAirflow3Support(runtimeVersion string) error {
+	if AirflowMajorVersionForRuntimeVersion(runtimeVersion) == "3" {
+		return errors.New("This command is not yet supported on Airflow 3 deployments")
+	}
+	return nil
 }

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -777,7 +777,7 @@ func ValidRuntimeVersion(currentVersion, tag string, deploymentOptionsRuntimeVer
 
 func WarnIfNonLatestVersion(version string, httpClient *httputil.HTTPClient) {
 	client := airflowversions.NewClient(httpClient, false)
-	latestRuntimeVersion, err := airflowversions.GetDefaultImageTag(client, "")
+	latestRuntimeVersion, err := airflowversions.GetDefaultImageTag(client, "", false)
 	if err != nil {
 		logger.Debugf("unable to get latest runtime version: %s", err)
 		return

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -240,7 +240,7 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 
 	// Check if the provided runtime version is for Airflow 3
 	if err := airflowversions.ValidateNoAirflow3Support(runtimeVersion); err != nil {
-		return err
+		return fmt.Errorf("%w. Use --runtime-version to specify an Airflow 2 runtime version", err)
 	}
 
 	// validate workspace

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -165,6 +165,11 @@ func Logs(deploymentID, ws, deploymentName, keyword string, logWebserver, logSch
 		return err
 	}
 
+	// Check if deployment is using Airflow 3
+	if err := airflowversions.ValidateNoAirflow3Support(deployment.RuntimeVersion); err != nil {
+		return err
+	}
+
 	deploymentID = deployment.Id
 	timeRange := 86400
 	offset := 0
@@ -230,6 +235,11 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 
 	configOption, err := GetDeploymentOptions("", deploymentOptionsParams, coreClient)
 	if err != nil {
+		return err
+	}
+
+	// Check if the provided runtime version is for Airflow 3
+	if err := airflowversions.ValidateNoAirflow3Support(runtimeVersion); err != nil {
 		return err
 	}
 
@@ -756,6 +766,12 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 	if err != nil {
 		return err
 	}
+
+	// Check if deployment is using Airflow 3
+	if err := airflowversions.ValidateNoAirflow3Support(currentDeployment.RuntimeVersion); err != nil {
+		return err
+	}
+
 	c, err := config.GetCurrentContext()
 	if err != nil {
 		return err

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -238,9 +238,9 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 		return err
 	}
 
-	// Check if the provided runtime version is for Airflow 3
+	// check that runtime version is not for Airflow 3
 	if err := airflowversions.ValidateNoAirflow3Support(runtimeVersion); err != nil {
-		return fmt.Errorf("%w. Use --runtime-version to specify an Airflow 2 runtime version", err)
+		return err
 	}
 
 	// validate workspace
@@ -1738,7 +1738,7 @@ func deploymentSelectionProcess(ws string, deployments []astroplatformcore.Deplo
 	if currentDeployment.Id == "" {
 		// get latest runtime version
 		airflowVersionClient := airflowversions.NewClient(httputil.NewHTTPClient(), false)
-		runtimeVersion, err := airflowversions.GetDefaultImageTag(airflowVersionClient, "")
+		runtimeVersion, err := airflowversions.GetDefaultImageTag(airflowVersionClient, "", false)
 		if err != nil {
 			return astroplatformcore.Deployment{}, err
 		}

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/pkg/printutil"
@@ -30,6 +31,11 @@ func VariableList(deploymentID, variableKey, ws, envFile, deploymentName string,
 	// get deployment
 	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, false, nil, platformCoreClient, nil)
 	if err != nil {
+		return err
+	}
+
+	// Check if deployment is using Airflow 3
+	if err := airflowversions.ValidateNoAirflow3Support(currentDeployment.RuntimeVersion); err != nil {
 		return err
 	}
 
@@ -93,6 +99,11 @@ func VariableModify(
 	// get deployment
 	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, false, nil, platformCoreClient, coreClient)
 	if err != nil {
+		return err
+	}
+
+	// Check if deployment is using Airflow 3
+	if err := airflowversions.ValidateNoAirflow3Support(currentDeployment.RuntimeVersion); err != nil {
 		return err
 	}
 

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"testing"
 
+	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -363,4 +365,69 @@ func TestAddVariablesFromArgs(t *testing.T) {
 		[]string{"test-key-2=test-value=4", "test-key-3=", "test-key-3"}, false, false, buf,
 	)
 	assert.Equal(t, []astroplatformcore.DeploymentEnvironmentVariableRequest{{Key: "test-key-2", Value: &testValue4}}, resp)
+}
+
+func TestAirflow3BlockingVariables(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	// Create a mock client for the tests
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+
+	// Set up a deployment with Airflow 3 runtime version
+	airflow3Version := "3.0-1"
+
+	// Create a deployment response with Airflow 3
+	airflow3DeploymentResponse := astroplatformcore.GetDeploymentResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &astroplatformcore.Deployment{
+			Id:             "test-id-airflow3",
+			Name:           "test-airflow3",
+			RuntimeVersion: airflow3Version,
+			WorkspaceId:    ws,
+		},
+	}
+
+	// Mock list deployments response with Airflow 3 deployment
+	airflow3ListDeploymentsResponse := astroplatformcore.ListDeploymentsResponse{
+		HTTPResponse: &http.Response{
+			StatusCode: 200,
+		},
+		JSON200: &astroplatformcore.DeploymentsPaginated{
+			Deployments: []astroplatformcore.Deployment{
+				{
+					Id:             "test-id-airflow3",
+					Name:           "test-airflow3",
+					RuntimeVersion: airflow3Version,
+					WorkspaceId:    ws,
+				},
+			},
+		},
+	}
+
+	t.Run("VariableList blocks operation for Airflow 3 deployments", func(t *testing.T) {
+		// Set expectations on the mock client
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3ListDeploymentsResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
+
+		buf := new(bytes.Buffer)
+		err := VariableList("test-id-airflow3", "", ws, "", "", false, mockPlatformCoreClient, buf)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "This command is not yet supported on Airflow 3 deployments")
+		mockPlatformCoreClient.AssertExpectations(t)
+	})
+
+	t.Run("VariableModify blocks operation for Airflow 3 deployments", func(t *testing.T) {
+		// Set expectations on the mock client
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3ListDeploymentsResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
+
+		buf := new(bytes.Buffer)
+		err := VariableModify("test-id-airflow3", "test-key", "test-value", ws, "", "", []string{}, false, false, false, mockCoreClient, mockPlatformCoreClient, buf)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "This command is not yet supported on Airflow 3 deployments")
+		mockPlatformCoreClient.AssertExpectations(t)
+	})
 }

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/astronomer/astro-cli/pkg/ansi"
 
+	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/cloud/deployment"
@@ -64,6 +65,11 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 	if requestedDeployment.Id == "" {
 		fmt.Printf("%s %s\n", deployment.NoDeploymentInWSMsg, ansi.Bold(ws))
 		return nil
+	}
+
+	// Check if deployment is using Airflow 3
+	if err := airflowversions.ValidateNoAirflow3Support(requestedDeployment.RuntimeVersion); err != nil {
+		return err
 	}
 
 	getDeploymentOptions := astroplatformcore.GetDeploymentOptionsParams{
@@ -507,6 +513,11 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, platformC
 	if requestedDeployment.Id == "" {
 		fmt.Printf("%s %s\n", deployment.NoDeploymentInWSMsg, ansi.Bold(ws))
 		return nil
+	}
+
+	// Check if deployment is using Airflow 3
+	if err := airflowversions.ValidateNoAirflow3Support(requestedDeployment.RuntimeVersion); err != nil {
+		return err
 	}
 
 	// prompt for queue name if one was not provided

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -485,7 +485,7 @@ func airflowInit(cmd *cobra.Command, args []string) error {
 	imageTag := runtimeVersion
 	if imageTag == "" {
 		httpClient := airflowversions.NewClient(httputil.NewHTTPClient(), useAstronomerCertified)
-		imageTag, err = getDefaultImageTag(httpClient, airflowVersion)
+		imageTag, err = getDefaultImageTag(httpClient, airflowVersion, true)
 		if err != nil {
 			return fmt.Errorf("error getting default image tag: %w", err)
 		}
@@ -634,7 +634,7 @@ func airflowUpgradeTest(cmd *cobra.Command, platformCoreClient astroplatformcore
 		// If user provides a runtime version, use it, otherwise retrieve the latest one (matching Airflow Version if provided
 		httpClient := airflowversions.NewClient(httputil.NewHTTPClient(), useAstronomerCertified)
 		var err error
-		runtimeVersion, err = getDefaultImageTag(httpClient, airflowVersion)
+		runtimeVersion, err = getDefaultImageTag(httpClient, airflowVersion, true)
 		if err != nil {
 			return fmt.Errorf("error getting default image tag: %w", err)
 		}

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -701,7 +701,8 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 	// Get latest runtime version
 	if runtimeVersion == "" {
 		airflowVersionClient := airflowversions.NewClient(httpClient, false)
-		runtimeVersion, err = airflowversions.GetDefaultImageTag(airflowVersionClient, "")
+		// Excludes Airflow 3 until the command supports it
+		runtimeVersion, err = airflowversions.GetDefaultImageTag(airflowVersionClient, "", true)
 		if err != nil {
 			return err
 		}

--- a/cmd/cloud/deployment_workerqueue.go
+++ b/cmd/cloud/deployment_workerqueue.go
@@ -120,5 +120,6 @@ func deploymentWorkerQueueDelete(cmd *cobra.Command, _ []string, out io.Writer) 
 	if err != nil {
 		return err
 	}
+
 	return workerqueue.Delete(ws, deploymentID, deploymentName, name, force, platformCoreClient, astroCoreClient, out)
 }


### PR DESCRIPTION
## Description

This change blocks `astro deployment` commands that are not yet supported for Airflow 3 deployments.

These are the commands that match:
- `astro deployment [create|update|logs]`
- `astro deployment [variable|airflow-variable|connection|pool|worker-queue] *` 

## 🧪 Functional Testing

- Unit tested added/updated
- Manually checked each impacted command against Airflow 2 and Airflow 3 deployments

## 📸 Screenshots

<img width="958" alt="Screenshot 2025-03-31 at 3 11 38 PM" src="https://github.com/user-attachments/assets/07fa1fc0-a8e2-4819-8164-4de1f56bb72a" />

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
