### PR TITLE
Initialize new projects with Airflow 3

### DIFF
--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -70,8 +70,12 @@ func getAstroRuntimeTag(runtimeVersions, runtimeVersionsV3 map[string]RuntimeVer
 
 	logger.Debugf("Available runtime versions: %v", availableVersions)
 
-	if airflowVersion != "" && len(availableVersions) == 0 {
-		return "", ErrNoTagAvailable{airflowVersion: airflowVersion}
+	if len(availableVersions) == 0 {
+		if airflowVersion != "" {
+			return "", ErrNoTagAvailable{airflowVersion: airflowVersion}
+		} else {
+			return "", fmt.Errorf("no runtime versions found")
+		}
 	}
 
 	latestVersion := availableVersions[0]

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -489,7 +489,7 @@ func airflowInit(cmd *cobra.Command, args []string) error {
 	imageTag := runtimeVersion
 	if imageTag == "" {
 		httpClient := airflowversions.NewClient(httputil.NewHTTPClient(), useAstronomerCertified)
-		imageTag, err = getDefaultImageTag(httpClient, airflowVersion, true)
+		imageTag, err = getDefaultImageTag(httpClient, airflowVersion, false)
 		if err != nil {
 			return fmt.Errorf("error getting default image tag: %w", err)
 		}
@@ -638,7 +638,7 @@ func airflowUpgradeTest(cmd *cobra.Command, platformCoreClient astroplatformcore
 		// If user provides a runtime version, use it, otherwise retrieve the latest one (matching Airflow Version if provided
 		httpClient := airflowversions.NewClient(httputil.NewHTTPClient(), useAstronomerCertified)
 		var err error
-		runtimeVersion, err = getDefaultImageTag(httpClient, airflowVersion, true)
+		runtimeVersion, err = getDefaultImageTag(httpClient, airflowVersion, false)
 		if err != nil {
 			return fmt.Errorf("error getting default image tag: %w", err)
 		}


### PR DESCRIPTION
## Description

This change enables initializing new projects with Airflow 3.

## 🧪 Functional Testing

Tested by manually changing the runtime versions repository to the dev list and confirmed a project initialized with Airflow 3.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
