### PR TITLE
fix(standalone): pass --python to uv pip install to target project venv

### DIFF
--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -267,9 +267,14 @@ func (s *Standalone) Start(opts *types.StartOptions) error {
 	}
 
 	// 6. Install dependencies (2-step install)
+	// --python explicitly targets the project venv so uv never installs into
+	// a parent venv even if VIRTUAL_ENV leaks through the environment.
+	venvPython := filepath.Join(s.airflowHome, ".venv", "bin", "python")
+
 	// Step 1: Install airflow with full freeze constraints (reproduces runtime env exactly)
 	installArgs := []string{
 		"pip", "install",
+		"--python", venvPython,
 		fmt.Sprintf("apache-airflow==%s", airflowVersion),
 		"-c", freezePath,
 		"--index-url", standaloneIndexURL,
@@ -285,6 +290,7 @@ func (s *Standalone) Start(opts *types.StartOptions) error {
 	if exists, _ := fileutil.Exists(requirementsPath, nil); exists {
 		userInstallArgs := []string{
 			"pip", "install",
+			"--python", venvPython,
 			"-r", requirementsPath,
 			fmt.Sprintf("apache-airflow==%s", airflowVersion),
 		}


### PR DESCRIPTION
## Summary
- When the CLI is launched from inside an activated venv (e.g. via `uv run`), the inherited `VIRTUAL_ENV` env var causes `uv pip install` to target the parent venv instead of the project's `.venv/`, leaving `.venv/bin/airflow` missing
- Passes `--python .venv/bin/python` explicitly to both `uv pip install` commands so they always install into the project venv regardless of the parent environment

## Test plan
- [x] Full `./airflow/` test suite passes
- [x] Integration test: `VIRTUAL_ENV=/fake astro dev start --standalone` succeeds, `.venv/bin/airflow` exists in project venv

🤖 Generated with [Claude Code](https://claude.com/claude-code)