### PR TITLE
Add `astro api registry` command

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -28,8 +28,9 @@ func NewAPICmdWithOutput(out io.Writer) *cobra.Command {
 The 'astro api' command provides direct access to Astronomer's REST APIs.
 
 Available subcommands:
-  airflow  Make requests to the Airflow REST API
-  cloud    Make requests to the Astro Cloud API (api.astronomer.io)
+  airflow   Make requests to the Airflow REST API
+  cloud     Make requests to the Astro Cloud API (api.astronomer.io)
+  registry  Query the Airflow Provider Registry
 
 Use "astro api [command] --help" for more information about a command.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -69,6 +70,7 @@ Use "astro api [command] --help" for more information about a command.`,
 
 	cmd.AddCommand(NewAirflowCmd(out))
 	cmd.AddCommand(NewCloudCmd(out))
+	cmd.AddCommand(NewRegistryCmd(out))
 
 	return cmd
 }

--- a/cmd/api/registry.go
+++ b/cmd/api/registry.go
@@ -1,0 +1,332 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/openapi"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultRegistryURL      = "https://airflow.apache.org/registry"
+	registryURLEnv          = "ASTRO_REGISTRY_URL"
+	registrySpecPath        = "/api/openapi.json"
+	registryCacheFileName   = "openapi-registry-cache.json"
+	registryStripPathPrefix = "/api"
+)
+
+// RegistryOptions holds all options for the registry api command.
+type RegistryOptions struct {
+	RequestOptions
+
+	RegistryURL string
+}
+
+// NewRegistryCmd creates the 'astro api registry' command.
+//
+//nolint:dupl
+func NewRegistryCmd(out io.Writer) *cobra.Command {
+	opts := &RegistryOptions{
+		RequestOptions: RequestOptions{
+			Out:    out,
+			ErrOut: os.Stderr,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "registry <endpoint | operation-id>",
+		Short: "Make requests to the Airflow Provider Registry API",
+		Long: `Make HTTP requests to the Airflow Provider Registry API.
+
+The argument can be either:
+  - A path of a registry API endpoint (e.g., /providers.json, /providers/amazon/modules.json)
+  - An operation ID from the API spec (e.g., listProviders, getProviderModulesLatest)
+
+The /api prefix is added automatically to paths. No authentication is required.
+
+Use "astro api registry ls" to discover all available endpoints and operation IDs.`,
+		Example: `  # List registry API endpoints
+  astro api registry ls
+
+  # Query by operation ID with path parameters
+  astro api registry getProviderModulesLatest -p providerId=amazon
+  astro api registry getProviderModulesByVersion -p providerId=amazon -p version=9.22.0
+
+  # Query by path
+  astro api registry /providers.json
+  astro api registry /providers/amazon/modules.json
+  astro api registry /providers/amazon/9.22.0/modules.json
+  astro api registry /modules.json
+
+  # Use jq filter on response
+  astro api registry /providers.json --jq '.providers[0].id'
+
+  # Use Go template for output
+  astro api registry listProviders \
+    --template '{{range .providers}}{{.id}}{{"\n"}}{{end}}'
+
+  # Generate curl command instead of executing
+  astro api registry /providers.json --generate
+
+  # Verbose mode showing full request/response
+  astro api registry /providers.json --verbose
+
+  # Override registry URL
+  astro api registry --registry-url https://custom.example.com /providers.json`,
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.RequestMethodPassed = cmd.Flags().Changed("method")
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return runRegistryInteractive(opts)
+			}
+			opts.RequestPath = args[0]
+			return runRegistry(opts)
+		},
+	}
+
+	// Registry-specific persistent flags
+	cmd.PersistentFlags().StringVar(&opts.RegistryURL, "registry-url", "", "Override the registry base URL (env: ASTRO_REGISTRY_URL)")
+
+	// Request flags
+	cmd.Flags().StringVarP(&opts.RequestMethod, "method", "X", "GET", "The HTTP method for the request")
+	cmd.Flags().StringArrayVarP(&opts.MagicFields, "field", "F", nil, "Add a typed parameter in key=value format")
+	cmd.Flags().StringArrayVarP(&opts.RawFields, "raw-field", "f", nil, "Add a string parameter in key=value format")
+	cmd.Flags().StringArrayVarP(&opts.RequestHeaders, "header", "H", nil, "Add a HTTP request header in key:value format")
+	cmd.Flags().StringVar(&opts.RequestInputFile, "input", "", "The file to use as body for the HTTP request (use \"-\" for stdin)")
+	cmd.Flags().StringArrayVarP(&opts.PathParams, "path-param", "p", nil, "Path parameter in key=value format (for use with operation IDs)")
+
+	// Output flags
+	cmd.Flags().BoolVarP(&opts.ShowResponseHeaders, "include", "i", false, "Include HTTP response status line and headers in the output")
+	cmd.Flags().BoolVar(&opts.Silent, "silent", false, "Do not print the response body")
+	cmd.Flags().StringVarP(&opts.Template, "template", "t", "", "Format JSON output using a Go template")
+	cmd.Flags().StringVarP(&opts.FilterOutput, "jq", "q", "", "Query to select values from the response using jq syntax")
+	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "Include full HTTP request and response in the output")
+
+	// Other flags
+	cmd.Flags().BoolVar(&opts.GenerateCurl, "generate", false, "Output a curl command instead of executing the request")
+
+	// Subcommands
+	cmd.AddCommand(NewRegistryListCmd(out, opts))
+	cmd.AddCommand(NewRegistryDescribeCmd(out, opts))
+
+	return cmd
+}
+
+// runRegistry executes a registry API request.
+func runRegistry(opts *RegistryOptions) error {
+	baseURL := resolveRegistryURL(opts.RegistryURL)
+
+	// Initialize the spec cache for operation ID resolution
+	initRegistrySpecCache(opts)
+
+	// Resolve operation ID to path if needed
+	requestPath := opts.RequestPath
+	method := opts.RequestMethod
+	methodFromSpec := false
+
+	if isOperationID(requestPath) {
+		endpoint, err := resolveOperationID(opts.specCache, requestPath, "registry")
+		if err != nil {
+			return err
+		}
+		requestPath = endpoint.Path
+		if !opts.RequestMethodPassed {
+			method = endpoint.Method
+			methodFromSpec = true
+		}
+	}
+
+	// Apply path params from flags
+	var err error
+	requestPath, err = applyPathParams(requestPath, opts.PathParams)
+	if err != nil {
+		return fmt.Errorf("applying path params: %w", err)
+	}
+
+	// Check for any remaining unfilled path parameters
+	if missing := findMissingPathParams(requestPath); len(missing) > 0 {
+		return fmt.Errorf("missing path parameter(s): %s. Use -p/--path-param to provide them (e.g., -p %s=value)",
+			strings.Join(missing, ", "), missing[0])
+	}
+
+	// Parse fields into request body
+	params, err := parseFields(opts.MagicFields, opts.RawFields)
+	if err != nil {
+		return fmt.Errorf("parsing fields: %w", err)
+	}
+
+	// Determine HTTP method (only override if not from spec and not explicitly passed)
+	if !methodFromSpec && !opts.RequestMethodPassed && (len(params) > 0 || opts.RequestInputFile != "") {
+		method = "POST"
+	}
+
+	// Build the full URL
+	url := registryBuildGenericURL(baseURL, requestPath)
+
+	// Generate curl command if requested
+	if opts.GenerateCurl {
+		return generateCurl(opts.Out, method, url, "", opts.RequestHeaders, params, opts.RequestInputFile)
+	}
+
+	// Build and execute the request
+	err = executeRequest(&opts.RequestOptions, method, url, "", params)
+	if isConnectionError(err) {
+		return registryConnectionError(url)
+	}
+	return err
+}
+
+// runRegistryInteractive runs the registry command in interactive mode (no args).
+func runRegistryInteractive(opts *RegistryOptions) error {
+	initRegistrySpecCache(opts)
+
+	if err := opts.specCache.Load(false); err != nil {
+		return fmt.Errorf("loading OpenAPI spec: %w", err)
+	}
+
+	endpoints := opts.specCache.GetEndpoints()
+	if len(endpoints) == 0 {
+		return fmt.Errorf("no endpoints found in API specification")
+	}
+
+	fmt.Fprintf(opts.Out, "\nFound %d endpoints. Use 'astro api registry ls' to list them.\n", len(endpoints))
+	fmt.Fprintf(opts.Out, "Run 'astro api registry <endpoint>' to make a request.\n\n")
+
+	return nil
+}
+
+// NewRegistryListCmd creates the 'astro api registry ls' command.
+func NewRegistryListCmd(out io.Writer, parentOpts *RegistryOptions) *cobra.Command {
+	var verbose bool
+	var refresh bool
+
+	cmd := &cobra.Command{
+		Use:     "ls [filter]",
+		Aliases: []string{"list"},
+		Short:   "List available registry API endpoints",
+		Long: `List all available endpoints from the Airflow Provider Registry API.
+
+You can optionally provide a filter to search for specific endpoints.
+The filter matches against endpoint paths, methods, operation IDs, summaries, and tags.`,
+		Example: `  # List all endpoints
+  astro api registry ls
+
+  # Filter endpoints
+  astro api registry ls providers
+
+  # Show verbose output with descriptions
+  astro api registry ls --verbose`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var filter string
+			if len(args) > 0 {
+				filter = args[0]
+			}
+
+			initRegistrySpecCache(parentOpts)
+
+			listOpts := &ListOptions{
+				Out:       out,
+				specCache: parentOpts.specCache,
+				Filter:    filter,
+				Verbose:   verbose,
+				Refresh:   refresh,
+			}
+			return runList(listOpts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show additional details like summaries and tags")
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
+
+	return cmd
+}
+
+// NewRegistryDescribeCmd creates the 'astro api registry describe' command.
+func NewRegistryDescribeCmd(out io.Writer, parentOpts *RegistryOptions) *cobra.Command {
+	var method string
+	var refresh bool
+	var verbose bool
+
+	cmd := &cobra.Command{
+		Use:   "describe <endpoint>",
+		Short: "Describe a registry API endpoint's request and response schema",
+		Long: `Show detailed information about a registry API endpoint, including:
+- Path parameters
+- Response schema
+
+The endpoint can be specified as a path or as an operation ID.`,
+		Example: `  # Describe an endpoint by path
+  astro api registry describe /providers/{providerId}/modules.json
+
+  # Describe by operation ID
+  astro api registry describe getProviderModulesLatest`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			initRegistrySpecCache(parentOpts)
+
+			descOpts := &DescribeOptions{
+				Out:       out,
+				specCache: parentOpts.specCache,
+				Endpoint:  args[0],
+				Method:    method,
+				Refresh:   refresh,
+				Verbose:   verbose,
+			}
+			return runDescribe(descOpts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (GET)")
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show spec URL and additional details")
+
+	return cmd
+}
+
+// initRegistrySpecCache initializes the OpenAPI spec cache for the registry.
+func initRegistrySpecCache(opts *RegistryOptions) {
+	if opts.specCache != nil {
+		return
+	}
+	base := resolveRegistryURL(opts.RegistryURL)
+	specURL := base + registrySpecPath
+	cachePath := filepath.Join(config.HomeConfigPath, registryCacheFileName)
+	opts.specCache = openapi.NewCacheWithOptions(specURL, cachePath)
+	opts.specCache.SetStripPrefix(registryStripPathPrefix)
+}
+
+// resolveRegistryURL returns the registry base URL using the precedence: flag > env > default.
+func resolveRegistryURL(flagURL string) string {
+	if flagURL != "" {
+		return strings.TrimRight(flagURL, "/")
+	}
+	if envURL := os.Getenv(registryURLEnv); envURL != "" {
+		return strings.TrimRight(envURL, "/")
+	}
+	return defaultRegistryURL
+}
+
+// registryBuildGenericURL constructs the full URL for a user-supplied path.
+func registryBuildGenericURL(base, path string) string {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return base + "/api" + path
+}
+
+// registryConnectionError returns a user-friendly error when the registry is unreachable.
+func registryConnectionError(requestURL string) error {
+	return fmt.Errorf("could not connect to registry at %s\n\n"+
+		"Check that the URL is correct. You can override it with:\n"+
+		"  --registry-url <url>\n"+
+		"  ASTRO_REGISTRY_URL=<url>", requestURL)
+}

--- a/cmd/api/registry_test.go
+++ b/cmd/api/registry_test.go
@@ -1,0 +1,426 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRegistryCmd_SubcommandsRegistered(t *testing.T) {
+	cmd := NewRegistryCmd(&bytes.Buffer{})
+
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+
+	assert.Contains(t, names, "ls")
+	assert.Contains(t, names, "describe")
+}
+
+func TestNewRegistryCmd_Flags(t *testing.T) {
+	cmd := NewRegistryCmd(&bytes.Buffer{})
+
+	// Persistent flags
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("registry-url"))
+
+	// Request flags (same as airflow/cloud)
+	assert.NotNil(t, cmd.Flags().Lookup("method"))
+	assert.NotNil(t, cmd.Flags().Lookup("field"))
+	assert.NotNil(t, cmd.Flags().Lookup("raw-field"))
+	assert.NotNil(t, cmd.Flags().Lookup("header"))
+	assert.NotNil(t, cmd.Flags().Lookup("input"))
+	assert.NotNil(t, cmd.Flags().Lookup("path-param"))
+
+	// Output flags
+	assert.NotNil(t, cmd.Flags().Lookup("include"))
+	assert.NotNil(t, cmd.Flags().Lookup("silent"))
+	assert.NotNil(t, cmd.Flags().Lookup("template"))
+	assert.NotNil(t, cmd.Flags().Lookup("jq"))
+	assert.NotNil(t, cmd.Flags().Lookup("verbose"))
+	assert.NotNil(t, cmd.Flags().Lookup("generate"))
+}
+
+func TestResolveRegistryURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagURL  string
+		envURL   string
+		expected string
+	}{
+		{
+			name:     "default",
+			expected: defaultRegistryURL,
+		},
+		{
+			name:     "flag takes precedence",
+			flagURL:  "https://custom.example.com/",
+			envURL:   "https://env.example.com",
+			expected: "https://custom.example.com",
+		},
+		{
+			name:     "env used when no flag",
+			envURL:   "https://env.example.com/",
+			expected: "https://env.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envURL != "" {
+				t.Setenv(registryURLEnv, tc.envURL)
+			}
+			got := resolveRegistryURL(tc.flagURL)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestRegistryBuildGenericURL(t *testing.T) {
+	base := "https://airflow.apache.org/registry"
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "with leading slash",
+			path:     "/providers.json",
+			expected: "https://airflow.apache.org/registry/api/providers.json",
+		},
+		{
+			name:     "without leading slash",
+			path:     "providers.json",
+			expected: "https://airflow.apache.org/registry/api/providers.json",
+		},
+		{
+			name:     "nested path",
+			path:     "/providers/amazon/versions.json",
+			expected: "https://airflow.apache.org/registry/api/providers/amazon/versions.json",
+		},
+		{
+			name:     "modules.json global",
+			path:     "/modules.json",
+			expected: "https://airflow.apache.org/registry/api/modules.json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := registryBuildGenericURL(base, tc.path)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestRegistryCmd_Execute_PathAccess(t *testing.T) {
+	payload := `{"providers":[{"id":"amazon"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/providers.json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers.json", "--registry-url", srv.URL})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "amazon")
+}
+
+func TestRegistryCmd_Execute_PathWithJQ(t *testing.T) {
+	payload := `{"providers":[{"id":"amazon"},{"id":"google"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers.json", "--registry-url", srv.URL, "--jq", ".providers[0].id"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Equal(t, "amazon\n", out.String())
+}
+
+func TestRegistryCmd_Execute_GenerateCurl(t *testing.T) {
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers.json", "--registry-url", "https://example.com/registry", "--generate"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "curl")
+	assert.Contains(t, out.String(), "https://example.com/registry/api/providers.json")
+}
+
+func TestRegistryCmd_Execute_IncludeHeaders(t *testing.T) {
+	payload := `{"providers":[]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Test", "hello")
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers.json", "--registry-url", srv.URL, "-i"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "X-Test")
+}
+
+func TestRegistryCmd_Execute_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/nonexistent.json", "--registry-url", srv.URL})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	var silentErr *SilentError
+	require.ErrorAs(t, err, &silentErr)
+	assert.Equal(t, http.StatusNotFound, silentErr.StatusCode)
+}
+
+func TestRegistryCmd_Execute_500WithBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers.json", "--registry-url", srv.URL})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	var silentErr *SilentError
+	require.ErrorAs(t, err, &silentErr)
+	assert.Equal(t, http.StatusInternalServerError, silentErr.StatusCode)
+	assert.Contains(t, out.String(), "internal server error")
+}
+
+func TestRegistryCmd_Execute_ConnectionError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := srv.URL
+	srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers.json", "--registry-url", closedURL})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not connect to registry")
+}
+
+func TestRegistryCmd_Execute_CustomHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "bar", r.Header.Get("X-Foo"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers.json", "--registry-url", srv.URL, "-H", "X-Foo:bar"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestRegistryCmd_Execute_SilentMode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"providers":[]}`))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers.json", "--registry-url", srv.URL, "--silent"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+}
+
+func TestRegistryCmd_Execute_OperationID(t *testing.T) {
+	// Serve the OpenAPI spec for operation ID resolution
+	specJSON := `{
+		"openapi": "3.0.0",
+		"info": {"title": "test", "version": "1.0"},
+		"paths": {
+			"/api/providers.json": {
+				"get": {
+					"operationId": "listProviders",
+					"summary": "List all providers",
+					"responses": {"200": {"description": "OK"}}
+				}
+			},
+			"/api/providers/{providerId}/modules.json": {
+				"get": {
+					"operationId": "getProviderModulesLatest",
+					"summary": "Get provider modules",
+					"parameters": [
+						{"name": "providerId", "in": "path", "required": true, "schema": {"type": "string"}}
+					],
+					"responses": {"200": {"description": "OK"}}
+				}
+			}
+		}
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/openapi.json":
+			_, _ = w.Write([]byte(specJSON))
+		case "/api/providers.json":
+			_, _ = w.Write([]byte(`{"providers":[{"id":"amazon"}]}`))
+		case "/api/providers/amazon/modules.json":
+			_, _ = w.Write([]byte(`{"modules":[{"name":"S3Hook"}]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	t.Run("operation ID without path params", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := NewRegistryCmd(&out)
+		cmd.SetArgs([]string{"listProviders", "--registry-url", srv.URL})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, out.String(), "amazon")
+	})
+
+	t.Run("operation ID with path params", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := NewRegistryCmd(&out)
+		cmd.SetArgs([]string{"getProviderModulesLatest", "-p", "providerId=amazon", "--registry-url", srv.URL})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, out.String(), "S3Hook")
+	})
+
+	t.Run("missing path param shows error", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := NewRegistryCmd(&out)
+		cmd.SetArgs([]string{"getProviderModulesLatest", "--registry-url", srv.URL})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing path parameter")
+		assert.Contains(t, err.Error(), "providerId")
+	})
+
+	t.Run("unknown operation ID shows error", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := NewRegistryCmd(&out)
+		cmd.SetArgs([]string{"nonExistentOperation", "--registry-url", srv.URL})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestRegistryCmd_Execute_Template(t *testing.T) {
+	payload := `{"providers":[{"id":"amazon"},{"id":"google"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers.json", "--registry-url", srv.URL, "--template", `{{range .providers}}{{.id}} {{end}}`})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "amazon")
+	assert.Contains(t, out.String(), "google")
+}
+
+func TestRegistryCmd_Execute_NoArgs_ShowsHelp(t *testing.T) {
+	// When run with no args and the spec isn't reachable, it should fall back gracefully.
+	// We test that it attempts to show interactive guidance.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"openapi": "3.0.0",
+			"info": {"title": "test", "version": "1.0"},
+			"paths": {
+				"/api/providers.json": {
+					"get": {
+						"operationId": "listProviders",
+						"responses": {"200": {"description": "OK"}}
+					}
+				}
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"--registry-url", srv.URL})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "astro api registry ls")
+}
+
+func TestRegistryConnectionError(t *testing.T) {
+	err := registryConnectionError("https://example.com/api/providers.json")
+	assert.Contains(t, err.Error(), "could not connect to registry")
+	assert.Contains(t, err.Error(), "--registry-url")
+	assert.Contains(t, err.Error(), "ASTRO_REGISTRY_URL")
+}
+
+func TestRegistryCmd_Execute_NestedPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/providers/amazon/9.22.0/modules.json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"modules":[]}`))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	cmd := NewRegistryCmd(&out)
+	cmd.SetArgs([]string{"/providers/amazon/9.22.0/modules.json", "--registry-url", srv.URL})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Contains(t, got, "modules")
+}

--- a/pkg/openapi/cache.go
+++ b/pkg/openapi/cache.go
@@ -82,6 +82,12 @@ func (c *Cache) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
 }
 
