### PR TITLE
fix(parse): handle PYTEST_THEME env var in DAG integrity test

### DIFF
--- a/airflow/include/airflow2/dagintegritytestdefault.py
+++ b/airflow/include/airflow2/dagintegritytestdefault.py
@@ -46,6 +46,10 @@ def os_getenv_monkeypatch(key: str, *args, **kwargs):
         key == "JENKINS_HOME" and default is None
     ):  # fix https://github.com/astronomer/astro-cli/issues/601
         return None
+    if (
+        key == "PYTEST_THEME" and default is None
+    ):  # fix pytest validation of pygment styles
+        return None
     if default:
         return default  # otherwise return whatever default has been passed
     return f"MOCKED_{key.upper()}_VALUE"  # if absolutely nothing has been passed - return the mocked value

--- a/airflow/include/airflow3/dagintegritytestdefault.py
+++ b/airflow/include/airflow3/dagintegritytestdefault.py
@@ -46,6 +46,10 @@ def os_getenv_monkeypatch(key: str, *args, **kwargs):
         key == "JENKINS_HOME" and default is None
     ):  # fix https://github.com/astronomer/astro-cli/issues/601
         return None
+    if (
+        key == "PYTEST_THEME" and default is None
+    ):  # fix pytest validation of pygment styles
+        return None
     if default:
         return default  # otherwise return whatever default has been passed
     return f"MOCKED_{key.upper()}_VALUE"  # if absolutely nothing has been passed - return the mocked value


### PR DESCRIPTION
Fixes a bug where `astro dev parse` fails when projects specify `--color=yes` in their pytest configuration. The monkeypatched `os.getenv()` in the DAG integrity test templates returns `MOCKED_PYTEST_THEME_VALUE` for unset environment variables, which pytest validates against known Pygment styles and rejects. This change adds special handling for `PYTEST_THEME` (similar to the existing `JENKINS_HOME` fix from #601), returning `None` when the variable is unset instead of a mocked value.

## 🎟 Issue(s)

Resolves a bug where pytest fails with:
```
ERROR: PYTEST_THEME environment variable had an invalid value: 'MOCKED_PYTEST_THEME_VALUE'.
Only valid pygment styles are allowed.
```

Related to #601 (similar fix pattern for JENKINS_HOME)

## 🧪 Functional Testing

1. Create an Astro project with pytest configured to use `--color=yes`:
   ```bash
   astro dev init
   ```

2. Add to `pytest.ini` or `pyproject.toml`:
   ```ini
   [tool.pytest.ini_options]
   addopts = "--color=yes"
   ```

3. Run parse command:
   ```bash
   astro dev parse
   ```

4. Verify it completes successfully without PYTEST_THEME error

**Before this fix:** Command fails with "PYTEST_THEME environment variable had an invalid value"
**After this fix:** Command succeeds and DAGs parse correctly

## 📸 Screenshots

N/A - This is a bug fix that prevents an error message, no visual changes

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests (N/A - no existing tests for monkeypatch functions)
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary). (N/A - local CLI fix only)
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary). (N/A - local CLI fix only)
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes. (N/A - internal fix)
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/) (N/A - fixes existing behavior)

## Files Changed

- `airflow/include/airflow2/dagintegritytestdefault.py` - Added PYTEST_THEME special case
- `airflow/include/airflow3/dagintegritytestdefault.py` - Added PYTEST_THEME special case
- `go.mod` - Fixed go version format from `1.24.0` to `1.24`

## Notes for Reviewers

This follows the exact same pattern as the JENKINS_HOME fix that was added for issue #601. The monkeypatch templates already have infrastructure for handling environment variables that need special treatment - this simply adds PYTEST_THEME to that list.
