### PR TITLE
Fix runtime version check for upgrade message

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -789,7 +789,7 @@ func WarnIfNonLatestVersion(version string, httpClient *httputil.HTTPClient) {
 		return
 	}
 
-	if airflowversions.CompareRuntimeVersions(version, latestRuntimeVersion) <= 0 {
+	if airflowversions.CompareRuntimeVersions(version, latestRuntimeVersion) < 0 {
 		fmt.Printf("WARNING! You are currently running Astro Runtime Version %s\nConsider upgrading to the latest version, Astro Runtime %s\n", version, latestRuntimeVersion)
 	}
 }


### PR DESCRIPTION
## Description

Fix the runtime version check condition for CLI version upgrade message

## 🎟 Issue(s)

Slack Conversation: https://astronomer.slack.com/archives/CL44PA4DB/p1748026544077119?thread_ts=1747757099.231729&cid=CL44PA4DB

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
