### PR TITLE
Fix service logs added to the default astro dev logs command to cover for new AF3 components

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -736,8 +736,8 @@ func airflowLogs(cmd *cobra.Command, args []string) error {
 	// default is to display all logs
 	containersNames := make([]string, 0)
 
-	if !schedulerLogs && !webserverLogs && !triggererLogs {
-		containersNames = append(containersNames, []string{airflow.WebserverDockerContainerName, airflow.SchedulerDockerContainerName, airflow.TriggererDockerContainerName}...)
+	if !schedulerLogs && !webserverLogs && !triggererLogs && !apiServerLogs && !dagProcessorLogs {
+		containersNames = append(containersNames, []string{airflow.WebserverDockerContainerName, airflow.SchedulerDockerContainerName, airflow.TriggererDockerContainerName, airflow.APIServerDockerContainerName, airflow.DAGProcessorDockerContainerName}...)
 	}
 	if webserverLogs {
 		containersNames = append(containersNames, []string{airflow.WebserverDockerContainerName}...)

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -833,7 +833,7 @@ func (s *AirflowSuite) TestAirflowLogs() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Logs", true, "webserver", "scheduler", "triggerer").Return(nil).Once()
+			mockContainerHandler.On("Logs", true, "webserver", "scheduler", "triggerer", "api-server", "dag-processor").Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 


### PR DESCRIPTION
## Description

- Add newly added AF 3 components: API Server, and DAG Processor logs for the default `astro dev logs` command

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Tested locally to ensure that the API Server and DAG Processor logs show in `astro dev logs` command output

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
