### PR TITLE
Run all lint checks in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
 ---
+ci:
+  # gofumpt and golangci-lint require Go tooling; covered by make lint in CircleCI
+  skip: [gofumpt, golangci-lint]
 exclude: '(vendor|.vscode)'  # regex
 repos:
   - repo: local


### PR DESCRIPTION
This changes the pre-commit config so that it runs the steps necessary for `make lint` to pass, which CI then enforces.