### PR TITLE
Add feature flag for new remote command

### DIFF
--- a/cmd/cloud/root.go
+++ b/cmd/cloud/root.go
@@ -7,6 +7,7 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroiamcore "github.com/astronomer/astro-cli/astro-client-iam-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	"github.com/astronomer/astro-cli/config"
 	"github.com/spf13/cobra"
 )
 
@@ -23,13 +24,16 @@ func AddCmds(astroPlatformCoreClient astroplatformcore.CoreClient, coreClient as
 	platformCoreClient = astroPlatformCoreClient
 	astroCoreIamClient = iamCoreClient
 	airflowAPIClient = airflowClient
-	return []*cobra.Command{
+	cmds := []*cobra.Command{
 		NewDeployCmd(),
 		newDeploymentRootCmd(out),
 		newWorkspaceCmd(out),
 		newOrganizationCmd(out),
 		newDbtCmd(),
 		newIDECommand(out),
-		newRemoteRootCmd(),
 	}
+	if config.CFG.RemoteCmd.GetBool() {
+		cmds = append(cmds, newRemoteRootCmd())
+	}
+	return cmds
 }

--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,7 @@ var (
 		RuffImage:               newCfg("ruff.image", "ghcr.io/astral-sh/ruff:latest"),
 		RemoteClientRegistry:    newCfg("remote.client_registry", ""),
 		RemoteBaseImageRegistry: newCfg("remote.base_image_registry", "images.astronomer.cloud"),
+		RemoteCmd:               newCfg("beta.remote_cmd", "false"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/types.go
+++ b/config/types.go
@@ -51,6 +51,7 @@ type cfgs struct {
 	RuffImage               cfg
 	RemoteClientRegistry    cfg
 	RemoteBaseImageRegistry cfg
+	RemoteCmd               cfg
 }
 
 // Creates a new cfg struct


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

This pull request introduces a new feature flag to conditionally enable the Remote command in the CLI. The flag is implemented as a configuration option and is used to control whether the Remote command is included in the available commands at runtime.

Feature flag addition and usage:

* Added a new configuration option `beta.remote_cmd` (exposed as `RemoteCmd` in the config types) to enable or disable the Remote command. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R92) [[2]](diffhunk://#diff-19256ae4e3e5bb4f0fb4cc9023ae00f4636ac83ec481d2acaa42c968454cd807R54)
* Updated the command registration logic in `cmd/cloud/root.go` to append the Remote command only if the `RemoteCmd` config flag is set to true.
* Imported the `config` package in `cmd/cloud/root.go` to access the new configuration flag.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

```
❯ ./astro config set -g beta.remote_cmd false
Setting beta.remote_cmd to false successfully

❯ ./astro remote
Error: unknown command "remote" for "astro"
Run 'astro --help' for usage.

❯ ./astro config set -g beta.remote_cmd true
Setting beta.remote_cmd to true successfully

❯ ./astro remote
Commands for interacting with remote registries and deploying client images

Current Context: Astro

Usage:
  astro remote [command]

Available Commands:
  deploy      Deploy a client image to the remote registry

Flags:
  -h, --help   help for remote

Global Flags:
      --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "warning")

Use "astro remote [command] --help" for more information about a command.
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
