### PR TITLE
fix(airflow_versions): correct astro-agent default image ordering

### DIFF
--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -1,12 +1,14 @@
 package airflowversions
 
 import (
+	"cmp"
 	"fmt"
 	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/astronomer/astro-cli/pkg/logger"
+	"golang.org/x/mod/semver"
 )
 
 const (
@@ -63,8 +65,8 @@ func ParseImageTag(imageTag string) (*ImageTagInfo, error) {
 	}, nil
 }
 
-// isBetterImage compares two ImageTagInfo objects to determine if the candidate has higher runtime version or python version than the current
-// Priority: Runtime version first, then Python version
+// isBetterImage reports whether candidate should replace current for default astro-agent image selection.
+// Priority: Astro runtime (CompareRuntimeVersions), then Python semver, then astro-agent semver.
 func isBetterImage(candidate, current *ImageTagInfo) bool {
 	if candidate == nil {
 		return false
@@ -72,18 +74,11 @@ func isBetterImage(candidate, current *ImageTagInfo) bool {
 	if current == nil {
 		return true
 	}
-
-	// Compare runtime versions first using existing function
-	runtimeComparison := CompareRuntimeVersions(candidate.RuntimeVersion, current.RuntimeVersion)
-	if runtimeComparison > 0 {
-		return true
-	}
-	if runtimeComparison < 0 {
-		return false
-	}
-
-	// Same runtime version, compare Python versions (string comparison works for semantic versions like "3.11" vs "3.12")
-	return candidate.PythonVersion > current.PythonVersion
+	return cmp.Or(
+		CompareRuntimeVersions(candidate.RuntimeVersion, current.RuntimeVersion),
+		semver.Compare("v"+candidate.PythonVersion, "v"+current.PythonVersion),
+		semver.Compare("v"+candidate.AgentVersion, "v"+current.AgentVersion),
+	) > 0
 }
 
 // GetDefaultImageTag returns default airflow image tag
@@ -176,12 +171,7 @@ func getAstroAgentTag(clientVersions map[string]ClientVersion, runtimeVersion st
 		return "", fmt.Errorf("no client versions found")
 	}
 
-	// sort the available versions by runtime version in descending order
-	sort.Slice(availableVersions, func(i, j int) bool {
-		return CompareRuntimeVersions(availableVersions[i], availableVersions[j]) < 0
-	})
-
-	// Parse and filter image tags, prioritizing latest Python version
+	// Parse and filter image tags; isBetterImage picks the best by runtime, Python, then agent semver.
 	var bestImageTag string
 	var bestInfo *ImageTagInfo
 
@@ -204,7 +194,7 @@ func getAstroAgentTag(clientVersions map[string]ClientVersion, runtimeVersion st
 				continue
 			}
 
-			// Select the best image based on runtime version first, then Python version
+			// Select the best image: runtime, then Python semver, then agent semver (isBetterImage).
 			if bestImageTag == "" || isBetterImage(tagInfo, bestInfo) {
 				bestImageTag = imageTags
 				bestInfo = tagInfo

--- a/airflow_versions/airflow_versions_test.go
+++ b/airflow_versions/airflow_versions_test.go
@@ -566,6 +566,60 @@ func (s *Suite) TestIsBetterImage() {
 			},
 			expected: false, // Same runtime, so Python version is the tiebreaker
 		},
+		{
+			name: "same runtime, python 3.10 beats 3.9 (semver, not lexicographic)",
+			candidate: &ImageTagInfo{
+				PythonVersion:  "3.10",
+				RuntimeVersion: "3.1-1",
+			},
+			current: &ImageTagInfo{
+				PythonVersion:  "3.9",
+				RuntimeVersion: "3.1-1",
+			},
+			expected: true,
+		},
+		{
+			name: "same runtime and python, higher agent version",
+			candidate: &ImageTagInfo{
+				PythonVersion:  "3.12",
+				RuntimeVersion: "3.1-13",
+				AgentVersion:   "1.3.7",
+			},
+			current: &ImageTagInfo{
+				PythonVersion:  "3.12",
+				RuntimeVersion: "3.1-13",
+				AgentVersion:   "1.3.6",
+			},
+			expected: true,
+		},
+		{
+			name: "same runtime and python, lower agent version",
+			candidate: &ImageTagInfo{
+				PythonVersion:  "3.12",
+				RuntimeVersion: "3.1-13",
+				AgentVersion:   "1.3.6",
+			},
+			current: &ImageTagInfo{
+				PythonVersion:  "3.12",
+				RuntimeVersion: "3.1-13",
+				AgentVersion:   "1.3.7",
+			},
+			expected: false,
+		},
+		{
+			name: "same runtime and python, agent 1.3.10 beats 1.3.9 (semver)",
+			candidate: &ImageTagInfo{
+				PythonVersion:  "3.12",
+				RuntimeVersion: "3.1-13",
+				AgentVersion:   "1.3.10",
+			},
+			current: &ImageTagInfo{
+				PythonVersion:  "3.12",
+				RuntimeVersion: "3.1-13",
+				AgentVersion:   "1.3.9",
+			},
+			expected: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -631,6 +685,32 @@ func (s *Suite) TestGetAstroAgentTag() {
 			clientVersions: clientVersions,
 			runtimeVersion: "",
 			expected:       "3.1-1-python-3.12-astro-agent-1.1.0",
+			shouldError:    false,
+		},
+		{
+			name: "prefers newer astro-agent when runtime and python match across client versions",
+			clientVersions: map[string]ClientVersion{
+				"1.3.6": {
+					Metadata: ClientVersionMetadata{
+						Channel:     VersionChannelStable,
+						ReleaseDate: "2026-02-18",
+					},
+					ImageTags: []string{
+						"3.1-13-python-3.12-astro-agent-1.3.6",
+					},
+				},
+				"1.3.7": {
+					Metadata: ClientVersionMetadata{
+						Channel:     VersionChannelStable,
+						ReleaseDate: "2026-03-04",
+					},
+					ImageTags: []string{
+						"3.1-13-python-3.12-astro-agent-1.3.7",
+					},
+				},
+			},
+			runtimeVersion: "",
+			expected:       "3.1-13-python-3.12-astro-agent-1.3.7",
 			shouldError:    false,
 		},
 		{


### PR DESCRIPTION
## Summary

Default **astro-agent** image selection (from the client-versions manifest) now ranks candidates with **Astro runtime** rules first, then **Python** and **astro-agent** versions using `golang.org/x/mod/semver` (`cmp.Or` + `semver.Compare` on `v`-prefixed fields). Runtime in the tag still uses `CompareRuntimeVersions`; only the Python/agent tie-breaks move from string compare to semver.

This fixes incorrect ordering where string comparison disagrees with semver (e.g. `3.10` vs `3.9`) and ensures a **newer agent** wins when image runtime and Python match across different client versions (e.g. `1.3.7` over `1.3.6` for the same `3.1-13-python-3.12-...` shape).

The redundant **sort of stable client-version keys** before scanning tags was removed; iteration order does not change the outcome once `isBetterImage` compares runtime, Python, and agent for every candidate.

## Test plan

- [x] `go test ./airflow_versions/...`
- [ ] CI / pre-commit