### PR TITLE
Only allow AF2->3 upgrade from Runtime 8.7.0+

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -764,12 +764,18 @@ func ValidRuntimeVersion(currentVersion, tag string, deploymentOptionsRuntimeVer
 		return false
 	}
 
-	// If upgrading from Airflow 2 to Airflow 3, we require the user to force the upgrade
+	// If upgrading from Airflow 2 to Airflow 3, we require at least Runtime 8.7.0 (Airflow 2.6.3) and that the user has forced the upgrade
 	currentVersionAirflowMajorVersion := airflowversions.AirflowMajorVersionForRuntimeVersion(currentVersion)
 	tagAirflowMajorVersion := airflowversions.AirflowMajorVersionForRuntimeVersion(tag)
-	if currentVersionAirflowMajorVersion == "2" && tagAirflowMajorVersion == "3" && !forceUpgradeToAF3 {
-		fmt.Println("Cannot upgrade from Airflow 2 to Airflow 3 without the --force-upgrade-to-af3 flag")
-		return false
+	if currentVersionAirflowMajorVersion == "2" && tagAirflowMajorVersion == "3" {
+		if airflowversions.CompareRuntimeVersions(currentVersion, "8.7.0") < 0 {
+			fmt.Println("Can only upgrade deployment from Airflow 2 to Airflow 3 with deployment at Astro Runtime 8.7.0 or higher")
+			return false
+		}
+		if !forceUpgradeToAF3 {
+			fmt.Println("Can only upgrade deployment from Airflow 2 to Airflow 3 with the --force-upgrade-to-af3 flag")
+			return false
+		}
 	}
 
 	return true

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -968,21 +968,30 @@ func TestValidRuntimeVersion(t *testing.T) {
 
 		// AF2 to AF3 upgrade cases
 		{
-			name:              "AF2 to AF3 version with force flag is valid upgrade",
-			currentVersion:    "4.2.5",
+			name:              "AF2 >= 8.7.0 to AF3 version with force flag is valid upgrade",
+			currentVersion:    "8.7.0",
 			newVersion:        "3.0-1",
 			deploymentOptions: []string{"3.0-1"},
 			forceUpgradeToAF3: true,
 			expected:          true,
 		},
 		{
-			name:              "AF2 to AF3 version without force flag is invalid upgrade",
+			name:              "AF2 < 8.7.0 to AF3 version with force flag is invalid upgrade",
 			currentVersion:    "4.2.5",
+			newVersion:        "3.0-1",
+			deploymentOptions: []string{"3.0-1"},
+			forceUpgradeToAF3: true,
+			expected:          false,
+			expectedError:     "Can only upgrade deployment from Airflow 2 to Airflow 3 with deployment at Astro Runtime 8.7.0 or higher",
+		},
+		{
+			name:              "AF2 >= 8.7.0 to AF3 version without force flag is invalid upgrade",
+			currentVersion:    "8.7.0",
 			newVersion:        "3.0-1",
 			deploymentOptions: []string{"3.0-1"},
 			forceUpgradeToAF3: false,
 			expected:          false,
-			expectedError:     "Cannot upgrade from Airflow 2 to Airflow 3 without the --force-upgrade-to-af3 flag",
+			expectedError:     "Can only upgrade deployment from Airflow 2 to Airflow 3 with the --force-upgrade-to-af3 flag",
 		},
 
 		// AF3 version cases


### PR DESCRIPTION
## Description

This change enforces that deployment upgrades from Airflow 2 to 3 can only be made on deployments that are at least on Runtime version 8.7.0 (Airflow 2.6.3), because there are upgrade incompatibilities with prior Airflow versions.

## 🎟 Issue(s)

Resolves #1824 

## 🧪 Functional Testing

- Updated unit tests
- Manually tested with deployments pre and post 8.7.0

## 📸 Screenshots

<img width="973" alt="Screenshot 2025-04-03 at 10 09 21 AM" src="https://github.com/user-attachments/assets/ac2662b6-d33a-4c7f-b1a0-c5f1944f8292" />
<img width="935" alt="Screenshot 2025-04-03 at 10 09 42 AM" src="https://github.com/user-attachments/assets/6616421e-66c6-442d-ae8d-5452b1886a53" />

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
