### PR TITLE
Add `--fix` flag to `astro dev upgrade-test`

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -37,7 +37,7 @@ type ContainerHandler interface {
 	ComposeExport(settingsFile, composeFile string) error
 	Pytest(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString string) (string, error)
 	Parse(customImageName, deployImageName, buildSecretString string) error
-	UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations bool, lintConfigFile string, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error
+	UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error
 }
 
 // RegistryHandler defines methods require to handle all operations with registry

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1239,7 +1239,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, "", nil) // All tests enabled by default
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // All tests enabled by default
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
@@ -1260,7 +1260,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", true, true, true, false, "", mockPlatformCoreClient) // All tests enabled by default
+		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", true, true, true, false, false, "", mockPlatformCoreClient) // All tests enabled by default
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
@@ -1272,7 +1272,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1284,7 +1284,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1297,7 +1297,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1312,7 +1312,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1328,7 +1328,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, "", nil) // dagTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // dagTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1343,7 +1343,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, "", nil) // dagTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // dagTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1355,7 +1355,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, "", mockPlatformCoreClient)
+		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", mockPlatformCoreClient)
 		s.Error(err)
 		// No image handler expectations needed as it fails before pull/build
 	})
@@ -1369,7 +1369,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", false, false, false, false, "", mockPlatformCoreClient)
+		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", false, false, false, false, false, "", mockPlatformCoreClient)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T()) // Only Pull is called
 	})
@@ -1383,7 +1383,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, false, false, "", nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1395,7 +1395,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		s.NoError(err)
 
 		// Add default values for new lint flags
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, "", nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", nil)
 		s.Error(err) // Expect error due to missing context/domain
 	})
 
@@ -1412,8 +1412,8 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
-		// Call with lintTest=true, includeLintDeprecations=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, "", nil)
+		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1431,8 +1431,8 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
-		// Call with lintTest=true, includeLintDeprecations=true, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, true, "", nil)
+		// Call with lintTest=true, includeLintDeprecations=true, lintFix=false, lintConfigFile=""
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, true, false, "", nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1466,7 +1466,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		originalWorkingPath := config.WorkingPath
 		config.WorkingPath = cwd
 		defer func() { config.WorkingPath = originalWorkingPath }()
-		err = mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, "my-custom-ruff.toml", nil)
+		err = mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "my-custom-ruff.toml", nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1484,8 +1484,8 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
-		// Call with lintTest=true, includeLintDeprecations=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, "", nil)
+		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil)
 		s.Error(err)
 		s.Contains(err.Error(), "one of the tests run above failed")
 
@@ -1502,13 +1502,33 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
-		// Call with lintTest=true, includeLintDeprecations=false, lintConfigFile=""
+		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
 		// Target version is 2.0.0, so lint test should be skipped internally
-		err := mockDockerCompose.UpgradeTest("2.0.0", "", "", "", false, false, true, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("2.0.0", "", "", "", false, false, true, false, false, "", nil)
 		s.NoError(err) // Should succeed without running lint
 
 		imageHandler.AssertExpectations(s.T())
 		ruffImageHandler.AssertExpectations(s.T()) // Verify RunCommand was not called
+	})
+
+	s.Run("success with lint test and fix flag", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
+
+		ruffImageHandler := new(mocks.ImageHandler)
+		ruffImageHandler.On("Pull", "", "", "").Return(nil).Once()
+		// Expect --fix and --unsafe-fixes flags to be passed to ruff
+		ruffImageHandler.On("RunCommand", []string{"check", "--config", "/app/ruff.toml", "/app/project", "--fix", "--unsafe-fixes"}, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+		mockDockerCompose.imageHandler = imageHandler
+		mockDockerCompose.ruffImageHandler = ruffImageHandler
+		// Call with lintTest=true, includeLintDeprecations=false, lintFix=true, lintConfigFile=""
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, true, "", nil)
+		s.NoError(err)
+
+		imageHandler.AssertExpectations(s.T())
+		ruffImageHandler.AssertExpectations(s.T())
 	})
 }
 

