### PR TITLE
chore: add setuptools to beautysh hook for Python 3.12+ compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
     hooks:
       - id: beautysh
         args: ['--indent-size', '2']
+        additional_dependencies: [setuptools]
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.37.1
     hooks:


### PR DESCRIPTION
## Summary

beautysh v6.2.1 imports `pkg_resources` at the top level, which is part of `setuptools`. In Python 3.12+, `setuptools` is not included in new virtual environments by default (it was removed from the default venv seeding).

prek (and pre-commit) create isolated venvs per hook using uv. uv's venvs don't include `setuptools` by default, causing beautysh to fail with:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

Adding `additional_dependencies: [setuptools]` tells prek/pre-commit to install setuptools alongside beautysh in its isolated venv, fixing the error.

## Alternative

Bump beautysh to a release that removes the `pkg_resources` dependency, but the project appears unmaintained (last release 2022).

🤖 Generated with [Claude Code](https://claude.com/claude-code)