### PR TITLE
fix-1909: handle default_pool updates with slots/include_deferred mask

### DIFF
--- a/airflow-client/airflow-client.go
+++ b/airflow-client/airflow-client.go
@@ -181,21 +181,13 @@ func (c *HTTPClient) CreatePool(airflowURL string, pool Pool) error {
 }
 
 func (c *HTTPClient) UpdatePool(airflowURL string, pool Pool) error {
-	payload := interface{}(pool)
 	path := fmt.Sprintf("https://%s/pools/%s", airflowURL, pool.Name)
 
 	if pool.Name == "default_pool" {
-		payload = struct {
-			Slots           int  `json:"slots"`
-			IncludeDeferred bool `json:"include_deferred"`
-		}{
-			Slots:           pool.Slots,
-			IncludeDeferred: pool.IncludeDeferred,
-		}
 		path += "?update_mask=slots&update_mask=include_deferred"
 	}
 
-	varJSON, err := json.Marshal(payload)
+	varJSON, err := json.Marshal(pool)
 	if err != nil {
 		return err
 	}

--- a/airflow-client/airflow-client.go
+++ b/airflow-client/airflow-client.go
@@ -183,6 +183,7 @@ func (c *HTTPClient) CreatePool(airflowURL string, pool Pool) error {
 func (c *HTTPClient) UpdatePool(airflowURL string, pool Pool) error {
 	path := fmt.Sprintf("https://%s/pools/%s", airflowURL, pool.Name)
 
+        // default pool does not allow updating other fields, such as description
 	if pool.Name == "default_pool" {
 		path += "?update_mask=slots&update_mask=include_deferred"
 	}

--- a/airflow-client/airflow-client.go
+++ b/airflow-client/airflow-client.go
@@ -183,7 +183,7 @@ func (c *HTTPClient) CreatePool(airflowURL string, pool Pool) error {
 func (c *HTTPClient) UpdatePool(airflowURL string, pool Pool) error {
 	path := fmt.Sprintf("https://%s/pools/%s", airflowURL, pool.Name)
 
-        // default pool does not allow updating other fields, such as description
+	// default pool does not allow updating other fields, such as description
 	if pool.Name == "default_pool" {
 		path += "?update_mask=slots&update_mask=include_deferred"
 	}

--- a/airflow-client/airflow-client_test.go
+++ b/airflow-client/airflow-client_test.go
@@ -592,6 +592,8 @@ func (s *Suite) TestUpdatePool() {
 			Slots:           64,
 			IncludeDeferred: true,
 		}
+		defaultPoolJSON, err := json.Marshal(defaultPool)
+		s.NoError(err)
 		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
 			s.Equal("PATCH", req.Method)
 			expectedURL := "https://test-airflow-url/pools/default_pool?update_mask=slots&update_mask=include_deferred"
@@ -600,15 +602,7 @@ func (s *Suite) TestUpdatePool() {
 
 			reqBody, err := io.ReadAll(req.Body)
 			s.NoError(err)
-
-			var body map[string]interface{}
-			err = json.Unmarshal(reqBody, &body)
-			s.NoError(err)
-
-			s.Equal(map[string]interface{}{
-				"slots":            float64(defaultPool.Slots),
-				"include_deferred": defaultPool.IncludeDeferred,
-			}, body)
+			s.Equal(defaultPoolJSON, reqBody)
 
 			return &http.Response{
 				StatusCode: 200,
@@ -618,7 +612,7 @@ func (s *Suite) TestUpdatePool() {
 		})
 		airflowClient := NewAirflowClient(client)
 
-		err := airflowClient.UpdatePool("test-airflow-url", defaultPool)
+		err = airflowClient.UpdatePool("test-airflow-url", defaultPool)
 		s.NoError(err)
 	})
 


### PR DESCRIPTION
## Description

- Update Airflow client to respect `default_pool` PATCH rules: send only `slots` and `include_deferred` with an update_mask.
- Added a regression test so future changes keep the special-case behavior intact.


## 🎟 Issue(s)

Related https://github.com/astronomer/astro-cli/issues/1909

## 🧪 Functional Testing
Tried copying pool with different slot values and number of pools and each request was successful. Attached screenshots from UI. 
```
./astro deployment pool copy --source-id cme0XXXXXX --target-id cme0XXXXXX

Using an Astro API Token
Copying Pool default_pool
Copying Pool test-pool
Copying Pool second_pool
==============
./astro deployment pool copy --source-id cme0XXXXXX --target-id cme0XXXXXX

Using an Astro API Token
Copying Pool default_pool
Copying Pool test-pool
Copying Pool second_pool
Copying Pool Fourth-pool

````

```
go test -count=1 ./airflow-client
ok  	github.com/astronomer/astro-cli/airflow-client	0.667s
```

## 📸 Screenshots
Confirmed from UI that the default pool slot value is being updated and reflected without any errors. 
<img width="1720" height="684" alt="image" src="https://github.com/user-attachments/assets/2b74c2fc-a9d5-4452-8f95-1ad353b0c60a" />

<img width="1728" height="840" alt="image" src="https://github.com/user-attachments/assets/d2746844-5376-4211-81c2-275b02f2e920" />

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer] (https://github.com/astronomer/astronomer/) (if necessary). - NA
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/) - NA
