### PR TITLE
Pull latest Ruff image on upgrade-test

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -804,6 +804,12 @@ func (d *DockerCompose) lintTest(testHomeDirectory string, includeDeprecations b
 		configFile:         "/app/ruff.toml",
 	}
 
+	// Pull the ruff image to get the latest image for the "latest" tag
+	err = d.ruffImageHandler.Pull("", "", "")
+	if err != nil {
+		return false, err
+	}
+
 	// Run ruff with the config file and the project directory
 	ruffArgs := []string{"check", "--config", "/app/ruff.toml", "/app/project"}
 	var buf bytes.Buffer

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -432,6 +432,10 @@ func (d *DockerImage) getRegistryToAuth(imageName string) (string, error) {
 }
 
 func (d *DockerImage) Pull(remoteImage, username, token string) error {
+	if remoteImage == "" {
+		remoteImage = d.imageName
+	}
+
 	// Pulling image to registry
 	fmt.Println(pullingImagePrompt)
 	containerRuntime, err := runtimes.GetContainerRuntimeBinary()

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1407,6 +1407,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
+		ruffImageHandler.On("Pull", "", "", "").Return(nil).Once()
 		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/project"}, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
@@ -1425,6 +1426,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
+		ruffImageHandler.On("Pull", "", "", "").Return(nil).Once()
 		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/project"}, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
@@ -1454,6 +1456,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 			cwd:             "/app/project",   // Use the dummy dags dir path from cwd
 			dummyConfigFile: "/app/ruff.toml", // Check this mapping
 		}
+		ruffImageHandler.On("Pull", "", "", "").Return(nil).Once()
 		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/project"}, expectedMounts, mock.Anything, mock.Anything).Return(nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
@@ -1476,6 +1479,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
+		ruffImageHandler.On("Pull", "", "", "").Return(nil).Once()
 		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/project"}, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler


### PR DESCRIPTION
## Description

This change adds an image pull of the latest Ruff image before running it to lint the project. Without this the Ruff image will not update itself as new rules are added.

## 🧪 Functional Testing

- Ran without the image locally, it pulls as already the case
- Ran with the image locally, it pulls for the latest

## 📸 Screenshots

<img width="734" alt="Screenshot 2025-04-21 at 4 23 32 PM" src="https://github.com/user-attachments/assets/043dbb23-58db-4ce9-81ab-f0244d8ca6ca" />

<img width="737" alt="Screenshot 2025-04-21 at 4 23 45 PM" src="https://github.com/user-attachments/assets/50a8ab19-765f-4c9e-b83e-270e7a83c343" />

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
