### PR TITLE
Fix remote deploy push logic around figuring out registry from the endpoint

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -441,11 +441,18 @@ func (d *DockerImage) getRegistryToAuth(imageName string) (string, error) {
 	if domain == "localhost" {
 		return config.CFG.LocalRegistry.GetString(), nil
 	}
+
+	// Handle different image name formats:
+	// 1. Standard format: registry.com/namespace/repo:tag
+	// 2. ECR format: 123456789012.dkr.ecr.us-west-2.amazonaws.com/repo:tag
 	parts := strings.SplitN(imageName, "/", 2)
-	if len(parts) != 2 || !strings.Contains(parts[1], "/") {
-		// This _should_ be impossible for users to hit
+	if len(parts) != 2 {
 		return "", fmt.Errorf("internal logic error: unsure how to get registry from image name %q", imageName)
 	}
+
+	// Both formats have the registry as the first part before the first "/"
+	// Standard format: registry.com/namespace/repo:tag -> registry.com
+	// ECR format: 123456789012.dkr.ecr.us-west-2.amazonaws.com/repo:tag -> 123456789012.dkr.ecr.us-west-2.amazonaws.com
 	return parts[0], nil
 }
 


### PR DESCRIPTION
## Description

- Fix the registry endpoint parse logic for remote registry, as they do not follow the standard for existing Astro registries.

Error that users were facing with AWS ECR:
```
astro remote deploy
Authenticated to Astro

Building client image for host platform
✔ Project image has been updated
Pushing client image to configured remote registry
Error: failed to push client image: internal logic error: unsure how to get registry from image name <registry endpoint>
```

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

<img width="755" height="694" alt="image" src="https://github.com/user-attachments/assets/6565f8b4-b3a5-4093-8942-6474e7744868" />


## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
