### PR TITLE
Add Houston API 1.0.1 support - remove desiredRuntimeVersion and AC fields

### DIFF
--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -732,30 +732,6 @@ var (
 				}
 			}`,
 		},
-		{
-			version: "1.0.1",
-			query: `
-			query GetDeployment(
-				$id: String!
-			){
-				deployment(
-					where: {id: $id}
-				){
-					id
-					runtimeVersion
-					runtimeAirflowVersion
-					releaseName
-					urls {
-						type
-						url
-					}
-					dagDeployment {
-						type
-					}
-					clusterId
-				}
-			}`,
-		},
 	}
 
 	DeploymentDeleteRequest = `


### PR DESCRIPTION
## Description
Note: This impacts APC `1.1.0` release but for local dev this is useful for post `1.0.1` which is still considered `1.0.1` in for the dev development phase


Adds version `1.0.1` GraphQL queries to support Houston API schema changes where `desiredAirflowVersion` and `desiredRuntimeVersion` fields have been removed from the `Deployment` type.

**Changes:**
- Added `1.0.1` version queries for:
  - `DeploymentCreateRequest` - uses `upsertDeployment` mutation
  - `DeploymentsGetRequest` - removes deprecated airflow version fields
  - `PaginatedDeploymentsGetRequest` - removes deprecated airflow version fields
  - `DeploymentUpdateRequest` - uses `upsertDeployment` mutation
  - `DeploymentGetRequest` - removes `desiredAirflowVersion` and `desiredRuntimeVersion`

**Problem:**
When deploying with the CLI against Houston versions that have removed these fields, users encounter:
```
Error: failed to get deployment info: Some fields requested by the CLI are not available in the server schema.
```

The underlying GraphQL errors are:
- `Cannot query field "desiredAirflowVersion" on type "Deployment"`
- `Cannot query field "desiredRuntimeVersion" on type "Deployment"`

## 🎟 Issue(s)

Related https://github.com/astronomer/issues/issues/8180

## 🧪 Functional Testing

1. Connect to a Houston instance running the updated schema (version ~1.0.1+)
2. Run `astro deploy` and select a deployment
3. Verify the deploy completes successfully without schema errors
4. Run `astro deployment list` and verify deployments are listed correctly
5. Run `astro deployment create` and verify creation works

**Debug verification:**
```bash
astro deploy --verbosity=debug
```
Should no longer show `Cannot query field` errors.

## 📸 Screenshots

> Add screenshots showing successful deploy output or CLI debug logs.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
