### PR TITLE
Fix remote deployment status text on update

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -1246,8 +1246,8 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		if !IsDeploymentStandard(*d.Type) {
 			clusterName = *d.ClusterName
 		}
-		isRemoteExecutionEnabled := IsRemoteExecutionEnabled(d)
-		tabDeployment.AddRow([]string{d.Name, releaseName, clusterName, cloudProvider, region, d.Id, runtimeVersionText, strconv.FormatBool(d.IsDagDeployEnabled), strconv.FormatBool(d.IsCicdEnforced), string(*d.Type)}, false, strconv.FormatBool(isRemoteExecutionEnabled))
+		isRemoteExecutionEnabled := IsRemoteExecutionEnabled(&d)
+		tabDeployment.AddRow([]string{d.Name, releaseName, clusterName, cloudProvider, region, d.Id, runtimeVersionText, strconv.FormatBool(d.IsDagDeployEnabled), strconv.FormatBool(d.IsCicdEnforced), string(*d.Type), strconv.FormatBool(isRemoteExecutionEnabled)}, false)
 		tabDeployment.SuccessMsg = "\n Successfully updated Deployment"
 		tabDeployment.Print(os.Stdout)
 	}


### PR DESCRIPTION
## Description
It fixes remote execution status text on deployment update

## 🎟 Issue(s)

Related #1959

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
