### PR TITLE
Update the deployment detail URL to match change in Cloud UI

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -1865,10 +1865,10 @@ func GetDeploymentURL(deploymentID, workspaceID string) (string, error) {
 	}
 	switch ctx.Domain {
 	case domainutil.LocalDomain:
-		deploymentURL = ctx.Domain + ":5000/" + workspaceID + "/deployments/" + deploymentID + "/overview"
+		deploymentURL = ctx.Domain + ":5000/" + workspaceID + "/deployments/" + deploymentID
 	default:
 		_, domain := domainutil.GetPRSubDomain(ctx.Domain)
-		deploymentURL = "cloud." + domain + "/" + workspaceID + "/deployments/" + deploymentID + "/overview"
+		deploymentURL = "cloud." + domain + "/" + workspaceID + "/deployments/" + deploymentID
 	}
 	return deploymentURL, nil
 }

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -2201,42 +2201,42 @@ func (s *Suite) TestGetDeploymentURL() {
 
 	s.Run("returns deploymentURL for dev environment", func() {
 		testUtil.InitTestConfig(testUtil.CloudDevPlatform)
-		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id/overview"
+		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		s.NoError(err)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns deploymentURL for stage environment", func() {
 		testUtil.InitTestConfig(testUtil.CloudStagePlatform)
-		expectedURL := "cloud.astronomer-stage.io/workspace-id/deployments/deployment-id/overview"
+		expectedURL := "cloud.astronomer-stage.io/workspace-id/deployments/deployment-id"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		s.NoError(err)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns deploymentURL for perf environment", func() {
 		testUtil.InitTestConfig(testUtil.CloudPerfPlatform)
-		expectedURL := "cloud.astronomer-perf.io/workspace-id/deployments/deployment-id/overview"
+		expectedURL := "cloud.astronomer-perf.io/workspace-id/deployments/deployment-id"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		s.NoError(err)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns deploymentURL for cloud (prod) environment", func() {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
-		expectedURL := "cloud.astronomer.io/workspace-id/deployments/deployment-id/overview"
+		expectedURL := "cloud.astronomer.io/workspace-id/deployments/deployment-id"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		s.NoError(err)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns deploymentURL for pr preview environment", func() {
 		testUtil.InitTestConfig(testUtil.CloudPrPreview)
-		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id/overview"
+		expectedURL := "cloud.astronomer-dev.io/workspace-id/deployments/deployment-id"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		s.NoError(err)
 		s.Equal(expectedURL, actualURL)
 	})
 	s.Run("returns deploymentURL for local environment", func() {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
-		expectedURL := "localhost:5000/workspace-id/deployments/deployment-id/overview"
+		expectedURL := "localhost:5000/workspace-id/deployments/deployment-id"
 		actualURL, err := GetDeploymentURL(deploymentID, workspaceID)
 		s.NoError(err)
 		s.Equal(expectedURL, actualURL)

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -503,7 +503,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
 `
 		fileutil.WriteStringToFile(filePath, data)
@@ -560,7 +560,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -621,7 +621,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -683,7 +683,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -744,7 +744,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -807,7 +807,7 @@ deployment:
             "workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -883,7 +883,7 @@ deployment:
     workloadIdentity: astro-great-release-name@provider-account.iam.gserviceaccount.com
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails: []
 `
@@ -963,7 +963,7 @@ deployment:
             "workloadIdentity": "astro-great-release-name@provider-account.iam.gserviceaccount.com",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -1034,7 +1034,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1092,7 +1092,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1170,7 +1170,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1268,7 +1268,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1366,7 +1366,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -1458,7 +1458,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -1544,7 +1544,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1606,7 +1606,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1680,7 +1680,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -1760,7 +1760,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -1833,7 +1833,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1890,7 +1890,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -1961,7 +1961,7 @@ deployment:
     status: HEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -2054,7 +2054,7 @@ deployment:
     status: HEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -2134,7 +2134,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -2221,7 +2221,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -2297,7 +2297,7 @@ deployment:
     status: HEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -2387,7 +2387,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -2462,7 +2462,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url"
         },
         "alert_emails": [
@@ -2543,7 +2543,7 @@ deployment:
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url"
         },
         "alert_emails": [

--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -772,7 +772,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
         status: UNHEALTHY
         created_at: 2022-11-17T13:25:55.275697-08:00
         updated_at: 2022-11-17T13:25:55.275697-08:00
-        deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+        deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
         webserver_url: some-url
         hibernation_override:
             is_hibernating: true
@@ -965,7 +965,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
         status: UNHEALTHY
         created_at: 2023-02-01T12:00:00Z
         updated_at: 2023-02-01T12:00:00Z
-        deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+        deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
         webserver_url: some-url
         airflow_api_url: some-url/api/v1
         hibernation_override:
@@ -1065,7 +1065,7 @@ func TestFormatPrintableDeployment(t *testing.T) {
             "status": "UNHEALTHY",
             "created_at": "2022-11-17T12:26:45.362983-08:00",
             "updated_at": "2022-11-17T12:26:45.362983-08:00",
-            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview",
+            "deployment_url": "cloud.astronomer.io/test-ws-id/deployments/test-deployment-id",
             "webserver_url": "some-url",
             "airflow_api_url": "some-url/api/v1"
 			"hibernation_override": {

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -638,7 +638,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com
@@ -977,7 +977,7 @@ deployment:
     status: UNHEALTHY
     created_at: 2022-11-17T13:25:55.275697-08:00
     updated_at: 2022-11-17T13:25:55.275697-08:00
-    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id/overview
+    deployment_url: cloud.astronomer.io/test-ws-id/deployments/test-deployment-id
     webserver_url: some-url
   alert_emails:
     - test1@test.com


### PR DESCRIPTION
## Description

Changes the output links to the Cloud UI Deployment from `/:workspaceId/deployments/:deploymentId/overview` to `/:workspaceId/deployments/:deploymentId` as a result of this changing in https://github.com/astronomer/astro/pull/32302. This change does maintain compatibility with the old/existing URLs used by current CLI versions.

Updated tests accordingly.

This change is almost identical to a previous change I made to CLI in #1378 a couple of years ago.


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
