### PR TITLE
Lint entire project, not just dags dir

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -798,14 +798,14 @@ func (d *DockerCompose) lintTest(testHomeDirectory string, includeDeprecations b
 		}
 	}
 
-	// Mount the dags directory and the ruff config file
+	// Mount the project and the ruff config file
 	mountDirs := map[string]string{
-		filepath.Join(config.WorkingPath, "dags"): "/app/dags",
-		configFile: "/app/ruff.toml",
+		config.WorkingPath: "/app/project",
+		configFile:         "/app/ruff.toml",
 	}
 
-	// Run ruff with the config file and the dags directory
-	ruffArgs := []string{"check", "--config", "/app/ruff.toml", "/app/dags"}
+	// Run ruff with the config file and the project directory
+	ruffArgs := []string{"check", "--config", "/app/ruff.toml", "/app/project"}
 	var buf bytes.Buffer
 	bufWriter := io.MultiWriter(os.Stdout, &buf)
 	ruffErr := d.ruffImageHandler.RunCommand(ruffArgs, mountDirs, bufWriter, bufWriter)

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1407,7 +1407,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
-		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/dags"}, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/project"}, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
@@ -1425,7 +1425,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
-		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/dags"}, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/project"}, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
@@ -1444,12 +1444,6 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		s.NoError(err)
 		defer os.Remove(dummyConfigFile) // Clean up dummy file
 
-		// Create dummy dags directory inside the temp test directory
-		dummyDagsDir := filepath.Join(cwd, "dags")
-		err = os.Mkdir(dummyDagsDir, 0o777)
-		s.NoError(err)
-		defer os.RemoveAll(dummyDagsDir) // Clean up dummy dags dir
-
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
@@ -1457,10 +1451,10 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		ruffImageHandler := new(mocks.ImageHandler)
 		// Expect RunCommand, specifically check that the provided config file and dags dir are mounted
 		expectedMounts := map[string]string{
-			dummyDagsDir:    "/app/dags",      // Use the dummy dags dir path from cwd
+			cwd:             "/app/project",   // Use the dummy dags dir path from cwd
 			dummyConfigFile: "/app/ruff.toml", // Check this mapping
 		}
-		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/dags"}, expectedMounts, mock.Anything, mock.Anything).Return(nil).Once()
+		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/project"}, expectedMounts, mock.Anything, mock.Anything).Return(nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
@@ -1482,7 +1476,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
-		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/dags"}, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
+		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/project"}, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler


### PR DESCRIPTION
## Description

This changes the new ruff linting feature for `astro dev upgrade-test` to lint the entire project, not just the `dags/` directory. This will capture issues in other files such as in `include/`.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
