### PR TITLE
Improve validation of remote execution support

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -382,7 +382,7 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 				WorkloadIdentity:     deplWorkloadIdentity,
 				RemoteExecution:      remoteExecution,
 			}
-			if standardDeploymentRequest.RemoteExecution == nil || !standardDeploymentRequest.RemoteExecution.Enabled {
+			if !remoteExecutionEnabled {
 				if strings.EqualFold(executor, CeleryExecutor) || strings.EqualFold(executor, CELERY) || strings.EqualFold(executor, AstroExecutor) || strings.EqualFold(executor, ASTRO) {
 					standardDeploymentRequest.WorkerQueues = &defautWorkerQueue
 				}
@@ -397,7 +397,7 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE)):
 				standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
-				if standardDeploymentRequest.RemoteExecution != nil && standardDeploymentRequest.RemoteExecution.Enabled {
+				if remoteExecutionEnabled {
 					standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSizeSMALL
 				} else {
 					standardDeploymentRequest.SchedulerSize = astroplatformcore.CreateStandardDeploymentRequestSchedulerSize(configOption.DefaultValues.SchedulerSize)
@@ -442,7 +442,7 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 				WorkloadIdentity:     deplWorkloadIdentity,
 				RemoteExecution:      remoteExecution,
 			}
-			if dedicatedDeploymentRequest.RemoteExecution == nil || !dedicatedDeploymentRequest.RemoteExecution.Enabled {
+			if !remoteExecutionEnabled {
 				if strings.EqualFold(executor, CeleryExecutor) || strings.EqualFold(executor, CELERY) || strings.EqualFold(executor, AstroExecutor) || strings.EqualFold(executor, ASTRO) {
 					dedicatedDeploymentRequest.WorkerQueues = &defautWorkerQueue
 				}
@@ -457,7 +457,7 @@ func Create(name, workspaceID, description, clusterID, runtimeVersion, dagDeploy
 			case strings.ToLower(string(astrocore.CreateStandardDeploymentRequestSchedulerSizeEXTRALARGE)):
 				dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeEXTRALARGE
 			case "":
-				if dedicatedDeploymentRequest.RemoteExecution != nil && dedicatedDeploymentRequest.RemoteExecution.Enabled {
+				if remoteExecutionEnabled {
 					dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSizeSMALL
 				} else {
 					dedicatedDeploymentRequest.SchedulerSize = astroplatformcore.CreateDedicatedDeploymentRequestSchedulerSize(configOption.DefaultValues.SchedulerSize)

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -2499,3 +2499,153 @@ func (s *Suite) TestDeleteDeploymentHibernationOverride() {
 		mockPlatformCoreClient.AssertExpectations(s.T())
 	})
 }
+
+func (s *Suite) TestCreateDefaultTaskPodCPU() {
+	s.Run("creates default task pod CPU if set", func() {
+		cpu := CreateDefaultTaskPodCPU("1CPU", false, nil)
+		s.Equal("1CPU", *cpu)
+	})
+
+	s.Run("defaults to nil if Remote Execution is enabled", func() {
+		cpu := CreateDefaultTaskPodCPU("", true, nil)
+		s.Nil(cpu)
+	})
+
+	s.Run("defaults to config option if Remote Execution is disabled", func() {
+		cpu := CreateDefaultTaskPodCPU("", false, &astrocore.DeploymentOptions{ResourceQuotas: astrocore.ResourceQuotaOptions{DefaultPodSize: astrocore.DefaultPodSizeOption{Cpu: astrocore.ResourceRange{Default: "0.5CPU"}}}})
+		s.Equal("0.5CPU", *cpu)
+	})
+}
+
+func (s *Suite) TestCreateDefaultTaskPodMemory() {
+	s.Run("creates default task pod memory if set", func() {
+		memory := CreateDefaultTaskPodMemory("1Gi", false, nil)
+		s.Equal("1Gi", *memory)
+	})
+
+	s.Run("defaults to nil if Remote Execution is enabled", func() {
+		memory := CreateDefaultTaskPodMemory("", true, nil)
+		s.Nil(memory)
+	})
+
+	s.Run("defaults to config option if Remote Execution is disabled", func() {
+		memory := CreateDefaultTaskPodMemory("", false, &astrocore.DeploymentOptions{ResourceQuotas: astrocore.ResourceQuotaOptions{DefaultPodSize: astrocore.DefaultPodSizeOption{Memory: astrocore.ResourceRange{Default: "2Gi"}}}})
+		s.Equal("2Gi", *memory)
+	})
+}
+
+func (s *Suite) TestCreateResourceQuotaCPU() {
+	s.Run("creates CPU if set", func() {
+		cpu := CreateResourceQuotaCPU("1CPU", false, nil)
+		s.Equal("1CPU", *cpu)
+	})
+
+	s.Run("defaults to nil if Remote Execution is enabled", func() {
+		cpu := CreateResourceQuotaCPU("", true, nil)
+		s.Nil(cpu)
+	})
+
+	s.Run("defaults to config option if Remote Execution is disabled", func() {
+		cpu := CreateResourceQuotaCPU("", false, &astrocore.DeploymentOptions{ResourceQuotas: astrocore.ResourceQuotaOptions{ResourceQuota: astrocore.ResourceOption{Cpu: astrocore.ResourceRange{Default: "0.5CPU"}}}})
+		s.Equal("0.5CPU", *cpu)
+	})
+}
+
+func (s *Suite) TestCreateResourceQuotaMemory() {
+	s.Run("creates memory if set", func() {
+		memory := CreateResourceQuotaMemory("1Gi", false, nil)
+		s.Equal("1Gi", *memory)
+	})
+
+	s.Run("defaults to nil if Remote Execution is enabled", func() {
+		memory := CreateResourceQuotaMemory("", true, nil)
+		s.Nil(memory)
+	})
+
+	s.Run("defaults to config option if Remote Execution is disabled", func() {
+		memory := CreateResourceQuotaMemory("", false, &astrocore.DeploymentOptions{ResourceQuotas: astrocore.ResourceQuotaOptions{ResourceQuota: astrocore.ResourceOption{Memory: astrocore.ResourceRange{Default: "2Gi"}}}})
+		s.Equal("2Gi", *memory)
+	})
+}
+
+func (s *Suite) TestUpdateDefaultTaskPodCPU() {
+	s.Run("updates CPU if set", func() {
+		cpu := UpdateDefaultTaskPodCPU("2CPU", nil, nil)
+		s.Equal("2CPU", *cpu)
+	})
+
+	s.Run("keeps existing CPU if set", func() {
+		existingDefaultTaskPodCPU := "1CPU"
+		cpu := UpdateDefaultTaskPodCPU("1CPU", &astroplatformcore.Deployment{DefaultTaskPodCpu: &existingDefaultTaskPodCPU}, nil)
+		s.Equal("1CPU", *cpu)
+	})
+
+	s.Run("defaults to nil if Remote Execution is enabled", func() {
+		cpu := UpdateDefaultTaskPodCPU("", &astroplatformcore.Deployment{RemoteExecution: &astroplatformcore.DeploymentRemoteExecution{Enabled: true}}, nil)
+		s.Nil(cpu)
+	})
+
+	s.Run("defaults to config option if Remote Execution is disabled", func() {
+		cpu := UpdateDefaultTaskPodCPU("", &astroplatformcore.Deployment{}, &astrocore.DeploymentOptions{ResourceQuotas: astrocore.ResourceQuotaOptions{DefaultPodSize: astrocore.DefaultPodSizeOption{Cpu: astrocore.ResourceRange{Default: "0.5CPU"}}}})
+		s.Equal("0.5CPU", *cpu)
+	})
+
+	s.Run("returns nil if CPU is not set, Remote Execution is disabled and config is not available", func() {
+		cpu := UpdateDefaultTaskPodCPU("", &astroplatformcore.Deployment{}, nil)
+		s.Nil(cpu)
+	})
+}
+
+func (s *Suite) TestUpdateDefaultTaskPodMemory() {
+	s.Run("updates memory if set", func() {
+		memory := UpdateDefaultTaskPodMemory("2Gi", nil, nil)
+		s.Equal("2Gi", *memory)
+	})
+
+	s.Run("keeps existing memory if set", func() {
+		existingDefaultTaskPodMemory := "1Gi"
+		memory := UpdateDefaultTaskPodMemory("1Gi", &astroplatformcore.Deployment{DefaultTaskPodMemory: &existingDefaultTaskPodMemory}, nil)
+		s.Equal("1Gi", *memory)
+	})
+
+	s.Run("defaults to nil if Remote Execution is enabled", func() {
+		memory := UpdateDefaultTaskPodMemory("", &astroplatformcore.Deployment{RemoteExecution: &astroplatformcore.DeploymentRemoteExecution{Enabled: true}}, nil)
+		s.Nil(memory)
+	})
+
+	s.Run("defaults to config option if Remote Execution is disabled", func() {
+		memory := UpdateDefaultTaskPodMemory("", &astroplatformcore.Deployment{}, &astrocore.DeploymentOptions{ResourceQuotas: astrocore.ResourceQuotaOptions{DefaultPodSize: astrocore.DefaultPodSizeOption{Memory: astrocore.ResourceRange{Default: "2Gi"}}}})
+		s.Equal("2Gi", *memory)
+	})
+
+	s.Run("returns nil if memory is not set, Remote Execution is disabled and config is not available", func() {
+		memory := UpdateDefaultTaskPodMemory("", &astroplatformcore.Deployment{}, nil)
+		s.Nil(memory)
+	})
+}
+
+func (s *Suite) TestUpdateResourceQuotaCPU() {
+	s.Run("updates CPU if set", func() {
+		cpu := UpdateResourceQuotaCPU("2CPU", nil)
+		s.Equal("2CPU", *cpu)
+	})
+
+	s.Run("keeps existing CPU", func() {
+		existingResourceQuotaCPU := "1CPU"
+		cpu := UpdateResourceQuotaCPU("1CPU", &astroplatformcore.Deployment{ResourceQuotaCpu: &existingResourceQuotaCPU})
+		s.Equal("1CPU", *cpu)
+	})
+}
+
+func (s *Suite) TestUpdateResourceQuotaMemory() {
+	s.Run("updates memory if set", func() {
+		memory := UpdateResourceQuotaMemory("2Gi", nil)
+		s.Equal("2Gi", *memory)
+	})
+
+	s.Run("keeps existing memory", func() {
+		existingResourceQuotaMemory := "1Gi"
+		memory := UpdateResourceQuotaMemory("1Gi", &astroplatformcore.Deployment{ResourceQuotaMemory: &existingResourceQuotaMemory})
+		s.Equal("1Gi", *memory)
+	})
+}

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -685,9 +685,6 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 	if organization.IsOrgHosted() && clusterID != "" && (deploymentType == standard || deploymentType == fromfile.HostedStandard || deploymentType == fromfile.HostedShared) {
 		return errors.New("flag --cluster-id cannot be used to create a standard deployment. If you want to create a dedicated deployment, use --type dedicated along with --cluster-id")
 	}
-	if flagRemoteExecutionEnabled && deploymentType != dedicated && deploymentType != fromfile.HostedDedicated {
-		return errors.New("flag --remote-execution-enabled can only be used when creating a dedicated deployment")
-	}
 	if cmd.Flags().Changed("allowed-ip-address-ranges") {
 		if !flagRemoteExecutionEnabled {
 			return errors.New("flag --allowed-ip-address-ranges cannot be used when remote execution is disabled")

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -746,16 +746,6 @@ deployment:
 		_, err = execDeploymentCmd(cmdArgs...)
 		assert.ErrorContains(t, err, "ibm is not a valid cloud provider. It can only be gcp")
 	})
-	t.Run("returns an error if remote execution is enabled but deployment type is not dedicated", func(t *testing.T) {
-		ctx, err := context.GetCurrentContext()
-		assert.NoError(t, err)
-		ctx.SetContextKey("organization_product", "HOSTED")
-		ctx.SetContextKey("organization", "test-org-id")
-		ctx.SetContextKey("workspace", ws)
-		cmdArgs := []string{"create", "--name", "test-name", "--workspace-id", ws, "--remote-execution-enabled"}
-		_, err = execDeploymentCmd(cmdArgs...)
-		assert.ErrorContains(t, err, "flag --remote-execution-enabled can only be used when creating a dedicated deployment")
-	})
 	t.Run("creates a hosted dedicated deployment", func(t *testing.T) {
 		ctx, err := context.GetCurrentContext()
 		assert.NoError(t, err)


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Currently, we allow passing remote execution fields on both standard and dedicated deployments. However, it is only truly supported at the moment for dedicated. Now, we always set the remote execution spec for hosted deployments, which means that if the user sets it on a standard deployment request, the api will return an error describing what's currently supported, vs silently not setting it.

## 🎟 Issue(s)

Related #1895 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

```
❯ ./astro deployment create --remote-execution-enabled
Current Workspace: felix

Please specify a name for your Deployment

Deployment name: test

Please select a Region for your Deployment:
 #     REGION            
 1     eastus2           
 2     westus2           
 3     australiaeast     
 4     westeurope        

> 1
Error: Invalid field values: field remoteExecution failed check on excluded_unless; remoteExecution is excluded unless Executor is 'ASTRO';,field workerQueues failed check on workerQueuesRequiredForCelery;
```

```
❯ ./astro deployment create --remote-execution-enabled --executor ASTRO
Current Workspace: felix

Please specify a name for your Deployment

Deployment name: test

Please select a Region for your Deployment:
 #     REGION            
 1     westeurope        
 2     westus2           
 3     australiaeast     
 4     eastus2           

> 2
Error: Invalid request: Remote execution is only supported for deployments on dedicated clusters
```

```
❯ ./astro deployment create --remote-execution-enabled --executor ASTRO --type dedicated --cluster-id cm4sauxuo03ig01rfux2aun5d --resource-quota-cpu 2
Current Workspace: felix

Please specify a name for your Deployment

Deployment name: testss
Error: Invalid field values: field resourceQuotaCpu failed check on excluded_if; resourceQuotaCpu is excluded if RemoteExecution.Enabled is 'true';
```

```
❯ ./astro deployment create --remote-execution-enabled --executor ASTRO --type dedicated --cluster-id cm4sauxuo03ig01rfux2aun5d --resource-quota-memory 2
Current Workspace: felix

Please specify a name for your Deployment

Deployment name: asd
Error: Invalid field values: field resourceQuotaMemory failed check on excluded_if; resourceQuotaMemory is excluded if RemoteExecution.Enabled is 'true';
```

- [x] Create Celery deployment with default worker queues
- [x] Create Astro deployment with default worker queues
- [x] Create Astro Remote deployment from file

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
