### PR TITLE
Fix deployment update worker queues

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -1271,7 +1271,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 
 func updateWorkerQueuesForExecutor(newExecutor astroplatformcore.DeploymentExecutor, workerQueuesRequest, defaultWorkerQueue *[]astroplatformcore.WorkerQueueRequest) *[]astroplatformcore.WorkerQueueRequest {
 	var workerQueuesRequestOrDefault *[]astroplatformcore.WorkerQueueRequest
-	if workerQueuesRequest == nil {
+	if workerQueuesRequest != nil {
 		workerQueuesRequestOrDefault = workerQueuesRequest
 	} else {
 		workerQueuesRequestOrDefault = defaultWorkerQueue

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1740,6 +1740,47 @@ func (s *Suite) TestUpdate() { //nolint
 		s.NoError(err)
 	})
 
+	s.Run("successfully update worker queues", func() {
+		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(2)
+		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(func(i astroplatformcore.UpdateDeploymentRequest) bool {
+			input, _ := i.AsUpdateDedicatedDeploymentRequest()
+			return input.WorkerQueues != nil && len(*input.WorkerQueues) == 1 && (*input.WorkerQueues)[0].Name == "worker-name"
+		})).Return(&mockUpdateDeploymentResponse, nil).Times(2)
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(2)
+
+		// change type to dedicated
+		deploymentResponse.JSON200.Type = &dedicatedType
+		deploymentResponse.JSON200.WorkerQueues = &[]astroplatformcore.WorkerQueue{
+			{
+				AstroMachine:      &astroMachine,
+				Id:                "queue-id",
+				IsDefault:         true,
+				MaxWorkerCount:    10,
+				MinWorkerCount:    1,
+				Name:              "worker-name",
+				WorkerConcurrency: 20,
+				NodePoolId:        &nodeID,
+			},
+		}
+
+		// mock os.Stdin
+		// Mock user input for deployment name
+		defer testUtil.MockUserInput(s.T(), "1")()
+
+		// success with dedicated type with name
+		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		s.NoError(err)
+
+		// mock os.Stdin
+		// Mock user input for deployment name
+		defer testUtil.MockUserInput(s.T(), "1")()
+
+		// success with dedicated type
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "disable", "enable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, nil, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		s.NoError(err)
+	})
+
 	s.Run("failed to validate resources", func() {
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, errMock).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

`updateWorkerQueuesForExecutor` used for deployment update currently overwrites the worker queues if the worker queues are not set. However, we want the opposite. We want to use the worker queues request if set, and if not, use the default.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

Inspect a deployment with worker queues
```
❯ ~/Projects/astro-cli/astro deployment inspect
Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME         DEPLOYMENT ID                 DAG DEPLOY ENABLED     
 1     test                modern-beam-2288     cmckmn35w0er001l4fw8v8136     true                   

> 1
deployment:
    ...
    worker_queues:
        - name: default
          min_worker_count: 0
          worker_type: A5
          pod_cpu: "1"
          pod_ram: 2Gi
        - name: foo
          min_worker_count: 0
          worker_type: A5
          pod_cpu: "1"
          pod_ram: 2Gi
...
```
Update the deployment
```
❯ ~/Projects/astro-cli/astro deployment update
Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME         DEPLOYMENT ID                 DAG DEPLOY ENABLED     
 1     test                modern-beam-2288     cmckmn35w0er001l4fw8v8136     true                   

> 1
 NAME     NAMESPACE            CLUSTER                  CLOUD PROVIDER     REGION      DEPLOYMENT ID                 RUNTIME VERSION                    DAG DEPLOY ENABLED     CI-CD ENFORCEMENT     DEPLOYMENT TYPE     
 test     modern-beam-2288     airflow3-testing_DND     AZURE              westus2     cmckmn35w0er001l4fw8v8136     3.0-4 (based on Airflow 3.0.2)     true                   false                 DEDICATED           

 Successfully updated Deployment
```
Inspect the deployment
```
❯ ~/Projects/astro-cli/astro deployment inspect
Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME         DEPLOYMENT ID                 DAG DEPLOY ENABLED     
 1     test                modern-beam-2288     cmckmn35w0er001l4fw8v8136     true                   

> 1
deployment:
    ...
    worker_queues:
        - name: default
          min_worker_count: 0
          worker_type: A5
          pod_cpu: "1"
          pod_ram: 2Gi
        - name: foo
          min_worker_count: 0
          worker_type: A5
          pod_cpu: "1"
          pod_ram: 2Gi
...
```
## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
