### PR TITLE
Add "REMOTE EXECUTION" column to deployment tables

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -76,7 +76,7 @@ func newTableOut() *printutil.Table {
 	return &printutil.Table{
 		Padding:        []int{30, 50, 10, 50, 10, 10, 10},
 		DynamicPadding: true,
-		Header:         []string{"NAME", "NAMESPACE", "CLUSTER", "CLOUD PROVIDER", "REGION", "DEPLOYMENT ID", "RUNTIME VERSION", "DAG DEPLOY ENABLED", "CI-CD ENFORCEMENT", "DEPLOYMENT TYPE"},
+		Header:         []string{"NAME", "NAMESPACE", "CLUSTER", "CLOUD PROVIDER", "REGION", "DEPLOYMENT ID", "RUNTIME VERSION", "DAG DEPLOY ENABLED", "CI-CD ENFORCEMENT", "DEPLOYMENT TYPE", "REMOTE EXECUTION"},
 	}
 }
 
@@ -84,7 +84,7 @@ func newTableOutAll() *printutil.Table {
 	return &printutil.Table{
 		Padding:        []int{30, 50, 10, 50, 10, 10, 10},
 		DynamicPadding: true,
-		Header:         []string{"NAME", "WORKSPACE", "NAMESPACE", "CLUSTER", "CLOUD PROVIDER", "REGION", "DEPLOYMENT ID", "RUNTIME VERSION", "DAG DEPLOY ENABLED", "CI-CD ENFORCEMENT", "DEPLOYMENT TYPE"},
+		Header:         []string{"NAME", "WORKSPACE", "NAMESPACE", "CLUSTER", "CLOUD PROVIDER", "REGION", "DEPLOYMENT ID", "RUNTIME VERSION", "DAG DEPLOY ENABLED", "CI-CD ENFORCEMENT", "DEPLOYMENT TYPE", "REMOTE EXECUTION"},
 	}
 }
 
@@ -593,6 +593,7 @@ func deploymentToTableRow(table *printutil.Table, d *astroplatformcore.Deploymen
 	if !IsDeploymentStandard(*d.Type) {
 		clusterName = *d.ClusterName
 	}
+	isRemoteExecutionEnabled := IsRemoteExecutionEnabled(d)
 	cols := []string{
 		d.Name,
 		releaseName,
@@ -604,6 +605,7 @@ func deploymentToTableRow(table *printutil.Table, d *astroplatformcore.Deploymen
 		strconv.FormatBool(d.IsDagDeployEnabled),
 		strconv.FormatBool(d.IsCicdEnforced),
 		string(*d.Type),
+		strconv.FormatBool(isRemoteExecutionEnabled),
 	}
 	if includeWorkspaceName {
 		cols = slices.Insert(cols, 1, *d.WorkspaceName)


### PR DESCRIPTION
## Description

Add remote execution status col to deployment display table

## 🎟 Issue(s)

Related #1897

## 🧪 Functional Testing

```bash
./astro deployment create -n "test_cli_remote_execution_create_3"  --remote-execution-enabled --executor Astro --type dedicated 

Current Workspace: roni


Please select a Cluster for your Deployment:
 #     CLUSTER NAME             CLOUD PROVIDER     CLUSTER ID                    
 1     Astro Agent CI_DND       AZURE              cmbjc2euc03ak01nlfpy5xtwr     
 2     airflow3-testing_DND     AZURE              cm4sauxuo03ig01rfux2aun5d     

> 2
 NAME                                   NAMESPACE                 CLUSTER                  CLOUD PROVIDER     REGION      DEPLOYMENT ID                 RUNTIME VERSION                    DAG DEPLOY ENABLED     CI-CD ENFORCEMENT     DEPLOYMENT TYPE     REMOTE EXECUTION     
 test_cli_remote_execution_create_3     uniform-buoyancy-7912     airflow3-testing_DND     AZURE              westus2     cmgguhtpl011501owe9woezt9     3.1-1 (based on Airflow 3.1.0)     false                  false                 DEDICATED           true                 

 Successfully created Deployment: test_cli_remote_execution_create_3
 Deployment can be accessed at the following URLs 

 Deployment Dashboard: cloud.astronomer-dev.io/cmfvjgjhv00hg01qj5115yydj/deployments/cmgguhtpl011501owe9woezt9
 Airflow Dashboard: clztuyh0a01z701mwxjahsza2.astronomer-dev.run/d9woezt9
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
