### PR TITLE
remove AF3 block for deployment object copy

### DIFF
--- a/cmd/cloud/deployment_objects.go
+++ b/cmd/cloud/deployment_objects.go
@@ -428,10 +428,6 @@ func deploymentConnectionCopy(cmd *cobra.Command, out io.Writer) error {
 		return errors.Wrap(err, "failed to find the source Deployment")
 	}
 
-	if err := airflowversions.ValidateNoAirflow3Support(fromDeployment.RuntimeVersion); err != nil {
-		return err
-	}
-
 	fromAirflowURL, err := getAirflowURL(&fromDeployment)
 	if err != nil {
 		return errors.Wrap(err, "failed to find the source Deployment Airflow webserver URL")
@@ -444,10 +440,6 @@ func deploymentConnectionCopy(cmd *cobra.Command, out io.Writer) error {
 	toDeployment, err := deployment.GetDeployment(ws, toDeploymentID, toDeploymentName, false, nil, platformCoreClient, astroCoreClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to find the target Deployment")
-	}
-
-	if err := airflowversions.ValidateNoAirflow3Support(toDeployment.RuntimeVersion); err != nil {
-		return err
 	}
 
 	toAirflowURL, err := getAirflowURL(&toDeployment)
@@ -562,10 +554,6 @@ func deploymentAirflowVariableCopy(cmd *cobra.Command, out io.Writer) error {
 		return errors.Wrap(err, "failed to find the source Deployment")
 	}
 
-	if err := airflowversions.ValidateNoAirflow3Support(fromDeployment.RuntimeVersion); err != nil {
-		return err
-	}
-
 	fromAirflowURL, err := getAirflowURL(&fromDeployment)
 	if err != nil {
 		return errors.Wrap(err, "failed to find the source deployments airflow webserver URL")
@@ -578,10 +566,6 @@ func deploymentAirflowVariableCopy(cmd *cobra.Command, out io.Writer) error {
 	toDeployment, err := deployment.GetDeployment(ws, toDeploymentID, toDeploymentName, false, nil, platformCoreClient, astroCoreClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to find the target Deployment")
-	}
-
-	if err := airflowversions.ValidateNoAirflow3Support(toDeployment.RuntimeVersion); err != nil {
-		return err
 	}
 
 	toAirflowURL, err := getAirflowURL(&toDeployment)
@@ -717,10 +701,6 @@ func deploymentPoolCopy(cmd *cobra.Command, out io.Writer) error {
 		return errors.Wrap(err, "failed to find the source Deployment")
 	}
 
-	if err := airflowversions.ValidateNoAirflow3Support(fromDeployment.RuntimeVersion); err != nil {
-		return err
-	}
-
 	fromAirflowURL, err := getAirflowURL(&fromDeployment)
 	if err != nil {
 		return errors.Wrap(err, "failed to find the source deployments airflow webserver URL")
@@ -733,10 +713,6 @@ func deploymentPoolCopy(cmd *cobra.Command, out io.Writer) error {
 	toDeployment, err := deployment.GetDeployment(ws, toDeploymentID, toDeploymentName, false, nil, platformCoreClient, astroCoreClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to find the target Deployment")
-	}
-
-	if err := airflowversions.ValidateNoAirflow3Support(toDeployment.RuntimeVersion); err != nil {
-		return err
 	}
 
 	toAirflowURL, err := getAirflowURL(&toDeployment)

--- a/cmd/cloud/deployment_objects_test.go
+++ b/cmd/cloud/deployment_objects_test.go
@@ -232,31 +232,6 @@ func TestConnectionCopy(t *testing.T) {
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 
-	t.Run("operations are blocked for Airflow 3 deployments when source is Airflow 3", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"connection", "copy", "--source-id", "test-id-1", "--target-id", "test-id-2"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
-	t.Run("operations are blocked for Airflow 3 deployments when target is Airflow 3", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		// For target Airflow 3 deployment, we'll just mock the minimum needed
-		// We don't need cluster response since ValidateNoAirflow3Support should fail first
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"connection", "copy", "--source-id", "test-id-1", "--target-id", "test-id-1"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
 	t.Run("successful connection copy", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		mockClient.On("GetConnections", mock.Anything).Return(mockResp, nil).Twice()
@@ -430,31 +405,6 @@ func TestVariableCopy(t *testing.T) {
 		cmdArgs := []string{"airflow-variable", "copy", "--source-id", "test-id-1", "--target-id", "test-id-1"}
 		_, err := execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
-	t.Run("operations are blocked for Airflow 3 deployments when source is Airflow 3", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"airflow-variable", "copy", "--source-id", "test-id-1", "--target-id", "test-id-2"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
-	t.Run("operations are blocked for Airflow 3 deployments when target is Airflow 3", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		// For target Airflow 3 deployment, we'll just mock the minimum needed
-		// We don't need cluster response since ValidateNoAirflow3Support should fail first
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"airflow-variable", "copy", "--source-id", "test-id-1", "--target-id", "test-id-1"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 
@@ -655,31 +605,6 @@ func TestPoolCopy(t *testing.T) {
 		cmdArgs := []string{"pool", "copy", "--source-id", "test-id-1", "--target-id", "test-id-1"}
 		_, err := execDeploymentCmd(cmdArgs...)
 		assert.Error(t, err)
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
-	t.Run("operations are blocked for Airflow 3 deployments when source is Airflow 3", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"pool", "copy", "--source-id", "test-id-1", "--target-id", "test-id-2"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
-		mockPlatformCoreClient.AssertExpectations(t)
-	})
-
-	t.Run("operations are blocked for Airflow 3 deployments when target is Airflow 3", func(t *testing.T) {
-		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		// For target Airflow 3 deployment, we'll just mock the minimum needed
-		// We don't need cluster response since ValidateNoAirflow3Support should fail first
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
-		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
-		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
-		cmdArgs := []string{"pool", "copy", "--source-id", "test-id-1", "--target-id", "test-id-1"}
-		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "This command is not yet supported on Airflow 3 deployments")
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

add copy support for AF 3 deployment objects

this just happened to work after removing blocks and the work already done by @feluelle in #1869

## 🎟 Issue(s)

Fixes #1868 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

https://astronomer.slack.com/archives/C07FWJXBQ3X/p1750790224330469

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
