### PR TITLE
Remove disable env objs config

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -259,10 +259,8 @@ func newAirflowStartCmd(astroCoreClient astrocore.CoreClient) *cobra.Command {
 	cmd.Flags().DurationVar(&waitTime, "wait", defaultWaitTime, "Duration to wait for webserver to get healthy. The default is 5 minutes. Use --wait 2m to wait for 2 minutes.")
 	cmd.Flags().StringVarP(&composeFile, "compose-file", "", "", "Location of a custom compose file to use for starting Airflow")
 	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
-	if !config.CFG.DisableEnvObjects.GetBool() {
-		cmd.Flags().StringVarP(&workspaceID, "workspace-id", "w", "", "ID of the Workspace to retrieve environment connections from. If not specified uses the current Workspace.")
-		cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "ID of the Deployment to retrieve environment connections from")
-	}
+	cmd.Flags().StringVarP(&workspaceID, "workspace-id", "w", "", "ID of the Workspace to retrieve environment connections from. If not specified uses the current Workspace.")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "ID of the Deployment to retrieve environment connections from")
 
 	return cmd
 }
@@ -347,10 +345,8 @@ func newAirflowRestartCmd(astroCoreClient astrocore.CoreClient) *cobra.Command {
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to restart airflow with")
 	cmd.Flags().StringVarP(&settingsFile, "settings-file", "s", "airflow_settings.yaml", "Settings or env file to import airflow objects from")
 	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
-	if !config.CFG.DisableEnvObjects.GetBool() {
-		cmd.Flags().StringVarP(&workspaceID, "workspace-id", "w", "", "ID of the Workspace to retrieve environment connections from. If not specified uses the current Workspace.")
-		cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "ID of the Deployment to retrieve environment connections from")
-	}
+	cmd.Flags().StringVarP(&workspaceID, "workspace-id", "w", "", "ID of the Workspace to retrieve environment connections from. If not specified uses the current Workspace.")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "ID of the Deployment to retrieve environment connections from")
 
 	return cmd
 }
@@ -683,7 +679,7 @@ func airflowStart(cmd *cobra.Command, args []string, astroCoreClient astrocore.C
 	}
 
 	var envConns map[string]astrocore.EnvironmentObjectConnection
-	if !config.CFG.DisableEnvObjects.GetBool() && (workspaceID != "" || deploymentID != "") {
+	if workspaceID != "" || deploymentID != "" {
 		var err error
 		envConns, err = environment.ListConnections(workspaceID, deploymentID, astroCoreClient)
 		if err != nil {
@@ -815,7 +811,7 @@ func airflowRestart(cmd *cobra.Command, args []string, astroCoreClient astrocore
 	noBrowser = true
 
 	var envConns map[string]astrocore.EnvironmentObjectConnection
-	if !config.CFG.DisableEnvObjects.GetBool() && (workspaceID != "" || deploymentID != "") {
+	if workspaceID != "" || deploymentID != "" {
 		var err error
 		envConns, err = environment.ListConnections(workspaceID, deploymentID, astroCoreClient)
 		if err != nil {

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -526,28 +526,6 @@ func (s *AirflowSuite) TestAirflowStart() {
 		mockContainerHandler.AssertExpectations(s.T())
 	})
 
-	s.Run("success with deployment id flag set but environment objects disabled", func() {
-		cmd := newAirflowStartCmd(nil)
-		deploymentID = "test-deployment-id"
-		cmd.Flag("deployment-id").Value.Set(deploymentID)
-		args := []string{"test-env-file"}
-		config.CFG.DisableEnvObjects.SetHomeString("true")
-		defer config.CFG.DisableEnvObjects.SetHomeString("false")
-
-		mockCoreClient := new(coreMocks.ClientWithResponsesInterface)
-
-		mockContainerHandler := new(mocks.ContainerHandler)
-		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Start", "", "airflow_settings.yaml", "", "", false, false, defaultWaitTime, map[string]astrocore.EnvironmentObjectConnection(nil)).Return(nil).Once()
-			return mockContainerHandler, nil
-		}
-
-		err := airflowStart(cmd, args, mockCoreClient)
-		s.NoError(err)
-		mockContainerHandler.AssertExpectations(s.T())
-		mockCoreClient.AssertExpectations(s.T())
-	})
-
 	s.Run("success with deployment id flag set", func() {
 		cmd := newAirflowStartCmd(nil)
 		deploymentID = "test-deployment-id"

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,6 @@ var (
 		PageSize:              newCfg("page_size", "20"),
 		UpgradeMessage:        newCfg("upgrade_message", "true"),
 		DisableAstroRun:       newCfg("disable_astro_run", "false"),
-		DisableEnvObjects:     newCfg("disable_env_objects", "false"),
 		AutoSelect:            newCfg("auto_select", "false"),
 		MachineCPU:            newCfg("machine.cpu", "2"),
 		MachineMemory:         newCfg("machine.memory", "4096"),

--- a/config/types.go
+++ b/config/types.go
@@ -44,7 +44,6 @@ type cfgs struct {
 	AuditLogs             cfg
 	UpgradeMessage        cfg
 	DisableAstroRun       cfg
-	DisableEnvObjects     cfg
 	AutoSelect            cfg
 	MachineCPU            cfg
 	MachineMemory         cfg


### PR DESCRIPTION
## Description

This change removes the `disable_env_objs` CLI config, which is no longer required now that the Astro environment manager feature is long GA, and that the feature already requires flags to be invoked.

## 🧪 Functional Testing

Checked locally that the feature continues to work.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
