### PR TITLE
Add Swagger 2.0 support and custom spec URL for api cloud

### DIFF
--- a/cmd/api/cloud.go
+++ b/cmd/api/cloud.go
@@ -19,6 +19,8 @@ import (
 // CloudOptions holds all options for the cloud api command.
 type CloudOptions struct {
 	RequestOptions
+	SpecURL         string // hidden flag: alternative OpenAPI spec URL
+	SpecTokenEnvVar string // hidden flag: env var name containing auth token for spec fetch
 }
 
 // NewCloudCmd creates the 'astro api cloud' command.
@@ -128,6 +130,12 @@ To pass nested values as arrays, declare multiple fields with key[]=value1.`,
 
 	// Other flags
 	cmd.Flags().BoolVar(&opts.GenerateCurl, "generate", false, "Output a curl command instead of executing the request")
+	cmd.PersistentFlags().StringVar(&opts.SpecURL, "spec-url", "", "OpenAPI spec URL (overrides default Cloud API spec)")
+	cmd.PersistentFlags().StringVar(&opts.SpecTokenEnvVar, "spec-token-env-var", "", "Environment variable containing auth token for fetching the spec")
+	//nolint:errcheck
+	cmd.PersistentFlags().MarkHidden("spec-url")
+	//nolint:errcheck
+	cmd.PersistentFlags().MarkHidden("spec-token-env-var")
 
 	// Add list and describe subcommands (cloud-specific to support lazy cache init)
 	cmd.AddCommand(NewCloudListCmd(out, opts))
@@ -206,7 +214,19 @@ func runCloud(opts *CloudOptions) error {
 	}
 
 	// Build the full URL using the domain-derived base URL
-	baseURL := ctx.GetPublicRESTAPIURL("v1")
+	var baseURL string
+	if opts.SpecURL != "" {
+		if err := opts.specCache.Load(false); err != nil {
+			return fmt.Errorf("loading spec: %w", err)
+		}
+		serverPath := opts.specCache.GetServerPath()
+		if serverPath == "" {
+			return fmt.Errorf("spec has no servers/basePath; cannot determine base URL")
+		}
+		baseURL = ctx.GetPublicRESTAPIURL(strings.TrimPrefix(serverPath, "/"))
+	} else {
+		baseURL = ctx.GetPublicRESTAPIURL("v1")
+	}
 	url := buildURL(baseURL, requestPath)
 
 	// Generate curl command if requested
@@ -372,6 +392,23 @@ func initCloudSpecCache(opts *CloudOptions, ctx *config.Context) error {
 	if opts.specCache != nil {
 		return nil
 	}
+
+	// When --spec-url is provided, use it. If --spec-token-env-var is also set,
+	// read the token from that env var and send it as auth when fetching the spec.
+	if opts.SpecURL != "" {
+		cachePath := filepath.Join(config.HomeConfigPath, openapi.SpecCacheFileName(opts.SpecURL))
+		if opts.SpecTokenEnvVar != "" {
+			token := os.Getenv(opts.SpecTokenEnvVar)
+			if token == "" {
+				return fmt.Errorf("environment variable %q is not set", opts.SpecTokenEnvVar)
+			}
+			opts.specCache = openapi.NewCacheWithAuth(opts.SpecURL, cachePath, token)
+		} else {
+			opts.specCache = openapi.NewCacheWithOptions(opts.SpecURL, cachePath)
+		}
+		return nil
+	}
+
 	domain := domainutil.FormatDomain(ctx.Domain)
 	specURL := ctx.GetPublicRESTAPIURL("spec/v1.0")
 	if specURL == "" {

--- a/cmd/api/cloud_test.go
+++ b/cmd/api/cloud_test.go
@@ -362,3 +362,153 @@ func TestCloudCmdLongDescription(t *testing.T) {
 	assert.Contains(t, cmd.Long, "Astro Cloud API")
 	assert.Contains(t, cmd.Example, "astro api cloud")
 }
+
+// --- --spec-url flag ---------------------------------------------------------
+
+func TestCloudSpecURLFlag(t *testing.T) {
+	out := new(bytes.Buffer)
+	cmd := NewCloudCmd(out)
+
+	flag := cmd.PersistentFlags().Lookup("spec-url")
+	require.NotNil(t, flag, "--spec-url flag should exist")
+
+	// Verify hidden
+	assert.True(t, flag.Hidden, "--spec-url should be hidden")
+}
+
+func TestInitCloudSpecCache_SpecURL(t *testing.T) {
+	initTestConfig(t)
+
+	opts := &CloudOptions{SpecURL: "https://example.com/spec.json"}
+	ctx := &config.Context{
+		Domain: "example.com",
+		Token:  "my-secret-token",
+	}
+
+	err := initCloudSpecCache(opts, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, opts.specCache)
+
+	// The spec URL should be the custom one
+	assert.Equal(t, "https://example.com/spec.json", opts.specCache.GetSpecURL())
+	// Cache file name should be hash-based
+	assert.Contains(t, openapi.SpecCacheFileName("https://example.com/spec.json"), "openapi-cache-")
+}
+
+func TestRunCloud_SpecURL_BaseURL(t *testing.T) {
+	initTestConfig(t)
+
+	// Create a test server that serves a Swagger 2.0 spec
+	specJSON := []byte(`{"swagger":"2.0","info":{"title":"T","version":"1"},"basePath":"/api/v1","paths":{"/items":{"get":{"operationId":"ListItems","responses":{"200":{"description":"OK"}}}}}}`)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(specJSON)
+	}))
+	defer ts.Close()
+
+	out := new(bytes.Buffer)
+	opts := &CloudOptions{
+		RequestOptions: RequestOptions{
+			Out:          out,
+			ErrOut:       out,
+			RequestPath:  "ListItems",
+			GenerateCurl: true,
+		},
+		SpecURL: ts.URL,
+	}
+
+	ctx := &config.Context{
+		Domain:       "example.com",
+		Token:        "test-token",
+		Organization: "org-123",
+	}
+
+	err := initCloudSpecCache(opts, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, opts.specCache)
+
+	// Verify the cache can load the v2 spec
+	err = opts.specCache.Load(false)
+	require.NoError(t, err)
+
+	// Verify the server path is extracted from the spec
+	serverPath := opts.specCache.GetServerPath()
+	assert.Equal(t, "/api/v1", serverPath)
+}
+
+// --- --spec-token-env-var flag -----------------------------------------------
+
+func TestCloudSpecTokenEnvVarFlag(t *testing.T) {
+	out := new(bytes.Buffer)
+	cmd := NewCloudCmd(out)
+
+	flag := cmd.PersistentFlags().Lookup("spec-token-env-var")
+	require.NotNil(t, flag, "--spec-token-env-var flag should exist")
+	assert.True(t, flag.Hidden, "--spec-token-env-var should be hidden")
+}
+
+func TestInitCloudSpecCache_SpecTokenEnvVar(t *testing.T) {
+	initTestConfig(t)
+
+	t.Setenv("TEST_SPEC_TOKEN", "my-secret-token-123")
+
+	opts := &CloudOptions{
+		SpecURL:         "https://example.com/private/spec.json",
+		SpecTokenEnvVar: "TEST_SPEC_TOKEN",
+	}
+	ctx := &config.Context{
+		Domain: "example.com",
+		Token:  "context-token",
+	}
+
+	err := initCloudSpecCache(opts, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, opts.specCache)
+
+	// Verify the spec URL
+	assert.Equal(t, "https://example.com/private/spec.json", opts.specCache.GetSpecURL())
+}
+
+func TestInitCloudSpecCache_SpecTokenEnvVar_FetchSendsAuth(t *testing.T) {
+	initTestConfig(t)
+
+	specJSON := []byte(`{"swagger":"2.0","info":{"title":"T","version":"1"},"basePath":"/api/v1","paths":{}}`)
+
+	var receivedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(specJSON)
+	}))
+	defer ts.Close()
+
+	t.Setenv("TEST_SPEC_AUTH", "secret-token-456")
+
+	opts := &CloudOptions{
+		SpecURL:         ts.URL,
+		SpecTokenEnvVar: "TEST_SPEC_AUTH",
+	}
+	ctx := &config.Context{Domain: "example.com"}
+
+	err := initCloudSpecCache(opts, ctx)
+	require.NoError(t, err)
+
+	err = opts.specCache.Load(false)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer secret-token-456", receivedAuth)
+}
+
+func TestInitCloudSpecCache_SpecTokenEnvVar_Empty(t *testing.T) {
+	initTestConfig(t)
+
+	opts := &CloudOptions{
+		SpecURL:         "https://example.com/spec.json",
+		SpecTokenEnvVar: "NONEXISTENT_VAR_FOR_TEST",
+	}
+	ctx := &config.Context{Domain: "example.com"}
+
+	err := initCloudSpecCache(opts, ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `environment variable "NONEXISTENT_VAR_FOR_TEST" is not set`)
+}

--- a/pkg/openapi/cache.go
+++ b/pkg/openapi/cache.go
@@ -2,16 +2,19 @@ package openapi
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/astronomer/astro-cli/config"
+	v2high "github.com/pb33f/libopenapi/datamodel/high/v2"
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
@@ -63,9 +66,11 @@ type Cache struct {
 	specURL     string
 	cachePath   string
 	stripPrefix string // optional prefix to strip from endpoint paths (e.g. "/api/v2")
+	authToken   string // optional auth token for fetching specs
 	httpClient  *http.Client
 	doc         *v3high.Document
-	rawSpec     []byte // raw spec bytes for cache serialization
+	v2doc       *v2high.Swagger // non-nil if spec is Swagger 2.0
+	rawSpec     []byte          // raw spec bytes for cache serialization
 	fetchedAt   time.Time
 }
 
@@ -96,6 +101,21 @@ func NewCacheWithOptions(specURL, cachePath string) *Cache {
 		specURL:   specURL,
 		cachePath: cachePath,
 	}
+}
+
+// NewCacheWithAuth creates a new OpenAPI cache that sends an auth token when fetching specs.
+func NewCacheWithAuth(specURL, cachePath, authToken string) *Cache {
+	return &Cache{
+		specURL:   specURL,
+		cachePath: cachePath,
+		authToken: authToken,
+	}
+}
+
+// SpecCacheFileName returns a deterministic cache file name derived from a spec URL.
+func SpecCacheFileName(specURL string) string {
+	h := sha256.Sum256([]byte(specURL))
+	return fmt.Sprintf("openapi-cache-%x.json", h[:8])
 }
 
 // NewAirflowCacheForVersion creates a new OpenAPI cache configured for a specific Airflow version.
@@ -137,7 +157,7 @@ func (c *Cache) Load(forceRefresh bool) error {
 	// Fetch fresh spec
 	if err := c.fetchSpec(); err != nil {
 		// If fetch fails and we have a stale cache, use it
-		if c.doc != nil {
+		if c.IsLoaded() {
 			return nil
 		}
 		return err
@@ -160,10 +180,15 @@ func (c *Cache) GetDoc() *v3high.Document {
 // GetEndpoints extracts all endpoints from the loaded spec.
 // If a stripPrefix is configured, it is removed from each endpoint path.
 func (c *Cache) GetEndpoints() []Endpoint {
-	if c.doc == nil {
+	var endpoints []Endpoint
+	switch {
+	case c.doc != nil:
+		endpoints = ExtractEndpoints(c.doc)
+	case c.v2doc != nil:
+		endpoints = ExtractEndpointsV2(c.v2doc)
+	default:
 		return nil
 	}
-	endpoints := ExtractEndpoints(c.doc)
 	if c.stripPrefix != "" {
 		for i := range endpoints {
 			endpoints[i].Path = strings.TrimPrefix(endpoints[i].Path, c.stripPrefix)
@@ -174,7 +199,23 @@ func (c *Cache) GetEndpoints() []Endpoint {
 
 // IsLoaded returns true if a spec has been loaded.
 func (c *Cache) IsLoaded() bool {
-	return c.doc != nil
+	return c.doc != nil || c.v2doc != nil
+}
+
+// GetServerPath returns the base path from the loaded spec.
+// For OpenAPI 3.x it extracts the path from servers[0].url.
+// For Swagger 2.0 it returns the basePath field.
+func (c *Cache) GetServerPath() string {
+	if c.doc != nil && len(c.doc.Servers) > 0 {
+		u, err := url.Parse(c.doc.Servers[0].URL)
+		if err == nil {
+			return strings.TrimSuffix(u.Path, "/")
+		}
+	}
+	if c.v2doc != nil {
+		return strings.TrimSuffix(c.v2doc.BasePath, "/")
+	}
+	return ""
 }
 
 // readCache attempts to read the cached spec from disk.
@@ -189,12 +230,13 @@ func (c *Cache) readCache() error {
 		return err
 	}
 
-	doc, err := parseSpec(cached.RawSpec)
+	v3doc, v2doc, err := parseSpec(cached.RawSpec)
 	if err != nil {
 		return err
 	}
 
-	c.doc = doc
+	c.doc = v3doc
+	c.v2doc = v2doc
 	c.rawSpec = cached.RawSpec
 	c.fetchedAt = cached.FetchedAt
 	return nil
@@ -239,6 +281,10 @@ func (c *Cache) fetchSpec() error {
 	// Accept both JSON and YAML
 	req.Header.Set("Accept", "application/json, application/yaml, text/yaml, */*")
 
+	if c.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.authToken)
+	}
+
 	resp, err := c.getHTTPClient().Do(req)
 	if err != nil {
 		return fmt.Errorf("fetching OpenAPI spec: %w", err)
@@ -254,32 +300,47 @@ func (c *Cache) fetchSpec() error {
 		return fmt.Errorf("reading response body: %w", err)
 	}
 
-	doc, err := parseSpec(body)
+	v3doc, v2doc, err := parseSpec(body)
 	if err != nil {
 		return fmt.Errorf("parsing OpenAPI spec: %w", err)
 	}
 
-	c.doc = doc
+	c.doc = v3doc
+	c.v2doc = v2doc
 	c.rawSpec = body
 	c.fetchedAt = time.Now()
 	return nil
 }
 
-// parseSpec parses raw bytes into an OpenAPI v3 document using libopenapi.
+// parseSpec parses raw bytes into an OpenAPI document using libopenapi.
+// It detects the spec version and returns either a v3 or v2 model.
 // This handles both JSON and YAML formats and resolves $ref references.
-func parseSpec(data []byte) (*v3high.Document, error) {
+func parseSpec(data []byte) (*v3high.Document, *v2high.Swagger, error) {
 	doc, err := newDocument(data)
 	if err != nil {
-		return nil, fmt.Errorf("creating document: %w", err)
+		return nil, nil, fmt.Errorf("creating document: %w", err)
 	}
+
+	version := doc.GetVersion()
+	if strings.HasPrefix(version, "2.") {
+		model, err := doc.BuildV2Model()
+		if err != nil {
+			return nil, nil, fmt.Errorf("building v2 model: %w", err)
+		}
+		if model == nil {
+			return nil, nil, fmt.Errorf("building v2 model: unknown error")
+		}
+		return nil, &model.Model, nil
+	}
+
 	model, err := doc.BuildV3Model()
 	if err != nil {
-		return nil, fmt.Errorf("building v3 model: %w", err)
+		return nil, nil, fmt.Errorf("building v3 model: %w", err)
 	}
 	if model == nil {
-		return nil, fmt.Errorf("building v3 model: unknown error")
+		return nil, nil, fmt.Errorf("building v3 model: unknown error")
 	}
-	return &model.Model, nil
+	return &model.Model, nil, nil
 }
 
 // ClearCache removes the cached spec file.

--- a/pkg/openapi/cache_test.go
+++ b/pkg/openapi/cache_test.go
@@ -113,7 +113,7 @@ func TestGetDoc_Nil(t *testing.T) {
 
 func TestGetDoc_Loaded(t *testing.T) {
 	body := minimalSpecJSON("Test", map[string]map[string]map[string]any{})
-	doc, err := parseSpec(body)
+	doc, _, err := parseSpec(body)
 	require.NoError(t, err)
 	cache := &Cache{doc: doc}
 	assert.NotNil(t, cache.GetDoc())
@@ -131,7 +131,7 @@ func TestGetEndpoints_NoPrefix(t *testing.T) {
 	body := minimalSpecJSON("Test", map[string]map[string]map[string]any{
 		"/dags": {"get": {"operationId": "get_dags"}},
 	})
-	doc, err := parseSpec(body)
+	doc, _, err := parseSpec(body)
 	require.NoError(t, err)
 
 	cache := &Cache{doc: doc}
@@ -145,7 +145,7 @@ func TestGetEndpoints_WithPrefixStripping(t *testing.T) {
 		"/api/v2/dags":    {"get": {"operationId": "get_dags"}},
 		"/api/v2/version": {"get": {"operationId": "version"}},
 	})
-	doc, err := parseSpec(body)
+	doc, _, err := parseSpec(body)
 	require.NoError(t, err)
 
 	cache := &Cache{doc: doc, stripPrefix: "/api/v2"}
@@ -184,7 +184,7 @@ func TestCacheReadWriteRoundTrip(t *testing.T) {
 	rawSpec := minimalSpecJSON("Test API", map[string]map[string]map[string]any{
 		"/test": {"get": {"operationId": "getTest"}},
 	})
-	doc, err := parseSpec(rawSpec)
+	doc, _, err := parseSpec(rawSpec)
 	require.NoError(t, err)
 
 	// Write
@@ -465,4 +465,144 @@ func TestClearCache_NotFound(t *testing.T) {
 	cache := &Cache{cachePath: "/nonexistent/cache.json"}
 	err := cache.ClearCache()
 	assert.Error(t, err)
+}
+
+// --- parseSpec version detection ---------------------------------------------
+
+func TestParseSpec_SwaggerV2(t *testing.T) {
+	spec := []byte(`{"swagger":"2.0","info":{"title":"V2 Spec","version":"1.0"},"basePath":"/api/v1","paths":{"/test":{"get":{"operationId":"getTest","responses":{"200":{"description":"OK"}}}}}}`)
+	v3doc, v2doc, err := parseSpec(spec)
+	require.NoError(t, err)
+	assert.Nil(t, v3doc)
+	require.NotNil(t, v2doc)
+	assert.Equal(t, "V2 Spec", v2doc.Info.Title)
+	assert.Equal(t, "/api/v1", v2doc.BasePath)
+}
+
+func TestParseSpec_OpenAPIV3(t *testing.T) {
+	spec := minimalSpecJSON("V3 Spec", map[string]map[string]map[string]any{})
+	v3doc, v2doc, err := parseSpec(spec)
+	require.NoError(t, err)
+	require.NotNil(t, v3doc)
+	assert.Nil(t, v2doc)
+	assert.Equal(t, "V3 Spec", v3doc.Info.Title)
+}
+
+// --- GetServerPath -----------------------------------------------------------
+
+func TestGetServerPath_V2(t *testing.T) {
+	spec := []byte(`{"swagger":"2.0","info":{"title":"T","version":"1"},"basePath":"/api/v1","paths":{}}`)
+	_, v2doc, err := parseSpec(spec)
+	require.NoError(t, err)
+
+	cache := &Cache{v2doc: v2doc}
+	assert.Equal(t, "/api/v1", cache.GetServerPath())
+}
+
+func TestGetServerPath_V3(t *testing.T) {
+	spec := []byte(`{"openapi":"3.0.0","info":{"title":"T","version":"1"},"servers":[{"url":"https://api.example.com/api/v2"}],"paths":{}}`)
+	v3doc, _, err := parseSpec(spec)
+	require.NoError(t, err)
+
+	cache := &Cache{doc: v3doc}
+	assert.Equal(t, "/api/v2", cache.GetServerPath())
+}
+
+func TestGetServerPath_V3_TrailingSlash(t *testing.T) {
+	spec := []byte(`{"openapi":"3.0.0","info":{"title":"T","version":"1"},"servers":[{"url":"https://api.example.com/v1/"}],"paths":{}}`)
+	v3doc, _, err := parseSpec(spec)
+	require.NoError(t, err)
+
+	cache := &Cache{doc: v3doc}
+	assert.Equal(t, "/v1", cache.GetServerPath())
+}
+
+func TestGetServerPath_NoServers(t *testing.T) {
+	cache := &Cache{}
+	assert.Equal(t, "", cache.GetServerPath())
+}
+
+// --- NewCacheWithAuth --------------------------------------------------------
+
+func TestNewCacheWithAuth(t *testing.T) {
+	cache := NewCacheWithAuth("https://example.com/spec", "/tmp/cache.json", "my-token")
+	assert.Equal(t, "https://example.com/spec", cache.specURL)
+	assert.Equal(t, "/tmp/cache.json", cache.cachePath)
+	assert.Equal(t, "my-token", cache.authToken)
+}
+
+// --- FetchSpec with auth -----------------------------------------------------
+
+func TestFetchSpec_WithAuth(t *testing.T) {
+	body := minimalSpecJSON("Auth Test", map[string]map[string]map[string]any{})
+
+	var receivedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer ts.Close()
+
+	cache := NewCacheWithAuth(ts.URL, t.TempDir()+"/cache.json", "test-token-123")
+	err := cache.fetchSpec()
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer test-token-123", receivedAuth)
+}
+
+func TestFetchSpec_NoAuth(t *testing.T) {
+	body := minimalSpecJSON("No Auth", map[string]map[string]map[string]any{})
+
+	var receivedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer ts.Close()
+
+	cache := NewCacheWithOptions(ts.URL, t.TempDir()+"/cache.json")
+	err := cache.fetchSpec()
+	require.NoError(t, err)
+	assert.Equal(t, "", receivedAuth)
+}
+
+// --- SpecCacheFileName -------------------------------------------------------
+
+func TestSpecCacheFileName(t *testing.T) {
+	name1 := SpecCacheFileName("https://api.example.com/spec/v1.0")
+	name2 := SpecCacheFileName("https://api.example.com/spec/v2")
+	name3 := SpecCacheFileName("https://api.example.com/spec/v1.0")
+
+	// Deterministic
+	assert.Equal(t, name1, name3)
+	// Different URLs produce different names
+	assert.NotEqual(t, name1, name2)
+	// Matches expected pattern
+	assert.Regexp(t, `^openapi-cache-[0-9a-f]+\.json$`, name1)
+}
+
+// --- IsLoaded with v2 --------------------------------------------------------
+
+func TestIsLoaded_V2(t *testing.T) {
+	spec := []byte(`{"swagger":"2.0","info":{"title":"T","version":"1"},"basePath":"/","paths":{}}`)
+	_, v2doc, err := parseSpec(spec)
+	require.NoError(t, err)
+
+	cache := &Cache{v2doc: v2doc}
+	assert.True(t, cache.IsLoaded())
+}
+
+// --- GetEndpoints with v2 ----------------------------------------------------
+
+func TestGetEndpoints_V2(t *testing.T) {
+	spec := []byte(`{"swagger":"2.0","info":{"title":"T","version":"1"},"basePath":"/api/v1","paths":{"/orgs":{"get":{"operationId":"ListOrgs","responses":{"200":{"description":"OK"}}}}}}`)
+	_, v2doc, err := parseSpec(spec)
+	require.NoError(t, err)
+
+	cache := &Cache{v2doc: v2doc}
+	endpoints := cache.GetEndpoints()
+	require.Len(t, endpoints, 1)
+	assert.Equal(t, "/orgs", endpoints[0].Path)
+	assert.Equal(t, "ListOrgs", endpoints[0].OperationID)
 }

--- a/pkg/openapi/endpoints.go
+++ b/pkg/openapi/endpoints.go
@@ -12,6 +12,16 @@ import (
 
 const defaultMethodOrder = 99
 
+// sortEndpoints sorts endpoints by path, then by method order.
+func sortEndpoints(endpoints []Endpoint) {
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Path != endpoints[j].Path {
+			return endpoints[i].Path < endpoints[j].Path
+		}
+		return methodOrder(endpoints[i].Method) < methodOrder(endpoints[j].Method)
+	})
+}
+
 // ExtractEndpoints extracts all endpoints from an OpenAPI v3 document.
 func ExtractEndpoints(doc *v3high.Document) []Endpoint {
 	if doc == nil || doc.Paths == nil || doc.Paths.PathItems == nil {
@@ -21,35 +31,32 @@ func ExtractEndpoints(doc *v3high.Document) []Endpoint {
 	var endpoints []Endpoint
 
 	for path, pathItem := range doc.Paths.PathItems.FromOldest() {
-		type methodOp struct {
-			method string
-			op     *v3high.Operation
-		}
-		ops := []methodOp{
-			{"GET", pathItem.Get},
-			{"POST", pathItem.Post},
-			{"PUT", pathItem.Put},
-			{"PATCH", pathItem.Patch},
-			{"DELETE", pathItem.Delete},
-			{"OPTIONS", pathItem.Options},
-			{"HEAD", pathItem.Head},
-		}
-		for _, mo := range ops {
+		for _, mo := range v3MethodOps(pathItem) {
 			if mo.op != nil {
 				endpoints = append(endpoints, newEndpoint(mo.method, path, mo.op))
 			}
 		}
 	}
 
-	// Sort endpoints by path, then method
-	sort.Slice(endpoints, func(i, j int) bool {
-		if endpoints[i].Path != endpoints[j].Path {
-			return endpoints[i].Path < endpoints[j].Path
-		}
-		return methodOrder(endpoints[i].Method) < methodOrder(endpoints[j].Method)
-	})
-
+	sortEndpoints(endpoints)
 	return endpoints
+}
+
+type v3MethodOp struct {
+	method string
+	op     *v3high.Operation
+}
+
+func v3MethodOps(pi *v3high.PathItem) []v3MethodOp {
+	return []v3MethodOp{
+		{"GET", pi.Get},
+		{"POST", pi.Post},
+		{"PUT", pi.Put},
+		{"PATCH", pi.Patch},
+		{"DELETE", pi.Delete},
+		{"OPTIONS", pi.Options},
+		{"HEAD", pi.Head},
+	}
 }
 
 // newEndpoint creates an Endpoint from a libopenapi Operation.
@@ -154,12 +161,19 @@ func convertContentMap(content *orderedmap.Map[string, *v3high.MediaType]) map[s
 }
 
 // convertSchemaProxy converts a libopenapi SchemaProxy to our SchemaRef type.
+// When the proxy is a $ref, we return just the ref name without resolving it
+// to avoid infinite recursion on circular references.
 func convertSchemaProxy(sp *base.SchemaProxy) *SchemaRef {
 	if sp == nil {
 		return nil
 	}
 	ref := &SchemaRef{
 		Ref: sp.GetReference(),
+	}
+	// If this is a $ref, don't resolve it — just return the ref name.
+	// Resolving would cause infinite recursion on circular schemas.
+	if ref.Ref != "" {
+		return ref
 	}
 	schema, err := sp.BuildSchema()
 	if err != nil || schema == nil {

--- a/pkg/openapi/endpoints_test.go
+++ b/pkg/openapi/endpoints_test.go
@@ -18,7 +18,7 @@ func TestExtractEndpoints(t *testing.T) {
 			"delete": {"operationId": "deleteOrganization", "summary": "Delete organization", "tags": []string{"Organizations"}, "deprecated": true},
 		},
 	})
-	doc, err := parseSpec(specJSON)
+	doc, _, err := parseSpec(specJSON)
 	require.NoError(t, err)
 
 	endpoints := ExtractEndpoints(doc)
@@ -132,7 +132,7 @@ func TestExtractEndpointsAllMethods(t *testing.T) {
 			"head":    {"operationId": "headResource"},
 		},
 	})
-	doc, err := parseSpec(specJSON)
+	doc, _, err := parseSpec(specJSON)
 	require.NoError(t, err)
 
 	endpoints := ExtractEndpoints(doc)
@@ -147,7 +147,7 @@ func TestExtractEndpointsAllMethods(t *testing.T) {
 
 func TestExtractEndpointsEmptyPaths(t *testing.T) {
 	specJSON := minimalSpecJSON("Test", map[string]map[string]map[string]any{})
-	doc, err := parseSpec(specJSON)
+	doc, _, err := parseSpec(specJSON)
 	require.NoError(t, err)
 
 	endpoints := ExtractEndpoints(doc)

--- a/pkg/openapi/endpoints_v2.go
+++ b/pkg/openapi/endpoints_v2.go
@@ -1,0 +1,150 @@
+package openapi
+
+import (
+	"strings"
+
+	v2high "github.com/pb33f/libopenapi/datamodel/high/v2"
+)
+
+// ExtractEndpointsV2 extracts all endpoints from a Swagger 2.0 document.
+func ExtractEndpointsV2(doc *v2high.Swagger) []Endpoint {
+	if doc == nil || doc.Paths == nil || doc.Paths.PathItems == nil {
+		return nil
+	}
+
+	var endpoints []Endpoint
+
+	for path, pathItem := range doc.Paths.PathItems.FromOldest() {
+		for _, mo := range v2MethodOps(pathItem) {
+			if mo.op != nil {
+				endpoints = append(endpoints, newEndpointV2(mo.method, path, mo.op))
+			}
+		}
+	}
+
+	sortEndpoints(endpoints)
+	return endpoints
+}
+
+type v2MethodOp struct {
+	method string
+	op     *v2high.Operation
+}
+
+func v2MethodOps(pi *v2high.PathItem) []v2MethodOp {
+	return []v2MethodOp{
+		{"GET", pi.Get},
+		{"POST", pi.Post},
+		{"PUT", pi.Put},
+		{"PATCH", pi.Patch},
+		{"DELETE", pi.Delete},
+		{"OPTIONS", pi.Options},
+		{"HEAD", pi.Head},
+	}
+}
+
+// newEndpointV2 creates an Endpoint from a Swagger 2.0 Operation.
+func newEndpointV2(method, path string, op *v2high.Operation) Endpoint {
+	ep := Endpoint{
+		Method:      method,
+		Path:        path,
+		OperationID: op.OperationId,
+		Summary:     op.Summary,
+		Description: op.Description,
+		Tags:        op.Tags,
+		Deprecated:  op.Deprecated,
+	}
+
+	// Convert parameters — separate body params from regular params.
+	for _, p := range op.Parameters {
+		if strings.EqualFold(p.In, "body") {
+			ep.RequestBody = convertV2BodyParam(p)
+		} else {
+			ep.Parameters = append(ep.Parameters, convertV2Parameter(p))
+		}
+	}
+
+	// Convert responses
+	if op.Responses != nil {
+		ep.Responses = convertV2Responses(op.Responses)
+	}
+
+	return ep
+}
+
+// convertV2Parameter converts a Swagger 2.0 Parameter (non-body) to our Parameter type.
+func convertV2Parameter(p *v2high.Parameter) *Parameter {
+	param := &Parameter{
+		Name:        p.Name,
+		In:          p.In,
+		Description: p.Description,
+		Required:    p.Required != nil && *p.Required,
+	}
+	if p.Schema != nil {
+		param.Schema = convertSchemaProxy(p.Schema)
+	} else if p.Type != "" {
+		// v2 non-body params define type/format inline rather than via Schema
+		param.Schema = &SchemaRef{
+			Value: &Schema{
+				Type:   p.Type,
+				Format: p.Format,
+			},
+		}
+	}
+	return param
+}
+
+// convertV2BodyParam converts a Swagger 2.0 body parameter to our RequestBody type.
+func convertV2BodyParam(p *v2high.Parameter) *RequestBody {
+	body := &RequestBody{
+		Description: p.Description,
+		Required:    p.Required != nil && *p.Required,
+	}
+	if p.Schema != nil {
+		body.Content = map[string]*MediaType{
+			"application/json": {
+				Schema: convertSchemaProxy(p.Schema),
+			},
+		}
+	}
+	return body
+}
+
+// convertV2Responses converts Swagger 2.0 Responses to our Responses type.
+func convertV2Responses(r *v2high.Responses) *Responses {
+	resp := &Responses{}
+
+	if r.Codes != nil {
+		for code, response := range r.Codes.FromOldest() {
+			entry := ResponseEntry{
+				Code:        code,
+				Description: response.Description,
+			}
+			if response.Schema != nil {
+				entry.Content = map[string]*MediaType{
+					"application/json": {
+						Schema: convertSchemaProxy(response.Schema),
+					},
+				}
+			}
+			resp.Codes = append(resp.Codes, entry)
+		}
+	}
+
+	if r.Default != nil {
+		entry := ResponseEntry{
+			Code:        "default",
+			Description: r.Default.Description,
+		}
+		if r.Default.Schema != nil {
+			entry.Content = map[string]*MediaType{
+				"application/json": {
+					Schema: convertSchemaProxy(r.Default.Schema),
+				},
+			}
+		}
+		resp.Codes = append(resp.Codes, entry)
+	}
+
+	return resp
+}

--- a/pkg/openapi/endpoints_v2_test.go
+++ b/pkg/openapi/endpoints_v2_test.go
@@ -1,0 +1,232 @@
+package openapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minimalSwagger20JSON returns a minimal valid Swagger 2.0 spec as JSON bytes.
+func minimalSwagger20JSON(basePath string, paths map[string]any) []byte {
+	spec := map[string]any{
+		"swagger":  "2.0",
+		"info":     map[string]any{"title": "Test", "version": "1.0"},
+		"basePath": basePath,
+		"paths":    paths,
+	}
+	data, _ := json.Marshal(spec)
+	return data
+}
+
+func TestExtractEndpointsV2(t *testing.T) {
+	specJSON := minimalSwagger20JSON("/api/v1", map[string]any{
+		"/organizations": map[string]any{
+			"get": map[string]any{
+				"operationId": "ListOrganizations",
+				"summary":     "List all organizations",
+				"tags":        []string{"Organization"},
+				"responses": map[string]any{
+					"200": map[string]any{"description": "OK"},
+				},
+			},
+			"post": map[string]any{
+				"operationId": "CreateOrganization",
+				"summary":     "Create an organization",
+				"tags":        []string{"Organization"},
+				"responses": map[string]any{
+					"200": map[string]any{"description": "Created"},
+				},
+			},
+		},
+		"/organizations/{organizationId}": map[string]any{
+			"get": map[string]any{
+				"operationId": "GetOrganization",
+				"summary":     "Get organization",
+				"parameters": []any{
+					map[string]any{
+						"name":     "organizationId",
+						"in":       "path",
+						"type":     "string",
+						"required": true,
+					},
+				},
+				"responses": map[string]any{
+					"200": map[string]any{"description": "OK"},
+				},
+			},
+		},
+	})
+
+	_, v2doc, err := parseSpec(specJSON)
+	require.NoError(t, err)
+	require.NotNil(t, v2doc)
+
+	endpoints := ExtractEndpointsV2(v2doc)
+	require.Len(t, endpoints, 3)
+
+	// Sorted by path then method
+	assert.Equal(t, "/organizations", endpoints[0].Path)
+	assert.Equal(t, "GET", endpoints[0].Method)
+	assert.Equal(t, "ListOrganizations", endpoints[0].OperationID)
+	assert.Equal(t, []string{"Organization"}, endpoints[0].Tags)
+
+	assert.Equal(t, "/organizations", endpoints[1].Path)
+	assert.Equal(t, "POST", endpoints[1].Method)
+
+	assert.Equal(t, "/organizations/{organizationId}", endpoints[2].Path)
+	assert.Equal(t, "GET", endpoints[2].Method)
+	require.Len(t, endpoints[2].Parameters, 1)
+	assert.Equal(t, "organizationId", endpoints[2].Parameters[0].Name)
+	assert.Equal(t, "path", endpoints[2].Parameters[0].In)
+	assert.True(t, endpoints[2].Parameters[0].Required)
+}
+
+func TestExtractEndpointsV2_BodyParam(t *testing.T) {
+	specJSON := minimalSwagger20JSON("/api/v1", map[string]any{
+		"/resources": map[string]any{
+			"post": map[string]any{
+				"operationId": "CreateResource",
+				"parameters": []any{
+					map[string]any{
+						"name":     "body",
+						"in":       "body",
+						"required": true,
+						"schema": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"name": map[string]any{"type": "string"},
+							},
+						},
+					},
+				},
+				"responses": map[string]any{
+					"200": map[string]any{"description": "Created"},
+				},
+			},
+		},
+	})
+
+	_, v2doc, err := parseSpec(specJSON)
+	require.NoError(t, err)
+	require.NotNil(t, v2doc)
+
+	endpoints := ExtractEndpointsV2(v2doc)
+	require.Len(t, endpoints, 1)
+
+	ep := endpoints[0]
+	assert.Equal(t, "CreateResource", ep.OperationID)
+	// Body param should be converted to RequestBody, not added to Parameters
+	assert.Empty(t, ep.Parameters)
+	require.NotNil(t, ep.RequestBody)
+	assert.True(t, ep.RequestBody.Required)
+	require.Contains(t, ep.RequestBody.Content, "application/json")
+	require.NotNil(t, ep.RequestBody.Content["application/json"].Schema)
+}
+
+func TestExtractEndpointsV2_Responses(t *testing.T) {
+	specJSON := minimalSwagger20JSON("/api/v1", map[string]any{
+		"/things": map[string]any{
+			"get": map[string]any{
+				"operationId": "ListThings",
+				"responses": map[string]any{
+					"200": map[string]any{
+						"description": "Success",
+						"schema": map[string]any{
+							"type": "array",
+							"items": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"id": map[string]any{"type": "string"},
+								},
+							},
+						},
+					},
+					"default": map[string]any{
+						"description": "Error",
+						"schema": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"message": map[string]any{"type": "string"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	_, v2doc, err := parseSpec(specJSON)
+	require.NoError(t, err)
+	require.NotNil(t, v2doc)
+
+	endpoints := ExtractEndpointsV2(v2doc)
+	require.Len(t, endpoints, 1)
+
+	ep := endpoints[0]
+	require.NotNil(t, ep.Responses)
+	require.Len(t, ep.Responses.Codes, 2)
+
+	// Check 200 response
+	assert.Equal(t, "200", ep.Responses.Codes[0].Code)
+	assert.Equal(t, "Success", ep.Responses.Codes[0].Description)
+	require.Contains(t, ep.Responses.Codes[0].Content, "application/json")
+	schema := ep.Responses.Codes[0].Content["application/json"].Schema.Value
+	assert.Equal(t, "array", schema.Type)
+
+	// Check default response
+	assert.Equal(t, "default", ep.Responses.Codes[1].Code)
+	assert.Equal(t, "Error", ep.Responses.Codes[1].Description)
+	require.Contains(t, ep.Responses.Codes[1].Content, "application/json")
+}
+
+func TestExtractEndpointsV2_NilDoc(t *testing.T) {
+	endpoints := ExtractEndpointsV2(nil)
+	assert.Nil(t, endpoints)
+}
+
+func TestExtractEndpointsV2_InlineParamType(t *testing.T) {
+	specJSON := minimalSwagger20JSON("/v1", map[string]any{
+		"/search": map[string]any{
+			"get": map[string]any{
+				"operationId": "Search",
+				"parameters": []any{
+					map[string]any{
+						"name": "q",
+						"in":   "query",
+						"type": "string",
+					},
+					map[string]any{
+						"name":   "limit",
+						"in":     "query",
+						"type":   "integer",
+						"format": "int32",
+					},
+				},
+				"responses": map[string]any{
+					"200": map[string]any{"description": "OK"},
+				},
+			},
+		},
+	})
+
+	_, v2doc, err := parseSpec(specJSON)
+	require.NoError(t, err)
+
+	endpoints := ExtractEndpointsV2(v2doc)
+	require.Len(t, endpoints, 1)
+	require.Len(t, endpoints[0].Parameters, 2)
+
+	// Query params with inline type/format should have Schema set
+	q := endpoints[0].Parameters[0]
+	assert.Equal(t, "q", q.Name)
+	require.NotNil(t, q.Schema)
+	assert.Equal(t, "string", q.Schema.Value.Type)
+
+	limit := endpoints[0].Parameters[1]
+	assert.Equal(t, "limit", limit.Name)
+	require.NotNil(t, limit.Schema)
+	assert.Equal(t, "integer", limit.Schema.Value.Type)
+	assert.Equal(t, "int32", limit.Schema.Value.Format)
+}

--- a/pkg/openapi/openapi31_test.go
+++ b/pkg/openapi/openapi31_test.go
@@ -31,7 +31,7 @@ paths:
           description: Success
 `)
 
