### PR TITLE
remove AF 3 block for astro variable create | list | update

### DIFF
--- a/airflow_versions/runtime_versions.go
+++ b/airflow_versions/runtime_versions.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 )
 

--- a/airflow_versions/runtime_versions.go
+++ b/airflow_versions/runtime_versions.go
@@ -152,15 +152,6 @@ func AirflowMajorVersionForRuntimeVersion(runtimeVersion string) string {
 	return RuntimeVersionMajor(runtimeVersion)
 }
 
-// ValidateNoAirflow3Support checks if the runtime version is for Airflow 3
-// and returns an error if it is since Airflow 3 is not yet supported for the command
-func ValidateNoAirflow3Support(runtimeVersion string) error {
-	if AirflowMajorVersionForRuntimeVersion(runtimeVersion) == "3" {
-		return errors.New("This command is not yet supported on Airflow 3 deployments")
-	}
-	return nil
-}
-
 func IsAirflow3(runtimeVersion string) bool {
 	return AirflowMajorVersionForRuntimeVersion(runtimeVersion) == "3"
 }

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/pkg/printutil"
@@ -31,11 +30,6 @@ func VariableList(deploymentID, variableKey, ws, envFile, deploymentName string,
 	// get deployment
 	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, false, nil, platformCoreClient, nil)
 	if err != nil {
-		return err
-	}
-
-	// Check if deployment is using Airflow 3
-	if err := airflowversions.ValidateNoAirflow3Support(currentDeployment.RuntimeVersion); err != nil {
 		return err
 	}
 
@@ -99,11 +93,6 @@ func VariableModify(
 	// get deployment
 	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, false, nil, platformCoreClient, coreClient)
 	if err != nil {
-		return err
-	}
-
-	// Check if deployment is using Airflow 3
-	if err := airflowversions.ValidateNoAirflow3Support(currentDeployment.RuntimeVersion); err != nil {
 		return err
 	}
 

--- a/cloud/deployment/deployment_variable_test.go
+++ b/cloud/deployment/deployment_variable_test.go
@@ -407,27 +407,25 @@ func TestAirflow3BlockingVariables(t *testing.T) {
 		},
 	}
 
-	t.Run("VariableList blocks operation for Airflow 3 deployments", func(t *testing.T) {
+	t.Run("VariableList does not block operation for Airflow 3 deployments", func(t *testing.T) {
 		// Set expectations on the mock client
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3ListDeploymentsResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
 
 		buf := new(bytes.Buffer)
 		err := VariableList("test-id-airflow3", "", ws, "", "", false, mockPlatformCoreClient, buf)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "This command is not yet supported on Airflow 3 deployments")
+		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 
-	t.Run("VariableModify blocks operation for Airflow 3 deployments", func(t *testing.T) {
+	t.Run("VariableModify does not block operation for Airflow 3 deployments", func(t *testing.T) {
 		// Set expectations on the mock client
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3ListDeploymentsResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&airflow3DeploymentResponse, nil).Times(1)
 
 		buf := new(bytes.Buffer)
 		err := VariableModify("test-id-airflow3", "test-key", "test-value", ws, "", "", []string{}, false, false, false, mockCoreClient, mockPlatformCoreClient, buf)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "This command is not yet supported on Airflow 3 deployments")
+		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

remove AF 3 block for `astro variable [create | update | list]`

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

```
jake@Jakes-MacBook-Pro astro-cli % ./astro deployment variable create -n test-astro-exec-from-cli hey=jake
adding variable hey

Updated list of your Deployment's variables:
 #     KEY                 VALUE     SECRET     
 1     AIRFLOW_VAR_FOO     bar       false      
 2     hey                 jake      false      
jake@Jakes-MacBook-Pro astro-cli % ./astro deployment variable list -n test-astro-exec-from-cli         
 #     KEY                 VALUE     SECRET     
 1     AIRFLOW_VAR_FOO     bar       false      
 2     hey                 jake      false      
jake@Jakes-MacBook-Pro astro-cli % ./astro deployment variable update -n test-astro-exec-from-cli hey=felix
updating variable hey 

Updated list of your Deployment's variables:
 #     KEY                 VALUE     SECRET     
 1     AIRFLOW_VAR_FOO     bar       false      
 2     hey                 felix     false  
```


## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
