### PR TITLE
Validate --remote-execution-enabled field on deployment creation

### DIFF
--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -685,6 +685,9 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 	if organization.IsOrgHosted() && clusterID != "" && (deploymentType == standard || deploymentType == fromfile.HostedStandard || deploymentType == fromfile.HostedShared) {
 		return errors.New("flag --cluster-id cannot be used to create a standard deployment. If you want to create a dedicated deployment, use --type dedicated along with --cluster-id")
 	}
+	if flagRemoteExecutionEnabled && deploymentType != dedicated && deploymentType != fromfile.HostedDedicated {
+		return errors.New("flag --remote-execution-enabled can only be used when creating a dedicated deployment")
+	}
 	if cmd.Flags().Changed("allowed-ip-address-ranges") {
 		if !flagRemoteExecutionEnabled {
 			return errors.New("flag --allowed-ip-address-ranges cannot be used when remote execution is disabled")

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -592,6 +592,11 @@ func TestDeploymentCreate(t *testing.T) {
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "KubeExecutor is not a valid executor")
 	})
+	t.Run("returns an error if remote-execution-enabled flag is set but org is not hosted", func(t *testing.T) {
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--cluster-id", csID, "--remote-execution-enabled"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.ErrorContains(t, err, "unknown flag: --remote-execution-enabled")
+	})
 	t.Run("creates a deployment from file", func(t *testing.T) {
 		filePath := "./test-deployment.yaml"
 		data := `
@@ -740,6 +745,16 @@ deployment:
 		}
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "ibm is not a valid cloud provider. It can only be gcp")
+	})
+	t.Run("returns an error if remote execution is enabled but deployment type is not dedicated", func(t *testing.T) {
+		ctx, err := context.GetCurrentContext()
+		assert.NoError(t, err)
+		ctx.SetContextKey("organization_product", "HOSTED")
+		ctx.SetContextKey("organization", "test-org-id")
+		ctx.SetContextKey("workspace", ws)
+		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--remote-execution-enabled"}
+		_, err = execDeploymentCmd(cmdArgs...)
+		assert.ErrorContains(t, err, "flag --remote-execution-enabled can only be used when creating a dedicated deployment")
 	})
 	t.Run("creates a hosted dedicated deployment", func(t *testing.T) {
 		ctx, err := context.GetCurrentContext()


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

When the user creates a deployment with the `--remote-execution-enabled` flag, we only use that for dedicated deployment requests and silently ignore the flag for standard Deployments. This is poor UX, and we should validate that this flag is not being passed if the type is not dedicated.

## 🎟 Issue(s)

closes: https://github.com/astronomer/astro-cli/issues/1895

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
