### PR TITLE
[PM-1197] Add `astro dev build` command to build image

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -31,6 +31,7 @@ type ContainerHandler interface {
 	Logs(follow bool, containerNames ...string) error
 	Run(args []string, user string) error
 	Bash(container string) error
+	Build(customImageName, buildSecretString string, noCache bool) error
 	RunDAG(dagID, settingsFile, dagFile, executionDate string, noCache, taskLogs bool) error
 	ImportSettings(settingsFile, envFile string, connections, variables, pools bool) error
 	ExportSettings(settingsFile, envFile string, connections, variables, pools, envExport bool) error

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -1201,6 +1201,19 @@ func (d *DockerCompose) Parse(customImageName, deployImageName, buildSecretStrin
 	return err
 }
 
+func (d *DockerCompose) Build(customImageName, buildSecretString string, noCache bool) error {
+	// If a custom image name is provided, tag it as our project image
+	if customImageName != "" {
+		return d.imageHandler.TagLocalImage(customImageName)
+	}
+
+	// Build the image
+	return d.imageHandler.Build(d.dockerfile, buildSecretString, airflowTypes.ImageBuildConfig{
+		Path:    d.airflowHome,
+		NoCache: noCache,
+	})
+}
+
 func (d *DockerCompose) Bash(component string) error {
 	// exec into schedueler by default
 	if component == "" {

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1609,6 +1609,73 @@ func (s *Suite) TestDockerComposeParse() {
 	})
 }
 
+func (s *Suite) TestDockerComposeBuild() {
+	s.Run("success", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", mock.Anything, "", airflowTypes.ImageBuildConfig{Path: "", NoCache: false}).Return(nil).Once()
+
+		mockDockerCompose := DockerCompose{
+			imageHandler: imageHandler,
+		}
+
+		err := mockDockerCompose.Build("", "", false)
+		s.NoError(err)
+		imageHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("success with no-cache", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", mock.Anything, "", airflowTypes.ImageBuildConfig{Path: "", NoCache: true}).Return(nil).Once()
+
+		mockDockerCompose := DockerCompose{
+			imageHandler: imageHandler,
+		}
+
+		err := mockDockerCompose.Build("", "", true)
+		s.NoError(err)
+		imageHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("success with custom image", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("TagLocalImage", "my-custom-image:latest").Return(nil).Once()
+
+		mockDockerCompose := DockerCompose{
+			imageHandler: imageHandler,
+		}
+
+		err := mockDockerCompose.Build("my-custom-image:latest", "", false)
+		s.NoError(err)
+		imageHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("build failure", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", mock.Anything, "", airflowTypes.ImageBuildConfig{Path: "", NoCache: false}).Return(errMock).Once()
+
+		mockDockerCompose := DockerCompose{
+			imageHandler: imageHandler,
+		}
+
+		err := mockDockerCompose.Build("", "", false)
+		s.ErrorIs(err, errMock)
+		imageHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("tag local image failure", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("TagLocalImage", "my-custom-image:latest").Return(errMock).Once()
+
+		mockDockerCompose := DockerCompose{
+			imageHandler: imageHandler,
+		}
+
+		err := mockDockerCompose.Build("my-custom-image:latest", "", false)
+		s.ErrorIs(err, errMock)
+		imageHandler.AssertExpectations(s.T())
+	})
+}
+
 func (s *Suite) TestDockerComposeBash() {
 	mockDockerCompose := DockerCompose{projectName: "test"}
 	component := "scheduler"

--- a/airflow/mocks/ContainerHandler.go
+++ b/airflow/mocks/ContainerHandler.go
@@ -34,6 +34,24 @@ func (_m *ContainerHandler) Bash(container string) error {
 	return r0
 }
 
+// Build provides a mock function with given fields: customImageName, buildSecretString, noCache
+func (_m *ContainerHandler) Build(customImageName string, buildSecretString string, noCache bool) error {
+	ret := _m.Called(customImageName, buildSecretString, noCache)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Build")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, bool) error); ok {
+		r0 = rf(customImageName, buildSecretString, noCache)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ComposeExport provides a mock function with given fields: settingsFile, composeFile
 func (_m *ContainerHandler) ComposeExport(settingsFile string, composeFile string) error {
 	ret := _m.Called(settingsFile, composeFile)

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -153,6 +153,7 @@ func newDevRootCmd(platformCoreClient astroplatformcore.CoreClient, astroCoreCli
 	cmd.AddCommand(
 		newAirflowInitCmd(),
 		newAirflowStartCmd(astroCoreClient),
+		newAirflowBuildCmd(),
 		newAirflowRunCmd(),
 		newAirflowPSCmd(),
 		newAirflowLogsCmd(),
@@ -394,6 +395,21 @@ func newAirflowParseCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to run parse with")
+	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+
+	return cmd
+}
+
+func newAirflowBuildCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "build",
+		Short:   "Build your Astro project into a Docker image",
+		Long:    "Build your Astro project into a Docker image without starting the local Airflow environment. This is useful for testing that your project builds successfully or for preparing an image before deployment.",
+		PreRunE: EnsureRuntime,
+		RunE:    airflowBuild,
+	}
+	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "Do not use cache when building container image")
+	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to tag as the project image")
 	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
 
 	return cmd
@@ -938,6 +954,26 @@ func airflowParse(cmd *cobra.Command, args []string) error {
 	buildSecretString = util.GetbuildSecretString(buildSecrets)
 
 	return containerHandler.Parse(customImageName, "", buildSecretString)
+}
+
+// Build the Airflow project image
+func airflowBuild(cmd *cobra.Command, args []string) error {
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+
+	imageName, err := projectNameUnique()
+	if err != nil {
+		return err
+	}
+
+	containerHandler, err := containerHandlerInit(config.WorkingPath, envFile, dockerfile, imageName)
+	if err != nil {
+		return err
+	}
+
+	buildSecretString = util.GetbuildSecretString(buildSecrets)
+
+	return containerHandler.Build(customImageName, buildSecretString, noCache)
 }
 
 // Exec into an airflow container

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1692,3 +1692,81 @@ func (s *AirflowSuite) TestAirflowObjectExport() {
 		s.ErrorIs(err, errMock)
 	})
 }
+
+func (s *AirflowSuite) TestAirflowBuild() {
+	s.Run("success", func() {
+		cmd := newAirflowBuildCmd()
+		args := []string{}
+
+		mockContainerHandler := new(mocks.ContainerHandler)
+		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
+			mockContainerHandler.On("Build", "", "", false).Return(nil).Once()
+			return mockContainerHandler, nil
+		}
+
+		err := airflowBuild(cmd, args)
+		s.NoError(err)
+		mockContainerHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("success with no-cache flag", func() {
+		cmd := newAirflowBuildCmd()
+		noCache = true
+		args := []string{}
+
+		mockContainerHandler := new(mocks.ContainerHandler)
+		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
+			mockContainerHandler.On("Build", "", "", true).Return(nil).Once()
+			return mockContainerHandler, nil
+		}
+
+		err := airflowBuild(cmd, args)
+		s.NoError(err)
+		mockContainerHandler.AssertExpectations(s.T())
+		noCache = false // reset
+	})
+
+	s.Run("success with custom image name", func() {
+		cmd := newAirflowBuildCmd()
+		customImageName = "my-custom-image:latest"
+		args := []string{}
+
+		mockContainerHandler := new(mocks.ContainerHandler)
+		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
+			mockContainerHandler.On("Build", "my-custom-image:latest", "", false).Return(nil).Once()
+			return mockContainerHandler, nil
+		}
+
+		err := airflowBuild(cmd, args)
+		s.NoError(err)
+		mockContainerHandler.AssertExpectations(s.T())
+		customImageName = "" // reset
+	})
+
+	s.Run("failure", func() {
+		cmd := newAirflowBuildCmd()
+		args := []string{}
+
+		mockContainerHandler := new(mocks.ContainerHandler)
+		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
+			mockContainerHandler.On("Build", "", "", false).Return(errMock).Once()
+			return mockContainerHandler, nil
+		}
+
+		err := airflowBuild(cmd, args)
+		s.ErrorIs(err, errMock)
+		mockContainerHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("containerHandlerInit failure", func() {
+		cmd := newAirflowBuildCmd()
+		args := []string{}
+
+		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
+			return nil, errMock
+		}
+
+		err := airflowBuild(cmd, args)
+		s.ErrorIs(err, errMock)
+	})
+}


### PR DESCRIPTION
## Summary
- Add a new `astro dev build` CLI command that only builds the Docker image without starting the local Airflow environment
- Supports `--no-cache` flag to build without Docker cache
- Supports `--image-name` flag to tag a custom image as the project image
- Supports `--build-secrets` flag for build secrets

## Use Cases
- Testing that a project builds successfully before deployment
- Preparing an image for deployment workflows
- Faster iteration when only the build step is needed

## Test plan
- [ ] Run `astro dev build` in an Astro project to verify the image is built
- [ ] Run `astro dev build --no-cache` to verify no-cache behavior
- [ ] Run `astro dev build --image-name custom:tag` to verify custom image tagging
- [ ] Run `astro dev build --help` to verify documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)