### PR TITLE
set explicit limit when listing organizations

### DIFF
--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	AstronomerConnectionErrMsg = "cannot connect to Astronomer. Try to log in with astro login or check your internet connection and user permissions. If you are using an API Key or Token make sure your context is correct.\n\nDetails"
+	listOrganizationsLimit     = 1000
 )
 
 var (
@@ -42,7 +43,7 @@ func newTableOut() *printutil.Table {
 }
 
 func ListOrganizations(platformCoreClient astroplatformcore.CoreClient) ([]astroplatformcore.Organization, error) {
-	limit := 1000
+	limit := listOrganizationsLimit
 	organizationListParams := &astroplatformcore.ListOrganizationsParams{
 		Limit: &limit,
 	}

--- a/cloud/organization/organization_test.go
+++ b/cloud/organization/organization_test.go
@@ -83,13 +83,19 @@ var (
 	errNetwork = errors.New("network error")
 )
 
+func matchListOrganizationsLimit() interface{} {
+	return mock.MatchedBy(func(p *astroplatformcore.ListOrganizationsParams) bool {
+		return p != nil && p.Limit != nil && *p.Limit == listOrganizationsLimit
+	})
+}
+
 func (s *Suite) TestList() {
 	// initialize empty config
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	s.Run("organization list success", func() {
 		mockClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 
 		buf := new(bytes.Buffer)
 		err := List(buf, mockClient)
@@ -99,7 +105,7 @@ func (s *Suite) TestList() {
 
 	s.Run("organization network error", func() {
 		mockClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(nil, errNetwork).Once()
+		mockClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(nil, errNetwork).Once()
 		buf := new(bytes.Buffer)
 		err := List(buf, mockClient)
 		s.Contains(err.Error(), "network error")
@@ -108,7 +114,7 @@ func (s *Suite) TestList() {
 
 	s.Run("organization list error", func() {
 		mockClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockErrorResponse, nil).Once()
+		mockClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockErrorResponse, nil).Once()
 		buf := new(bytes.Buffer)
 		err := List(buf, mockClient)
 		s.Contains(err.Error(), "failed to fetch organizations")
@@ -119,7 +125,7 @@ func (s *Suite) TestList() {
 func TestListOrganizations(t *testing.T) {
 	mockClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 
-	limit := 1000
+	limit := listOrganizationsLimit
 	orgs := []astroplatformcore.Organization{
 		{Id: "org-1", Name: "Org 1"},
 		{Id: "org-2", Name: "Org 2"},
@@ -154,7 +160,7 @@ func (s *Suite) TestGetOrganizationSelection() {
 	s.Run("get organiation selection success", func() {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 
 		// mock os.Stdin
 		input := []byte("1")
@@ -177,7 +183,7 @@ func (s *Suite) TestGetOrganizationSelection() {
 
 	s.Run("get organization selection list error", func() {
 		mockClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockErrorResponse, nil).Once()
+		mockClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockErrorResponse, nil).Once()
 
 		buf := new(bytes.Buffer)
 		_, err := getOrganizationSelection(buf, mockClient)
@@ -187,7 +193,7 @@ func (s *Suite) TestGetOrganizationSelection() {
 
 	s.Run("get organization selection select error", func() {
 		mockClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 
 		// mock os.Stdin
 		input := []byte("3")
@@ -214,7 +220,7 @@ func (s *Suite) TestSwitch() {
 	s.Run("successful switch with name", func() {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 		CheckUserSession = func(c *config.Context, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
 			return nil
 		}
@@ -229,7 +235,7 @@ func (s *Suite) TestSwitch() {
 	s.Run("switching to a current organization", func() {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 
 		buf := new(bytes.Buffer)
 		err := Switch("org1", mockCoreClient, mockPlatformCoreClient, buf, false)
@@ -242,7 +248,7 @@ func (s *Suite) TestSwitch() {
 	s.Run("successful switch without name", func() {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 		CheckUserSession = func(c *config.Context, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
 			return nil
 		}
@@ -267,7 +273,7 @@ func (s *Suite) TestSwitch() {
 	s.Run("failed switch wrong name", func() {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 		CheckUserSession = func(c *config.Context, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
 			return nil
 		}
@@ -281,7 +287,7 @@ func (s *Suite) TestSwitch() {
 	s.Run("failed switch bad selection", func() {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 		CheckUserSession = func(c *config.Context, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
 			return nil
 		}
@@ -316,7 +322,7 @@ func (s *Suite) TestSwitch() {
 		}
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 		CheckUserSession = func(c *config.Context, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
 			return nil
 		}
@@ -392,7 +398,7 @@ func (s *Suite) TestExportAuditLogs() {
 	s.Run("export audit logs success", func() {
 		mockPlatformClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 		mockClient.On("GetOrganizationAuditLogsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockOKAuditLogResponse, nil).Once()
 		err := ExportAuditLogs(mockClient, mockPlatformClient, "", "", 1)
 		s.NoError(err)
@@ -402,7 +408,7 @@ func (s *Suite) TestExportAuditLogs() {
 	s.Run("export audit logs and select org success", func() {
 		mockPlatformClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 		mockClient.On("GetOrganizationAuditLogsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockOKAuditLogResponse, nil).Once()
 		err := ExportAuditLogs(mockClient, mockPlatformClient, "org1", "", 1)
 		s.NoError(err)
@@ -412,7 +418,7 @@ func (s *Suite) TestExportAuditLogs() {
 	s.Run("export failure", func() {
 		mockPlatformClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 		mockClient.On("GetOrganizationAuditLogsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errNetwork).Once()
 		err := ExportAuditLogs(mockClient, mockPlatformClient, "", "", 1)
 		s.Contains(err.Error(), "network error")
@@ -422,7 +428,7 @@ func (s *Suite) TestExportAuditLogs() {
 	s.Run("list failure", func() {
 		mockPlatformClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(nil, errNetwork).Once()
+		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(nil, errNetwork).Once()
 		err := ExportAuditLogs(mockClient, mockPlatformClient, "org1", "", 1)
 		s.Contains(err.Error(), "network error")
 		mockPlatformClient.AssertExpectations(s.T())
@@ -431,7 +437,7 @@ func (s *Suite) TestExportAuditLogs() {
 	s.Run("organization list error", func() {
 		mockPlatformClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOKResponse, nil).Once()
+		mockPlatformClient.On("ListOrganizationsWithResponse", mock.Anything, matchListOrganizationsLimit()).Return(&mockOKResponse, nil).Once()
 		mockClient.On("GetOrganizationAuditLogsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockOKAuditLogResponseError, nil).Once()
 		err := ExportAuditLogs(mockClient, mockPlatformClient, "", "", 1)
 		s.Contains(err.Error(), "failed to fetch organizations audit logs")

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -472,7 +472,9 @@ func TestCheckAPIToken(t *testing.T) {
 			return &mockClaims, nil
 		}
 
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrgsResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, mock.MatchedBy(func(p *astroplatformcore.ListOrganizationsParams) bool {
+			return p != nil && p.Limit != nil && *p.Limit == 1000
+		})).Return(&mockOrgsResponse, nil).Once()
 
 		t.Setenv("ASTRO_API_TOKEN", "token")
 
@@ -495,7 +497,9 @@ func TestCheckAPIToken(t *testing.T) {
 			return nil, errors.New("Failed to parse token")
 		}
 
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrgsResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, mock.MatchedBy(func(p *astroplatformcore.ListOrganizationsParams) bool {
+			return p != nil && p.Limit != nil && *p.Limit == 1000
+		})).Return(&mockOrgsResponse, nil).Once()
 
 		t.Setenv("ASTRO_API_TOKEN", "token")
 
@@ -517,7 +521,9 @@ func TestCheckAPIToken(t *testing.T) {
 			return &mockClaims, nil
 		}
 
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrgsResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, mock.MatchedBy(func(p *astroplatformcore.ListOrganizationsParams) bool {
+			return p != nil && p.Limit != nil && *p.Limit == 1000
+		})).Return(&mockOrgsResponse, nil).Once()
 
 		t.Setenv("ASTRO_API_TOKEN", "token")
 		err := config.ResetCurrentContext()
@@ -551,7 +557,9 @@ func TestCheckAPIToken(t *testing.T) {
 			return &mockClaims, nil
 		}
 
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrgsResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, mock.MatchedBy(func(p *astroplatformcore.ListOrganizationsParams) bool {
+			return p != nil && p.Limit != nil && *p.Limit == 1000
+		})).Return(&mockOrgsResponse, nil).Once()
 
 		t.Setenv("ASTRO_API_TOKEN", "token")
 
@@ -591,7 +599,9 @@ func TestCheckAPIToken(t *testing.T) {
 			return &mockClaims, nil
 		}
 
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrgsResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, mock.MatchedBy(func(p *astroplatformcore.ListOrganizationsParams) bool {
+			return p != nil && p.Limit != nil && *p.Limit == 1000
+		})).Return(&mockOrgsResponse, nil).Once()
 
 		t.Setenv("ASTRO_API_TOKEN", "token")
 
@@ -630,7 +640,9 @@ func TestCheckAPIToken(t *testing.T) {
 			return &mockClaims, nil
 		}
 
-		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrgsResponse, nil).Once()
+		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, mock.MatchedBy(func(p *astroplatformcore.ListOrganizationsParams) bool {
+			return p != nil && p.Limit != nil && *p.Limit == 1000
+		})).Return(&mockOrgsResponse, nil).Once()
 
 		t.Setenv("ASTRO_API_TOKEN", "token")
 


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Set an explicit limit when listing organisations

## 🎟 Issue(s)

Related [#1974 ](https://github.com/astronomer/astro-cli/issues/1974)

## 🧪 Functional Testing
```
./astro organization switch 
#   NAME                                   ID
1   Organization A                         org_a9f3k61tk008t01lpduvhq01
2   Organization B                         org_b1ojnif514gu01q1h6gi402
3   Organization C                         org_c7m6sqsr0dup01mziqj3dh
4   Organization D                         org_d74r2a000ia501jxb3zecy
5   Organization E                         org_e1deotszu0bx40txq4hs39
6   Organization F                         org_f9v2n8o204i401hvdms70b
7   Organization G                         org_glyencvlg051701g5nuy35
8   Organization H                         org_hhajccrv17v601kb14gt3m
9   Organization I                         org_if2bq65w2n6x01psvqqz5c
10  Organization J                         org_jlzvofruy0h8n01htzvl6n
11  Organization K                         org_kmf35hf6s2v0i01o4k9d3o
12  Organization L                         org_lm0gx1hiu008c01llx94j2k
13  Organization M                         org_mmbb539wy0nsc01lrvj1g0r
14  Organization N                         org_nmafgwb8c0olq01mgp8k9w2
15  Organization O                         org_olpsyubyx00aa01nk371zi
16  Organization P                         org_pclilt7rt8009l01i7wf7x
17  Organization Q                         org_qclqngdd1m018v01p0xkl8
18  Organization R                         org_rclksfpyij003x01nfaqz8
19  Organization S                         org_sclddgzqej00kv0tzf97r5
20  Organization T                         org_tcluu3c4uy018601orkdvl
21  Organization U                         org_ucknaqyipv05731evsry6c
>
```

> List the functional testing steps to confirm this feature or fix.

Ran `astro organization switch ` with a user assigned to more than 20 orgs.

## 📸 Screenshots

NA since public repo.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
