### PR TITLE
Fix standard deployment worker queue updates

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -997,6 +997,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 				DefaultTaskPodCpu:    &defaultTaskPodCpu,
 				DefaultTaskPodMemory: &defaultTaskPodMemory,
 				WorkloadIdentity:     deplWorkloadIdentity,
+				WorkerQueues:         &workerQueuesRequest,
 			}
 			switch schedulerSize {
 			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeSMALL)):


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Add the missing worker queues setting on the standard deployment request, which is used as input to convert the worker queues. Since it was always empty, it used the default working queue.

## 🎟 Issue(s)

https://astronomer.slack.com/archives/C094HLLJ7LG/p1751456555675199?thread_ts=1751379015.279859&cid=C094HLLJ7LG

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

```
❯ ./astro deployment inspect
Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME             DEPLOYMENT ID                 DAG DEPLOY ENABLED     
 1     test                dynamical-light-7996     cmcnmomkv03d201kkqlytrnys     true                   

> 1
deployment:
    ...
    worker_queues:
        - name: default
          min_worker_count: 0
          worker_type: A5
          pod_cpu: "1"
          pod_ram: 2Gi
        - name: foo
          min_worker_count: 0
          worker_type: A5
          pod_cpu: "1"
          pod_ram: 2Gi
```
```
❯ ./astro deployment update
Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME             DEPLOYMENT ID                 DAG DEPLOY ENABLED     
 1     test                dynamical-light-7996     cmcnmomkv03d201kkqlytrnys     true                   

> 1
 NAME     NAMESPACE                CLUSTER     CLOUD PROVIDER     REGION        DEPLOYMENT ID                 RUNTIME VERSION                    DAG DEPLOY ENABLED     CI-CD ENFORCEMENT     DEPLOYMENT TYPE     
 test     dynamical-light-7996     N/A         AWS                us-east-1     cmcnmomkv03d201kkqlytrnys     3.0-4 (based on Airflow 3.0.2)     true                   false                 STANDARD            

 Successfully updated Deployment
```
```
❯ ./astro deployment inspect
Select a Deployment
 #     DEPLOYMENT NAME     RELEASE NAME             DEPLOYMENT ID                 DAG DEPLOY ENABLED     
 1     test                dynamical-light-7996     cmcnmomkv03d201kkqlytrnys     true                   

> 1
deployment:
    ...
    worker_queues:
        - name: default
          min_worker_count: 0
          worker_type: A5
          pod_cpu: "1"
          pod_ram: 2Gi
        - name: foo
          min_worker_count: 0
          worker_type: A5
          pod_cpu: "1"
          pod_ram: 2Gi
...
```
## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