+// SetStripPrefix configures a path prefix to strip from endpoint paths
+// (e.g. "/api") so callers work with shorter paths.
+func (c *Cache) SetStripPrefix(prefix string) {
+	c.stripPrefix = prefix
+}
+
 // NewCache creates a new OpenAPI cache with default settings.
 func NewCache() *Cache {
 	return &Cache{


### PR DESCRIPTION
## Summary

Adds `astro api registry` for querying the public [Airflow Provider Registry](https://airflow.apache.org/registry), following the same patterns and infrastructure as `astro api airflow` and `astro api cloud`.

Supports both **path-based** and **operation ID-based** queries, plus `ls` and `describe` for endpoint discovery — identical UX to the other `astro api` subcommands.

## Design Rationale

**Consistent with airflow/cloud:** Reuses `RequestOptions`, `executeRequest`, `resolveOperationID`, `applyPathParams`, `findMissingPathParams`, `generateCurl`, the shared output pipeline, and `openapi.Cache`. The only registry-specific code is URL resolution and the connection error message.

**No convenience subcommands:** The operation ID approach (`getProviderModulesLatest -p providerId=amazon`) is consistent with how airflow/cloud work and covers all 9 endpoints without hardcoding any of them. Convenience commands can be added later under `astro registry` if there's demand.

**Only addition to shared code:** `SetStripPrefix` on `openapi.Cache` — the registry's OpenAPI spec uses `/api` path prefixes that need stripping for `ls`/`describe` display.

## Usage Examples

```bash
# Discover endpoints
astro api registry ls
astro api registry describe getProviderModulesLatest

# Query by operation ID
astro api registry listProviders
astro api registry getProviderModulesLatest -p providerId=amazon
astro api registry getProviderModulesByVersion -p providerId=amazon -p version=9.22.0
astro api registry getProviderVersions -p providerId=google

# Query by path
astro api registry /providers.json
astro api registry /providers/amazon/modules.json
astro api registry /providers/amazon/9.22.0/modules.json
astro api registry /modules.json

# Same flags as airflow/cloud
astro api registry listProviders --jq '.providers[0].id'
astro api registry /providers.json --template '{{range .providers}}{{.id}}{{"\n"}}{{end}}'
astro api registry /providers.json --generate
astro api registry /providers.json --verbose
astro api registry /providers.json -i
astro api registry /providers.json --silent
astro api registry /providers.json -H "X-Custom:value"

# Override registry URL
astro api registry --registry-url https://custom.example.com listProviders
ASTRO_REGISTRY_URL=https://custom.example.com astro api registry listProviders
```

## Gotchas / Tradeoffs

- The `/api` prefix is added automatically for path-based access, so users pass `/providers.json` not `/api/providers.json`
- `ls` and `describe` strip the `/api` prefix from paths for readability (via `SetStripPrefix`)
- No auth required — the registry is a public API, so the `token` parameter to `executeRequest` is always empty
- `--registry-url` precedence: flag > `ASTRO_REGISTRY_URL` env > default
- Pagination flags (`--paginate`, `--slurp`) are intentionally omitted since the registry API doesn't paginate