### PR TITLE
feat: enhance error messaging for environment secrets fetching permission

### DIFF
--- a/cloud/environment/environment_test.go
+++ b/cloud/environment/environment_test.go
@@ -1,6 +1,8 @@
 package environment
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -115,4 +117,83 @@ func (s *Suite) TestListConnections() {
 
 		mockClient.AssertExpectations(s.T())
 	})
+
+	s.Run("List connections handles secrets fetching error from listEnvironmentObjects", func() {
+		// This test focuses on verifying that the error detection logic works
+		// The integration will be tested end-to-end manually
+		secretsError := errors.New("showSecrets on organization with id someOrganization is not allowed")
+		result := isSecretsFetchingNotAllowedError(secretsError)
+		s.True(result)
+	})
+}
+
+func (s *Suite) TestIsSecretsFetchingNotAllowedError() {
+	testCases := []struct {
+		name        string
+		err         error
+		expectedResult bool
+	}{
+		{
+			"exact match", 
+			errors.New("showSecrets on organization with id clt4farh34gm801n753x80fo8 is not allowed"),
+			true,
+		},
+		{
+			"case insensitive match", 
+			errors.New("ShowSecrets on ORGANIZATION with id someId IS NOT ALLOWED"),
+			true,
+		},
+		{
+			"wrapped error with secrets error", 
+			fmt.Errorf("API error: %w", errors.New("showSecrets on organization with id test is not allowed")),
+			true,
+		},
+		{
+			"different organization error", 
+			errors.New("organization with id test not found"),
+			false,
+		},
+		{
+			"different secrets error", 
+			errors.New("secrets access denied"),
+			false,
+		},
+		{
+			"regular error", 
+			errors.New("network timeout"),
+			false,
+		},
+		{
+			"nil error", 
+			nil,
+			false,
+		},
+		{
+			"empty error", 
+			errors.New(""),
+			false,
+		},
+		{
+			"partial match - missing showSecrets", 
+			errors.New("organization with id test is not allowed"),
+			false,
+		},
+		{
+			"partial match - missing organization", 
+			errors.New("showSecrets with id test is not allowed"),
+			false,
+		},
+		{
+			"partial match - missing not allowed", 
+			errors.New("showSecrets on organization with id test is allowed"),
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			result := isSecretsFetchingNotAllowedError(tc.err)
+			s.Equal(tc.expectedResult, result, "Expected isSecretsFetchingNotAllowedError(%v) to be %v", tc.err, tc.expectedResult)
+		})
+	}
 }

--- a/cloud/environment/environment_test.go
+++ b/cloud/environment/environment_test.go
@@ -129,62 +129,62 @@ func (s *Suite) TestListConnections() {
 
 func (s *Suite) TestIsSecretsFetchingNotAllowedError() {
 	testCases := []struct {
-		name        string
-		err         error
+		name           string
+		err            error
 		expectedResult bool
 	}{
 		{
-			"exact match", 
+			"exact match",
 			errors.New("showSecrets on organization with id clt4farh34gm801n753x80fo8 is not allowed"),
 			true,
 		},
 		{
-			"case insensitive match", 
+			"case insensitive match",
 			errors.New("ShowSecrets on ORGANIZATION with id someId IS NOT ALLOWED"),
 			true,
 		},
 		{
-			"wrapped error with secrets error", 
+			"wrapped error with secrets error",
 			fmt.Errorf("API error: %w", errors.New("showSecrets on organization with id test is not allowed")),
 			true,
 		},
 		{
-			"different organization error", 
+			"different organization error",
 			errors.New("organization with id test not found"),
 			false,
 		},
 		{
-			"different secrets error", 
+			"different secrets error",
 			errors.New("secrets access denied"),
 			false,
 		},
 		{
-			"regular error", 
+			"regular error",
 			errors.New("network timeout"),
 			false,
 		},
 		{
-			"nil error", 
+			"nil error",
 			nil,
 			false,
 		},
 		{
-			"empty error", 
+			"empty error",
 			errors.New(""),
 			false,
 		},
 		{
-			"partial match - missing showSecrets", 
+			"partial match - missing showSecrets",
 			errors.New("organization with id test is not allowed"),
 			false,
 		},
 		{
-			"partial match - missing organization", 
+			"partial match - missing organization",
 			errors.New("showSecrets with id test is not allowed"),
 			false,
 		},
 		{
-			"partial match - missing not allowed", 
+			"partial match - missing not allowed",
 			errors.New("showSecrets on organization with id test is allowed"),
 			false,
 		},


### PR DESCRIPTION
## Problem

Users encountering environment secrets fetching permission errors during `astro dev start --deployment-id XXX` receive a cryptic error message that provides no actionable guidance for resolution.

**Current Error Message:**
```
Error: showSecrets on organization with id clt4farh34gm801n753x80fo8 is not allowed
```

This error occurs when the organization does not have "Environment Secrets Fetching" enabled in organization settings, but users have no way to understand what this means or how to resolve it.

## Solution

Enhanced error handling in the environment objects listing flow to detect secrets fetching permission errors and provide specific, actionable troubleshooting guidance. 

**New Error Message:**
```
Error: environment secrets fetching is not enabled for this organization.

To resolve this issue:
• Ask an organization administrator to enable "Environment Secrets Fetching" in organization settings
• Navigate to Organization Settings > General > Environment Secrets Fetching
• Toggle the setting to "Enabled"

This setting controls whether deployments can access organization environment secrets during local development.

Without this setting enabled, you can still use 'astro dev start' without the --deployment-id flag for local development.
```

## Technical Implementation

### Changes Made

**Enhanced Error Detection** (`cloud/environment/environment.go`):
- Added `isSecretsFetchingNotAllowedError()` helper function to detect API permission errors
- Enhanced `listEnvironmentObjects()` to intercept and transform secrets permission errors
- Implemented error chain checking to handle wrapped errors properly

**Comprehensive Testing** (`cloud/environment/environment_test.go`):
- Added `TestIsSecretsFetchingNotAllowedError()` with 11 test cases covering:
  - Exact error message matching
  - Case-insensitive matching
  - Wrapped error handling
  - False positive prevention
  - Edge cases (nil, empty errors)

### Error Detection Logic

The detection function checks for errors containing all three key components:
- "showsecrets" (case-insensitive)
- "organization" (case-insensitive) 
- "not allowed" (case-insensitive)

This ensures precise matching while avoiding false positives from other organization or secrets-related errors.

## Testing

### Unit Tests
```bash
go test -v ./cloud/environment
# All 16 test cases pass, including comprehensive error detection scenarios
```

### End-to-End Testing
Tested with real deployment ID that triggers the permission error:
```bash
./astro dev start --deployment-id cmf4jvuwd3a7u01p561iekhzn
# ✅ Enhanced error message displays correctly
# ✅ Provides clear actionable guidance
# ✅ Explains the setting location and purpose
```
<img width="1331" height="334" alt="Screenshot 2025-09-03 at 3 48 35 PM" src="https://github.com/user-attachments/assets/9438f030-eaae-44a8-9cb3-a3fcb14b4ef3" />
### Code Quality
- ✅ All linter checks pass (gofumpt, golangci-lint)
- ✅ Follows Go error handling conventions
- ✅ Maintains backward compatibility


This enhancement transforms a confusing technical error into helpful user guidance, improving the developer experience for users setting up local Airflow development with Astro deployments.
