### PR TITLE
Fix create/update deployment from file not respecting astro executor for standard deployments

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -323,6 +323,8 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				requestedExecutor = astroplatformcore.CreateStandardDeploymentRequestExecutorCELERY
 			case deployment.KubeExecutor, deployment.KUBERNETES:
 				requestedExecutor = astroplatformcore.CreateStandardDeploymentRequestExecutorKUBERNETES
+			case deployment.AstroExecutor, deployment.ASTRO:
+				requestedExecutor = astroplatformcore.CreateStandardDeploymentRequestExecutorASTRO
 			}
 
 			var schedulerSize astroplatformcore.CreateStandardDeploymentRequestSchedulerSize
@@ -511,6 +513,8 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				requestedExecutor = astroplatformcore.UpdateStandardDeploymentRequestExecutorCELERY
 			case strings.ToUpper(deployment.KubeExecutor), deployment.KUBERNETES:
 				requestedExecutor = astroplatformcore.UpdateStandardDeploymentRequestExecutorKUBERNETES
+			case strings.ToUpper(deployment.AstroExecutor), deployment.ASTRO:
+				requestedExecutor = astroplatformcore.UpdateStandardDeploymentRequestExecutorASTRO
 			}
 
 			var schedulerSize astroplatformcore.UpdateStandardDeploymentRequestSchedulerSize


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Currently, when trying to create a standard deployment from a file using Astro executor, we get:
```
Error: Missing fields: executor
```
because it is not being added to the request payload. This PR adds that field to standard deployment creation and update requests.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
