### PR TITLE
Update airflow 3 image repo

### DIFF
--- a/airflow/constants.go
+++ b/airflow/constants.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	QuayBaseImageName               = "quay.io/astronomer"
-	AstroImageRegistryBaseImageName = "air.astronomer.io"
+	AstroImageRegistryBaseImageName = "astrocrpublic.azurecr.io"
 	AstronomerCertifiedImageName    = "ap-airflow"
 	AstroRuntimeAirflow2ImageName   = "astro-runtime"
 	AstroRuntimeAirflow3ImageName   = "runtime"

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -820,7 +820,7 @@ func upgradeDockerfile(oldDockerfilePath, newDockerfilePath, newTag, customImage
 	var newImage string
 	switch airflowversions.AirflowMajorVersionForRuntimeVersion(newTag) {
 	case "3":
-		newImage = "air.astronomer.io/runtime"
+		newImage = "astrocrpublic.azurecr.io/runtime"
 	case "2":
 		newImage = "quay.io/astronomer/astro-runtime"
 	}
@@ -837,7 +837,7 @@ func upgradeDockerfile(oldDockerfilePath, newDockerfilePath, newTag, customImage
 		for _, line := range lines {
 			line = strings.TrimSpace(line)
 			if strings.HasPrefix(line, "FROM quay.io/astronomer/astro-runtime") ||
-				strings.HasPrefix(line, "FROM air.astronomer.io/runtime") {
+				strings.HasPrefix(line, "FROM astrocrpublic.azurecr.io/runtime") {
 				if strings.HasPrefix(line, fmt.Sprintf("FROM %s", newImage)) {
 					parts := strings.SplitN(line, ":", partsNum)
 					if len(parts) == partsNum {

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1989,7 +1989,7 @@ func (s *Suite) TestUpgradeDockerfile() {
 		// Read the new Dockerfile and check its content
 		newContent, err := os.ReadFile(newDockerfilePath)
 		s.NoError(err)
-		s.Contains(string(newContent), "FROM air.astronomer.io/runtime:3.0-1")
+		s.Contains(string(newContent), "FROM astrocrpublic.azurecr.io/runtime:3.0-1")
 	})
 
 	s.Run("update Dockerfile with new image", func() {

--- a/airflow/include/airflow3/dockerfile
+++ b/airflow/include/airflow3/dockerfile
@@ -1,1 +1,1 @@
-FROM air.astronomer.io/%s:%s
+FROM astrocrpublic.azurecr.io/%s:%s


### PR DESCRIPTION
## Description

This PR updates airflow 3 specific image repo address from `air.astronomer.io/runtime` to `astrocrpublic.azurecr.io/runtime` in order to prevent Podman and Kaniko pull issues due to redirect errors. 

## 🎟 Issue(s)

Related https://github.com/astronomer/astro-cli/issues/1826

## 🧪 Functional Testing

Tested the change locally:

```
astro dev init --runtime-version 3.0-1
Initialized empty Astro project in /tmp/AF3
```

```
cat dockerfile
FROM astrocrpublic.azurecr.io/runtime:3.0-1
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