-	doc, err := parseSpec(spec)
+	doc, _, err := parseSpec(spec)
 	require.NoError(t, err)
 	require.NotNil(t, doc)
 
@@ -69,7 +69,7 @@ paths:
                       - "null"
 `)
 
-	doc, err := parseSpec(spec)
+	doc, _, err := parseSpec(spec)
 	require.NoError(t, err)
 	require.NotNil(t, doc)
 


### PR DESCRIPTION
## Summary
- Add Swagger 2.0 (OpenAPI 2.x) parsing support alongside existing OpenAPI 3.x — version is auto-detected
- Add `--spec-url` flag on `astro api cloud` to override the default spec URL, with base URL derived from the spec's servers/basePath
- Add `--spec-token-env-var` flag to read an auth token from a named environment variable when fetching specs that require authentication
- Extract `GetServerPath()` to pull the API base path from v3 `servers[0].url` or v2 `basePath`
- Fix circular `$ref` stack overflow in schema conversion

Both new flags are hidden.

## Test plan
- [x] `go test ./pkg/openapi/...` — all existing + new tests pass
- [x] `go test ./cmd/api/...` — all existing + new tests pass
- [x] `go build .` compiles cleanly
- [x] `astro api cloud --help` does not show hidden flags
- [x] Manual: `astro api cloud --spec-url <url> ls` with an OpenAPI 3.0 spec
- [x] Manual: `astro api cloud --spec-url <url> ls` with a Swagger 2.0 spec
- [x] Manual: `astro api cloud --spec-url <url> --spec-token-env-var <env> ls` with an auth-protected spec