### PR TITLE
Enhance deploy command docs to clarify behavior for RE deployments

### DIFF
--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -51,7 +51,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "deploy DEPLOYMENT-ID",
 		Short:   "Deploy your project to a Deployment on Astro",
-		Long:    "Deploy your project to a Deployment on Astro. This command bundles your project files into a Docker image and pushes that Docker image to Astronomer. It does not include any metadata associated with your local Airflow environment.",
+		Long:    "Deploy your project to a Deployment on Astro. This command bundles your project files into a Docker image and pushes that Docker image to Astronomer. In Deployments with Remote Execution enabled, this only updates the Orchestration Plane components (the API Server and Scheduler). For all other components, use `astro remote deploy` instead. It does not include any metadata associated with your local Airflow environment.",
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: EnsureProjectDir,
 		RunE:    deploy,


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

This pull request updates the help text for the `deploy` command to clarify its behavior when Remote Execution is enabled. The new description explains that, in such cases, only certain components are updated, and users should use a different command for other components.

- **Command documentation update:**
  * Updated the `Long` description in `cmd/cloud/deploy.go` to clarify that when Remote Execution is enabled, `deploy` only updates the Orchestration Plane components (API Server and Scheduler), and instructs users to use `astro remote deploy` for all other components.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
