### PR TITLE
Update deprecated imports in the exampledag for 3.0

### DIFF
--- a/airflow/include/airflow3/exampledag.py
+++ b/airflow/include/airflow3/exampledag.py
@@ -20,17 +20,15 @@ first DAG tutorial: https://www.astronomer.io/docs/learn/get-started-with-airflo
 ![Picture of the ISS](https://www.esa.int/var/esa/storage/images/esa_multimedia/images/2010/02/space_station_over_earth/10293696-3-eng-GB/Space_Station_over_Earth_card_full.jpg)
 """
 
-from airflow.sdk.definitions.asset import Asset
-from airflow.decorators import dag, task
+from airflow.sdk import Asset, dag, task
 from pendulum import datetime
 import requests
 
 
 # Define the basic parameters of the DAG, like schedule and start_date
 @dag(
-    start_date=datetime(2024, 1, 1),
+    start_date=datetime(2025, 4, 22),
     schedule="@daily",
-    catchup=False,
     doc_md=__doc__,
     default_args={"owner": "Astro", "retries": 3},
     tags=["example"],
@@ -38,9 +36,9 @@ import requests
 def example_astronauts():
     # Define tasks
     @task(
-        # Define a dataset outlet for the task. This can be used to schedule downstream DAGs when this task has run.
+        # Define an asset outlet for the task. This can be used to schedule downstream DAGs when this task has run.
         outlets=[Asset("current_astronauts")]
-    )  # Define that this task updates the `current_astronauts` Dataset
+    )  # Define that this task updates the `current_astronauts` Asset
     def get_astronauts(**context) -> list[dict]:
         """
         This task uses the requests library to retrieve a list of Astronauts


### PR DESCRIPTION
The dag runs fine but uses some deprecated imports, so I changed that as well as removed catchup because the default is now false and updated the date. :)

## 🧪 Functional Testing

Ran the updated DAG.