### PR TITLE
Add core fernet key to Airflow 3 env vars

### DIFF
--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -361,6 +361,7 @@ services:
   AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS: "True"
   AIRFLOW__CORE__EXECUTION_API_SERVER_URL: "http://api-server:8080/execution/"
   AIRFLOW__CORE__EXECUTOR: LocalExecutor
+  AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
   AIRFLOW__CORE__LOAD_EXAMPLES: "False"
   AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://postgres:postgres@postgres:5432
   AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql://postgres:postgres@postgres:5432

--- a/airflow/include/airflow3/composeyml.go.tmpl
+++ b/airflow/include/airflow3/composeyml.go.tmpl
@@ -6,6 +6,7 @@ x-common-env-vars: &common-env-vars
   AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS: "True"
   AIRFLOW__CORE__EXECUTION_API_SERVER_URL: "http://api-server:8080/execution/"
   AIRFLOW__CORE__EXECUTOR: LocalExecutor
+  AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
   AIRFLOW__CORE__LOAD_EXAMPLES: "False"
   AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@{{ .PostgresHost }}:5432
   AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql://{{ .PostgresUser }}:{{ .PostgresPassword }}@{{ .PostgresHost }}:5432


### PR DESCRIPTION
## Description

This change adds the core fernet key to Airflow 3 env vars that is already being set for Airflow 2.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
