### PR TITLE
Fix whitespace. Remove unnecessary '| head'

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -80,7 +80,7 @@ func CompareVersions(client *github.Client, owner, repo string) error {
 			fmt.Fprintf(os.Stderr, "\nA newer version of Astro CLI is available: %s\nPlease see https://www.astronomer.io/docs/astro/cli/install-cli#upgrade-the-astro-cli for information on how to update the Astro CLI\n\n", latestSemver)
 		}
 		fmt.Fprint(os.Stderr, ansi.Cyan("\nTo learn more about what's new in this version, please see https://www.astronomer.io/docs/astro/cli/release-notes\n\n"))
-		fmt.Fprintf(os.Stderr, "If you don't want to see this message again run 'astro config set -g upgrade_message false'or pass '2>/dev/null | head' to print this text to stderr\n\n")
+		fmt.Fprintf(os.Stderr, "If you don't want to see this message again run 'astro config set -g upgrade_message false' or pass '2>/dev/null' to print this text to stderr\n\n")
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Fix a whitespace problem in version upgrade alert text.

Remove unnecessary `| head` from version upgrade alert text.

## 🎟 Issue(s)

N/A

## 🧪 Functional Testing

I have done no testing.

## 📸 Screenshots

I have not run this code.

## 📋 Checklist

- [X] Rebased from the main (or release if patching) branch (before testing)
- [X] Ran `make test` before taking out of draft
- [X] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
