### PR TITLE
Added the support for clusterID for the runtime releases flows in CLI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
 *  @neel-astro @jeremybeard @kushalmalani @sunkickr
 
 /cmd/*.go @neel-astro @jeremybeard @kushalmalani @sunkickr @lzdanski
+/software/ @karankhanchandani @pgvishnuram @rujhan-arora-astronomer
+/cmd/software/ @karankhanchandani @pgvishnuram @rujhan-arora-astronomer

--- a/cmd/software/deployment_logs_test.go
+++ b/cmd/software/deployment_logs_test.go
@@ -82,6 +82,7 @@ func (s *Suite) TestDeploymentLogsWebServerRemoteLogs() {
 			api := new(mocks.ClientInterface)
 			// Have to use mock.Anything because since is computed in the function by using time.Now()
 			api.On("ListDeploymentLogs", mock.Anything).Return(mockLogs, nil)
+			api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 
 			houstonClient = api
 			output, err := execDeploymentCmd("logs", test.component, mockDeployment.ID)
@@ -93,6 +94,7 @@ func (s *Suite) TestDeploymentLogsWebServerRemoteLogs() {
 		s.Run(fmt.Sprintf("list %s logs error", test.component), func() {
 			api := new(mocks.ClientInterface)
 			api.On("ListDeploymentLogs", mock.Anything).Return(nil, errMock)
+			api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 
 			houstonClient = api
 			_, err := execDeploymentCmd("logs", test.component, mockDeployment.ID)

--- a/cmd/software/deployment_service_account_test.go
+++ b/cmd/software/deployment_service_account_test.go
@@ -29,7 +29,7 @@ func (s *Suite) TestDeploymentSAListCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("ListDeploymentServiceAccounts", mockDeployment.ID).Return([]houston.ServiceAccount{mockSA}, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd("sa", "list", "--deployment-id="+mockDeployment.ID)
 	s.NoError(err)
@@ -58,6 +58,7 @@ func (s *Suite) TestDeploymentSaDeleteRootCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("DeleteDeploymentServiceAccount", houston.DeleteServiceAccountRequest{DeploymentID: "1234", ServiceAccountID: mockDeploymentSA.ID}).Return(mockDeploymentSA, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd("service-account", "delete", mockDeploymentSA.ID, "--deployment-id=1234")
 	s.NoError(err)
@@ -94,6 +95,7 @@ func (s *Suite) TestDeploymentSaCreateCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("CreateDeploymentServiceAccount", expectedSARequest).Return(mockSA, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 
 	houstonClient = api
 	output, err := execDeploymentCmd(

--- a/cmd/software/deployment_teams_test.go
+++ b/cmd/software/deployment_teams_test.go
@@ -34,6 +34,7 @@ Successfully added team cl0evnxfl0120dxxu1s4nbnk7 to deployment cknz133ra49758zr
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("AddDeploymentTeam", houston.AddDeploymentTeamRequest{DeploymentID: mockDeployment.ID, TeamID: mockDeploymentTeamRole.Team.ID, Role: mockDeploymentTeamRole.Role}).Return(mockDeploymentTeamRole, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 
 	output, err := execDeploymentCmd(
@@ -58,6 +59,7 @@ func (s *Suite) TestDeploymentTeamRm() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("RemoveDeploymentTeam", houston.RemoveDeploymentTeamRequest{DeploymentID: mockDeployment.ID, TeamID: mockDeploymentTeamRole.Team.ID}).Return(mockDeploymentTeamRole, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 
 	output, err := execDeploymentCmd(
@@ -77,6 +79,7 @@ func (s *Suite) TestDeploymentTeamUpdateCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("UpdateDeploymentTeamRole", houston.UpdateDeploymentTeamRequest{DeploymentID: mockDeployment.ID, TeamID: mockDeploymentTeamRole.Team.ID, Role: mockDeploymentTeamRole.Role}).Return(mockDeploymentTeamRole, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 
 	_, err := execDeploymentCmd(

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -83,6 +83,7 @@ func (s *Suite) TestDeploymentCreateCommandNfsMountDisabled() {
 
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 	myTests := []struct {
@@ -112,6 +113,7 @@ func (s *Suite) TestDeploymentCreateCommandTriggererDisabled() {
 
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 	myTests := []struct {
@@ -143,6 +145,7 @@ func (s *Suite) TestDeploymentCreateCommandTriggererEnabled() {
 	}
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 	myTests := []struct {
@@ -174,6 +177,7 @@ func (s *Suite) TestDeploymentCreateCommandNfsMountEnabled() {
 
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil).Times(2)
 
 	myTests := []struct {
@@ -206,6 +210,7 @@ func (s *Suite) TestDeploymentCreateCommandGitSyncEnabled() {
 
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil).Times(5)
 
 	myTests := []struct {
@@ -241,6 +246,7 @@ func (s *Suite) TestDeploymentCreateCommandDagOnlyDeployEnabled() {
 
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil).Times(5)
 
 	myTests := []struct {
@@ -270,6 +276,7 @@ func (s *Suite) TestDeploymentCreateCommandGitSyncDisabled() {
 
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 	myTests := []struct {
@@ -279,6 +286,35 @@ func (s *Suite) TestDeploymentCreateCommandGitSyncDisabled() {
 	}{
 		{cmdArgs: []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=git_sync", "--git-repository-url=https://github.com/bote795/public-ariflow-dags-test.git", "--dag-directory-path=dagscopy/", "--git-branch-name=main", "--sync-interval=200"}, expectedOutput: "", expectedError: "unknown flag: --dag-deployment-type"},
 		{cmdArgs: []string{"create", "--label=new-deployment-name", "--executor=celery"}, expectedOutput: "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs", expectedError: ""},
+	}
+	for _, tt := range myTests {
+		houstonClient = api
+		output, err := execDeploymentCmd(tt.cmdArgs...)
+		if tt.expectedError != "" {
+			s.EqualError(err, tt.expectedError)
+		} else {
+			s.NoError(err)
+		}
+		s.Contains(output, tt.expectedOutput)
+	}
+}
+
+func (s *Suite) TestDeploymentCreateCommandGitSyncDisabledAndVersionIs1_0_0AndClusterIDIsNotSet() {
+	appConfig = &houston.AppConfig{
+		Flags: houston.FeatureFlags{GitSyncEnabled: false},
+	}
+
+	api := new(mocks.ClientInterface)
+	api.On("GetAppConfig", nil).Return(appConfig, nil)
+	api.On("GetPlatformVersion", nil).Return("1.0.0", nil)
+	api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
+
+	myTests := []struct {
+		cmdArgs        []string
+		expectedOutput string
+		expectedError  string
+	}{
+		{cmdArgs: []string{"create", "--label=new-deployment-name", "--executor=celery"}, expectedOutput: "", expectedError: "required flag(s) \"cluster-id\" not set"},
 	}
 	for _, tt := range myTests {
 		houstonClient = api
@@ -302,6 +338,7 @@ func (s *Suite) TestDeploymentCreateWithTypeDagDeploy() {
 		}
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--triggerer-replicas=1"}
@@ -323,6 +360,7 @@ func (s *Suite) TestDeploymentCreateWithTypeDagDeploy() {
 		}
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 
 		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--triggerer-replicas=1", "--force"}
@@ -345,6 +383,7 @@ func (s *Suite) TestDeploymentCreateWithTypeDagDeploy() {
 
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--triggerer-replicas=1"}
 		houstonClient = api
@@ -379,6 +418,7 @@ func (s *Suite) TestDeploymentCreateWithTypeDagDeploy() {
 
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		api.On("CreateDeployment", mock.Anything).Return(mockDeployment, nil)
 		cmdArgs := []string{"create", "--label=new-deployment-name", "--executor=celery", "--dag-deployment-type=dag_deploy", "--triggerer-replicas=1"}
 		houstonClient = api
@@ -413,6 +453,7 @@ func (s *Suite) TestDeploymentUpdateWithTypeDagDeploy() {
 
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
 		dagDeployment := &houston.DagDeploymentConfig{
 			Type: houston.ImageDeploymentType,
@@ -438,6 +479,7 @@ func (s *Suite) TestDeploymentUpdateWithTypeDagDeploy() {
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
 		api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		getDeploymentError := errors.New("Test error")
 		api.On("GetDeployment", mock.Anything).Return(nil, getDeploymentError).Once()
 		cmdArgs := []string{"update", "cknrml96n02523xr97ygj95n5", "--label=test22222", "--dag-deployment-type=dag_deploy"}
@@ -456,6 +498,7 @@ func (s *Suite) TestDeploymentUpdateWithTypeDagDeploy() {
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
 		api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		dagDeployment := &houston.DagDeploymentConfig{
 			Type: houston.DagOnlyDeploymentType,
 		}
@@ -480,6 +523,7 @@ func (s *Suite) TestDeploymentUpdateWithTypeDagDeploy() {
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
 		api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		dagDeployment := &houston.DagDeploymentConfig{
 			Type: houston.ImageDeploymentType,
 		}
@@ -520,6 +564,7 @@ func (s *Suite) TestDeploymentUpdateWithTypeDagDeploy() {
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
 		api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		dagDeployment := &houston.DagDeploymentConfig{
 			Type: houston.ImageDeploymentType,
 		}
@@ -560,6 +605,7 @@ func (s *Suite) TestDeploymentUpdateFromTypeDagDeployToNonDagDeploy() {
 		}
 		api := new(mocks.ClientInterface)
 		api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		dagDeployment := &houston.DagDeploymentConfig{
 			Type: houston.DagOnlyDeploymentType,
 		}
@@ -600,6 +646,7 @@ func (s *Suite) TestDeploymentUpdateFromTypeDagDeployToNonDagDeploy() {
 		api := new(mocks.ClientInterface)
 		api.On("GetAppConfig", nil).Return(appConfig, nil)
 		api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 		dagDeployment := &houston.DagDeploymentConfig{
 			Type: houston.DagOnlyDeploymentType,
 		}
@@ -643,6 +690,7 @@ func (s *Suite) TestDeploymentUpdateCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
 	api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil).Times(8)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	dagDeployment := &houston.DagDeploymentConfig{
 		Type: houston.ImageDeploymentType,
 	}
@@ -687,6 +735,7 @@ func (s *Suite) TestDeploymentUpdateTriggererEnabledCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
 	api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil).Twice()
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	dagDeployment := &houston.DagDeploymentConfig{
 		Type: houston.ImageDeploymentType,
 	}
@@ -726,6 +775,7 @@ func (s *Suite) TestDeploymentUpdateCommandGitSyncDisabled() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
 	api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	dagDeployment := &houston.DagDeploymentConfig{
 		Type: houston.ImageDeploymentType,
 	}
@@ -763,7 +813,7 @@ func (s *Suite) TestDeploymentUpdateCommandDagOnlyDeployEnabled() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
 	api.On("UpdateDeployment", mock.Anything).Return(mockDeployment, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	myTests := []struct {
 		cmdArgs        []string
 		expectedOutput string
@@ -800,7 +850,7 @@ func (s *Suite) TestDeploymentAirflowUpgradeCommand() {
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("GetDeployment", mockDeploymentResponse.ID).Return(&mockDeploymentResponse, nil)
 	api.On("UpdateDeploymentAirflow", mockUpdateRequest).Return(&mockDeploymentResponse, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd(
 		"airflow",
@@ -831,7 +881,7 @@ func (s *Suite) TestDeploymentAirflowUpgradeCancelCommand() {
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("GetDeployment", mockDeploymentResponse.ID).Return(&mockDeploymentResponse, nil)
 	api.On("UpdateDeploymentAirflow", expectedUpdateRequest).Return(&mockDeploymentUpdated, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd(
 		"airflow",
@@ -849,7 +899,7 @@ func (s *Suite) TestDeploymentDelete() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("DeleteDeployment", houston.DeleteDeploymentRequest{DeploymentID: mockDeployment.ID, HardDelete: false}).Return(mockDeployment, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd("delete", mockDeployment.ID)
 	s.NoError(err)
@@ -863,7 +913,7 @@ func (s *Suite) TestDeploymentList() {
 
 	api := new(mocks.ClientInterface)
 	api.On("ListPaginatedDeployments", expectedRequest).Return([]houston.Deployment{*mockDeployment}, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd("list", "--all")
 	s.NoError(err)
@@ -881,7 +931,7 @@ func (s *Suite) TestDeploymentDeleteHardResponseNo() {
 
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	// mock os.Stdin
 	input := []byte("n")
 	r, w, err := os.Pipe()
@@ -911,7 +961,7 @@ func (s *Suite) TestDeploymentDeleteHardResponseYes() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(appConfig, nil)
 	api.On("DeleteDeployment", houston.DeleteDeploymentRequest{DeploymentID: mockDeployment.ID, HardDelete: true}).Return(mockDeployment, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	// mock os.Stdin
 	input := []byte("y")
 	r, w, err := os.Pipe()
@@ -954,7 +1004,7 @@ func (s *Suite) TestDeploymentRuntimeUpgradeCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetDeployment", mockDeploymentResponse.ID).Return(&mockDeploymentResponse, nil)
 	api.On("UpdateDeploymentRuntime", mockUpdateRequest).Return(&mockDeploymentResponse, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd(
 		"runtime",
@@ -992,7 +1042,7 @@ func (s *Suite) TestDeploymentRuntimeUpgradeCancelCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetDeployment", mockDeploymentResponse.ID).Return(&mockDeploymentResponse, nil)
 	api.On("CancelUpdateDeploymentRuntime", expectedUpdateRequest).Return(&mockDeploymentUpdated, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd(
 		"runtime",
@@ -1032,7 +1082,7 @@ func (s *Suite) TestDeploymentRuntimeMigrateCommand() {
 	vars["airflowVersion"] = mockDeploymentResponse.AirflowVersion
 	vars["clusterId"] = ""
 	api.On("GetRuntimeReleases", vars).Return(mockRuntimeReleaseResp, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd(
 		"runtime",
@@ -1072,7 +1122,7 @@ func (s *Suite) TestDeploymentRuntimeMigrateCommandFor1_0_0() {
 	vars["airflowVersion"] = mockDeploymentResponse.AirflowVersion
 	vars["clusterId"] = mockDeploymentResponse.ClusterID
 	api.On("GetRuntimeReleases", vars).Return(mockRuntimeReleaseResp, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd(
 		"runtime",
@@ -1106,7 +1156,7 @@ func (s *Suite) TestDeploymentRuntimeMigrateCancelCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetDeployment", mockDeploymentResponse.ID).Return(&mockDeploymentResponse, nil)
 	api.On("CancelUpdateDeploymentRuntime", mockUpdateRequest).Return(&mockDeploymentResponse, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd(
 		"runtime",

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -1056,7 +1056,7 @@ func (s *Suite) TestDeploymentRuntimeMigrateCommandFor1_0_0() {
 	mockDeploymentResponse := *mockDeployment
 	mockDeploymentResponse.AirflowVersion = "2.2.4"
 	mockDeploymentResponse.DesiredAirflowVersion = "2.2.4"
-	mockDeploymentResponse.ClusterId = "ckn4phn1k0104v5xtrer5lpli"
+	mockDeploymentResponse.ClusterID = "ckn4phn1k0104v5xtrer5lpli"
 
 	mockUpdateRequest := map[string]interface{}{
 		"deploymentUuid":        mockDeploymentResponse.ID,
@@ -1070,7 +1070,7 @@ func (s *Suite) TestDeploymentRuntimeMigrateCommandFor1_0_0() {
 	api.On("UpdateDeploymentRuntime", mockUpdateRequest).Return(&mockDeploymentResponse, nil)
 	vars := make(map[string]interface{})
 	vars["airflowVersion"] = mockDeploymentResponse.AirflowVersion
-	vars["clusterId"] = mockDeploymentResponse.ClusterId
+	vars["clusterId"] = mockDeploymentResponse.ClusterID
 	api.On("GetRuntimeReleases", vars).Return(mockRuntimeReleaseResp, nil)
 
 	houstonClient = api

--- a/cmd/software/deployment_user_test.go
+++ b/cmd/software/deployment_user_test.go
@@ -22,7 +22,7 @@ func (s *Suite) TestDeploymentUserAddCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("AddDeploymentUser", expectedAddUserRequest).Return(mockDeploymentUserRole, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd(
 		"user",
@@ -46,7 +46,7 @@ func (s *Suite) TestDeploymentUserDeleteCommand() {
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("DeleteDeploymentUser", houston.DeleteDeploymentUserRequest{DeploymentID: mockDeploymentUserRole.Deployment.ID, Email: mockDeploymentUserRole.User.Username}).
 		Return(mockDeploymentUserRole, nil)
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd(
 		"user",
@@ -70,7 +70,7 @@ func (s *Suite) TestDeploymentUserList() {
 	}
 	api := new(mocks.ClientInterface)
 	api.On("ListDeploymentUsers", houston.ListDeploymentUsersRequest{UserID: "test-user-id", Email: "test-email", FullName: "test-name", DeploymentID: "test-id"}).Return(mockUser, nil).Once()
-
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 	houstonClient = api
 	output, err := execDeploymentCmd("user", "list", "--deployment-id", "test-id", "-u", "test-user-id", "-e", "test-email", "-n", "test-name")
 	s.NoError(err)
@@ -95,6 +95,7 @@ func (s *Suite) TestDeploymentUserUpdateCommand() {
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", nil).Return(mockAppConfig, nil)
 	api.On("UpdateDeploymentUser", expectedUpdateUserRequest).Return(&mockResponseUserRole, nil)
+	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
 
 	houstonClient = api
 	output, err := execDeploymentCmd(

--- a/houston/app.go
+++ b/houston/app.go
@@ -68,12 +68,26 @@ var (
 		},
 	}
 
-	AvailableNamespacesGetRequest = `
+	AvailableNamespacesGetRequest = queryList{
+		{
+			version: "0.25.0",
+			query: `
 	query availableNamespaces {
-		availableNamespaces{
+		availableNamespaces {
 			name
 		}
-	}`
+	}`,
+		},
+		{
+			version: "1.0.0",
+			query: `
+	query availableNamespaces($clusterId: Uuid!) {
+		availableNamespaces(clusterId: $clusterId) {
+			name
+		}
+	}`,
+		},
+	}
 
 	HoustonVersionQuery = `
 	query AppConfig {
@@ -117,9 +131,14 @@ func (h ClientImplementation) GetAppConfig(_ interface{}) (*AppConfig, error) {
 }
 
 // GetAvailableNamespace - get namespaces to create deployments
-func (h ClientImplementation) GetAvailableNamespaces(_ interface{}) ([]Namespace, error) {
+func (h ClientImplementation) GetAvailableNamespaces(vars map[string]interface{}) ([]Namespace, error) {
+	reqVars := map[string]interface{}{}
+	if vars["clusterID"] != "" && vars["clusterID"] != nil {
+		reqVars["clusterId"] = vars["clusterID"]
+	}
 	req := Request{
-		Query: AvailableNamespacesGetRequest,
+		Query:     AvailableNamespacesGetRequest.GreatestLowerBound(version),
+		Variables: reqVars,
 	}
 
 	r, err := req.DoWithClient(h.client)

--- a/houston/app.go
+++ b/houston/app.go
@@ -72,20 +72,20 @@ var (
 		{
 			version: "0.25.0",
 			query: `
-	query availableNamespaces {
-		availableNamespaces {
-			name
-		}
-	}`,
+			query availableNamespaces {
+				availableNamespaces {
+					name
+				}
+			}`,
 		},
 		{
 			version: "1.0.0",
 			query: `
-	query availableNamespaces($clusterId: Uuid!) {
-		availableNamespaces(clusterId: $clusterId) {
-			name
-		}
-	}`,
+			query availableNamespaces($clusterId: Uuid!) {
+				availableNamespaces(clusterId: $clusterId) {
+					name
+				}
+			}`,
 		},
 	}
 

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -237,7 +237,7 @@ var (
 				}
 			}`,
 		},
-        {
+		{
 			version: "1.0.0",
 			query: `
 			query GetDeployment(

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -237,6 +237,37 @@ var (
 				}
 			}`,
 		},
+        {
+			version: "1.0.0",
+			query: `
+			query GetDeployment(
+				$workspaceId: Uuid!
+				$releaseName: String
+			){
+				workspaceDeployments(
+					workspaceUuid: $workspaceId
+					releaseName: $releaseName
+				){
+					id
+					type
+					label
+					releaseName
+					workspace {
+						id
+					}
+					deployInfo {
+						nextCli
+						current
+					}
+					version
+					airflowVersion
+					runtimeVersion
+					clusterId
+					createdAt
+					updatedAt
+				}
+			}`,
+		},
 	}
 
 	PaginatedDeploymentsGetRequest = queryList{
@@ -389,6 +420,33 @@ var (
 					dagDeployment {
 						type
 					}
+				}
+			}`,
+		},
+		{
+			version: "1.0.0",
+			query: `
+			query GetDeployment(
+				$id: String!
+			){
+				deployment(
+					where: {id: $id}
+				){
+					id
+					airflowVersion
+					desiredAirflowVersion
+					runtimeVersion
+					desiredRuntimeVersion
+					runtimeAirflowVersion
+					releaseName
+					urls {
+						type
+						url
+					}
+					dagDeployment {
+						type
+					}
+					clusterId
 				}
 			}`,
 		},

--- a/houston/deployment_user_test.go
+++ b/houston/deployment_user_test.go
@@ -109,6 +109,7 @@ func (s *Suite) TestAddDeploymentUser() {
 				Header:     make(http.Header),
 			}
 		})
+
 		api := NewClient(client)
 
 		_, err := api.AddDeploymentUser(UpdateDeploymentUserRequest{})

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -76,7 +76,7 @@ type ClientInterface interface {
 	ListWorkspaceServiceAccounts(workspaceID string) ([]ServiceAccount, error)
 	// app
 	GetAppConfig(interface{}) (*AppConfig, error)
-	GetAvailableNamespaces(interface{}) ([]Namespace, error)
+	GetAvailableNamespaces(vars map[string]interface{}) ([]Namespace, error)
 	GetPlatformVersion(interface{}) (string, error)
 	// runtime
 	GetRuntimeReleases(vars map[string]interface{}) (RuntimeReleases, error)

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -79,7 +79,7 @@ type ClientInterface interface {
 	GetAvailableNamespaces(interface{}) ([]Namespace, error)
 	GetPlatformVersion(interface{}) (string, error)
 	// runtime
-	GetRuntimeReleases(airflowVersion string) (RuntimeReleases, error)
+	GetRuntimeReleases(vars map[string]interface{}) (RuntimeReleases, error)
 	// teams
 	GetTeam(teamID string) (*Team, error)
 	GetTeamUsers(teamID string) ([]User, error)

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -668,9 +668,9 @@ func (_m *ClientInterface) GetAuthConfig(ctx *config.Context) (*houston.AuthConf
 	return r0, r1
 }
 
-// GetAvailableNamespaces provides a mock function with given fields: _a0
-func (_m *ClientInterface) GetAvailableNamespaces(_a0 interface{}) ([]houston.Namespace, error) {
-	ret := _m.Called(_a0)
+// GetAvailableNamespaces provides a mock function with given fields: vars
+func (_m *ClientInterface) GetAvailableNamespaces(vars map[string]interface{}) ([]houston.Namespace, error) {
+	ret := _m.Called(vars)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAvailableNamespaces")
@@ -678,19 +678,19 @@ func (_m *ClientInterface) GetAvailableNamespaces(_a0 interface{}) ([]houston.Na
 
 	var r0 []houston.Namespace
 	var r1 error
-	if rf, ok := ret.Get(0).(func(interface{}) ([]houston.Namespace, error)); ok {
-		return rf(_a0)
+	if rf, ok := ret.Get(0).(func(map[string]interface{}) ([]houston.Namespace, error)); ok {
+		return rf(vars)
 	}
-	if rf, ok := ret.Get(0).(func(interface{}) []houston.Namespace); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(map[string]interface{}) []houston.Namespace); ok {
+		r0 = rf(vars)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]houston.Namespace)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(interface{}) error); ok {
-		r1 = rf(_a0)
+	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
+		r1 = rf(vars)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -786,9 +786,9 @@ func (_m *ClientInterface) GetPlatformVersion(_a0 interface{}) (string, error) {
 	return r0, r1
 }
 
-// GetRuntimeReleases provides a mock function with given fields: airflowVersion
-func (_m *ClientInterface) GetRuntimeReleases(airflowVersion string) (houston.RuntimeReleases, error) {
-	ret := _m.Called(airflowVersion)
+// GetRuntimeReleases provides a mock function with given fields: vars
+func (_m *ClientInterface) GetRuntimeReleases(vars map[string]interface{}) (houston.RuntimeReleases, error) {
+	ret := _m.Called(vars)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRuntimeReleases")
@@ -796,19 +796,19 @@ func (_m *ClientInterface) GetRuntimeReleases(airflowVersion string) (houston.Ru
 
 	var r0 houston.RuntimeReleases
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (houston.RuntimeReleases, error)); ok {
-		return rf(airflowVersion)
+	if rf, ok := ret.Get(0).(func(map[string]interface{}) (houston.RuntimeReleases, error)); ok {
+		return rf(vars)
 	}
-	if rf, ok := ret.Get(0).(func(string) houston.RuntimeReleases); ok {
-		r0 = rf(airflowVersion)
+	if rf, ok := ret.Get(0).(func(map[string]interface{}) houston.RuntimeReleases); ok {
+		r0 = rf(vars)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(houston.RuntimeReleases)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(airflowVersion)
+	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
+		r1 = rf(vars)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/houston/runtime.go
+++ b/houston/runtime.go
@@ -1,19 +1,15 @@
 package houston
 
 var GetRuntimeReleases = `
-	query runtimeReleases($airflowVersion: String) {
-		runtimeReleases(airflowVersion: $airflowVersion) {
+	query runtimeReleases($airflowVersion: String, $clusterId: Uuid) {
+		runtimeReleases(airflowVersion: $airflowVersion, clusterId: $clusterId) {
 			version
 			airflowVersion
 			airflowDatabaseMigrations
 		}
 	}`
 
-func (h ClientImplementation) GetRuntimeReleases(airflowVersion string) (RuntimeReleases, error) {
-	vars := make(map[string]interface{})
-	if airflowVersion != "" {
-		vars["airflowVersion"] = airflowVersion
-	}
+func (h ClientImplementation) GetRuntimeReleases(vars map[string]interface{}) (RuntimeReleases, error) {
 	dReq := Request{
 		Query:     GetRuntimeReleases,
 		Variables: vars,

--- a/houston/runtime_test.go
+++ b/houston/runtime_test.go
@@ -32,7 +32,25 @@ func (s *Suite) TestGetRuntimeReleases() {
 		})
 		api := NewClient(client)
 
-		resp, err := api.GetRuntimeReleases("")
+		vars := make(map[string]interface{})
+		resp, err := api.GetRuntimeReleases(vars)
+		s.NoError(err)
+		s.Equal(resp, mockResp.Data.RuntimeReleases)
+	})
+
+	s.Run("success without airflow version for 1.0.0", func() {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		vars := make(map[string]interface{})
+		vars["clusterId"] = "test-cluster-id"
+		resp, err := api.GetRuntimeReleases(vars)
 		s.NoError(err)
 		s.Equal(resp, mockResp.Data.RuntimeReleases)
 	})
@@ -47,7 +65,9 @@ func (s *Suite) TestGetRuntimeReleases() {
 		})
 		api := NewClient(client)
 
-		resp, err := api.GetRuntimeReleases("2.2.4")
+		vars := make(map[string]interface{})
+		vars["airflowVersion"] = "2.2.4"
+		resp, err := api.GetRuntimeReleases(vars)
 		s.NoError(err)
 		s.Equal(resp, mockResp.Data.RuntimeReleases)
 	})
@@ -62,7 +82,8 @@ func (s *Suite) TestGetRuntimeReleases() {
 		})
 		api := NewClient(client)
 
-		_, err := api.GetRuntimeReleases("")
+		vars := make(map[string]interface{})
+		_, err := api.GetRuntimeReleases(vars)
 		s.Contains(err.Error(), "Internal Server Error")
 	})
 }

--- a/houston/types.go
+++ b/houston/types.go
@@ -119,6 +119,7 @@ type Deployment struct {
 	CreatedAt             time.Time           `json:"createdAt"`
 	UpdatedAt             time.Time           `json:"updatedAt"`
 	DagDeployment         DagDeploymentConfig `json:"dagDeployment"`
+	ClusterId             string              `json:"clusterId"`
 }
 
 type DagDeploymentConfig struct {

--- a/houston/types.go
+++ b/houston/types.go
@@ -119,7 +119,7 @@ type Deployment struct {
 	CreatedAt             time.Time           `json:"createdAt"`
 	UpdatedAt             time.Time           `json:"updatedAt"`
 	DagDeployment         DagDeploymentConfig `json:"dagDeployment"`
-	ClusterId             string              `json:"clusterId"`
+	ClusterID             string              `json:"clusterId"`
 }
 
 type DagDeploymentConfig struct {

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -138,7 +138,7 @@ func validateRuntimeVersion(houstonClient houston.ClientInterface, tag string, d
 		return err
 	}
 	vars := make(map[string]interface{})
-	vars["clusterId"] = deploymentInfo.ClusterId
+	vars["clusterId"] = deploymentInfo.ClusterID
 	// ignoring the error as user can be connected to platform where runtime is not enabled
 	runtimeReleases, _ := houston.Call(houstonClient.GetRuntimeReleases)(vars)
 	var validTags string

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -137,8 +137,10 @@ func validateRuntimeVersion(houstonClient houston.ClientInterface, tag string, d
 	if err != nil {
 		return err
 	}
+	vars := make(map[string]interface{})
+	vars["clusterId"] = deploymentInfo.ClusterId
 	// ignoring the error as user can be connected to platform where runtime is not enabled
-	runtimeReleases, _ := houston.Call(houstonClient.GetRuntimeReleases)("")
+	runtimeReleases, _ := houston.Call(houstonClient.GetRuntimeReleases)(vars)
 	var validTags string
 	if config.CFG.ShowWarnings.GetBool() && deploymentInfo.DesiredAirflowVersion != "" && !deploymentConfig.IsValidTag(tag) {
 		validTags = strings.Join(deploymentConfig.GetValidTags(tag), ", ")

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -153,7 +153,9 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithTagWarning() {
 	mockedDeploymentConfig := &houston.DeploymentConfig{
 		AirflowImages: mockAirflowImageList,
 	}
-	s.houstonMock.On("GetRuntimeReleases", "").Return(houston.RuntimeReleases{}, nil)
+	vars := make(map[string]interface{})
+	vars["clusterId"] = ""
+	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(mockedDeploymentConfig, nil)
 
 	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
@@ -176,8 +178,10 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithImageRepoWarning() {
 	mockedDeploymentConfig := &houston.DeploymentConfig{
 		AirflowImages: mockAirflowImageList,
 	}
+	vars := make(map[string]interface{})
+	vars["clusterId"] = ""
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(mockedDeploymentConfig, nil)
-	s.houstonMock.On("GetRuntimeReleases", "").Return(houston.RuntimeReleases{}, nil)
+	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 
 	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.NoError(err)
@@ -215,7 +219,9 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithBYORegistry() {
 		AirflowImages: mockAirflowImageList,
 	}
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(mockedDeploymentConfig, nil)
-	s.houstonMock.On("GetRuntimeReleases", "").Return(houston.RuntimeReleases{}, nil)
+	vars := make(map[string]interface{})
+	vars["clusterId"] = ""
+	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	s.houstonMock.On("UpdateDeploymentImage", houston.UpdateDeploymentImageRequest{ReleaseName: "test", Image: "test.registry.io:test-test", AirflowVersion: "1.10.12", RuntimeVersion: ""}).Return(nil, nil)
 
 	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, "")
@@ -274,7 +280,9 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithBYORegistryAndCustomImageName
 		AirflowImages: mockAirflowImageList,
 	}
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(mockedDeploymentConfig, nil)
-	s.houstonMock.On("GetRuntimeReleases", "").Return(houston.RuntimeReleases{}, nil)
+	vars := make(map[string]interface{})
+	vars["clusterId"] = ""
+	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	s.houstonMock.On("UpdateDeploymentImage", houston.UpdateDeploymentImageRequest{ReleaseName: "test", Image: "test.registry.io:latest", AirflowVersion: "1.10.12", RuntimeVersion: "12.2.0"}).Return(nil, nil)
 
 	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, customImageName)
@@ -293,7 +301,9 @@ func (s *Suite) TestBuildPushDockerImageFailure() {
 		AirflowImages: mockAirflowImageList,
 	}
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(nil, errMockHouston).Once()
-	s.houstonMock.On("GetRuntimeReleases", "").Return(houston.RuntimeReleases{}, nil)
+	vars := make(map[string]interface{})
+	vars["clusterId"] = ""
+	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	// houston GetDeploymentConfig call failure
 	err = buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.Error(err, errMockHouston)
@@ -425,7 +435,9 @@ func (s *Suite) TestAirflowSuccess() {
 	s.houstonMock.On("ListDeployments", mock.Anything).Return([]houston.Deployment{{ID: "test-deployment-id"}}, nil).Once()
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(mockedDeploymentConfig, nil).Once()
 	s.houstonMock.On("GetDeployment", mock.Anything).Return(&houston.Deployment{}, nil).Once()
-	s.houstonMock.On("GetRuntimeReleases", "").Return(mockRuntimeReleases, nil)
+	vars := make(map[string]interface{})
+	vars["clusterId"] = ""
+	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 
 	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", "", false, false, false, description, false, "")
 	s.NoError(err)
@@ -458,7 +470,9 @@ func (s *Suite) TestAirflowSuccessForImageOnly() {
 	}
 
 	s.houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
-	s.houstonMock.On("GetRuntimeReleases", "").Return(mockRuntimeReleases, nil)
+	vars := make(map[string]interface{})
+	vars["clusterId"] = ""
+	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 
 	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", "", false, false, false, description, true, "")
 	s.NoError(err)
@@ -492,7 +506,9 @@ func (s *Suite) TestAirflowSuccessForImageName() {
 	}
 
 	s.houstonMock.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
-	s.houstonMock.On("GetRuntimeReleases", "").Return(mockRuntimeReleases, nil)
+	vars := make(map[string]interface{})
+	vars["clusterId"] = ""
+	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 
 	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", "", false, false, false, description, true, customImageName)
 	s.NoError(err)

--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -153,7 +153,7 @@ func Create(req *CreateDeploymentRequest, client houston.ClientInterface, out io
 	vars := map[string]interface{}{"label": req.Label, "workspaceId": req.WS, "executor": req.Executor, "cloudRole": req.CloudRole}
 
 	if CheckPreCreateNamespaceDeployment(client) {
-		namespace, err := getDeploymentSelectionNamespaces(client, out)
+		namespace, err := getDeploymentSelectionNamespaces(client, out, req.ClusterID)
 		if err != nil {
 			return err
 		}
@@ -245,7 +245,7 @@ func Delete(id string, hardDelete bool, client houston.ClientInterface, out io.W
 }
 
 // list all available namespaces
-func getDeploymentSelectionNamespaces(client houston.ClientInterface, out io.Writer) (string, error) {
+func getDeploymentSelectionNamespaces(client houston.ClientInterface, out io.Writer, clusterID string) (string, error) {
 	tab := &printutil.Table{
 		Padding:        []int{30},
 		DynamicPadding: true,
@@ -255,7 +255,7 @@ func getDeploymentSelectionNamespaces(client houston.ClientInterface, out io.Wri
 	logger.Debug("checking namespaces available for platform")
 	tab.GetUserInput = true
 
-	names, err := houston.Call(client.GetAvailableNamespaces)(nil)
+	names, err := houston.Call(client.GetAvailableNamespaces)(map[string]interface{}{"clusterID": clusterID})
 	if err != nil {
 		return "", err
 	}

--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -463,7 +463,7 @@ func RuntimeUpgrade(id, desiredRuntimeVersion string, client houston.ClientInter
 	}
 
 	if desiredRuntimeVersion == "" {
-		selectedVersion, err := getRuntimeVersionSelection(deployment.RuntimeVersion, deployment.RuntimeAirflowVersion, deployment.ClusterId, client, out)
+		selectedVersion, err := getRuntimeVersionSelection(deployment.RuntimeVersion, deployment.RuntimeAirflowVersion, deployment.ClusterID, client, out)
 		if err != nil {
 			return err
 		}
@@ -538,7 +538,7 @@ func RuntimeMigrate(deploymentID string, client houston.ClientInterface, out io.
 
 	vars := make(map[string]interface{})
 	vars["airflowVersion"] = deployment.AirflowVersion
-	vars["clusterId"] = deployment.ClusterId
+	vars["clusterId"] = deployment.ClusterID
 	runtimeReleases, err := houston.Call(client.GetRuntimeReleases)(vars)
 	if err != nil {
 		return err
@@ -647,7 +647,7 @@ func getAirflowVersionSelection(airflowVersion string, client houston.ClientInte
 	return filteredVersions[i-1], nil
 }
 
-func getRuntimeVersionSelection(runtimeVersion, airflowVersion, clusterId string, client houston.ClientInterface, out io.Writer) (string, error) {
+func getRuntimeVersionSelection(runtimeVersion, airflowVersion, clusterID string, client houston.ClientInterface, out io.Writer) (string, error) {
 	currentRuntimeVersion, err := semver.NewVersion(runtimeVersion)
 	if err != nil {
 		return "", err
@@ -659,7 +659,7 @@ func getRuntimeVersionSelection(runtimeVersion, airflowVersion, clusterId string
 
 	// prepare list of AC airflow versions
 	vars := make(map[string]interface{})
-	vars["clusterId"] = clusterId
+	vars["clusterId"] = clusterID
 	runtimeVersions, err := houston.Call(client.GetRuntimeReleases)(vars)
 	if err != nil {
 		return "", err

--- a/software/deployment/deployment_test.go
+++ b/software/deployment/deployment_test.go
@@ -1460,7 +1460,7 @@ To cancel, run:
 		expectedVars := map[string]interface{}{"deploymentUuid": mockDeployment.ID, "desiredRuntimeVersion": "4.2.4"}
 
 		mockDeploymentResp := *mockDeployment
-		mockDeploymentResp.ClusterId = "test-cluster-id"
+		mockDeploymentResp.ClusterID = "test-cluster-id"
 		api := new(mocks.ClientInterface)
 		api.On("GetDeployment", mockDeployment.ID).Return(&mockDeploymentResp, nil)
 		vars := make(map[string]interface{})

--- a/software/deployment/types.go
+++ b/software/deployment/types.go
@@ -18,4 +18,5 @@ type CreateDeploymentRequest struct {
 	KnownHosts        string
 	GitSyncInterval   int
 	TriggererReplicas int
+	ClusterID         string
 }


### PR DESCRIPTION
## Description

Currently, the CLI fetches the list of available Runtime versions and applies filters based on the Houston configmap. This approach is problematic for 1.0 because it doesn't account for feature flags or specific configurations that may be enabled on a per-cluster basis.

As a result, a user might see a list of Runtimes that is not accurate for their target environment. For example, a cluster with a feature flag enabled for Airflow 3 would not see it in the list of available versions if it is disabled at the global level, preventing them from using it. 
This PR resolves this issue by ensuring that whenever the CLI requests a list of available Runtime versions, it passes the relevant clusterId ID. The backend API can then use this ID to evaluate cluster-specific feature flags and return a precise, filtered list of Runtimes that are actually available for that cluster.

## 🎟 Issue(s)

Related 7572(https://github.com/astronomer/issues/issues/7572)

## 🧪 Functional Testing

Tested locally
Unit tests

## 📸 Screenshots

<img width="702" height="268" alt="Screenshot 2025-07-31 at 1 30 42 PM" src="https://github.com/user-attachments/assets/2d3672be-2999-4b8a-a32e-c508b68b22fc" />
<img width="1584" height="345" alt="Screenshot 2025-07-31 at 1 30 18 PM" src="https://github.com/user-attachments/assets/51d925df-94f2-4b77-92a0-4824447905c2" />
<img width="1584" height="345" alt="Screenshot 2025-07-31 at 1 29 58 PM" src="https://github.com/user-attachments/assets/44bdd1c5-0859-4676-b123-74e1eddf3960" />
<img width="1584" height="345" alt="Screenshot 2025-07-31 at 1 18 30 PM" src="https://github.com/user-attachments/assets/e353faf9-4256-4b86-8593-668104005a07" />
<img width="1584" height="345" alt="Screenshot 2025-07-31 at 1 11 54 PM" src="https://github.com/user-attachments/assets/52364511-fb49-4ac2-b27d-e9d2cd528d33" />
<img width="448" height="635" alt="Screenshot 2025-07-31 at 1 11 19 PM" src="https://github.com/user-attachments/assets/2b8c65d5-13d4-4f14-a3f5-2742fccfcad3" />



## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
