### PR TITLE
Support AF3 connections, variables and pools CLU

### DIFF
--- a/airflow-client/airflow-client.go
+++ b/airflow-client/airflow-client.go
@@ -41,7 +41,7 @@ func NewAirflowClient(c *httputil.HTTPClient) *HTTPClient {
 
 func (c *HTTPClient) GetConnections(airflowURL string) (Response, error) {
 	doOpts := &httputil.DoOptions{
-		Path:   "https://" + airflowURL + "/api/v1/connections",
+		Path:   "https://" + airflowURL + "/connections",
 		Method: http.MethodGet,
 	}
 
@@ -60,7 +60,7 @@ func (c *HTTPClient) CreateConnection(airflowURL string, conn *Connection) error
 		return err
 	}
 	doOpts := &httputil.DoOptions{
-		Path:   "https://" + airflowURL + "/api/v1/connections",
+		Path:   "https://" + airflowURL + "/connections",
 		Method: http.MethodPost,
 		Data:   connJSON,
 	}
@@ -80,7 +80,7 @@ func (c *HTTPClient) UpdateConnection(airflowURL string, conn *Connection) error
 	}
 
 	doOpts := &httputil.DoOptions{
-		Path:   fmt.Sprintf("https://%s/api/v1/connections/%s", airflowURL, conn.ConnID),
+		Path:   fmt.Sprintf("https://%s/connections/%s", airflowURL, conn.ConnID),
 		Method: http.MethodPatch,
 		Data:   connJSON,
 	}
@@ -95,7 +95,7 @@ func (c *HTTPClient) UpdateConnection(airflowURL string, conn *Connection) error
 
 func (c *HTTPClient) GetVariables(airflowURL string) (Response, error) {
 	doOpts := &httputil.DoOptions{
-		Path:   "https://" + airflowURL + "/api/v1/variables",
+		Path:   "https://" + airflowURL + "/variables",
 		Method: http.MethodGet,
 	}
 
@@ -114,7 +114,7 @@ func (c *HTTPClient) CreateVariable(airflowURL string, variable Variable) error 
 		return err
 	}
 	doOpts := &httputil.DoOptions{
-		Path:   "https://" + airflowURL + "/api/v1/variables",
+		Path:   "https://" + airflowURL + "/variables",
 		Method: http.MethodPost,
 		Data:   varJSON,
 	}
@@ -134,7 +134,7 @@ func (c *HTTPClient) UpdateVariable(airflowURL string, variable Variable) error 
 	}
 
 	doOpts := &httputil.DoOptions{
-		Path:   fmt.Sprintf("https://%s/api/v1/variables/%s", airflowURL, variable.Key),
+		Path:   fmt.Sprintf("https://%s/variables/%s", airflowURL, variable.Key),
 		Method: http.MethodPatch,
 		Data:   varJSON,
 	}