--- a/airflow/mocks/ContainerHandler.go
+++ b/airflow/mocks/ContainerHandler.go
@@ -267,17 +267,17 @@ func (_m *ContainerHandler) Stop(waitForExit bool) error {
 	return r0
 }
 
-// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintConfigFile, astroPlatformCore
-func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, customImageName string, buildSecretString string, versionTest bool, dagTest bool, lintTest bool, includeLintDeprecations bool, lintConfigFile string, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error {
-	ret := _m.Called(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintConfigFile, astroPlatformCore)
+// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroPlatformCore
+func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, customImageName string, buildSecretString string, versionTest bool, dagTest bool, lintTest bool, includeLintDeprecations bool, lintFix bool, lintConfigFile string, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error {
+	ret := _m.Called(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroPlatformCore)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpgradeTest")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, bool, bool, string, astroplatformcore.ClientWithResponsesInterface) error); ok {
-		r0 = rf(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintConfigFile, astroPlatformCore)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, bool, bool, bool, string, astroplatformcore.ClientWithResponsesInterface) error); ok {
+		r0 = rf(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroPlatformCore)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -70,6 +70,7 @@ var (
 	dagTest                bool
 	lintTest               bool
 	lintDeprecations       bool
+	lintFix                bool
 	lintConfigFile         string
 	waitTime               time.Duration
 	containerRuntime       runtimes.ContainerRuntime
@@ -224,6 +225,7 @@ func newAirflowUpgradeTestCmd(platformCoreClient astroplatformcore.CoreClient) *
 	cmd.Flags().BoolVarP(&dagTest, "dag-test", "d", false, "Only run DAG tests. These tests check whether your DAGs will generate import errors after you upgrade.")
 	cmd.Flags().BoolVarP(&lintTest, "lint-test", "l", false, "Only run ruff lint tests. These tests check whether your DAGs are compatible with Airflow.")
 	cmd.Flags().BoolVarP(&lintDeprecations, "lint-deprecations", "", false, "Include Airflow deprecations in lint tests.")
+	cmd.Flags().BoolVarP(&lintFix, "fix", "", false, "Automatically apply lint fixes where possible.")
 	cmd.Flags().StringVarP(&lintConfigFile, "lint-config-file", "", "", "Relative path within project to a custom ruff config file. If not specified, a default config will be used.")
 	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "i", "", "ID of the Deployment you want run dependency tests against.")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "n", "", "Name of the upgraded image. Updates the FROM line in your Dockerfile to pull this image for the upgrade.")
@@ -699,7 +701,7 @@ func airflowUpgradeTest(cmd *cobra.Command, platformCoreClient astroplatformcore
 
 	buildSecretString = util.GetbuildSecretString(buildSecrets)
 
-	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, lintDeprecations, lintConfigFile, platformCoreClient)
+	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, lintDeprecations, lintFix, lintConfigFile, platformCoreClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -753,7 +753,7 @@ func (s *AirflowSuite) TestAirflowUpgradeTest() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, "", nil).Return(nil).Once()
+			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -767,7 +767,7 @@ func (s *AirflowSuite) TestAirflowUpgradeTest() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, "", nil).Return(errMock).Once()
+			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil).Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 


### PR DESCRIPTION
## Description

This change adds a new `--fix` flag to the `astro dev upgrade-test` command to automatically fix linting issues reported by ruff.

## 🧪 Functional Testing

- Added unit test coverage for ruff command
- Tested on example Airflow 2 DAG, which fixed all identified issues

## 📸 Screenshots

<img width="392" height="150" alt="Screenshot 2026-01-05 at 12 01 52 PM" src="https://github.com/user-attachments/assets/f4a3531d-c29d-4f4d-affe-41129100e927" />

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
