### PR TITLE
fixed podman builds by passing through machine socket

### DIFF
--- a/airflow/runtimes/podman_runtime.go
+++ b/airflow/runtimes/podman_runtime.go
@@ -266,6 +266,13 @@ func (rt PodmanRuntime) configureMachineForUsage(machine *types.InspectedMachine
 		return fmt.Errorf("error setting DOCKER_HOST: %s", err)
 	}
 
+	// Set CONTAINER_HOST for native Podman commands (e.g., podman build)
+	// This ensures podman commands also use the machine socket
+	err = os.Setenv("CONTAINER_HOST", dockerHost)
+	if err != nil {
+		return fmt.Errorf("error setting CONTAINER_HOST: %s", err)
+	}
+
 	// Set the podman default connection to our machine.
 	return rt.Engine.SetMachineAsDefault(machine.Name)
 }


### PR DESCRIPTION
Assisted by: Claude Code

## Description

> Fixes https://github.com/astronomer/astro-cli/issues/1995. 
  The issue was with the podman machine socket not being forwarded to other podman tools when building.

## 🎟 Issue(s)

Related #1995 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.
- Try running astro dev start on a vanilla fedora 43 machine, with podman
- I ran `astro dev kill`, and afterwards `astro dev start --verbosity debug` gives me the error in the screenshot
- Building the CLI with the patch worked with podman.

## 📸 Screenshots

Before:
<img width="1659" height="306" alt="image" src="https://github.com/user-attachments/assets/74217a26-6fd1-4aa5-86f7-02a314a395b6" />


Build after patch:
<img width="944" height="460" alt="image" src="https://github.com/user-attachments/assets/908f03a2-c8ee-4b8d-961d-e3b558deb037" />


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
