### PR TITLE
Fix Airflow 3 health check endpoint

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -283,7 +283,7 @@ func (d *DockerCompose) Start(imageName, settingsFile, composeFile, buildSecretS
 	var healthURL, healthComponent string
 	switch airflowMajorVersion {
 	case "3":
-		healthURL = fmt.Sprintf("http://localhost:%s/public/monitor/health", config.CFG.APIServerPort.GetString())
+		healthURL = fmt.Sprintf("http://localhost:%s/api/v2/monitor/health", config.CFG.APIServerPort.GetString())
 		healthComponent = "api-server"
 	case "2":
 		healthURL = fmt.Sprintf("http://localhost:%s/health", config.CFG.WebserverPort.GetString())
@@ -1476,30 +1476,30 @@ var createDockerProject = func(projectName, airflowHome, envFile, buildImage, se
 }
 
 func printStatus(settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, project *composetypes.Project, composeService api.Service, airflowDockerVersion uint64, noBrowser bool) error {
-	psInfo, err := composeService.Ps(context.Background(), project.Name, api.PsOptions{
+	containers, err := composeService.Ps(context.Background(), project.Name, api.PsOptions{
 		All: true,
 	})
 	if err != nil {
 		return errors.Wrap(err, composeStatusCheckErrMsg)
 	}
 
-	fileState, err := fileutil.Exists(settingsFile, nil)
+	settingsFileExists, err := fileutil.Exists(settingsFile, nil)
 	if err != nil {
 		return errors.Wrap(err, errSettingsPath)
 	}
-
-	if fileState {
-		for i := range psInfo {
-			if strings.Contains(psInfo[i].Name, project.Name) &&
-				(strings.Contains(psInfo[i].Name, WebserverDockerContainerName) ||
-					strings.Contains(psInfo[i].Name, APIServerDockerContainerName)) {
-				err = initSettings(psInfo[i].ID, settingsFile, envConns, airflowDockerVersion, true, true, true)
+	if settingsFileExists {
+		for _, container := range containers { //nolint:gocritic
+			if strings.Contains(container.Name, project.Name) &&
+				(strings.Contains(container.Name, WebserverDockerContainerName) ||
+					strings.Contains(container.Name, APIServerDockerContainerName)) {
+				err = initSettings(container.ID, settingsFile, envConns, airflowDockerVersion, true, true, true)
 				if err != nil {
 					return err
 				}
 			}
 		}
 	}
+
 	parts := strings.Split(config.CFG.WebserverPort.GetString(), ":")
 	webserverURL := "http://localhost:" + parts[len(parts)-1]
 	bullet := ansi.Cyan("\u27A4") + " "


### PR DESCRIPTION
## Description

This change fixes the Airflow 3 health check endpoint so that the CLI does not attempt to load the settings file before the API server is ready to respond to requests.

## 🧪 Functional Testing

Checked that the project still starts.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
