### PR TITLE
improve the dag server upload url flow

### DIFF
--- a/houston/constants.go
+++ b/houston/constants.go
@@ -16,7 +16,8 @@ const (
 	NoneRole             = "NONE"
 
 	// Deployment
-	AirflowURLType = "airflow"
+	AirflowURLType   = "airflow"
+	DagServerURLType = "dagserver"
 
 	CeleryExecutorType     = "CeleryExecutor"
 	LocalExecutorType      = "LocalExecutor"

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -428,7 +428,7 @@ func getDagDeployURL(deploymentInfo *houston.Deployment) string {
 		parsedAirflowURL, err := neturl.Parse(url.URL)
 		if err != nil {
 			logger.Infof("Error parsing airflow URL: %v", err)
-			continue
+			break
 		}
 
 		// Use URL scheme and host from the airflow URL

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -419,7 +419,7 @@ func getDagDeployURL(deploymentInfo *houston.Deployment) string {
 		}
 	}
 
-	// If no dagserver URL is found, it look for airflow URL
+	// If no dagserver URL is found, we look for airflow URL to detect upload url
 	for _, url := range deploymentInfo.Urls {
 		if url.Type == houston.AirflowURLType {
 			parsedURL, err := neturl.Parse(url.URL)
@@ -428,7 +428,7 @@ func getDagDeployURL(deploymentInfo *houston.Deployment) string {
 				continue
 			}
 
-			// Use just the scheme and host from the URL
+			// Use URL scheme and host from the airflow URL
 			uploadURL := fmt.Sprintf("%s://%s/%s/dags/upload", parsedURL.Scheme, parsedURL.Host, deploymentInfo.ReleaseName)
 			logger.Infof("Constructed URL from airflow base URL: %s", uploadURL)
 			return uploadURL

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -433,7 +433,7 @@ func getDagDeployURL(deploymentInfo *houston.Deployment) string {
 
 		// Use URL scheme and host from the airflow URL
 		dagUploadURL := fmt.Sprintf("https://%s/%s/dags/upload", parsedAirflowURL.Host, deploymentInfo.ReleaseName)
-		logger.Infof("Constructed URL from airflow base URL: %s", dagUploadURL)
+		logger.Infof("Generated Dag Upload URL from airflow base URL: %s", dagUploadURL)
 		return dagUploadURL
 	}
 	return ""

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -425,16 +425,16 @@ func getDagDeployURL(deploymentInfo *houston.Deployment) string {
 			continue
 		}
 
-		parsedURL, err := neturl.Parse(url.URL)
+		parsedAirflowURL, err := neturl.Parse(url.URL)
 		if err != nil {
 			logger.Infof("Error parsing airflow URL: %v", err)
 			continue
 		}
 
 		// Use URL scheme and host from the airflow URL
-		uploadURL := fmt.Sprintf("%s://%s/%s/dags/upload", parsedURL.Scheme, parsedURL.Host, deploymentInfo.ReleaseName)
-		logger.Infof("Constructed URL from airflow base URL: %s", uploadURL)
-		return uploadURL
+		dagUploadURL := fmt.Sprintf("https://%s/%s/dags/upload", parsedAirflowURL.Host, deploymentInfo.ReleaseName)
+		logger.Infof("Constructed URL from airflow base URL: %s", dagUploadURL)
+		return dagUploadURL
 	}
 	return ""
 }

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -411,15 +411,17 @@ func validateIfDagDeployURLCanBeConstructed(deploymentInfo *houston.Deployment) 
 }
 
 func getDagDeployURL(deploymentInfo *houston.Deployment) string {
-	// Running single loop to find either dag server or airflow URL
+	// Checks if dagserver URL exists and returns the URL
 	for _, url := range deploymentInfo.Urls {
-		switch url.Type {
-		case "dagserver":
-			// If we find dagserver URL, use it directly and return immediately
+		if url.Type == houston.DagServerURLType {
 			logger.Infof("Using dag deploy URL from dagserver: %s", url.URL)
 			return url.URL
-		default:
-			// Assuming no dag server upload URL is returned from api
+		}
+	}
+
+	// If no dagserver URL is found, it look for airflow URL
+	for _, url := range deploymentInfo.Urls {
+		if url.Type == houston.AirflowURLType {
 			parsedURL, err := neturl.Parse(url.URL)
 			if err != nil {
 				logger.Infof("Error parsing airflow URL: %v", err)

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -421,18 +421,20 @@ func getDagDeployURL(deploymentInfo *houston.Deployment) string {
 
 	// If no dagserver URL is found, we look for airflow URL to detect upload url
 	for _, url := range deploymentInfo.Urls {
-		if url.Type == houston.AirflowURLType {
-			parsedURL, err := neturl.Parse(url.URL)
-			if err != nil {
-				logger.Infof("Error parsing airflow URL: %v", err)
-				continue
-			}
-
-			// Use URL scheme and host from the airflow URL
-			uploadURL := fmt.Sprintf("%s://%s/%s/dags/upload", parsedURL.Scheme, parsedURL.Host, deploymentInfo.ReleaseName)
-			logger.Infof("Constructed URL from airflow base URL: %s", uploadURL)
-			return uploadURL
+		if url.Type != houston.AirflowURLType {
+			continue
 		}
+
+		parsedURL, err := neturl.Parse(url.URL)
+		if err != nil {
+			logger.Infof("Error parsing airflow URL: %v", err)
+			continue
+		}
+
+		// Use URL scheme and host from the airflow URL
+		uploadURL := fmt.Sprintf("%s://%s/%s/dags/upload", parsedURL.Scheme, parsedURL.Host, deploymentInfo.ReleaseName)
+		logger.Infof("Constructed URL from airflow base URL: %s", uploadURL)
+		return uploadURL
 	}
 	return ""
 }


### PR DESCRIPTION
## Description

Previously dag upload URL's were harded to fetch from the baseDomain, this will no longer work with 1.0 api and with this new change we look for dagserver url directly and if not exists it will reconstruct the url from airflow url in order to handle both old api version and new code changes

## 🎟 Issue(s)

- - https://github.com/astronomer/issues/issues/7743

## 🧪 Functional Testing

There is no change from the user prespective

astro deploy --dags will auto detect and use the upload url for respective clustered deployments

## 📸 Screenshots

with above code  changes it auto detects the url from deployments without needing to use hardcoded base domain from the config
<img width="1715" height="85" alt="image" src="https://github.com/user-attachments/assets/acb5404a-e667-4894-bb97-bccfb364bac5" />

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
