### PR TITLE
Repoint authentication configs

### DIFF
--- a/config/cloud.go
+++ b/config/cloud.go
@@ -7,10 +7,6 @@ import (
 	"github.com/astronomer/astro-cli/pkg/printutil"
 )
 
-const (
-	graphqlEndpoint = "graphql"
-)
-
 // PrintCloudContext prints current context to stdOut
 func (c *Context) PrintCloudContext(out io.Writer) error {
 	context, err := c.GetContext()
@@ -53,22 +49,11 @@ func PrintCurrentCloudContext(out io.Writer) error {
 	return nil
 }
 
-// GetPublicGraphQLAPIURL returns full Astrohub API Url for the provided Context
-func (c *Context) GetPublicGraphQLAPIURL() string {
-	if c.Domain == localhostDomain || c.Domain == astrohubDomain {
-		return CFG.LocalPublicAstro.GetString()
-	}
-	domain := domainutil.FormatDomain(c.Domain)
-	return domainutil.GetURLToEndpoint(CFG.CloudAPIProtocol.GetString(), domain, graphqlEndpoint)
-}
-
 // GetPublicRESTAPIURL returns full core API Url for the provided Context
 func (c *Context) GetPublicRESTAPIURL(version string) string {
-	if c.Domain == localhostDomain || c.Domain == astrohubDomain {
+	if c.Domain == localhostDomain {
 		return CFG.LocalCore.GetString() + "/" + version
 	}
 
-	domain := domainutil.FormatDomain(c.Domain)
-	addr := domainutil.GetURLToEndpoint(CFG.CloudAPIProtocol.GetString(), domain, version)
-	return domainutil.TransformToCoreAPIEndpoint(addr)
+	return domainutil.GetURLToEndpoint(CFG.CloudAPIProtocol.GetString(), domainutil.FormatDomain(c.Domain), version)
 }

--- a/config/cloud_test.go
+++ b/config/cloud_test.go
@@ -30,40 +30,6 @@ contexts:
 	InitConfig(fs)
 }
 
-func (s *Suite) TestContextGetPublicGraphQLAPIURL() {
-	initTestConfig()
-	CFG.CloudAPIProtocol.SetHomeString("https")
-	type fields struct {
-		Domain string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   string
-	}{
-		{
-			name:   "basic localhost case",
-			fields: fields{Domain: "localhost"},
-			want:   "http://localhost:8871/graphql",
-		},
-		{
-			name:   "basic cloud case",
-			fields: fields{Domain: "cloud.astro.io"},
-			want:   "https://api.astro.io/hub/graphql",
-		},
-	}
-	for _, tt := range tests {
-		s.Run(tt.name, func() {
-			c := &Context{
-				Domain: tt.fields.Domain,
-			}
-			if got := c.GetPublicGraphQLAPIURL(); got != tt.want {
-				s.Fail("Context.GetPublicGraphQLAPIURL() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func (s *Suite) TestContextGetPublicRESTAPIURL() {
 	initTestConfig()
 	CFG.CloudAPIProtocol.SetHomeString("https")

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,6 @@ const (
 	PrPreview        = "prprievew"
 
 	localhostDomain = "localhost"
-	astrohubDomain  = "astrohub"
 	cloudDomain     = "cloud"
 	houstonDomain   = "houston"
 
@@ -57,9 +56,7 @@ var (
 		Context:               newCfg("context", ""),
 		Contexts:              newCfg("contexts", ""),
 		DockerCommand:         newCfg("container.binary", ""),
-		LocalAstro:            newCfg("local.astrohub", "http://localhost:8871/v1"),
 		LocalCore:             newCfg("local.core", "http://localhost:8888"),
-		LocalPublicAstro:      newCfg("local.public_astrohub", "http://localhost:8871/graphql"),
 		LocalRegistry:         newCfg("local.registry", "localhost:5555"),
 		LocalHouston:          newCfg("local.houston", ""),
 		LocalPlatform:         newCfg("local.platform", CloudPlatform),

--- a/context/context.go
+++ b/context/context.go
@@ -16,9 +16,6 @@ import (
 
 var (
 	// CloudDomainRegex is used to differentiate cloud domain from software domain
-	// See https://github.com/astronomer/astrohub-cli/issues/7 for regexp rationale
-	// This will need to be handled as part of the permanent solution to issue #432
-	// CloudDomainRegex     = regexp.MustCompile(`(?:(pr\d{4,6})\.|^)(?:cloud\.|)astronomer(?:-(dev|stage|perf))?\.io$`)
 	CloudDomainRegex     = regexp.MustCompile(`(?:https:\/\/|^)(?:(pr\d{4,6})\.|)(?:cloud\.|)astronomer(?:-(dev|stage|perf))?\.io(?:\/|)$`)
 	contextDeleteWarnMsg = "Are you sure you want to delete currently used context: %s"
 	cancelCtxDeleteMsg   = "Canceling context delete..."

--- a/pkg/domainutil/domain.go
+++ b/pkg/domainutil/domain.go
@@ -41,23 +41,15 @@ func GetURLToEndpoint(protocol, domain, endpoint string) string {
 
 	switch domain {
 	case LocalDomain:
-		addr = fmt.Sprintf("%s://%s:8871/%s", "http", domain, endpoint)
+		addr = fmt.Sprintf("%s://%s:8888/%s", "http", domain, endpoint)
 		return addr
 	default:
 		if isPrPreviewDomain(domain) {
 			prSubDomain, domain = GetPRSubDomain(domain)
-			addr = fmt.Sprintf("%s://%s.api.%s/hub/%s", protocol, prSubDomain, domain, endpoint)
+			addr = fmt.Sprintf("%s://%s.api.%s/%s", protocol, prSubDomain, domain, endpoint)
 			return addr
 		}
-		addr = fmt.Sprintf("%s://api.%s/hub/%s", protocol, domain, endpoint)
-	}
-	return addr
-}
-
-func TransformToCoreAPIEndpoint(addr string) string {
-	if strings.Contains(addr, "v1alpha1") || strings.Contains(addr, "v1beta1") {
-		addr = strings.Replace(addr, "/hub", "", 1)
-		addr = strings.Replace(addr, "localhost:8871", "localhost:8888", 1)
+		addr = fmt.Sprintf("%s://api.%s/%s", protocol, domain, endpoint)
 	}
 	return addr
 }

--- a/pkg/domainutil/domain_test.go
+++ b/pkg/domainutil/domain_test.go
@@ -139,60 +139,45 @@ func (s *Suite) TestGetURLToEndpoint() {
 	endpoint = "myendpoint"
 	s.Run("returns localhost endpoint", func() {
 		domain = "localhost"
-		expectedURL = fmt.Sprintf("http://%s:8871/%s", domain, endpoint)
-		actualURL := GetURLToEndpoint("https", domain, endpoint)
+		expectedURL = fmt.Sprintf("http://%s:8888/%s", domain, endpoint)
+		actualURL := GetURLToEndpoint("http", domain, endpoint)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns pr preview endpoint", func() {
 		prSubDomain = "pr1234"
 		domain = "pr1234.astronomer-dev.io"
-		expectedURL = fmt.Sprintf("https://%s.api.%s/hub/%s", prSubDomain, "astronomer-dev.io", endpoint)
+		expectedURL = fmt.Sprintf("https://%s.api.%s/%s", prSubDomain, "astronomer-dev.io", endpoint)
 		actualURL := GetURLToEndpoint("https", domain, endpoint)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns cloud endpoint for prod", func() {
 		domain = "astronomer.io"
-		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		expectedURL = fmt.Sprintf("https://api.%s/%s", domain, endpoint)
 		actualURL := GetURLToEndpoint("https", domain, endpoint)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns cloud endpoint for dev", func() {
 		domain = "astronomer-dev.io"
-		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		expectedURL = fmt.Sprintf("https://api.%s/%s", domain, endpoint)
 		actualURL := GetURLToEndpoint("https", domain, endpoint)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns cloud endpoint for stage", func() {
 		domain = "astronomer-stage.io"
-		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		expectedURL = fmt.Sprintf("https://api.%s/%s", domain, endpoint)
 		actualURL := GetURLToEndpoint("https", domain, endpoint)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns cloud endpoint for perf", func() {
 		domain = "astronomer-perf.io"
-		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		expectedURL = fmt.Sprintf("https://api.%s/%s", domain, endpoint)
 		actualURL := GetURLToEndpoint("https", domain, endpoint)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns cloud endpoint for everything else", func() {
 		domain = "someotherdomain.io"
-		expectedURL = fmt.Sprintf("https://api.%s/hub/%s", domain, endpoint)
+		expectedURL = fmt.Sprintf("https://api.%s/%s", domain, endpoint)
 		actualURL := GetURLToEndpoint("https", domain, endpoint)
 		s.Equal(expectedURL, actualURL)
-	})
-}
-
-func (s *Suite) TestTransformToCoreApiEndpoint() {
-	s.Run("transforms non-local url to core api endpoint", func() {
-		actual := TransformToCoreAPIEndpoint("https://somedomain.io/hub/v1alpha1/great-endpoint")
-		s.Equal("https://somedomain.io/v1alpha1/great-endpoint", actual)
-	})
-	s.Run("transforms local url to core api endpoint", func() {
-		actual := TransformToCoreAPIEndpoint("http://localhost:8871/v1alpha1/great-endpoint")
-		s.Equal("http://localhost:8888/v1alpha1/great-endpoint", actual)
-	})
-	s.Run("returns without changes if url is not meant for core api", func() {
-		actual := TransformToCoreAPIEndpoint("https://somedomain.io/hub/valpha1/great-enedpoint")
-		s.Equal("https://somedomain.io/hub/valpha1/great-enedpoint", actual)
 	})
 }


### PR DESCRIPTION
## Description

This change repoints the `astro login` command to get the authentication configurations for the Astro environment from a Core endpoint instead of from Astrohub. This removes the last reference to Astrohub in the CLI.

## 🧪 Functional Testing

- Unit tests updated
- Manually logged in to each environment

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
