### PR TITLE
fix: preserve venv on standalone restart with --allow-existing

### DIFF
--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -267,7 +267,7 @@ func (s *Standalone) Start(opts *types.StartOptions) error {
 	sp.Start()
 
 	// 5. Create venv
-	err = runCommand(s.airflowHome, "uv", "venv", "--python", pythonVersion)
+	err = runCommand(s.airflowHome, "uv", "venv", "--python", pythonVersion, "--allow-existing")
 	if err != nil {
 		sp.Stop()
 		return fmt.Errorf("error creating virtual environment: %w", err)


### PR DESCRIPTION
## Problem

`astro dev start --standalone` calls `uv venv` on every restart without the `--allow-existing` flag. This causes `uv` to wipe all installed packages in the virtual environment before each run, forcing a full reinstall of ~124 packages from the CDN on every restart.

This is:
- **Slow** in normal environments (full CDN download on every start)
- **Broken** in dev containers with restricted network access, where the reinstall hangs indefinitely

## Fix

Add `--allow-existing` to the `uv venv` invocation in `airflow/standalone.go`.

With this flag, `uv venv` reuses the existing virtual environment and its installed packages. The subsequent `uv pip install` step still always runs, so any changes to `requirements.txt` are picked up — it just audits the existing packages (~80ms) rather than reinstalling everything from scratch.

## Changes

- `airflow/standalone.go`: Add `--allow-existing` flag to `uv venv` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)