### PR TITLE
Allow importing IDE projects to non-empty directories with user confirmation

### DIFF
--- a/cloud/ide/project.go
+++ b/cloud/ide/project.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/browser"
 
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
+	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -480,7 +481,11 @@ func ImportProject(client astrocore.CoreClient, projectID, organizationID, works
 		return fmt.Errorf("failed to read current directory: %w", err)
 	}
 	if len(entries) > 0 {
-		return fmt.Errorf("current directory is not empty. Please run this command in an empty directory")
+		proceed, _ := input.Confirm(fmt.Sprintf("Current directory is not empty. Do you want to import the project here? %s", config.WorkingPath))
+
+		if !proceed {
+			return fmt.Errorf("import canceled by user")
+		}
 	}
 
 	// If projectID is not provided, select one


### PR DESCRIPTION
## Description

Previously, the astro ide project import command would fail if run in a non-empty directory, forcing users to create a new empty directory first. This change makes the experience more flexible by prompting users for confirmation before proceeding.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Tested the change on locally:

```
~ astro ide project import
Current directory is not empty. Do you want to import the project here? /tmp/test (y/n) y
Only one Project was found. Using the following Project by default: 

 Project Name: test
 Project ID: cmhevveiz010501nlj05z8t8o

Successfully exported project from cmhevveiz010501nlj05z8t8o
```
```
~ astro ide project import
Current directory is not empty. Do you want to import the project here? /tmp/test/dags (y/n) n
Error: import canceled by user
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
