### PR TITLE
fix: conditionally pass -t flag to docker exec based on TTY detection

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/term"
 )
 
 const (
@@ -1251,7 +1252,12 @@ func (d *DockerCompose) Bash(component string) error {
 	if err != nil {
 		return err
 	}
-	err = cmdExec(containerRuntime, os.Stdout, os.Stderr, "exec", "-it", containerName, "bash")
+	execArgs := []string{"exec", "-i"}
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		execArgs = append(execArgs, "-t")
+	}
+	execArgs = append(execArgs, containerName, "bash")
+	err = cmdExec(containerRuntime, os.Stdout, os.Stderr, execArgs...)
 	if err != nil {
 		return err
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/astronomer/astro-cli/airflow/runtimes"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
+	"golang.org/x/term"
 )
 
 const (
@@ -22,7 +23,12 @@ func AirflowCommand(id, airflowCommand string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cmd := exec.Command(containerRuntime, "exec", "-it", id, "bash", "-c", airflowCommand)
+	args := []string{"exec", "-i"}
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		args = append(args, "-t")
+	}
+	args = append(args, id, "bash", "-c", airflowCommand)
+	cmd := exec.Command(containerRuntime, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
## Summary

- Fixes hardcoded `-it` flags in `docker exec` calls that caused `the input device is not a TTY` errors in non-interactive environments (CI/CD, IDE terminals, cron, piped shells)
- Now detects whether stdin is a terminal and only passes `-t` when appropriate, while always keeping `-i` for stdin attachment
- Applies the fix to both `AirflowCommand()` in `docker/docker.go` (used by `airflow_settings.yaml` import for pools/connections/variables) and `Bash()` in `airflow/docker.go` (used by `astro dev bash`)

Closes #2022

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./docker/` — 19 tests pass
- [x] `go test ./settings/` — 27 tests pass
- [x] `go test ./airflow/` — 150+ tests pass (including `TestUseBash`)
- [x] Verified in non-TTY environment: `-t` is correctly omitted, args are `exec -i <container> bash -c <cmd>`
- [x] No new dependencies — `golang.org/x/term` was already in `go.mod`
- [ ] Manual test: `astro dev start` with `airflow_settings.yaml` pools/connections/variables in a CI-like environment
- [ ] Manual test: `astro dev bash` in an interactive terminal still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)