### PR TITLE
Add wait time flag instead of hardcoded timeouts

### DIFF
--- a/cloud/deploy/bundle.go
+++ b/cloud/deploy/bundle.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
@@ -25,6 +26,7 @@ type DeployBundleInput struct {
 	BundleType         string
 	Description        string
 	Wait               bool
+	WaitTime           time.Duration
 	PlatformCoreClient astroplatformcore.CoreClient
 	CoreClient         astrocore.CoreClient
 }
@@ -85,7 +87,7 @@ func DeployBundle(input *DeployBundleInput) error {
 
 	// if requested, wait for the deploy to finish by polling the deployment until it is healthy
 	if input.Wait {
-		err = deployment.HealthPoll(currentDeployment.Id, currentDeployment.WorkspaceId, dagOnlyDeploySleepTime, tickNum, timeoutNum, input.PlatformCoreClient)
+		err = deployment.HealthPoll(currentDeployment.Id, currentDeployment.WorkspaceId, dagOnlyDeploySleepTime, tickNum, int(input.WaitTime.Seconds()), input.PlatformCoreClient)
 		if err != nil {
 			return err
 		}
@@ -101,6 +103,7 @@ type DeleteBundleInput struct {
 	BundleType         string
 	Description        string
 	Wait               bool
+	WaitTime           time.Duration
 	CoreClient         astrocore.CoreClient
 	PlatformCoreClient astroplatformcore.CoreClient
 }
@@ -132,7 +135,7 @@ func DeleteBundle(input *DeleteBundleInput) error {
 
 	// if requested, wait for the deploy to finish by polling the deployment until it is healthy
 	if input.Wait {
-		err = deployment.HealthPoll(input.DeploymentID, input.WorkspaceID, dagOnlyDeploySleepTime, tickNum, timeoutNum, input.PlatformCoreClient)
+		err = deployment.HealthPoll(input.DeploymentID, input.WorkspaceID, dagOnlyDeploySleepTime, tickNum, int(input.WaitTime.Seconds()), input.PlatformCoreClient)
 		if err != nil {
 			return err
 		}

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -75,7 +75,6 @@ var (
 	sleepTime              = 90
 	dagOnlyDeploySleepTime = 30
 	tickNum                = 10
-	timeoutNum             = 180
 )
 
 type deploymentInfo struct {
@@ -106,6 +105,7 @@ type InputDeploy struct {
 	Dags              bool
 	Image             bool
 	WaitForStatus     bool
+	WaitTime          time.Duration
 	DagsPath          string
 	Description       string
 	BuildSecretString string
@@ -307,7 +307,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 
 		if deployInput.WaitForStatus {
 			// Keeping wait timeout low since dag only deploy is faster
-			err = deployment.HealthPoll(deployInfo.deploymentID, deployInfo.workspaceID, dagOnlyDeploySleepTime, tickNum, timeoutNum, platformCoreClient)
+			err = deployment.HealthPoll(deployInfo.deploymentID, deployInfo.workspaceID, dagOnlyDeploySleepTime, tickNum, int(deployInput.WaitTime.Seconds()), platformCoreClient)
 			if err != nil {
 				return err
 			}
@@ -396,7 +396,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 		}
 
 		if deployInput.WaitForStatus {
-			err = deployment.HealthPoll(deployInfo.deploymentID, deployInfo.workspaceID, sleepTime, tickNum, timeoutNum, platformCoreClient)
+			err = deployment.HealthPoll(deployInfo.deploymentID, deployInfo.workspaceID, sleepTime, tickNum, int(deployInput.WaitTime.Seconds()), platformCoreClient)
 			if err != nil {
 				return err
 			}

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -255,7 +255,6 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 	deployInput.Pytest = ""
 	deployInput.WaitForStatus = true
 	sleepTime = 1
-	timeoutNum = 1
 	err = Deploy(deployInput, mockPlatformCoreClient, mockCoreClient)
 	assert.ErrorIs(t, err, deployment.ErrTimedOut)
 
@@ -356,7 +355,6 @@ func TestDeployOnRemoteExecutionDeployment(t *testing.T) {
 	deployInput.Pytest = ""
 	deployInput.WaitForStatus = true
 	sleepTime = 1
-	timeoutNum = 1
 	err = Deploy(deployInput, mockPlatformCoreClient, mockCoreClient)
 	assert.ErrorIs(t, err, deployment.ErrTimedOut)
 
@@ -611,7 +609,6 @@ func TestDagsDeploySuccess(t *testing.T) {
 	deployInput.Pytest = ""
 	deployInput.WaitForStatus = true
 	dagOnlyDeploySleepTime = 1
-	timeoutNum = 1
 	err = Deploy(deployInput, mockPlatformCoreClient, mockCoreClient)
 	assert.ErrorIs(t, err, deployment.ErrTimedOut)
 

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -470,7 +470,7 @@ func (s *Suite) TestGetDeployment() {
 			name, workspaceID, description, clusterID, runtimeVersion, dagDeploy, executor, cloudProvider, region, schedulerSize, highAvailability, developmentMode, cicdEnforcement,
 			defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string,
 			deploymentType astroplatformcore.DeploymentType, schedulerAU, schedulerReplicas int, remoteExecutionEnabled bool, allowedIpAddressRanges *[]string, taskLogBucket *string, taskLogURLPattern *string,
-			platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, waitForStatus bool,
+			platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, waitForStatus bool, waitTimeForDeployment time.Duration,
 		) error {
 			return errMock
 		}
@@ -501,7 +501,7 @@ func (s *Suite) TestGetDeployment() {
 		createDeployment = func(
 			label, workspaceID, description, clusterID, runtimeVersion, dagDeploy, executor, cloudProvider, region, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string,
 			deploymentType astroplatformcore.DeploymentType, schedulerAU, schedulerReplicas int, remoteExecutionEnabled bool, allowedIpAddressRanges *[]string, taskLogBucket *string, taskLogURLPattern *string,
-			platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, waitForStatus bool,
+			platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, waitForStatus bool, waitTimeForDeployment time.Duration,
 		) error {
 			return nil
 		}
@@ -536,7 +536,7 @@ func (s *Suite) TestGetDeployment() {
 			label, workspaceID, description, clusterID, runtimeVersion, dagDeploy, executor, cloudProvider, region, schedulerSize, highAvailability, developmentMode, cicdEnforcement,
 			defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string,
 			deploymentType astroplatformcore.DeploymentType, schedulerAU, schedulerReplicas int, remoteExecutionEnabled bool, allowedIpAddressRanges *[]string, taskLogBucket *string, taskLogURLPattern *string,
-			platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, waitForStatus bool,
+			platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, waitForStatus bool, waitTimeForDeployment time.Duration,
 		) error {
 			return nil
 		}
@@ -1010,7 +1010,7 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// Call the Create function
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1030,19 +1030,19 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// Call the Create function
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "extra_large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "extra_large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1062,7 +1062,7 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 
 		// Call the Create function with ci-cd enforcement enabled
-		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "enable", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "enable", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1080,7 +1080,7 @@ func (s *Suite) TestCreate() {
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 		// Call the Create function with development mode enabled
-		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "enable", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "enable", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1098,7 +1098,7 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 
 		// Call the Create function with deployment type as STANDARD, cloud provider, and region set
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1124,7 +1124,7 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 
 		// Call the Create function with a non-empty workload ID
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "", "", "", "", "", "", "", "", mockWorkloadIdentity, astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "", "", "", "", "", "", "", "", mockWorkloadIdentity, astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1149,7 +1149,7 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 
 		// Call the Create function with a non-empty workload ID
-		err := Create("test-name", ws, "test-desc", csID, "12.0.0", dagDeploy, CeleryExecutor, "aws", "us-west-2", strings.ToLower(string(astrocore.DeploymentSchedulerSizeSMALL)), "", "", "", "", "", "", "", mockWorkloadIdentity, astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "12.0.0", dagDeploy, CeleryExecutor, "aws", "us-west-2", strings.ToLower(string(astrocore.DeploymentSchedulerSizeSMALL)), "", "", "", "", "", "", "", mockWorkloadIdentity, astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1167,40 +1167,40 @@ func (s *Suite) TestCreate() {
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 		// Call the Create function with deployment type as STANDARD, cloud provider, and region set
-		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, AstroExecutor, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
-		s.NoError(err)
-
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KUBERNETES, gcpCloud,
-			"us-west-2", "large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, AstroExecutor, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KUBERNETES, gcpCloud,
-			"us-west-2", "extra_large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+			"us-west-2", "large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
+		s.NoError(err)
+
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KUBERNETES, gcpCloud,
+			"us-west-2", "extra_large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Call the Create function with deployment type as DEDICATED, cloud provider, and region set
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "us-west-2", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CELERY, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CELERY, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, AstroExecutor, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, AstroExecutor, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, ASTRO, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, ASTRO, azureCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", "large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", "large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", "extra_large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, gcpCloud, "us-west-2", "extra_large", "enable", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1219,7 +1219,7 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// Call the Create function with region selection
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "aws", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1240,7 +1240,7 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "2")()
 
 		// Call the Create function with Kube Executor
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, KubeExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1264,7 +1264,7 @@ func (s *Suite) TestCreate() {
 		TickNum = 2
 
 		// Call the Create function with Dedicated Deployment and wait for status
-		err := Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, AstroExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, true)
+		err := Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, AstroExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, true, 300*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1291,7 +1291,7 @@ func (s *Suite) TestCreate() {
 		allowedIPAddressRanges := []string{"1.2.3.4/32"}
 		taskLogBucket := "task-log-bucket"
 		taskLogURLPattern := "task-log-url-pattern"
-		err := Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, AstroExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, true, &allowedIPAddressRanges, &taskLogBucket, &taskLogURLPattern, mockPlatformCoreClient, mockCoreClient, true)
+		err := Create("test-name", ws, "test-desc", csID, "3.0-1", dagDeploy, AstroExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, true, &allowedIPAddressRanges, &taskLogBucket, &taskLogURLPattern, mockPlatformCoreClient, mockCoreClient, true, 300*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1316,7 +1316,7 @@ func (s *Suite) TestCreate() {
 		TickNum = 2
 
 		// Call the Create function with Dedicated Deployment and wait for status
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, true)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeDEDICATED, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, true, 300*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1336,7 +1336,7 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 
 		// Call the Create function with Hybrid Deployment that returns an error during creation
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.Error(err)
 		s.Contains(err.Error(), "failed to create deployment")
 
@@ -1350,7 +1350,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, errMock).Once()
 
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.ErrorIs(err, errMock)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1358,7 +1358,7 @@ func (s *Suite) TestCreate() {
 	s.Run("failed to get default options", func() {
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, errMock).Once()
 
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.ErrorIs(err, errMock)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1373,7 +1373,7 @@ func (s *Suite) TestCreate() {
 		defer testUtil.MockUserInput(s.T(), "invalid-cluster-choice")()
 
 		// Call the Create function and expect an error due to invalid cluster choice
-		err := Create("test-name", ws, "test-desc", "", "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", "", "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.Error(err)
 		s.Contains(err.Error(), "invalid Cluster selected")
 
@@ -1390,7 +1390,7 @@ func (s *Suite) TestCreate() {
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
 		// Call the Create function and expect an error due to invalid cluster choice
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 10, 10, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 10, 10, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.Error(err)
 		s.ErrorIs(err, ErrInvalidResourceRequest)
 
@@ -1404,7 +1404,7 @@ func (s *Suite) TestCreate() {
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Once()
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
 
-		err := Create("test-name", "wrong-workspace", "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", "wrong-workspace", "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.ErrorContains(err, "no Workspace with id")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1420,19 +1420,19 @@ func (s *Suite) TestCreate() {
 		// defer testUtil.MockUserInput(s.T(), "1")()
 
 		// Call the Create function
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "small", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "medium", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Call the Create function
-		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "extra_large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err = Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, awsCloud, "us-west-2", "extra_large", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeSTANDARD, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -1452,7 +1452,7 @@ func (s *Suite) TestCreate() {
 
 		defer testUtil.MockUserInput(s.T(), "test-name")()
 
-		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false)
+		err := Create("test-name", ws, "test-desc", csID, "4.2.5", dagDeploy, CeleryExecutor, "", "", "", "", "", "", "", "", "", "", "", astroplatformcore.DeploymentTypeHYBRID, 0, 0, false, nil, nil, nil, mockPlatformCoreClient, mockCoreClient, false, 0*time.Second)
 		s.NoError(err)
 
 		// Assert expectations
@@ -2250,26 +2250,26 @@ func (s *Suite) TestGetDeploymentURL() {
 	})
 }
 
-func (s *Suite) TestPrintWarning() {
-	s.Run("when KubernetesExecutor is requested", func() {
-		s.Run("returns true > 1 queues exist", func() {
-			actual := printWarning(KubeExecutor, 3)
-			s.True(actual)
-		})
-		s.Run("returns false if only 1 queue exists", func() {
-			actual := printWarning(KubeExecutor, 1)
-			s.False(actual)
-		})
-	})
-	s.Run("returns true when CeleryExecutor is requested", func() {
-		actual := printWarning(CeleryExecutor, 2)
-		s.True(actual)
-	})
-	s.Run("returns false for any other executor is requested", func() {
-		actual := printWarning("non-existent", 2)
-		s.False(actual)
-	})
-}
+// func (s *Suite) TestPrintWarning() {
+// 	s.Run("when KubernetesExecutor is requested", func() {
+// 		s.Run("returns true > 1 queues exist", func() {
+// 			actual := printWarning(KubeExecutor, 3)
+// 			s.True(actual)
+// 		})
+// 		s.Run("returns false if only 1 queue exists", func() {
+// 			actual := printWarning(KubeExecutor, 1)
+// 			s.False(actual)
+// 		})
+// 	})
+// 	s.Run("returns true when CeleryExecutor is requested", func() {
+// 		actual := printWarning(CeleryExecutor, 2)
+// 		s.True(actual)
+// 	})
+// 	s.Run("returns false for any other executor is requested", func() {
+// 		actual := printWarning("non-existent", 2)
+// 		s.False(actual)
+// 	})
+// }
 
 func (s *Suite) TestGetPlatformDeploymentOptions() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
@@ -52,7 +53,7 @@ const (
 // CreateOrUpdate takes a file and creates a deployment with the confiuration specified in the file.
 // inputFile can be in yaml or json format
 // It returns an error if any required information is missing or incorrectly specified.
-func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcore.CoreClient, coreClient astrocore.CoreClient, out io.Writer, waitForStatus bool) error { //nolint
+func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcore.CoreClient, coreClient astrocore.CoreClient, out io.Writer, waitForStatus bool, waitTime time.Duration) error { //nolint
 	var (
 		err                                           error
 		errHelp, clusterID, workspaceID, outputFormat string
@@ -127,7 +128,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 		}
 		// this deployment does not exist so create it
 		// transform formattedDeployment to DeploymentCreateInput
-		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, createAction, &astroplatformcore.Deployment{}, nodePools, dagDeploy, envVars, coreClient, astroPlatformCore, waitForStatus)
+		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, createAction, &astroplatformcore.Deployment{}, nodePools, dagDeploy, envVars, coreClient, astroPlatformCore, waitForStatus, waitTime)
 		if err != nil {
 			return err
 		}
@@ -170,7 +171,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 			return fmt.Errorf("%w \n failed to %s alert emails", err, action)
 		}
 		// transform formattedDeployment to DeploymentUpdateInput
-		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, dagDeploy, envVars, coreClient, astroPlatformCore, waitForStatus)
+		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, dagDeploy, envVars, coreClient, astroPlatformCore, waitForStatus, waitTime)
 		if err != nil {
 			return err
 		}
@@ -195,7 +196,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 // It returns an error if node pool id could not be found for the worker type.
 //
 //nolint:dupl
-func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astroplatformcore.Deployment, nodePools []astroplatformcore.NodePool, dagDeploy bool, envVars []astroplatformcore.DeploymentEnvironmentVariableRequest, coreClient astrocore.CoreClient, astroPlatformCore astroplatformcore.CoreClient, waitForStatus bool) error { //nolint
+func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astroplatformcore.Deployment, nodePools []astroplatformcore.NodePool, dagDeploy bool, envVars []astroplatformcore.DeploymentEnvironmentVariableRequest, coreClient astrocore.CoreClient, astroPlatformCore astroplatformcore.CoreClient, waitForStatus bool, waitTime time.Duration) error { //nolint
 	var (
 		defaultOptions          astroplatformcore.WorkerQueueOptions
 		configOptions           astroplatformcore.DeploymentOptions
@@ -498,7 +499,7 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				workspaceID,
 				deployment.SleepTime,
 				deployment.TickNum,
-				deployment.TimeoutNum,
+				int(waitTime.Seconds()),
 				astroPlatformCore,
 			)
 			if err != nil {

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
@@ -428,7 +429,7 @@ func (s *Suite) TestCreateOrUpdate() {
 	)
 
 	s.Run("returns an error if file does not exist", func() {
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second)
 		s.ErrorContains(err, "open deployment.yaml: no such file or directory")
 	})
 	s.Run("returns an error if file exists but user provides incorrect path", func() {
@@ -437,7 +438,7 @@ func (s *Suite) TestCreateOrUpdate() {
 		err = fileutil.WriteStringToFile(filePath, data)
 		s.NoError(err)
 		defer afero.NewOsFs().RemoveAll("./2")
-		err = CreateOrUpdate("1/deployment.yaml", "create", nil, nil, nil, false)
+		err = CreateOrUpdate("1/deployment.yaml", "create", nil, nil, nil, false, 0*time.Second)
 		s.ErrorContains(err, "open 1/deployment.yaml: no such file or directory")
 	})
 	s.Run("returns an error if file is empty", func() {
@@ -445,7 +446,7 @@ func (s *Suite) TestCreateOrUpdate() {
 		data = ""
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second)
 		s.ErrorIs(err, errEmptyFile)
 		s.ErrorContains(err, "deployment.yaml has no content")
 	})
@@ -454,7 +455,7 @@ func (s *Suite) TestCreateOrUpdate() {
 		data = "test"
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second)
 		s.ErrorContains(err, "error unmarshaling JSON:")
 	})
 	s.Run("returns an error if required fields are missing", func() {
@@ -509,7 +510,7 @@ deployment:
 `
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second)
 		s.ErrorContains(err, "missing required field: deployment.configuration.name")
 	})
 	s.Run("returns an error if getting context fails", func() {
@@ -570,7 +571,7 @@ deployment:
 
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorContains(err, "no context set")
 	})
 	s.Run("returns an error if cluster does not exist", func() {
@@ -631,7 +632,7 @@ deployment:
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorIs(err, errNotFound)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -693,7 +694,7 @@ deployment:
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, errTest).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorIs(err, errTest)
 	})
 	s.Run("returns an error if listing deployment fails", func() {
@@ -756,7 +757,7 @@ deployment:
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, errTest).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorIs(err, errTest)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -829,7 +830,7 @@ deployment:
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.NotNil(out)
 		mockCoreClient.AssertExpectations(s.T())
@@ -899,7 +900,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.NotNil(out)
 		mockCoreClient.AssertExpectations(s.T())
@@ -983,7 +984,7 @@ deployment:
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, errTest).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorIs(err, errTest)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1052,7 +1053,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1109,7 +1110,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1211,7 +1212,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, "test-deployment-id").Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1300,7 +1301,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, "test-deployment-id").Return(&deploymentResponseRemoteExecution, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1390,7 +1391,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "\"configuration\": {\n            \"name\": \"test-deployment-label\"")
 		s.Contains(out.String(), "\"metadata\": {\n            \"deployment_id\": \"test-deployment-id\"")
@@ -1490,7 +1491,7 @@ deployment:
 		)).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "\"configuration\": {\n            \"name\": \"test-deployment-label\"")
 		s.Contains(out.String(), "\"metadata\": {\n            \"deployment_id\": \"test-deployment-id\"")
@@ -1592,7 +1593,7 @@ deployment:
 		)).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "\"configuration\": {\n            \"name\": \"test-deployment-label\"")
 		s.Contains(out.String(), "\"metadata\": {\n            \"deployment_id\": \"test-deployment-id\"")
@@ -1658,7 +1659,7 @@ deployment:
 		defer afero.NewOsFs().Remove(filePath)
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&EmptyListWorkspacesResponseOK, errTest).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorIs(err, errTest)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1721,7 +1722,7 @@ deployment:
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(1)
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorContains(err, "deployment: test-deployment-label already exists: use deployment update --deployment-file deployment.yaml instead")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1800,7 +1801,7 @@ deployment:
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.Error(err)
 		s.ErrorContains(err, "worker queue option is invalid: worker concurrency")
 		mockCoreClient.AssertExpectations(s.T())
@@ -1885,7 +1886,7 @@ deployment:
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(1)
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, errCreateFailed).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorIs(err, errCreateFailed)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1952,7 +1953,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2008,7 +2009,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2096,7 +2097,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2181,7 +2182,7 @@ deployment:
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2260,7 +2261,7 @@ deployment:
 			return false
 		}
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		defer testUtil.MockUserInput(s.T(), "n")()
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
@@ -2344,7 +2345,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "test-deployment-label")
 		s.Contains(out.String(), "description 1")
@@ -2435,7 +2436,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2503,7 +2504,7 @@ deployment:
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorContains(err, "deployment: test-deployment-label does not exist: use deployment create --deployment-file deployment.yaml instead")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -2583,7 +2584,7 @@ deployment:
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(2)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.Error(err)
 		s.ErrorContains(err, "worker queue option is invalid: worker concurrency")
 		mockCoreClient.AssertExpectations(s.T())
@@ -2665,7 +2666,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, errUpdateFailed).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second)
 		s.ErrorIs(err, errUpdateFailed)
 		s.ErrorContains(err, "failed to update deployment with input")
 		mockCoreClient.AssertExpectations(s.T())
@@ -2706,13 +2707,11 @@ deployment:
 		origGet := deployment.CoreGetDeployment
 		origSleep := deployment.SleepTime
 		origTick := deployment.TickNum
-		origTimeout := deployment.TimeoutNum
 		defer func() {
 			deployment.CoreCreateDeployment = origCreate
 			deployment.CoreGetDeployment = origGet
 			deployment.SleepTime = origSleep
 			deployment.TickNum = origTick
-			deployment.TimeoutNum = origTimeout
 		}()
 
 		// Patch CoreCreateDeployment to return a stub deployment
@@ -2733,15 +2732,14 @@ deployment:
 		// Reduce wait timings so the test does not take long
 		deployment.SleepTime = 0
 		deployment.TickNum = 1
-		deployment.TimeoutNum = 3
 
 		// Build the FormattedDeployment from YAML
 		var fd inspect.FormattedDeployment
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		// Run createOrUpdateDeployment with waitForStatus=true
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true)
+		// Run createOrUpdateDeployment with waitForStatus=true, allow time for 2 polls
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true, 3*time.Second)
 		s.NoError(err)
 		s.Equal(2, callCount, "expected two polling iterations before becoming healthy")
 	})
@@ -2767,7 +2765,7 @@ deployment:
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, false)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, false, 0*time.Second)
 		s.NoError(err)
 		s.Equal(0, callCount, "expected no polling when waitForStatus is false")
 	})
@@ -2777,13 +2775,11 @@ deployment:
 		origGet := deployment.CoreGetDeployment
 		origSleep := deployment.SleepTime
 		origTick := deployment.TickNum
-		origTimeout := deployment.TimeoutNum
 		defer func() {
 			deployment.CoreCreateDeployment = origCreate
 			deployment.CoreGetDeployment = origGet
 			deployment.SleepTime = origSleep
 			deployment.TickNum = origTick
-			deployment.TimeoutNum = origTimeout
 		}()
 
 		deployment.CoreCreateDeployment = func(orgID string, req astroplatformcore.CreateDeploymentJSONRequestBody, pc astroplatformcore.CoreClient) (astroplatformcore.Deployment, error) {
@@ -2795,13 +2791,12 @@ deployment:
 		}
 		deployment.SleepTime = 0
 		deployment.TickNum = 1
-		deployment.TimeoutNum = 1
 
 		var fd inspect.FormattedDeployment
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true, 100*time.Millisecond)
 		s.ErrorIs(err, deployment.ErrTimedOut, "expected ErrTimedOut when deployment does not become healthy")
 	})
 
@@ -2810,13 +2805,11 @@ deployment:
 		origGet := deployment.CoreGetDeployment
 		origSleep := deployment.SleepTime
 		origTick := deployment.TickNum
-		origTimeout := deployment.TimeoutNum
 		defer func() {
 			deployment.CoreCreateDeployment = origCreate
 			deployment.CoreGetDeployment = origGet
 			deployment.SleepTime = origSleep
 			deployment.TickNum = origTick
-			deployment.TimeoutNum = origTimeout
 		}()
 
 		deployment.CoreCreateDeployment = func(orgID string, req astroplatformcore.CreateDeploymentJSONRequestBody, pc astroplatformcore.CoreClient) (astroplatformcore.Deployment, error) {
@@ -2829,13 +2822,12 @@ deployment:
 		}
 		deployment.SleepTime = 0
 		deployment.TickNum = 1
-		deployment.TimeoutNum = 2
 
 		var fd inspect.FormattedDeployment
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true, 3*time.Second)
 		s.ErrorIs(err, apiErr, "expected error returned from CoreGetDeployment to propagate")
 	})
 }
@@ -2894,7 +2886,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.ErrorContains(err, "worker_type: test-worker-8 does not exist in cluster: test-cluster")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -2940,7 +2932,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.ErrorContains(err, "worker queue option is invalid: min worker count")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -2986,7 +2978,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, errTest).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.ErrorIs(err, errTest)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3048,7 +3040,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3086,7 +3078,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.ErrorContains(err, "don't use 'worker_queues' to update default queue with KubernetesExecutor")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3103,7 +3095,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, nil, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, nil, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3133,7 +3125,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3199,7 +3191,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3235,7 +3227,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3256,7 +3248,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			Name:      "test-deployment",
 			ClusterId: &clusterID,
 		}
-		err = createOrUpdateDeployment(&deploymentFromFile, "diff-cluster", workspaceID, "update", &existingDeployment, nil, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, "diff-cluster", workspaceID, "update", &existingDeployment, nil, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.ErrorIs(err, errNotPermitted)
 		s.ErrorContains(err, "changing an existing deployment's cluster is not permitted")
 		mockCoreClient.AssertExpectations(s.T())
@@ -3296,7 +3288,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3337,7 +3329,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3387,7 +3379,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3437,7 +3429,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3511,7 +3503,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -755,14 +755,11 @@ deployment:
 
 		origSleep := deployment.SleepTime
 		origTick := deployment.TickNum
-		origTimeout := deployment.TimeoutNum
 		deployment.SleepTime = 0
 		deployment.TickNum = 1
-		deployment.TimeoutNum = 5
 		defer func() {
 			deployment.SleepTime = origSleep
 			deployment.TickNum = origTick
-			deployment.TimeoutNum = origTimeout
 		}()
 
 		cmdArgs := []string{"create", "--deployment-file", "test-deployment.yaml", "--wait", "--verbosity", "debug"}


### PR DESCRIPTION
## Description

While adding the `--wait` flag to the deploy-action, we noticed that at times the default hardcoded timeout can be too small, so we bumped up the defaults and added a flag to set the values to allow users to configure the value in this PR.

Changes:
- Add `--wait-time` flag for `astro deployment create`, `astro deploy`, and `astro dbt deploy` commands. This would be used alongside the `--wait` flag to set the timeouts, instead of the default values
- Bump the defaults to 300 seconds to be on the safer side.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Validated that wait timeout works as expected:
```
❯ ../astro deploy --wait-time=500s --wait -f --dags
Authenticated to astronomer-dev.io 

Select a Deployment
 #     DEPLOYMENT NAME                                          RELEASE NAME                     DEPLOYMENT ID                 DAG DEPLOY ENABLED     
 1     test                                                     inductive-torque-5951            cmh080n740omw01qvmpek0a3e     true                   

> 1
Initiating DAG deploy for: cmh080n740omw01qvmpek0a3e
Deployed DAG bundle:  2025-10-21T07:12:28.1809730Z
Deployed Image Tag:  3.1-2

Waiting for the deployment to become healthy…

This may take a few minutes
Deployment test is now healthy

Successfully uploaded DAGs with version 2025-10-21T07:12:28.1809730Z to Astro. Navigate to the Airflow UI to confirm that your deploy was successful.

 Access your Deployment:

 Deployment View: cloud.astronomer-dev.io/cm7xi0c1604ar01mpuy1pbi63/deployments/cmh080n740omw01qvmpek0a3e
 Airflow UI: cm7xhxjm9048m01mppvu90ekx.astronomer-dev.run/dpek0a3e
```

Validated that shorter wait timeout results in failure:
```
❯ ../astro deploy --wait-time=5s --wait -f --dags
Authenticated to astronomer-dev.io 

Select a Deployment
 #     DEPLOYMENT NAME                                          RELEASE NAME                     DEPLOYMENT ID                 DAG DEPLOY ENABLED     
 1     test                                                     inductive-torque-5951            cmh080n740omw01qvmpek0a3e     true                   

> 1
Initiating DAG deploy for: cmh080n740omw01qvmpek0a3e
Deployed DAG bundle:  2025-10-21T07:11:04.9282601Z
Deployed Image Tag:  3.1-2

Waiting for the deployment to become healthy…

This may take a few minutes
Error: timed out waiting for the Deployment to enter a Healthy state
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
