### PR TITLE
fix(deploy: exit non-zero if uncommitted changes are present

### DIFF
--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -192,8 +192,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 	}
 
 	if git.HasUncommittedChanges("") && !forceDeploy {
-		fmt.Println(registryUncommitedChangesMsg)
-		return nil
+		return errors.New(registryUncommitedChangesMsg)
 	}
 
 	// case for astro deploy --dags whose default operation should be not running any tests


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Customers using GitLab or other CI/CD platforms rely on command exit codes to programmatically determine whether an astro deploy invocation succeeded or failed.

## 🎟 Issue(s)

Related [#1721](https://github.com/astronomer/astro-cli/issues/1721)

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.
Run astro deploy <deployment-id> with uncommitted git changes --> command fails with error and exits non-zero.

Run astro deploy <deployment-id> -f with uncommitted changes --> deploy proceeds successfully.

Run astro deploy <deployment-id> with a clean git state --> deploy succeeds as before.

## 📸 Screenshots
<img width="1529" height="572" alt="image" src="https://github.com/user-attachments/assets/d753253a-0fdd-4825-9941-6e9d142e25d8" />





## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
