### PR TITLE
add af3 deployment logs support

### DIFF
--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -836,6 +836,11 @@ func (s *Suite) TestLogs() {
 					Timestamp: 2,
 					Source:    astrocore.DeploymentLogEntrySourceWorker,
 				},
+				{
+					Raw:       "test log line 5",
+					Timestamp: 1,
+					Source:    astrocore.DeploymentLogEntrySourceApiserver,
+				},
 			},
 			SearchId: "search-id",
 		},
@@ -918,6 +923,22 @@ func (s *Suite) TestLogs() {
 
 		mockPlatformCoreClient.AssertExpectations(s.T())
 		mockCoreClient.AssertExpectations(s.T())
+	})
+	// Add after the "multiple components" subtest
+	s.Run("airflow 3 deployment fetches apiserver logs", func() {
+		// Mock Airflow 3 deployment
+		airflow3Deployment := deploymentResponse
+		if airflow3Deployment.JSON200 != nil {
+			airflow3Deployment.JSON200.RuntimeVersion = "3.0-1"
+		}
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3Deployment, nil).Once()
+
+		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(&astrocore.GetDeploymentLogsResponse{JSON200: &astrocore.DeploymentLog{Results: []astrocore.DeploymentLogEntry{{Raw: "apiserver log", Timestamp: 1, Source: astrocore.DeploymentLogEntrySourceApiserver}}}, HTTPResponse: &http.Response{StatusCode: 200}}, nil).Once()
+
+		err := Logs("test-id-1", ws, "", "", true, false, false, false, false, false, false, 1, mockPlatformCoreClient, mockCoreClient)
+		s.NoError(err)
 	})
 }
 
@@ -2344,61 +2365,5 @@ func (s *Suite) TestDeleteDeploymentHibernationOverride() {
 		err := DeleteDeploymentHibernationOverride("", ws, "", false, mockPlatformCoreClient)
 		s.NoError(err)
 		mockPlatformCoreClient.AssertExpectations(s.T())
-	})
-}
-
-func (s *Suite) TestAirflow3Blocking() {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
-
-	// Set up a deployment with Airflow 3 runtime version
-	airflow3Version := "3.0-1"
-
-	// Create a local copy of the deployment response with Airflow 3
-	airflow3DeploymentResponse := astroplatformcore.GetDeploymentResponse{
-		HTTPResponse: &http.Response{
-			StatusCode: 200,
-		},
-		JSON200: &astroplatformcore.Deployment{
-			Id:             "test-id-airflow3",
-			Name:           "test-airflow3",
-			RuntimeVersion: airflow3Version,
-			WorkspaceId:    ws,
-		},
-	}
-
-	// Mock list deployments response with Airflow 3 deployment
-	airflow3ListDeploymentsResponse := astroplatformcore.ListDeploymentsResponse{
-		HTTPResponse: &http.Response{
-			StatusCode: 200,
-		},
-		JSON200: &astroplatformcore.DeploymentsPaginated{
-			Deployments: []astroplatformcore.Deployment{
-				{
-					Id:             "test-id-airflow3",
-					Name:           "test-airflow3",
-					RuntimeVersion: airflow3Version,
-					WorkspaceId:    ws,
-				},
-			},
-		},
-	}
-
-	s.Run("Logs blocks operation for Airflow 3 deployments", func() {
-		// Create a fresh local mock clients for this subtest
-		logsMockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		logsMockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
-
-		// Set expectations on the local mock client
-		// Mock the ListDeploymentsWithResponse method which is called by GetDeployment
-		logsMockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3ListDeploymentsResponse, nil)
-		logsMockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil)
-
-		// Test viewing logs for an Airflow 3 deployment
-		// logWebserver, logScheduler, logTriggerer, logWorkers, warnLogs, errorLogs, infoLogs
-		err := Logs("test-id-airflow3", ws, "", "", true, true, true, true, false, false, false, 10, logsMockPlatformCoreClient, logsMockCoreClient)
-
-		s.Error(err)
-		s.Contains(err.Error(), "This command is not yet supported on Airflow 3 deployments")
-		logsMockPlatformCoreClient.AssertExpectations(s.T())
 	})
 }

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -73,6 +73,7 @@ var (
 	removeOverride            bool
 	forceOverride             bool
 	logWebserver              bool
+	logApiserver              bool
 	logScheduler              bool
 	logWorkers                bool
 	logTriggerer              bool
@@ -364,6 +365,7 @@ func newDeploymentLogsCmd() *cobra.Command {
 	cmd.Flags().IntVarP(&logCount, "log-count", "c", logCount, "Number of logs to show")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to show logs of")
 	cmd.Flags().BoolVar(&logWebserver, "webserver", false, "Show logs from the webserver")
+	cmd.Flags().BoolVar(&logApiserver, "apiserver", false, "Show logs from the api server")
 	cmd.Flags().BoolVar(&logScheduler, "scheduler", false, "Show logs from the scheduler")
 	cmd.Flags().BoolVar(&logWorkers, "workers", false, "Show logs from the workers")
 	cmd.Flags().BoolVar(&logTriggerer, "triggerer", false, "Show logs from the triggerer")
@@ -621,8 +623,9 @@ func deploymentLogs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to find a valid Workspace")
 	}
+	logServer := logWebserver || logApiserver
 
-	return deployment.Logs(deploymentID, ws, deploymentName, logsKeyword, logWebserver, logScheduler, logTriggerer, logWorkers, warnLogs, errorLogs, infoLogs, logCount, platformCoreClient, astroCoreClient)
+	return deployment.Logs(deploymentID, ws, deploymentName, logsKeyword, logServer, logScheduler, logTriggerer, logWorkers, warnLogs, errorLogs, infoLogs, logCount, platformCoreClient, astroCoreClient)
 }
 
 func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //nolint:gocognit,gocyclo

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/astronomer/astro-cli
 
 go 1.23.0
 
-// toolchain go1.24.1
+toolchain go1.24.1
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

- removes AF3 block for `astro deployment logs`
- introduces logic to get the apiserver component if AF3 else webserver component 

## 🎟 Issue(s)

fixes #1877 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
