### PR TITLE
fix: mock registry API in tests and add HTTP client timeouts

### DIFF
--- a/cmd/registry/dag.go
+++ b/cmd/registry/dag.go
@@ -13,8 +13,11 @@ import (
 	"github.com/astronomer/astro-cli/pkg/logger"
 )
 
+var registryHost = "api.astronomer.io"
+
+var registryScheme = "https"
+
 const (
-	registryHost        = "api.astronomer.io"
 	registryAPI         = "registryV2/v1alpha1/organizations/public"
 	dagRoute            = "dags/%s/versions/%s"
 	providerRoute       = "providers/%s/versions/%s"
@@ -103,7 +106,7 @@ func downloadDag(dagID, dagVersion string, addProviders bool, out io.Writer) {
 func getDagRoute(dagID, dagVersion string) string {
 	filledDagRoute := fmt.Sprintf(dagRoute, dagID, dagVersion)
 	getDagURL := url.URL{
-		Scheme: "https",
+		Scheme: registryScheme,
 		Host:   registryHost,
 		Path:   fmt.Sprintf("%s/%s", registryAPI, filledDagRoute),
 	}

--- a/cmd/registry/dag_test.go
+++ b/cmd/registry/dag_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"os"
 
-	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -26,6 +25,11 @@ func execDagCmd(args ...string) (string, error) {
 func (s *Suite) TestDagAdd() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
+	server := newMockRegistryServer()
+	defer server.Close()
+	cleanup := setMockRegistry(server)
+	defer cleanup()
+
 	defer os.Remove("dags/sagemaker-batch-inference.py")
 
 	cmdArgs := []string{"add", "sagemaker-batch-inference"}
@@ -33,9 +37,9 @@ func (s *Suite) TestDagAdd() {
 	s.NoError(err)
 	s.Contains(resp, "dags/sagemaker-batch-inference.py", "we mention where we downloaded it in stdout")
 
-	fileContents, _ := fileutil.ReadFileToString("dags/sagemaker-batch-inference.py")
-	s.Contains(fileContents, "airflow", "The DAG has words in it")
-	s.Contains(fileContents, "DAG", "The DAG has words in it")
+	fileContents, _ := os.ReadFile("dags/sagemaker-batch-inference.py")
+	s.Contains(string(fileContents), "airflow", "The DAG has words in it")
+	s.Contains(string(fileContents), "DAG", "The DAG has words in it")
 
 	_ = os.Remove("dags/sagemaker-batch-inference.py")
 }

--- a/cmd/registry/provider.go
+++ b/cmd/registry/provider.go
@@ -50,7 +50,7 @@ func newRegistryAddProviderCmd(out io.Writer) *cobra.Command {
 
 func getProviderSearchRoute(providerName string) string {
 	getProviderURL := url.URL{
-		Scheme:   "https",
+		Scheme:   registryScheme,
 		Host:     registryHost,
 		Path:     fmt.Sprintf("%s/%s", registryAPI, providerSearchRoute),
 		RawQuery: fmt.Sprintf(providerSearchQuery, url.QueryEscape(providerName)),
@@ -60,7 +60,7 @@ func getProviderSearchRoute(providerName string) string {
 
 func getProviderRoute(providerID, providerVersion string) string {
 	getProviderURL := url.URL{
-		Scheme: "https",
+		Scheme: registryScheme,
 		Host:   registryHost,
 		Path:   fmt.Sprintf("%s/%s", registryAPI, fmt.Sprintf(providerRoute, providerID, providerVersion)),
 	}

--- a/cmd/registry/provider_test.go
+++ b/cmd/registry/provider_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"os"
 
-	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -26,6 +25,11 @@ func execProviderCmd(args ...string) (string, error) {
 func (s *Suite) TestProviderAdd() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
+	server := newMockRegistryServer()
+	defer server.Close()
+	cleanup := setMockRegistry(server)
+	defer cleanup()
+
 	defer os.Remove("requirements.txt")
 
 	cmdArgs := []string{"add", "snowflake"}
@@ -33,14 +37,13 @@ func (s *Suite) TestProviderAdd() {
 	s.NoError(err)
 	s.NotContains(resp, "I don't know why this is empty", "I don't know why stdout is empty")
 
-	fileContents, _ := fileutil.ReadFileToString("requirements.txt")
-	s.Regexp(`apache-airflow-providers-snowflake==\d+\.\d+\.\d+\n$`, fileContents, "We added the provider to the file")
+	fileContents, _ := os.ReadFile("requirements.txt")
+	s.Regexp(`apache-airflow-providers-snowflake==\d+\.\d+\.\d+\n$`, string(fileContents), "We added the provider to the file")
 
 	_, err = execProviderCmd(cmdArgs...)
 	s.NoError(err)
-	// TODO - assert against stdout "apache-airflow-providers-snowflake already exists in requirements.txt"
-	fileContents, _ = fileutil.ReadFileToString("requirements.txt")
-	s.Regexp(`apache-airflow-providers-snowflake==\d+\.\d+\.\d+\n$`, fileContents, "We didn't write it again")
+	fileContents, _ = os.ReadFile("requirements.txt")
+	s.Regexp(`apache-airflow-providers-snowflake==\d+\.\d+\.\d+\n$`, string(fileContents), "We didn't write it again")
 
 	_ = os.Remove("requirements.txt")
 }

--- a/cmd/registry/root_test.go
+++ b/cmd/registry/root_test.go
@@ -2,6 +2,10 @@ package registry
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -15,6 +19,51 @@ type Suite struct {
 
 func TestRegistry(t *testing.T) {
 	suite.Run(t, new(Suite))
+}
+
+// newMockRegistryServer creates an httptest server that mocks the Astronomer Registry API.
+func newMockRegistryServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case fmt.Sprintf("/%s/dags/sagemaker-batch-inference/versions/latest", registryAPI):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"githubRawSourceUrl": fmt.Sprintf("http://%s/raw/sagemaker-batch-inference.py", r.Host),
+				"filePath":           "dags/sagemaker-batch-inference.py",
+			})
+		case "/raw/sagemaker-batch-inference.py":
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("from airflow import DAG\n# sagemaker-batch-inference DAG\n"))
+		case fmt.Sprintf("/%s/providers", registryAPI):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"providers": []interface{}{
+					map[string]interface{}{
+						"name":    "apache-airflow-providers-snowflake",
+						"version": "6.10.0",
+					},
+				},
+			})
+		case fmt.Sprintf("/%s/providers/apache-airflow-providers-snowflake/versions/6.10.0", registryAPI):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"name":    "apache-airflow-providers-snowflake",
+				"version": "6.10.0",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// setMockRegistry points the registry client at the given test server and returns a cleanup function.
+func setMockRegistry(server *httptest.Server) func() {
+	origHost := registryHost
+	origScheme := registryScheme
+	registryHost = server.Listener.Addr().String()
+	registryScheme = "http"
+	return func() {
+		registryHost = origHost
+		registryScheme = origScheme
+	}
 }
 
 func (s *Suite) TestRegistryCommand() {

--- a/pkg/httputil/http.go
+++ b/pkg/httputil/http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/astronomer/astro-cli/pkg/logger"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context/ctxhttp"
 )
+
+const defaultHTTPTimeout = 30 * time.Second
 
 var ErrorBaseURL = errors.New("invalid baseurl")
 
@@ -121,6 +124,7 @@ func DownloadResponseToFile(sourceURL, path string) {
 	}
 
 	client := http.Client{
+		Timeout: defaultHTTPTimeout,
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			r.URL.Opaque = r.URL.Path
 			return nil
@@ -141,7 +145,8 @@ func DownloadResponseToFile(sourceURL, path string) {
 }
 
 func RequestAndGetJSONBody(route string) map[string]interface{} {
-	res, err := http.Get(route) //nolint
+	client := &http.Client{Timeout: defaultHTTPTimeout}
+	res, err := client.Get(route) //nolint
 	if err != nil {
 		logger.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Registry tests (`cmd/registry`) were making real HTTP calls to `api.astronomer.io` with **no timeout** on the HTTP client, causing CI to hang for 120+ seconds and fail when the API is slow or unresponsive
- Replaced real API calls with `httptest` mock servers so tests are fast, deterministic, and have no external dependency
- Added a 30-second timeout to HTTP clients in `RequestAndGetJSONBody` and `DownloadResponseToFile` to prevent the CLI itself from hanging indefinitely

## Test plan
- [x] `go test -count=1 ./cmd/registry/...` passes in <1s (was 120s+ timeout)
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)