### PR TITLE
Set default executor based on latest runtime

### DIFF
--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -653,6 +653,15 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 	// clean output
 	deployment.CleanOutput = cleanOutput
 
+	// Get latest runtime version
+	if runtimeVersion == "" {
+		airflowVersionClient := airflowversions.NewClient(httpClient, false)
+		runtimeVersion, err = airflowversions.GetDefaultImageTag(airflowVersionClient, "", false)
+		if err != nil {
+			return err
+		}
+	}
+
 	// set default executor if none was specified
 	if executor == "" {
 		if airflowversions.IsAirflow3(runtimeVersion) {
@@ -741,14 +750,6 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 		}
 	}
 
-	// Get latest runtime version
-	if runtimeVersion == "" {
-		airflowVersionClient := airflowversions.NewClient(httpClient, false)
-		runtimeVersion, err = airflowversions.GetDefaultImageTag(airflowVersionClient, "", false)
-		if err != nil {
-			return err
-		}
-	}
 	// validate cloudProvider
 	if cloudProvider != "" {
 		if !isValidCloudProvider(astrocore.SharedClusterCloudProvider(cloudProvider)) {


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Currently, the default executor does not consider the latest version in case no runtime version is set.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