@@ -149,7 +149,7 @@ func (c *HTTPClient) UpdateVariable(airflowURL string, variable Variable) error 
 
 func (c *HTTPClient) GetPools(airflowURL string) (Response, error) {
 	doOpts := &httputil.DoOptions{
-		Path:   "https://" + airflowURL + "/api/v1/pools",
+		Path:   "https://" + airflowURL + "/pools",
 		Method: http.MethodGet,
 	}
 
@@ -168,7 +168,7 @@ func (c *HTTPClient) CreatePool(airflowURL string, pool Pool) error {
 		return err
 	}
 	doOpts := &httputil.DoOptions{
-		Path:   "https://" + airflowURL + "/api/v1/pools",
+		Path:   "https://" + airflowURL + "/pools",
 		Method: http.MethodPost,
 		Data:   varJSON,
 	}
@@ -188,7 +188,7 @@ func (c *HTTPClient) UpdatePool(airflowURL string, pool Pool) error {
 	}
 
 	doOpts := &httputil.DoOptions{
-		Path:   fmt.Sprintf("https://%s/api/v1/pools/%s", airflowURL, pool.Name),
+		Path:   fmt.Sprintf("https://%s/pools/%s", airflowURL, pool.Name),
 		Method: http.MethodPatch,
 		Data:   varJSON,
 	}
@@ -219,8 +219,8 @@ func (c *HTTPClient) DoAirflowClient(doOpts *httputil.DoOptions) (*Response, err
 	}
 	defer response.Body.Close()
 
-	// Check the response status code
-	if response.StatusCode != http.StatusOK {
+	// Check the response status code, return error for non-2xx codes
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected response status code: %d", response.StatusCode)
 	}
 

--- a/airflow-client/airflow-client_test.go
+++ b/airflow-client/airflow-client_test.go
@@ -91,7 +91,7 @@ func (s *Suite) TestGetConnections() {
 	s.Run("success", func() {
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 			s.Equal("GET", req.Method)
-			s.Equal("https://test-airflow-url/api/v1/connections", req.URL.String())
+			s.Equal("https://test-airflow-url/connections", req.URL.String())
 			s.Equal("token", req.Header.Get("authorization"))
 
 			return &http.Response{
@@ -147,7 +147,7 @@ func (s *Suite) TestUpdateConnection() {
 	s.Run("success", func() {
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 			s.Equal("PATCH", req.Method)
-			expectedURL := fmt.Sprintf("https://test-airflow-url/api/v1/connections/%s", mockConn.ConnID)
+			expectedURL := fmt.Sprintf("https://test-airflow-url/connections/%s", mockConn.ConnID)
 			s.Equal(expectedURL, req.URL.String())
 			s.Equal("token", req.Header.Get("authorization"))
 
@@ -225,7 +225,7 @@ func (s *Suite) TestCreateConnection() {
 	s.Run("success", func() {
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 			s.Equal("POST", req.Method)
-			expectedURL := "https://test-airflow-url/api/v1/connections"
+			expectedURL := "https://test-airflow-url/connections"
 			s.Equal(expectedURL, req.URL.String())
 			s.Equal("token", req.Header.Get("authorization"))
 
@@ -295,7 +295,7 @@ func (s *Suite) TestCreateConnection() {
 
 func (s *Suite) TestCreateVariable() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	expectedURL := "https://test-airflow-url/api/v1/variables"
+	expectedURL := "https://test-airflow-url/variables"
 
 	s.Run("success", func() {
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
@@ -357,7 +357,7 @@ func (s *Suite) TestCreateVariable() {
 
 func (s *Suite) TestGetVariables() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	expectedURL := "https://test-airflow-url/api/v1/variables"
+	expectedURL := "https://test-airflow-url/variables"
 
 	s.Run("success", func() {
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
@@ -399,7 +399,7 @@ func (s *Suite) TestGetVariables() {
 
 func (s *Suite) TestUpdateVariable() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	expectedURL := "https://test-airflow-url/api/v1/variables/test-key"
+	expectedURL := "https://test-airflow-url/variables/test-key"
 
 	s.Run("success", func() {
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
@@ -486,7 +486,7 @@ func (s *Suite) TestCreatePool() {
 	s.Run("success", func() {
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 			s.Equal("POST", req.Method)
-			expectedURL := "https://test-airflow-url/api/v1/pools"
+			expectedURL := "https://test-airflow-url/pools"
 			s.Equal(expectedURL, req.URL.String())
 			s.Equal("token", req.Header.Get("authorization"))
 
@@ -564,7 +564,7 @@ func (s *Suite) TestUpdatePool() {
 	s.Run("success", func() {
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 			s.Equal("PATCH", req.Method)
-			expectedURL := fmt.Sprintf("https://test-airflow-url/api/v1/pools/%s", mockPool.Name)
+			expectedURL := fmt.Sprintf("https://test-airflow-url/pools/%s", mockPool.Name)
 			s.Equal(expectedURL, req.URL.String())
 			s.Equal("token", req.Header.Get("authorization"))
 
@@ -640,7 +640,7 @@ func (s *Suite) TestGetPools() {
 	s.Run("success", func() {
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 			s.Equal("GET", req.Method)
-			expectedURL := "https://test-airflow-url/api/v1/pools"
+			expectedURL := "https://test-airflow-url/pools"
 			s.Equal(expectedURL, req.URL.String())
 			s.Equal("token", req.Header.Get("authorization"))
 

--- a/airflow-client/types.go
+++ b/airflow-client/types.go
@@ -22,9 +22,10 @@ type Variable struct {
 
 // Pool represents the structure of an Airflow pool
 type Pool struct {
-	Description string `json:"description"`
-	Name        string `json:"name"`
-	Slots       int    `json:"slots"`
+	Description     string `json:"description"`
+	Name            string `json:"name"`
+	Slots           int    `json:"slots"`
+	IncludeDeferred bool   `json:"include_deferred"`
 }
 
 type Response struct {

--- a/cloud/deployment/deployment_objects.go
+++ b/cloud/deployment/deployment_objects.go
@@ -214,7 +214,7 @@ func PoolList(airflowURL string, airflowAPIClient airflowclient.Client, out io.W
 	conTab := printutil.Table{
 		Padding:        []int{5, 30, 30, 50},
 		DynamicPadding: true,
-		Header:         []string{"NAME", "SLOTS"},
+		Header:         []string{"NAME", "SLOTS", "INCLUDE DEFERRED"},
 	}
 
 	// get pools
@@ -222,23 +222,23 @@ func PoolList(airflowURL string, airflowAPIClient airflowclient.Client, out io.W
 	if err != nil {
 		return err
 	}
-	// Print Connections
+	// Print pools
 	for i := range poolsResp.Pools {
 		pool := poolsResp.Pools[i]
-		conTab.AddRow([]string{pool.Name, fmt.Sprint(pool.Slots)}, false)
+		conTab.AddRow([]string{pool.Name, fmt.Sprint(pool.Slots), fmt.Sprint(pool.IncludeDeferred)}, false)
 	}
 
 	return conTab.Print(out)
 }
 
-func PoolCreate(airflowURL, name, description string, slots int, airflowAPIClient airflowclient.Client, out io.Writer) error {
+func PoolCreate(airflowURL, name, description string, slots int, includeDeferred bool, airflowAPIClient airflowclient.Client, out io.Writer) error {
 	pool := airflowclient.Pool{
-		Name:        name,
-		Slots:       slots,
-		Description: description,
+		Name:            name,
+		Slots:           slots,
+		Description:     description,
+		IncludeDeferred: includeDeferred,
 	}
 
-	// create connections
 	fmt.Printf("Creating pool %s\n", pool.Name)
 	err := airflowAPIClient.CreatePool(airflowURL, pool)
 	if err != nil {
@@ -247,14 +247,14 @@ func PoolCreate(airflowURL, name, description string, slots int, airflowAPIClien
 	return nil
 }
 
-func PoolUpdate(airflowURL, name, description string, slots int, airflowAPIClient airflowclient.Client, out io.Writer) error {
+func PoolUpdate(airflowURL, name, description string, slots int, includeDeferred bool, airflowAPIClient airflowclient.Client, out io.Writer) error {
 	pool := airflowclient.Pool{
-		Name:        name,
-		Slots:       slots,
-		Description: description,
+		Name:            name,
+		Slots:           slots,
+		Description:     description,
+		IncludeDeferred: includeDeferred,
 	}
 
-	// update connection
 	fmt.Printf("updating pool %s\n", pool.Name)
 	err := airflowAPIClient.UpdatePool(airflowURL, pool)
 	if err != nil {

--- a/cloud/deployment/deployment_objects_test.go
+++ b/cloud/deployment/deployment_objects_test.go
@@ -338,13 +338,15 @@ func (s *Suite) TestPoolCreate() {
 		poolName := "test_pool"
 		poolSlots := 5
 		poolDescription := "Test pool for unit testing"
+		poolIncludeDeferred := true
 		mockClient.On("CreatePool", testAirflowURL, airflowclient.Pool{
-			Name:        poolName,
-			Slots:       poolSlots,
-			Description: poolDescription,
+			Name:            poolName,
+			Slots:           poolSlots,
+			Description:     poolDescription,
+			IncludeDeferred: poolIncludeDeferred,
 		}).Return(nil).Once()
 
-		err := PoolCreate(testAirflowURL, poolName, poolDescription, poolSlots, mockClient, out)
+		err := PoolCreate(testAirflowURL, poolName, poolDescription, poolSlots, poolIncludeDeferred, mockClient, out)
 		s.NoError(err)
 	})
 
@@ -354,13 +356,15 @@ func (s *Suite) TestPoolCreate() {
 		poolName := "test_pool"
 		poolSlots := 5
 		poolDescription := "Test pool for unit testing"
+		poolIncludeDeferred := true
 		mockClient.On("CreatePool", testAirflowURL, airflowclient.Pool{
-			Name:        poolName,
-			Slots:       poolSlots,
-			Description: poolDescription,
+			Name:            poolName,
+			Slots:           poolSlots,
+			Description:     poolDescription,
+			IncludeDeferred: poolIncludeDeferred,
 		}).Return(errTest).Once()
 
-		err := PoolCreate(testAirflowURL, poolName, poolDescription, poolSlots, mockClient, out)
+		err := PoolCreate(testAirflowURL, poolName, poolDescription, poolSlots, poolIncludeDeferred, mockClient, out)
 		s.Error(err)
 		s.Equal("error", err.Error())
 	})
@@ -373,13 +377,15 @@ func (s *Suite) TestPoolUpdate() {
 		poolName := "test_pool"
 		poolSlots := 5
 		poolDescription := "Test pool for unit testing"
+		poolIncludeDeferred := true
 		mockClient.On("UpdatePool", testAirflowURL, airflowclient.Pool{
-			Name:        poolName,
-			Slots:       poolSlots,
-			Description: poolDescription,
+			Name:            poolName,
+			Slots:           poolSlots,
+			Description:     poolDescription,
+			IncludeDeferred: poolIncludeDeferred,
 		}).Return(nil).Once()
 
-		err := PoolUpdate(testAirflowURL, poolName, poolDescription, poolSlots, mockClient, out)
+		err := PoolUpdate(testAirflowURL, poolName, poolDescription, poolSlots, poolIncludeDeferred, mockClient, out)
 		s.NoError(err)
 	})
 
@@ -389,13 +395,15 @@ func (s *Suite) TestPoolUpdate() {
 		poolName := "test_pool"
 		poolSlots := 5
 		poolDescription := "Test pool for unit testing"
+		poolIncludeDeferred := true
 		mockClient.On("UpdatePool", testAirflowURL, airflowclient.Pool{
-			Name:        poolName,
-			Slots:       poolSlots,
-			Description: poolDescription,
+			Name:            poolName,
+			Slots:           poolSlots,
+			Description:     poolDescription,
+			IncludeDeferred: poolIncludeDeferred,
 		}).Return(errTest).Once()
 
-		err := PoolUpdate(testAirflowURL, poolName, poolDescription, poolSlots, mockClient, out)
+		err := PoolUpdate(testAirflowURL, poolName, poolDescription, poolSlots, poolIncludeDeferred, mockClient, out)
 		s.Error(err)
 		s.Equal("error", err.Error())
 	})

--- a/cmd/cloud/deployment_objects_test.go
+++ b/cmd/cloud/deployment_objects_test.go
@@ -32,8 +32,31 @@ var (
 			StatusCode: 200,
 		},
 		JSON200: &astroplatformcore.Deployment{
-			Id:             "test-id-1",
-			RuntimeVersion: "3.0-1",
+			Id:                     "test-id-1",
+			RuntimeVersion:         "3.0-1",
+			Namespace:              "test-name",
+			WorkspaceId:            "workspace-id",
+			WebServerUrl:           "test-url",
+			IsDagDeployEnabled:     false,
+			Description:            &description,
+			Name:                   "test-deployment-label",
+			Status:                 "HEALTHY",
+			Type:                   &standardType,
+			ClusterId:              &csID,
+			ClusterName:            &testCluster,
+			Executor:               &executorCelery,
+			IsHighAvailability:     &highAvailabilityTest,
+			IsDevelopmentMode:      &developmentModeTest,
+			ResourceQuotaCpu:       &resourceQuotaCPU,
+			ResourceQuotaMemory:    &ResourceQuotaMemory,
+			SchedulerSize:          &schedulerTestSize,
+			Region:                 &region,
+			WorkspaceName:          &workspaceName,
+			CloudProvider:          (*astroplatformcore.DeploymentCloudProvider)(&cloudProvider),
+			DefaultTaskPodCpu:      &defaultTaskPodCPU,
+			DefaultTaskPodMemory:   &defaultTaskPodMemory,
+			WebServerAirflowApiUrl: "airflow-url",
+			WorkerQueues:           &[]astroplatformcore.WorkerQueue{},
 		},
 	}
 )
@@ -80,15 +103,6 @@ func TestConnectionList(t *testing.T) {
 		assert.Error(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
-	t.Run("operations are blocked for Airflow 3 deployments", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"connection", "list", "-d", "test-id-1"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
 }
 
 func TestConnectionCreate(t *testing.T) {
@@ -120,15 +134,6 @@ func TestConnectionCreate(t *testing.T) {
 		cmdArgs := []string{"connection", "create"}
 		_, err := execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-	t.Run("operations are blocked for Airflow 3 deployments", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"connection", "create", "-d", "test-id-1", "--conn-id", "conn-id", "--conn-type", "conn-type"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 	t.Run("successful airflow variable create", func(t *testing.T) {
@@ -176,16 +181,6 @@ func TestConnectionUpdate(t *testing.T) {
 		cmdArgs := []string{"connection", "update"}
 		_, err := execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
-	t.Run("operations are blocked for Airflow 3 deployments", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"connection", "update", "-d", "test-id-1", "--conn-id", "conn-id"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 
@@ -308,15 +303,6 @@ func TestVariableList(t *testing.T) {
 		assert.Error(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
-	t.Run("operations are blocked for Airflow 3 deployments", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"airflow-variable", "list", "-d", "test-id-1"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
 }
 
 func TestVariableUpdate(t *testing.T) {
@@ -353,16 +339,6 @@ func TestVariableUpdate(t *testing.T) {
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 
-	t.Run("operations are blocked for Airflow 3 deployments", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"airflow-variable", "update", "-d", "test-id-1", "--key", "KEY"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
 	t.Run("successful airflow variable update", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
@@ -376,7 +352,7 @@ func TestVariableUpdate(t *testing.T) {
 	})
 }
 
-func TestVaraibleCreate(t *testing.T) {
+func TestVariableCreate(t *testing.T) {
 	expectedHelp := "Create Airflow variables for an Astro Deployment"
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	mockClient := new(airflowclient_mocks.Client)
@@ -406,16 +382,6 @@ func TestVaraibleCreate(t *testing.T) {
 		cmdArgs := []string{"airflow-variable", "create"}
 		_, err := execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
-	t.Run("operations are blocked for Airflow 3 deployments", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"airflow-variable", "create", "-d", "test-id-1", "--key", "KEY", "--value", "VAR"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 
@@ -538,15 +504,6 @@ func TestPoolList(t *testing.T) {
 		assert.Error(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
-	t.Run("operations are blocked for Airflow 3 deployments", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"pool", "list", "-d", "test-id-1"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
 }
 
 func TestPoolUpdate(t *testing.T) {
@@ -584,16 +541,6 @@ func TestPoolUpdate(t *testing.T) {
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 
-	t.Run("operations are blocked for Airflow 3 deployments", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"pool", "update", "-d", "test-id-1", "--name", "name"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
 	t.Run("successful pool update", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
@@ -601,6 +548,18 @@ func TestPoolUpdate(t *testing.T) {
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 		mockClient.On("UpdatePool", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
 		cmdArgs := []string{"pool", "update", "-d", "test-id-1", "--name", "name"}
+		_, err := execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		mockPlatformCoreClient.AssertExpectations(t)
+	})
+
+	t.Run("successful pool update for AF3 with --include-deferred flag", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
+		mockClient.On("UpdatePool", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
+		cmdArgs := []string{"pool", "update", "-d", "test-id-1", "--name", "name", "--include-deferred", "enable"}
 		_, err := execDeploymentCmd(cmdArgs...)
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -640,16 +599,6 @@ func TestPoolCreate(t *testing.T) {
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 
-	t.Run("operations are blocked for Airflow 3 deployments", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"pool", "create", "-d", "test-id-1", "--name", "name"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
 	t.Run("successful pool create", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
@@ -657,6 +606,18 @@ func TestPoolCreate(t *testing.T) {
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 		mockClient.On("CreatePool", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
 		cmdArgs := []string{"pool", "create", "-d", "test-id-1", "--name", "name"}
+		_, err := execDeploymentCmd(cmdArgs...)
+		assert.NoError(t, err)
+		mockPlatformCoreClient.AssertExpectations(t)
+	})
+
+	t.Run("successful pool create for AF3 with --include-deferred flag", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
+		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
+		mockClient.On("CreatePool", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
+		cmdArgs := []string{"pool", "create", "-d", "test-id-1", "--name", "name", "--include-deferred", "enable"}
 		_, err := execDeploymentCmd(cmdArgs...)
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Support AF3 connections, variables and pools CLU

- update airflow client to be api version agnostic
- use metadata airflow api url for airflow client
- add include_deferred to airflow client pool schema
- add include-deferred cli flag to pool create
- add include-deferred cli flag to pool update as it is required for AF3
- show include deferred in pool listing

> [!NOTE]  
> This PR removes support for pools CLU (Create, List, and Update) in Airflow Versions 2.6 and below. Airflow 2.6 corresponds to Runtime Version 8, which has reached [End of maintenance date](https://www.astronomer.io/docs/astro/runtime-version-lifecycle-policy/#astro-runtime-lifecycle-schedule) and is close to reaching `End of basic support` (see also [Basic Support](https://www.astronomer.io/docs/astro/runtime-version-lifecycle-policy/#basic-support)).

## 🎟 Issue(s)

closes: https://github.com/astronomer/astro-cli/issues/1867

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

### Connections

#### AF2

```bash
❯ ./astro deployment connection create -d cmbutodaf03vx01jq3q59u9d3 --conn-id my_conn --conn-type generic
Creating connection my_conn

❯ ./astro deployment connection list -d cmbutodaf03vx01jq3q59u9d3
 CONNECTION ID     CONN TYPE     
 my_conn           generic

❯ ./astro deployment connection update -d cmbutodaf03vx01jq3q59u9d3 --conn-id my_conn --conn-type generic_2
updating connection my_conn

❯ ./astro deployment connection list -d cmbutodaf03vx01jq3q59u9d3
 CONNECTION ID     CONN TYPE     
 my_conn           generic_2
```

#### AF3

```bash
❯ ./astro deployment connection create -d cmbuofehz007l01l3m8f6i5o9 --conn-id my_conn --conn-type generic
Creating connection my_conn

❯ ./astro deployment connection list -d cmbuofehz007l01l3m8f6i5o9
 CONNECTION ID     CONN TYPE     
 my_conn           generic

❯ ./astro deployment connection update -d cmbuofehz007l01l3m8f6i5o9 --conn-id my_conn --conn-type generic_2
updating connection my_conn

❯ ./astro deployment connection list -d cmbuofehz007l01l3m8f6i5o9
 CONNECTION ID     CONN TYPE     
 my_conn           generic_2
```

### Variables

#### AF2

```bash
❯ ./astro deployment airflow-variable create -d cmbutodaf03vx01jq3q59u9d3 --key foo --value bar
Creating variable foo

❯ ./astro deployment airflow-variable list -d cmbutodaf03vx01jq3q59u9d3
 KEY     DESCRIPTION     
 foo 

❯ ./astro deployment airflow-variable update -d cmbutodaf03vx01jq3q59u9d3 --key foo --value fiz
updating variable foo
```

#### AF3

```bash
❯ ./astro deployment airflow-variable create -d cmbuofehz007l01l3m8f6i5o9 --key foo --value bar
Creating variable foo

❯ ./astro deployment airflow-variable list -d cmbuofehz007l01l3m8f6i5o9
 KEY     DESCRIPTION     
 foo

❯ ./astro deployment airflow-variable update -d cmbuofehz007l01l3m8f6i5o9 --key foo --value fiz
updating variable foo
```

### Pools

#### AF2

```bash
❯ ./astro deployment pool create -d cmbutodaf03vx01jq3q59u9d3 --name foo --slots 1
Creating pool foo

❯ ./astro deployment pool list -d cmbutodaf03vx01jq3q59u9d3
 NAME             SLOTS     INCLUDE DEFERRED     
 default_pool     128       false                
 foo              1         false

❯ ./astro deployment pool update -d cmbutodaf03vx01jq3q59u9d3 --name foo --slots 2 --include-deferred enable
updating pool foo

❯ ./astro deployment pool list -d cmbutodaf03vx01jq3q59u9d3
 NAME             SLOTS     INCLUDE DEFERRED     
 default_pool     128       false                
 foo              2         true
```

#### AF3

```bash
❯ ./astro deployment pool create -d cmbuofehz007l01l3m8f6i5o9 --name foo --slots 1
Creating pool foo

❯ ./astro deployment pool list -d cmbuofehz007l01l3m8f6i5o9
 NAME             SLOTS     INCLUDE DEFERRED     
 default_pool     128       false                
 foo              1         false

❯ ./astro deployment pool update -d cmbuofehz007l01l3m8f6i5o9 --name foo --slots 2 --include-deferred enable
updating pool foo

❯ ./astro deployment pool list -d cmbuofehz007l01l3m8f6i5o9
 NAME             SLOTS     INCLUDE DEFERRED     
 default_pool     128       false                
 foo              2         true
```

#### AF2.6

```bash
❯ ./astro deployment pool create -d cmbuzidah01c501m1qy7vtp2t --name foo --slots 1
Creating pool foo
Error: API error (400): {
  "detail": "{'include_deferred': ['Unknown field.']}",
  "status": 400,
  "title": "Bad Request",
  "type": "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/stable-rest-api-ref.html#section/Errors/BadRequest"
}

❯ ./astro deployment pool update -d cmbuzidah01c501m1qy7vtp2t --name foo --slots 1
updating pool foo
Error: API error (400): {
  "detail": "{'include_deferred': ['Unknown field.']}",
  "status": 400,
  "title": "Bad Request",
  "type": "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/stable-rest-api-ref.html#section/Errors/BadRequest"
}
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
