### PR TITLE
astro deployment inspect fails to return configuration.cluster_id for…

### DIFF
--- a/cloud/deployment/inspect/inspect_test.go
+++ b/cloud/deployment/inspect/inspect_test.go
@@ -343,7 +343,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "configuration.cluster_name", false, false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "deployment.configuration.cluster_name", false, false)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), *deploymentResponse.ClusterName)
 		mockCoreClient.AssertExpectations(t)
@@ -452,7 +452,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "configuration.workload_identity", false, false)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "deployment.configuration.workload_identity", false, false)
 		assert.ErrorIs(t, err, errKeyNotFound)
 		assert.Equal(t, out.String(), "")
 		mockCoreClient.AssertExpectations(t)
@@ -465,7 +465,7 @@ func TestInspect(t *testing.T) {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "configuration.workload_identity", false, true)
+		err := Inspect(workspaceID, "", deploymentID, "yaml", mockPlatformCoreClient, mockCoreClient, out, "deployment.configuration.workload_identity", false, true)
 		assert.NoError(t, err)
 		assert.Contains(t, out.String(), workloadIdentity)
 		mockCoreClient.AssertExpectations(t)
@@ -1233,55 +1233,55 @@ func TestGetSpecificField(t *testing.T) {
 		},
 	}
 	t.Run("returns a value if key is found in deployment.metadata", func(t *testing.T) {
-		requestedField := "metadata.workspace_id"
+		requestedField := "deployment.metadata.workspace_id"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, sourceDeployment.WorkspaceId, actual)
 	})
 	t.Run("returns a value if key is found in deployment.configuration", func(t *testing.T) {
-		requestedField := "configuration.scheduler_count"
+		requestedField := "deployment.configuration.scheduler_count"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, sourceDeployment.SchedulerReplicas, actual)
 	})
 	t.Run("returns a value if key is alert_emails", func(t *testing.T) {
-		requestedField := "alert_emails"
+		requestedField := "deployment.alert_emails"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, sourceDeployment.ContactEmails, actual)
 	})
 	t.Run("returns a value if key is environment_variables", func(t *testing.T) {
-		requestedField := "environment_variables"
+		requestedField := "deployment.environment_variables"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, getVariablesMap(*sourceDeployment.EnvironmentVariables), actual)
 	})
 	t.Run("returns a value if key is worker_queues", func(t *testing.T) {
-		requestedField := "worker_queues"
+		requestedField := "deployment.worker_queues"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, getQMap(&sourceDeployment, nodePools), actual)
 	})
 	t.Run("returns a value if key is hibernation_schedules", func(t *testing.T) {
-		requestedField := "hibernation_schedules"
+		requestedField := "deployment.hibernation_schedules"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, getHibernationSchedulesMap(*sourceDeployment.ScalingSpec.HibernationSpec.Schedules), actual)
 	})
 	t.Run("returns a value if key is metadata", func(t *testing.T) {
-		requestedField := "metadata"
+		requestedField := "deployment.metadata"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, info, actual)
 	})
 	t.Run("returns value regardless of upper or lower case key", func(t *testing.T) {
-		requestedField := "Configuration.Cluster_NAME"
+		requestedField := "deployment.Configuration.Cluster_NAME"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, *sourceDeployment.ClusterName, actual)
 	})
 	t.Run("returns correct boolean value", func(t *testing.T) {
-		requestedField := "configuration.is_development_mode"
+		requestedField := "deployment.configuration.is_development_mode"
 		actual, err := getSpecificField(printableDeployment, requestedField)
 		assert.NoError(t, err)
 		assert.Equal(t, *sourceDeployment.IsDevelopmentMode, actual)
@@ -1443,7 +1443,7 @@ func TestReturnSpecifiedValue(t *testing.T) {
 	t.Run("run function successfully", func(t *testing.T) {
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		value, err := ReturnSpecifiedValue(&sourceDeployment, "configuration.name", mockPlatformCoreClient)
+		value, err := ReturnSpecifiedValue(&sourceDeployment, "deployment.configuration.name", mockPlatformCoreClient)
 		assert.NoError(t, err)
 		assert.Contains(t, value, deploymentName)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -1453,7 +1453,7 @@ func TestReturnSpecifiedValue(t *testing.T) {
 		clusterErr := errors.New("test cluster error")
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, clusterErr).Once()
 
-		_, err := ReturnSpecifiedValue(&sourceDeployment, "configuration.name", mockPlatformCoreClient)
+		_, err := ReturnSpecifiedValue(&sourceDeployment, "deployment.configuration.name", mockPlatformCoreClient)
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "test cluster error")
 		mockPlatformCoreClient.AssertExpectations(t)

--- a/cmd/cloud/deployment_inspect.go
+++ b/cmd/cloud/deployment_inspect.go
@@ -29,7 +29,7 @@ func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to inspect.")
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "yaml", "Output format can be one of: yaml or json. By default the inspected deployment will be in YAML format.")
 	cmd.Flags().BoolVarP(&template, "template", "t", false, "Create a template from the deployment being inspected.")
-	cmd.Flags().StringVarP(&requestedField, "key", "k", "", "A specific key for the deployment. Use --key configuration.cluster_id to get a deployment's cluster id.")
+	cmd.Flags().StringVarP(&requestedField, "key", "k", "", "A specific key for the deployment. Use --key deployment.configuration.cluster_id to get a deployment's cluster id.")
 	cmd.Flags().BoolVarP(&cleanOutput, "clean-output", "c", false, "clean output to only include inspect yaml or json file in any situation.")
 	cmd.Flags().BoolVarP(&showWorkloadIdentity, "show-workload-identity", "", false, "Include the workload identity configured for the deployment in the output.")
 	return cmd

--- a/cmd/cloud/deployment_inspect_test.go
+++ b/cmd/cloud/deployment_inspect_test.go
@@ -62,7 +62,7 @@ func TestNewDeploymentInspectCmd(t *testing.T) {
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
-		cmdArgs := []string{"inspect", "-n", "test", "-k", "metadata.cluster_id"}
+		cmdArgs := []string{"inspect", "-n", "test", "-k", "deployment.metadata.cluster_id"}
 		_, err := execDeploymentCmd(cmdArgs...)
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)

--- a/cmd/cloud/deployment_objects.go
+++ b/cmd/cloud/deployment_objects.go
@@ -33,7 +33,7 @@ var (
 )
 
 const (
-	webserverURLField        = "metadata.airflow_api_url"
+	webserverURLField        = "deployment.metadata.airflow_api_url"
 	warningConnectionCopyCMD = "WARNING! The password and extra field are not copied over. You will need to manually add these values"
 	warningVariableCopyCMD   = "WARNING! Secret values are not copied over. You will need to manually add these values"
 )

--- a/houston/types.go
+++ b/houston/types.go
@@ -323,7 +323,7 @@ func (config *DeploymentConfig) GetValidTags(tag string) (tags []string) {
 	// if tag doesn't follow the semver standard return empty array
 	if err != nil {
 		fmt.Println(err)
-		return
+		return tags
 	}
 
 	for _, image := range config.AirflowImages {
@@ -336,7 +336,7 @@ func (config *DeploymentConfig) GetValidTags(tag string) (tags []string) {
 			tags = append(tags, image.Tag)
 		}
 	}
-	return
+	return tags
 }
 
 func (config *DeploymentConfig) IsValidTag(tag string) bool {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -141,5 +141,5 @@ func Filter[T any](ss []T, test func(T) bool) (ret []T) {
 			ret = append(ret, s)
 		}
 	}
-	return
+	return ret
 }


### PR DESCRIPTION
… Dedicated deployments

## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
