### PR TITLE
Support reading env objs without settings file

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -1507,7 +1507,7 @@ func printStatus(settingsFile string, envConns map[string]astrocore.EnvironmentO
 	if err != nil {
 		return errors.Wrap(err, errSettingsPath)
 	}
-	if settingsFileExists {
+	if settingsFileExists || len(envConns) > 0 {
 		for _, container := range containers { //nolint:gocritic
 			if strings.Contains(container.Name, project.Name) &&
 				(strings.Contains(container.Name, WebserverDockerContainerName) ||

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1956,6 +1956,132 @@ func (s *Suite) TestDockerComposeRunDAG() {
 
 var errExecMock = errors.New("docker is not running")
 
+func (s *Suite) TestInitSettings() {
+	testCases := []struct {
+		name                     string
+		settingsFile             string
+		envConns                 map[string]astrocore.EnvironmentObjectConnection
+		airflowMajorVersion      uint64
+		project                  *types.Project
+		containerSummary         []api.ContainerSummary
+		expectInitSettingsCalled bool
+	}{
+		{
+			name:                "initSettings called when only settings file exists",
+			settingsFile:        "./testfiles/airflow_settings.yaml",
+			envConns:            map[string]astrocore.EnvironmentObjectConnection{},
+			airflowMajorVersion: airflowMajorVersion2,
+			project: &types.Project{
+				Name: "test-project",
+				Services: map[string]types.ServiceConfig{
+					"webserver": {Name: "test-project-webserver"},
+				},
+			},
+			containerSummary: []api.ContainerSummary{
+				{ID: "test-webserver-id", Name: "test-project-webserver", State: "running"},
+			},
+			expectInitSettingsCalled: true,
+		},
+		{
+			name:         "initSettings called when only env connections exist",
+			settingsFile: "./testfiles/non_existent_settings.yaml",
+			envConns: map[string]astrocore.EnvironmentObjectConnection{
+				"test-conn": {},
+			},
+			airflowMajorVersion: airflowMajorVersion2,
+			project: &types.Project{
+				Name: "test-project",
+				Services: map[string]types.ServiceConfig{
+					"webserver": {Name: "test-project-webserver"},
+				},
+			},
+			containerSummary: []api.ContainerSummary{
+				{ID: "test-webserver-id", Name: "test-project-webserver", State: "running"},
+			},
+			expectInitSettingsCalled: true,
+		},
+		{
+			name:         "initSettings called when both settings file and env connections exist",
+			settingsFile: "./testfiles/airflow_settings.yaml",
+			envConns: map[string]astrocore.EnvironmentObjectConnection{
+				"test-conn": {},
+			},
+			airflowMajorVersion: airflowMajorVersion2,
+			project: &types.Project{
+				Name: "test-project",
+				Services: map[string]types.ServiceConfig{
+					"webserver": {Name: "test-project-webserver"},
+				},
+			},
+			containerSummary: []api.ContainerSummary{
+				{ID: "test-webserver-id", Name: "test-project-webserver", State: "running"},
+			},
+			expectInitSettingsCalled: true,
+		},
+		{
+			name:                "initSettings NOT called when neither settings file nor env connections exist",
+			settingsFile:        "./testfiles/non_existent_settings.yaml",
+			envConns:            map[string]astrocore.EnvironmentObjectConnection{},
+			airflowMajorVersion: airflowMajorVersion2,
+			project: &types.Project{
+				Name: "test-project",
+				Services: map[string]types.ServiceConfig{
+					"webserver": {Name: "test-project-webserver"},
+				},
+			},
+			containerSummary: []api.ContainerSummary{
+				{ID: "test-webserver-id", Name: "test-project-webserver", State: "running"},
+			},
+			expectInitSettingsCalled: false,
+		},
+		{
+			name:                "initSettings called for API server container in Airflow 3",
+			settingsFile:        "./testfiles/airflow_settings.yaml",
+			envConns:            map[string]astrocore.EnvironmentObjectConnection{},
+			airflowMajorVersion: airflowMajorVersion3,
+			project: &types.Project{
+				Name: "test-project",
+				Services: map[string]types.ServiceConfig{
+					"api-server": {Name: "test-project-api-server"},
+				},
+			},
+			containerSummary: []api.ContainerSummary{
+				{ID: "test-api-server-id", Name: "test-project-api-server", State: "running"},
+			},
+			expectInitSettingsCalled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			initSettingsCalled := false
+
+			// Mock initSettings to track if it's called
+			originalInitSettings := initSettings
+			initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, version uint64, connections, variables, pools bool) error {
+				initSettingsCalled = true
+				return nil
+			}
+			defer func() { initSettings = originalInitSettings }()
+
+			// Mock openURL to avoid opening browser
+			originalOpenURL := openURL
+			openURL = func(url string) error {
+				return nil
+			}
+			defer func() { openURL = originalOpenURL }()
+
+			composeMock := new(mocks.DockerComposeAPI)
+			composeMock.On("Ps", mock.Anything, tc.project.Name, api.PsOptions{All: true}).Return(tc.containerSummary, nil).Once()
+
+			err := printStatus(tc.settingsFile, tc.envConns, tc.project, composeMock, tc.airflowMajorVersion, true)
+			s.NoError(err)
+			s.Equal(tc.expectInitSettingsCalled, initSettingsCalled)
+			composeMock.AssertExpectations(s.T())
+		})
+	}
+}
+
 func (s *Suite) TestCreateDockerProject() {
 	fs := afero.NewMemMapFs()
 	configYaml := testUtil.NewTestConfig(testUtil.LocalPlatform)

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -64,7 +64,7 @@ func ConfigSettings(id, settingsFile string, envConns map[string]astrocore.Envir
 	}
 	err := InitSettings(settingsFile)
 	if err != nil {
-		return err
+		logger.Debugf("Unable to initialize settings file: %s", err)
 	}
 	if pools {
 		if err := AddPools(id, version); err != nil {
@@ -97,13 +97,11 @@ func InitSettings(settingsFile string) error {
 
 	// Read in project config
 	readErr := viperSettings.ReadInConfig()
-
 	if readErr != nil {
-		fmt.Printf(configReadErrorMsg, readErr)
+		return errors.Wrap(readErr, "unable to read config file")
 	}
 
 	err := viperSettings.Unmarshal(&settings)
-	// Try and use old settings file if error
 	if err != nil {
 		return errors.Wrap(err, "unable to decode file")
 	}

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -32,9 +32,6 @@ func (s *Suite) TestConfigSettings() {
 	// config setttings no id error
 	err = ConfigSettings("", "", nil, 2, false, false, false)
 	s.ErrorIs(err, errNoID)
-	// config settings settings file error
-	err = ConfigSettings("container-id", "testfiles/airflow_settings_invalid.yaml", nil, 2, false, false, false)
-	s.Contains(err.Error(), "unable to decode file")
 }
 
 func (s *Suite) TestAddConnectionsAirflowOne() {
@@ -349,15 +346,11 @@ func (s *Suite) TestEnvExport() {
 		s.Contains(err.Error(), "there was an error during env export")
 		_ = fileutil.WriteStringToFile("testfiles/test.env", "")
 	})
-
-	s.Run("not airflow 2", func() {
-		err := EnvExport("id", "", 1, true, true)
-		s.Contains(err.Error(), "Command must be used with Airflow 2.X")
-	})
 }
 
 func (s *Suite) TestExport() {
 	s.Run("success", func() {
+		WorkingPath = "./testfiles/"
 		execAirflowCommand = func(id, airflowCommand string) (string, error) {
 			switch airflowCommand {
 			case airflowConnectionList:
@@ -399,6 +392,7 @@ func (s *Suite) TestExport() {
 	})
 
 	s.Run("variable failure", func() {
+		WorkingPath = "./testfiles/"
 		execAirflowCommand = func(id, airflowCommand string) (string, error) {
 			switch airflowCommand {
 			case airflowVarExport:
@@ -415,11 +409,6 @@ func (s *Suite) TestExport() {
 	s.Run("missing id", func() {
 		err := Export("", "", 2, true, true, true)
 		s.ErrorIs(err, errNoID)
-	})
-
-	s.Run("not airflow 2", func() {
-		err := Export("id", "", 1, true, true, true)
-		s.Contains(err.Error(), "Command must be used with Airflow 2.X")
 	})
 }
 

--- a/settings/testfiles/airflow_settings_export.yaml
+++ b/settings/testfiles/airflow_settings_export.yaml
@@ -1,23 +1,23 @@
 airflow:
-  connections:
-  - conn_id: local_postgres
-    conn_type: postgres
-    conn_host: example.db.example.com
-    conn_schema: schema
-    conn_login: username
-    conn_password: password
-    conn_port: 5432
-    conn_uri: ""
-    conn_extra: {}
-  pools:
-  - pool_name: pool_name
-    pool_slot: 3
-    pool_description: pool_desc
-  - pool_name: default_pool
-    pool_slot: 128
-    pool_description: Default pool
-  variables:
-  - variable_name: email_list
-    variable_value: test@test.com
-  - variable_name: myvar
-    variable_value: myval
+    connections:
+        - conn_id: local_postgres
+          conn_type: postgres
+          conn_host: example.db.example.com
+          conn_schema: schema
+          conn_login: username
+          conn_password: password
+          conn_port: 5432
+          conn_uri: ""
+          conn_extra: {}
+    pools:
+        - pool_name: pool_name
+          pool_slot: 3
+          pool_description: pool_desc
+        - pool_name: default_pool
+          pool_slot: 128
+          pool_description: Default pool
+    variables:
+        - variable_name: email_list
+          variable_value: test@test.com
+        - variable_name: myvar
+          variable_value: myval


### PR DESCRIPTION
## Description

This change fixes a confusing behavior where the CLI will silently not load connections from the specified Astro deployment or workspace if the CLI settings file (default `airflow_settings.yaml`) is not present. The new behavior is to read Astro connections regardless of whether the settings file is present.

## 🧪 Functional Testing

- Unit tests added
- Manually tested locally

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
