### PR TITLE
feat(organization): add --workspace-id flag to org switch for non-interactive use

### DIFF
--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -206,8 +206,7 @@ func organizationSwitch(cmd *cobra.Command, out io.Writer, args []string) error 
 		organizationNameOrID = args[0]
 	}
 
-	err := orgSwitch(organizationNameOrID, astroCoreClient, platformCoreClient, out, shouldDisplayLoginLink)
-	if err != nil {
+	if err := orgSwitch(organizationNameOrID, astroCoreClient, platformCoreClient, out, shouldDisplayLoginLink); err != nil {
 		return err
 	}
 

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -12,6 +12,7 @@ import (
 	roleClient "github.com/astronomer/astro-cli/cloud/role"
 	"github.com/astronomer/astro-cli/cloud/team"
 	"github.com/astronomer/astro-cli/cloud/user"
+	"github.com/astronomer/astro-cli/cloud/workspace"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/printutil"
 	"github.com/spf13/cobra"
@@ -22,6 +23,7 @@ var (
 	orgList                            = organization.List
 	orgSwitch                          = organization.Switch
 	orgExportAuditLogs                 = organization.ExportAuditLogs
+	wsSwitch                           = workspace.Switch
 	orgName                            string
 	auditLogsOutputFilePath            string
 	auditLogsEarliestParam             int
@@ -93,7 +95,12 @@ func newOrganizationSwitchCmd(out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&shouldDisplayLoginLink, "login-link", "l", false, "Get login link to login on a separate device for organization switch")
+	cmd.Flags().BoolVarP(&shouldDisplayLoginLink, "login-link", "l", false,
+		"Get login link to login on a separate device for organization switch")
+
+	// 🔹 Add this new flag:
+	cmd.Flags().StringVarP(&workspaceID, "workspace-id", "w", "", "The Workspace's unique identifier")
+
 	return cmd
 }
 
@@ -202,7 +209,15 @@ func organizationSwitch(cmd *cobra.Command, out io.Writer, args []string) error 
 		organizationNameOrID = args[0]
 	}
 
-	return orgSwitch(organizationNameOrID, astroCoreClient, platformCoreClient, out, shouldDisplayLoginLink)
+	err := orgSwitch(organizationNameOrID, astroCoreClient, platformCoreClient, out, shouldDisplayLoginLink)
+	if err != nil {
+		return err
+	}
+
+	if workspaceID != "" {
+		return wsSwitch(workspaceID, astroCoreClient, out)
+	}
+	return nil
 }
 
 func organizationExportAuditLogs(cmd *cobra.Command) error {

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -95,10 +95,7 @@ func newOrganizationSwitchCmd(out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&shouldDisplayLoginLink, "login-link", "l", false,
-		"Get login link to login on a separate device for organization switch")
-
-	// 🔹 Add this new flag:
+	cmd.Flags().BoolVarP(&shouldDisplayLoginLink, "login-link", "l", false, "Get login link to login on a separate device for organization switch")
 	cmd.Flags().StringVarP(&workspaceID, "workspace-id", "w", "", "The Workspace's unique identifier")
 
 	return cmd

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -83,13 +83,27 @@ func TestOrganizationList(t *testing.T) {
 }
 
 func TestOrganizationSwitch(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
 	orgSwitch = func(orgName string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 		return nil
 	}
 
-	cmdArgs := []string{"switch"}
+	called := false
+	gotID := ""
+	origWsSwitch := wsSwitch
+	wsSwitch = func(id string, client astrocore.CoreClient, out io.Writer) error {
+		called = true
+		gotID = id
+		return nil
+	}
+	defer func() { wsSwitch = origWsSwitch }()
+
+	cmdArgs := []string{"switch", "-w", "ws-test-id"}
 	_, err := execOrganizationCmd(cmdArgs...)
 	assert.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "ws-test-id", gotID)
 }
 
 func TestOrganizationExportAuditLogs(t *testing.T) {

--- a/cmd/cloud/organization_test.go
+++ b/cmd/cloud/organization_test.go
@@ -83,27 +83,55 @@ func TestOrganizationList(t *testing.T) {
 }
 
 func TestOrganizationSwitch(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	t.Run("workspace flag triggers wsSwitch with provided id", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
 
-	orgSwitch = func(orgName string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
-		return nil
-	}
+		origOrgSwitch := orgSwitch
+		orgSwitch = func(orgName string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+			return nil
+		}
+		defer func() { orgSwitch = origOrgSwitch }()
 
-	called := false
-	gotID := ""
-	origWsSwitch := wsSwitch
-	wsSwitch = func(id string, client astrocore.CoreClient, out io.Writer) error {
-		called = true
-		gotID = id
-		return nil
-	}
-	defer func() { wsSwitch = origWsSwitch }()
+		called := false
+		gotID := ""
+		origWsSwitch := wsSwitch
+		wsSwitch = func(id string, client astrocore.CoreClient, out io.Writer) error {
+			called = true
+			gotID = id
+			return nil
+		}
+		defer func() { wsSwitch = origWsSwitch }()
 
-	cmdArgs := []string{"switch", "-w", "ws-test-id"}
-	_, err := execOrganizationCmd(cmdArgs...)
-	assert.NoError(t, err)
-	assert.True(t, called)
-	assert.Equal(t, "ws-test-id", gotID)
+		cmdArgs := []string{"switch", "-w", "ws-test-id"}
+		_, err := execOrganizationCmd(cmdArgs...)
+		assert.NoError(t, err)
+		assert.True(t, called)
+		assert.Equal(t, "ws-test-id", gotID)
+	})
+
+	t.Run("orgSwitch error propagates and wsSwitch not called", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+		expectedErr := fmt.Errorf("org switch failed")
+
+		origOrgSwitch := orgSwitch
+		orgSwitch = func(orgName string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+			return expectedErr
+		}
+		defer func() { orgSwitch = origOrgSwitch }()
+
+		calledWs := false
+		origWsSwitch := wsSwitch
+		wsSwitch = func(id string, client astrocore.CoreClient, out io.Writer) error {
+			calledWs = true
+			return nil
+		}
+		defer func() { wsSwitch = origWsSwitch }()
+
+		_, err := execOrganizationCmd("switch", "-w", "ws-test-id")
+		assert.ErrorIs(t, err, expectedErr)
+		assert.False(t, calledWs)
+	})
 }
 
 func TestOrganizationExportAuditLogs(t *testing.T) {


### PR DESCRIPTION
## Description
Add --workspace-id (-w) to astro organization switch to allow non-interactive workspace switching after changing org.

## 🎟 Issue(s)

Related #1805

## 🧪 Functional Testing

- astro organization switch <org-id> → still prompts if multiple workspaces.
- astro organization switch <org-id> --workspace-id <ws-id> → switches org and workspace without prompt.
- Verified via unit tests (TestOrganizationSwitch).

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
