### PR TITLE
Added support for cluster id in the astro deployment list command

### DIFF
--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -923,7 +923,7 @@ func (s *Suite) TestDeploymentList() {
 
 func (s *Suite) TestDeploymentListWithClusterID() {
 	expectedRequest := houston.PaginatedDeploymentsRequest{
-		Take: -1,
+		Take:      -1,
 		ClusterID: "testClusterID",
 	}
 

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -921,6 +921,22 @@ func (s *Suite) TestDeploymentList() {
 	api.AssertExpectations(s.T())
 }
 
+func (s *Suite) TestDeploymentListWithClusterID() {
+	expectedRequest := houston.PaginatedDeploymentsRequest{
+		Take: -1,
+		ClusterID: "testClusterID",
+	}
+
+	api := new(mocks.ClientInterface)
+	api.On("ListPaginatedDeployments", expectedRequest).Return([]houston.Deployment{*mockDeployment}, nil)
+	api.On("GetPlatformVersion", nil).Return("1.0.0", nil)
+	houstonClient = api
+	output, err := execDeploymentCmd("list", "--all", "--cluster-id=testClusterID")
+	s.NoError(err)
+	s.Contains(output, mockDeployment.ID)
+	api.AssertExpectations(s.T())
+}
+
 func (s *Suite) TestDeploymentDeleteHardResponseNo() {
 	appConfig = &houston.AppConfig{
 		HardDeleteDeployment: true,

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -11,7 +11,8 @@ type ListDeploymentsRequest struct {
 }
 
 type PaginatedDeploymentsRequest struct {
-	Take int `json:"take"`
+	Take      int    `json:"take"`
+	ClusterID string `json:"clusterId"`
 }
 
 // ListDeploymentLogsRequest - filters to list logs from a deployment
@@ -295,6 +296,37 @@ var (
 					version
 					airflowVersion
 					runtimeVersion
+					createdAt
+					updatedAt
+				}
+			}`,
+		},
+		{
+			version: "1.0.0",
+			query: `
+			query paginatedDeployments( $take: Int, $name: String, $cursor: Uuid, $pageNumber: Int, $clusterId: Uuid) {
+				paginatedDeployments(
+					take: $take
+					name: $name
+					cursor: $cursor
+					pageNumber: $pageNumber
+					clusterId: $clusterId
+				) {
+					id
+					type
+					label
+					releaseName
+					workspace {
+						id
+					}
+					deployInfo {
+						nextCli
+						current
+					}
+					version
+					airflowVersion
+					runtimeVersion
+					clusterId
 					createdAt
 					updatedAt
 				}
@@ -625,6 +657,9 @@ func (h ClientImplementation) ListDeployments(filters ListDeploymentsRequest) ([
 func (h ClientImplementation) ListPaginatedDeployments(filters PaginatedDeploymentsRequest) ([]Deployment, error) {
 	variables := map[string]interface{}{}
 	variables["take"] = filters.Take
+	if filters.ClusterID != "" {
+		variables["clusterId"] = filters.ClusterID
+	}
 	reqQuery := PaginatedDeploymentsGetRequest.GreatestLowerBound(version)
 	req := Request{
 		Query: reqQuery,

--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -295,7 +295,7 @@ func getDeploymentNamespaceName() (string, error) {
 func getDeploymentsFromHouston(ws string, all bool, client houston.ClientInterface, clusterID string) ([]houston.Deployment, error) {
 	if all {
 		return houston.Call(client.ListPaginatedDeployments)(houston.PaginatedDeploymentsRequest{
-			Take: -1,
+			Take:      -1,
 			ClusterID: clusterID,
 		})
 	}

--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -292,10 +292,11 @@ func getDeploymentNamespaceName() (string, error) {
 	return namespaceName, nil
 }
 
-func getDeploymentsFromHouston(ws string, all bool, client houston.ClientInterface) ([]houston.Deployment, error) {
+func getDeploymentsFromHouston(ws string, all bool, client houston.ClientInterface, clusterID string) ([]houston.Deployment, error) {
 	if all {
 		return houston.Call(client.ListPaginatedDeployments)(houston.PaginatedDeploymentsRequest{
 			Take: -1,
+			ClusterID: clusterID,
 		})
 	}
 	listDeploymentRequest := houston.ListDeploymentsRequest{}
@@ -304,8 +305,8 @@ func getDeploymentsFromHouston(ws string, all bool, client houston.ClientInterfa
 }
 
 // List all airflow deployments
-func List(ws string, all bool, client houston.ClientInterface, out io.Writer) error {
-	deployments, err := getDeploymentsFromHouston(ws, all, client)
+func List(ws string, all bool, client houston.ClientInterface, out io.Writer, clusterID string) error {
+	deployments, err := getDeploymentsFromHouston(ws, all, client, clusterID)
 	if err != nil {
 		return err
 	}

--- a/software/deployment/deployment_test.go
+++ b/software/deployment/deployment_test.go
@@ -508,6 +508,7 @@ func (s *Suite) TestDelete() {
 }
 
 func (s *Suite) TestList() {
+	clusterID := "testClusterID"
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
 	mockDeployments := []houston.Deployment{
 		{
@@ -534,7 +535,7 @@ func (s *Suite) TestList() {
 		api.On("ListDeployments", expectedRequest).Return(mockDeployments, nil)
 
 		buf := new(bytes.Buffer)
-		err := List(mockDeployments[0].Workspace.ID, false, api, buf)
+		err := List(mockDeployments[0].Workspace.ID, false, api, buf, clusterID)
 		s.NoError(err)
 		expected := ` NAME     DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 TAG     IMAGE VERSION                  
  test     burning-terrestrial-5940     v1.1.0     ckbv801t300qh0760pck7ea0c     ?       Astronomer-Certified-1.1.0     
@@ -548,7 +549,7 @@ func (s *Suite) TestList() {
 		api.On("ListDeployments", expectedRequest).Return([]houston.Deployment{}, errMock)
 
 		buf := new(bytes.Buffer)
-		err := List(mockDeployments[0].Workspace.ID, false, api, buf)
+		err := List(mockDeployments[0].Workspace.ID, false, api, buf, clusterID)
 		s.EqualError(err, errMock.Error())
 		api.AssertExpectations(s.T())
 	})
@@ -556,13 +557,14 @@ func (s *Suite) TestList() {
 	s.Run("list namespace all enabled", func() {
 		expectedRequest := houston.PaginatedDeploymentsRequest{
 			Take: -1,
+			ClusterID: clusterID,
 		}
 
 		api := new(mocks.ClientInterface)
 		api.On("ListPaginatedDeployments", expectedRequest).Return(mockDeployments, nil)
 
 		buf := new(bytes.Buffer)
-		err := List(mockDeployments[0].Workspace.ID, true, api, buf)
+		err := List(mockDeployments[0].Workspace.ID, true, api, buf, clusterID)
 		s.NoError(err)
 		expected := ` NAME     DEPLOYMENT NAME              ASTRO      DEPLOYMENT ID                 TAG     IMAGE VERSION                  
  test     burning-terrestrial-5940     v1.1.0     ckbv801t300qh0760pck7ea0c     ?       Astronomer-Certified-1.1.0     

--- a/software/deployment/deployment_test.go
+++ b/software/deployment/deployment_test.go
@@ -556,7 +556,7 @@ func (s *Suite) TestList() {
 
 	s.Run("list namespace all enabled", func() {
 		expectedRequest := houston.PaginatedDeploymentsRequest{
-			Take: -1,
+			Take:      -1,
 			ClusterID: clusterID,
 		}
 


### PR DESCRIPTION
## Description

Added support for cluster ID in the astro deployment list command. Customers will have an option to pass the cluster ID, too.

## 🎟 Issue(s)

[Related #7590
](https://github.com/astronomer/issues/issues/7590)

## 🧪 Functional Testing

Tested locally against Houston local

## 📸 Screenshots
<img width="1418" height="399" alt="Screenshot 2025-08-12 at 1 24 26 PM" src="https://github.com/user-attachments/assets/58c4ff79-b8d6-48d2-a77c-761306bee85e" />


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
