### PR TITLE
Bump min requirement for AF2 to AF3 upgrade from 8.7 to 12.0

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -772,12 +772,12 @@ func ValidRuntimeVersion(currentVersion, tag string, deploymentOptionsRuntimeVer
 		return false
 	}
 
-	// If upgrading from Airflow 2 to Airflow 3, we require at least Runtime 8.7.0 (Airflow 2.6.3) and that the user has forced the upgrade
+	// If upgrading from Airflow 2 to Airflow 3, we require at least Runtime 12.0.0 (Airflow 2.10.0) and that the user has forced the upgrade
 	currentVersionAirflowMajorVersion := airflowversions.AirflowMajorVersionForRuntimeVersion(currentVersion)
 	tagAirflowMajorVersion := airflowversions.AirflowMajorVersionForRuntimeVersion(tag)
 	if currentVersionAirflowMajorVersion == "2" && tagAirflowMajorVersion == "3" {
-		if airflowversions.CompareRuntimeVersions(currentVersion, "8.7.0") < 0 {
-			fmt.Println("Can only upgrade deployment from Airflow 2 to Airflow 3 with deployment at Astro Runtime 8.7.0 or higher")
+		if airflowversions.CompareRuntimeVersions(currentVersion, "12.0.0") < 0 {
+			fmt.Println("Can only upgrade deployment from Airflow 2 to Airflow 3 with deployment at Astro Runtime 12.0.0 or higher")
 			return false
 		}
 		if !forceUpgradeToAF3 {

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -1091,25 +1091,25 @@ func TestValidRuntimeVersion(t *testing.T) {
 
 		// AF2 to AF3 upgrade cases
 		{
-			name:              "AF2 >= 8.7.0 to AF3 version with force flag is valid upgrade",
-			currentVersion:    "8.7.0",
+			name:              "AF2 >= 12.0.0 to AF3 version with force flag is valid upgrade",
+			currentVersion:    "12.0.0",
 			newVersion:        "3.0-1",
 			deploymentOptions: []string{"3.0-1"},
 			forceUpgradeToAF3: true,
 			expected:          true,
 		},
 		{
-			name:              "AF2 < 8.7.0 to AF3 version with force flag is invalid upgrade",
+			name:              "AF2 < 12.0.0 to AF3 version with force flag is invalid upgrade",
 			currentVersion:    "4.2.5",
 			newVersion:        "3.0-1",
 			deploymentOptions: []string{"3.0-1"},
 			forceUpgradeToAF3: true,
 			expected:          false,
-			expectedError:     "Can only upgrade deployment from Airflow 2 to Airflow 3 with deployment at Astro Runtime 8.7.0 or higher",
+			expectedError:     "Can only upgrade deployment from Airflow 2 to Airflow 3 with deployment at Astro Runtime 12.0.0 or higher",
 		},
 		{
-			name:              "AF2 >= 8.7.0 to AF3 version without force flag is invalid upgrade",
-			currentVersion:    "8.7.0",
+			name:              "AF2 >= 12.0.0 to AF3 version without force flag is invalid upgrade",
+			currentVersion:    "12.0.0",
 			newVersion:        "3.0-1",
 			deploymentOptions: []string{"3.0-1"},
 			forceUpgradeToAF3: false,


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Update the minimum version requirement for AF2 to AF3 upgrades from 8.7 to 12.0 to align with server-side validation in the next Astro Cloud release.

## 🎟 Issue(s)

Related https://github.com/astronomer/astro/issues/33454

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
