### PR TITLE
fix: add Windows build tags for proxy package

### DIFF
--- a/airflow/proxy/daemon.go
+++ b/airflow/proxy/daemon.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package proxy
 
 import (

--- a/airflow/proxy/daemon_windows.go
+++ b/airflow/proxy/daemon_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package proxy
+
+import (
+	"fmt"
+)
+
+var errUnsupportedWindows = fmt.Errorf("proxy daemon is not supported on Windows")
+
+// StartDaemon is not supported on Windows.
+var StartDaemon = func(port string) error {
+	return errUnsupportedWindows
+}
+
+// IsRunning always returns false on Windows.
+func IsRunning() (int, bool) {
+	return 0, false
+}
+
+// EnsureRunning returns an error on Windows.
+func EnsureRunning(port string) (string, error) {
+	return "", errUnsupportedWindows
+}
+
+// StopDaemon is a no-op on Windows.
+func StopDaemon() error {
+	return nil
+}
+
+// StopIfEmpty is a no-op on Windows.
+func StopIfEmpty() {}

--- a/airflow/proxy/routes.go
+++ b/airflow/proxy/routes.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/astronomer/astro-cli/config"
@@ -44,41 +43,6 @@ func routesFilePath() string {
 // lockFilePath returns the path used for the flock-based file lock.
 func lockFilePath() string {
 	return filepath.Join(proxyDirPath(), lockFileName)
-}
-
-// acquireLock acquires an exclusive file lock (flock) with timeout.
-// Returns the lock file which must be passed to releaseLock.
-func acquireLock() (*os.File, error) {
-	if err := os.MkdirAll(proxyDirPath(), dirPermRWX); err != nil {
-		return nil, fmt.Errorf("error creating proxy directory: %w", err)
-	}
-
-	f, err := os.OpenFile(lockFilePath(), os.O_CREATE|os.O_RDWR, filePermRW)
-	if err != nil {
-		return nil, fmt.Errorf("error opening lock file: %w", err)
-	}
-
-	deadline := time.Now().Add(lockTimeout)
-	for {
-		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-		if err == nil {
-			return f, nil
-		}
-		if time.Now().After(deadline) {
-			f.Close()
-			return nil, fmt.Errorf("timed out waiting for routes lock")
-		}
-		time.Sleep(50 * time.Millisecond) //nolint:mnd
-	}
-}
-
-// releaseLock releases the flock and closes the lock file.
-func releaseLock(f *os.File) {
-	if f == nil {
-		return
-	}
-	syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint:errcheck
-	f.Close()
 }
 
 // readRoutes reads routes from the routes file. Returns empty slice if file doesn't exist.
@@ -122,18 +86,6 @@ func writeRoutes(routes []Route) error {
 		return fmt.Errorf("error renaming routes temp file: %w", err)
 	}
 	return nil
-}
-
-// isPIDAlive checks if a process with the given PID is still running.
-var isPIDAlive = func(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return proc.Signal(syscall.Signal(0)) == nil
 }
 
 // pruneStaleRoutes removes routes whose owner process is no longer alive.

--- a/airflow/proxy/routes_unix.go
+++ b/airflow/proxy/routes_unix.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+// acquireLock acquires an exclusive file lock (flock) with timeout.
+// Returns the lock file which must be passed to releaseLock.
+func acquireLock() (*os.File, error) {
+	if err := os.MkdirAll(proxyDirPath(), dirPermRWX); err != nil {
+		return nil, fmt.Errorf("error creating proxy directory: %w", err)
+	}
+
+	f, err := os.OpenFile(lockFilePath(), os.O_CREATE|os.O_RDWR, filePermRW)
+	if err != nil {
+		return nil, fmt.Errorf("error opening lock file: %w", err)
+	}
+
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return f, nil
+		}
+		if time.Now().After(deadline) {
+			f.Close()
+			return nil, fmt.Errorf("timed out waiting for routes lock")
+		}
+		time.Sleep(50 * time.Millisecond) //nolint:mnd
+	}
+}
+
+// releaseLock releases the flock and closes the lock file.
+func releaseLock(f *os.File) {
+	if f == nil {
+		return
+	}
+	syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint:errcheck
+	f.Close()
+}
+
+// isPIDAlive checks if a process with the given PID is still running.
+var isPIDAlive = func(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/airflow/proxy/routes_windows.go
+++ b/airflow/proxy/routes_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package proxy
+
+import (
+	"fmt"
+	"os"
+)
+
+// acquireLock on Windows opens the lock file without flock.
+// The proxy daemon does not run on Windows, so file locking is best-effort.
+func acquireLock() (*os.File, error) {
+	if err := os.MkdirAll(proxyDirPath(), dirPermRWX); err != nil {
+		return nil, fmt.Errorf("error creating proxy directory: %w", err)
+	}
+
+	f, err := os.OpenFile(lockFilePath(), os.O_CREATE|os.O_RDWR, filePermRW)
+	if err != nil {
+		return nil, fmt.Errorf("error opening lock file: %w", err)
+	}
+	return f, nil
+}
+
+// releaseLock closes the lock file.
+func releaseLock(f *os.File) {
+	if f != nil {
+		f.Close()
+	}
+}
+
+// isPIDAlive on Windows always returns false.
+// The proxy daemon is not supported on Windows.
+var isPIDAlive = func(pid int) bool {
+	return false
+}


### PR DESCRIPTION
## Summary
- The reverse proxy feature (#2026) introduced Unix-only syscalls (`Setpgid`, `Kill`, `Flock`) in `airflow/proxy` that break the Windows build targets in goreleaser.
- Adds `//go:build !windows` tag to `daemon.go` and extracts platform-specific functions (`acquireLock`, `releaseLock`, `isPIDAlive`) from `routes.go` into `routes_unix.go`.
- Creates Windows stubs (`daemon_windows.go`, `routes_windows.go`) that make the proxy daemon unavailable on Windows while keeping the rest of the package functional.

## Test plan
- [x] `go build ./...` passes on darwin/linux/windows
- [x] `go test ./airflow/proxy/` passes
- [ ] goreleaser cross-compilation succeeds for all targets (linux, darwin, windows × amd64, arm64, 386)

🤖 Generated with [Claude Code](https://claude.com/claude-code)