### PR TITLE
fix: standardize error messages for missing required flags

### DIFF
--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -109,7 +109,7 @@ var (
 		$ astro deployment variable update --deployment-id <deployment-id> --load --env .env.my-deployment
 		`
 	httpClient              = httputil.NewHTTPClient()
-	errFlag                 = errors.New("--deployment-file can not be used with other arguments")
+	errFlag                 = errors.New("--deployment-file cannot be used with other arguments. See --help for usage")
 	errInvalidExecutor      = errors.New("not a valid executor")
 	errInvalidCloudProvider = errors.New("not a valid cloud provider. It can only be gcp, azure or aws")
 )
@@ -158,7 +158,7 @@ func newDeploymentTeamRootCmd(out io.Writer) *cobra.Command {
 		newDeploymentTeamRemoveCmd(out),
 		newDeploymentTeamAddCmd(out),
 	)
-	cmd.PersistentFlags().StringVar(&deploymentID, "deployment-id", "", "deployment where you'd like to manage teams")
+	cmd.PersistentFlags().StringVar(&deploymentID, "deployment-id", "", "deployment where you'd like to manage teams. Run 'astro deployment list' to find valid IDs")
 	return cmd
 }
 
@@ -191,7 +191,7 @@ func newDeploymentTeamRemoveCmd(out io.Writer) *cobra.Command {
 
 func listDeploymentTeam(cmd *cobra.Command, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	cmd.SilenceUsage = true
 	return team.ListDeploymentTeams(out, astroCoreClient, deploymentID)
@@ -199,7 +199,7 @@ func listDeploymentTeam(cmd *cobra.Command, out io.Writer) error {
 
 func removeDeploymentTeam(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	var id string
 
@@ -220,7 +220,7 @@ func newDeploymentTeamAddCmd(out io.Writer) *cobra.Command {
 			return addDeploymentTeam(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "w", "", "The Deployment's unique identifier")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "w", "", "The Deployment's unique identifier. Run 'astro deployment list' to find valid IDs")
 	cmd.Flags().StringVarP(&addDeploymentRole, "role", "r", "DEPLOYMENT_ADMIN", "The role for the "+
 		"new team. Possible values are DEPLOYMENT_ADMIN or the custom role name.")
 	return cmd
@@ -228,7 +228,7 @@ func newDeploymentTeamAddCmd(out io.Writer) *cobra.Command {
 
 func addDeploymentTeam(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	var id string
 
@@ -256,7 +256,7 @@ func newDeploymentTeamUpdateCmd(out io.Writer) *cobra.Command {
 
 func updateDeploymentTeam(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	var id string
 
@@ -287,7 +287,7 @@ func newDeploymentUserRootCmd(out io.Writer) *cobra.Command {
 		newDeploymentUserRemoveCmd(out),
 		newDeploymentUserAddCmd(out),
 	)
-	cmd.PersistentFlags().StringVar(&deploymentID, "deployment-id", "", "deployment where you'd like to manage users")
+	cmd.PersistentFlags().StringVar(&deploymentID, "deployment-id", "", "deployment where you'd like to manage users. Run 'astro deployment list' to find valid IDs")
 
 	return cmd
 }
@@ -521,7 +521,7 @@ func newDeploymentVariableListCmd(out io.Writer) *cobra.Command {
 			return deploymentVariableList(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "Deployment to list variables for")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "Deployment to list variables for. Run 'astro deployment list' to find valid IDs")
 	cmd.Flags().StringVarP(&variableKey, "key", "k", "", "Specify a key to find a specific variable")
 	cmd.Flags().BoolVarP(&useEnvFile, "save", "s", false, "Save Deployment variables to an environment file")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of the file to save environment variables to")
@@ -542,7 +542,7 @@ func newDeploymentVariableCreateCmd(out io.Writer) *cobra.Command {
 			return deploymentVariableCreate(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "Deployment assigned to variables")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "Deployment assigned to variables. Run 'astro deployment list' to find valid IDs")
 	cmd.Flags().StringVarP(&variableKey, "key", "k", "", "Key for the new variable")
 	cmd.Flags().StringVarP(&variableValue, "value", "v", "", "Value for the new variable")
 	cmd.Flags().BoolVarP(&useEnvFile, "load", "l", false, "Create environment variables loaded from an environment file")
@@ -566,7 +566,7 @@ func newDeploymentVariableUpdateCmd(out io.Writer) *cobra.Command {
 			return deploymentVariableUpdate(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "Deployment assigned to variables")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "Deployment assigned to variables. Run 'astro deployment list' to find valid IDs")
 	cmd.Flags().StringVarP(&variableKey, "key", "k", "", "Key of the variable to update")
 	cmd.Flags().StringVarP(&variableValue, "value", "v", "", "Value of the variable to update")
 	cmd.Flags().BoolVarP(&useEnvFile, "load", "l", false, "Update environment variables loaded from an environment file")
@@ -948,7 +948,7 @@ func isValidCloudProvider(cloudProvider astrocore.SharedClusterCloudProvider) bo
 
 func addDeploymentUser(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	var email string
 
@@ -964,7 +964,7 @@ func addDeploymentUser(cmd *cobra.Command, args []string, out io.Writer) error {
 
 func listDeploymentUser(cmd *cobra.Command, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	cmd.SilenceUsage = true
 	return user.ListDeploymentUsers(out, astroCoreClient, deploymentID)
@@ -972,7 +972,7 @@ func listDeploymentUser(cmd *cobra.Command, out io.Writer) error {
 
 func updateDeploymentUser(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	var email string
 
@@ -993,7 +993,7 @@ func updateDeploymentUser(cmd *cobra.Command, args []string, out io.Writer) erro
 
 func removeDeploymentUser(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	var email string
 
@@ -1025,7 +1025,7 @@ func newDeploymentTokenRootCmd(out io.Writer) *cobra.Command {
 		newWorkspaceTokenManageCmd(out),
 		newOrgTokenManageCmd(out),
 	)
-	cmd.PersistentFlags().StringVar(&deploymentID, "deployment-id", "", "deployment where you would like to manage tokens")
+	cmd.PersistentFlags().StringVar(&deploymentID, "deployment-id", "", "deployment where you would like to manage tokens. Run 'astro deployment list' to find valid IDs")
 	return cmd
 }
 
@@ -1213,7 +1213,7 @@ func newUpdateWorkspaceTokenDeploymentRole(out io.Writer) *cobra.Command {
 
 func addOrgTokenToDeploymentRole(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -1231,7 +1231,7 @@ func addOrgTokenToDeploymentRole(cmd *cobra.Command, args []string, out io.Write
 
 func updateOrgTokenToDeploymentRole(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -1249,7 +1249,7 @@ func updateOrgTokenToDeploymentRole(cmd *cobra.Command, args []string, out io.Wr
 
 func addWorkspaceTokenDeploymentRole(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -1268,7 +1268,7 @@ func addWorkspaceTokenDeploymentRole(cmd *cobra.Command, args []string, out io.W
 
 func updateWorkspaceTokenDeploymentRole(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -1313,7 +1313,7 @@ func newRemoveWorkspaceTokenDeploymentRole(out io.Writer) *cobra.Command {
 
 func removeOrgTokenFromDeploymentRole(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -1327,7 +1327,7 @@ func removeOrgTokenFromDeploymentRole(cmd *cobra.Command, args []string, out io.
 
 func removeWorkspaceTokenDeploymentRole(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -1365,7 +1365,7 @@ func newListWorkspaceTokensInDeployment(out io.Writer) *cobra.Command {
 
 func listOrganizationTokensInDeployment(cmd *cobra.Command, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 
@@ -1378,7 +1378,7 @@ func listOrganizationTokensInDeployment(cmd *cobra.Command, out io.Writer) error
 
 func listWorkspaceTokensInDeployment(cmd *cobra.Command, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 
@@ -1391,7 +1391,7 @@ func listWorkspaceTokensInDeployment(cmd *cobra.Command, out io.Writer) error {
 
 func listDeploymentToken(cmd *cobra.Command, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	cmd.SilenceUsage = true
 	return deployment.ListTokens(astroCoreClient, deploymentID, nil, out)
@@ -1399,7 +1399,7 @@ func listDeploymentToken(cmd *cobra.Command, out io.Writer) error {
 
 func createDeploymentToken(cmd *cobra.Command, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	if tokenName == "" {
 		// no role was provided so ask the user for it
@@ -1417,7 +1417,7 @@ func createDeploymentToken(cmd *cobra.Command, out io.Writer) error {
 
 func updateDeploymentToken(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -1431,7 +1431,7 @@ func updateDeploymentToken(cmd *cobra.Command, args []string, out io.Writer) err
 
 func rotateDeploymentToken(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 	if len(args) > 0 {
@@ -1444,7 +1444,7 @@ func rotateDeploymentToken(cmd *cobra.Command, args []string, out io.Writer) err
 
 func deleteDeploymentToken(cmd *cobra.Command, args []string, out io.Writer) error {
 	if deploymentID == "" {
-		return errors.New("flag --deployment-id is required")
+		return errRequiredFlag("deployment-id", "astro deployment list")
 	}
 	// if an id was provided in the args we use it
 	if len(args) > 0 {

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -1857,7 +1857,7 @@ func TestDeploymentUserList(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"user", "list"}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 	t.Run("any errors from api are returned and users are not listed", func(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -1891,7 +1891,7 @@ func TestDeploymentUserUpdate(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"user", "update", "user@1.com", "--role", "DEPLOYMENT_ADMIN"}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 	t.Run("valid email with valid role updates user", func(t *testing.T) {
 		expectedOut := "The deployment user user@1.com role was successfully updated to DEPLOYMENT_ADMIN"
@@ -1965,7 +1965,7 @@ func TestDeploymentUserAdd(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"user", "add", "user@1.com", "--role", "DEPLOYMENT_ADMIN"}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 	t.Run("valid email with valid role adds user", func(t *testing.T) {
 		expectedOut := "The user user@1.com was successfully added to the deployment with the role DEPLOYMENT_ADMIN\n"
@@ -2040,7 +2040,7 @@ func TestDeploymentUserRemove(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"user", "remove", "user@1.com"}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 	t.Run("valid email removes user", func(t *testing.T) {
 		expectedOut := "The user user@1.com was successfully removed from the deployment"
@@ -2114,7 +2114,7 @@ func TestDeploymentTeamList(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"team", "list"}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 	t.Run("any errors from api are returned and teams are not listed", func(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -2148,7 +2148,7 @@ func TestDeploymentTeamUpdate(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"team", "update", team1.Id, "--role", "DEPLOYMENT_ADMIN"}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 	t.Run("valid id with valid role updates team", func(t *testing.T) {
 		expectedOut := fmt.Sprintf("The deployment team %s role was successfully updated to DEPLOYMENT_ADMIN", team1.Id)
@@ -2235,7 +2235,7 @@ func TestDeploymentTeamAdd(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"team", "add", team1.Id}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 	t.Run("any errors from api are returned and team is not added", func(t *testing.T) {
 		mockClient := new(astrocore_mocks.ClientWithResponsesInterface)
@@ -2301,7 +2301,7 @@ func TestDeploymentTeamRemove(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"team", "remove", team1.Id}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 	t.Run("valid id removes team", func(t *testing.T) {
 		expectedOut := fmt.Sprintf("Astro Team %s was successfully removed from deployment %s\n", team1.Name, mockDeploymentID)
@@ -2387,7 +2387,7 @@ func TestDeploymentTokenList(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"token", "list"}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 
 	t.Run("any errors from api are returned and tokens are not listed", func(t *testing.T) {
@@ -2436,7 +2436,7 @@ func TestDeploymentTokenCreate(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"token", "create", "--name", "Token 1", "--role", "DEPLOYMENT_ADMIN"}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 
 	t.Run("any errors from api are returned and token is not created", func(t *testing.T) {
@@ -2525,7 +2525,7 @@ func TestDeploymentTokenUpdate(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"token", "update", "--name", tokenName1}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 
 	t.Run("any errors from api are returned and token is not updated", func(t *testing.T) {
@@ -2615,7 +2615,7 @@ func TestDeploymentTokenRotate(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"token", "rotate", "--name", tokenName1, "--force"}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 
 	t.Run("any errors from api are returned and token is not rotated", func(t *testing.T) {
@@ -2720,7 +2720,7 @@ func TestDeploymentTokenDelete(t *testing.T) {
 		astroCoreClient = mockClient
 		cmdArgs := []string{"token", "delete", apiToken1.Id}
 		_, err := execDeploymentCmd(cmdArgs...)
-		assert.EqualError(t, err, "flag --deployment-id is required")
+		assert.EqualError(t, err, "required flag --deployment-id not set. To find valid values, run: astro deployment list")
 	})
 	t.Run("any errors from api are returned and token is not deleted", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)

--- a/cmd/cloud/deployment_workerqueue.go
+++ b/cmd/cloud/deployment_workerqueue.go
@@ -44,7 +44,7 @@ func newDeploymentWorkerQueueCreateCmd(out io.Writer) *cobra.Command {
 			return deploymentWorkerQueueCreateOrUpdate(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be deleted.")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be deleted. Run 'astro deployment list' to find valid IDs")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment where the worker queue should be deleted.")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue. Queue names must not exceed 63 characters and contain only lowercase alphanumeric characters or '-' and start with an alphabetical character.")
 	cmd.Flags().IntVarP(&minWorkerCount, "min-count", "", 0, "The min worker count of the worker queue.")
@@ -65,7 +65,7 @@ func newDeploymentWorkerQueueUpdateCmd(out io.Writer) *cobra.Command {
 			return deploymentWorkerQueueCreateOrUpdate(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be created.")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be created. Run 'astro deployment list' to find valid IDs")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment where the worker queue should be created.")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue. Queue names must not exceed 63 characters and contain only lowercase alphanumeric characters or '-' and start with an alphabetical character.")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force update: Don't prompt a user for confirmation")
@@ -87,7 +87,7 @@ func newDeploymentWorkerQueueDeleteCmd(out io.Writer) *cobra.Command {
 			return deploymentWorkerQueueDelete(cmd, args, out)
 		},
 	}
-	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be created.")
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "The deployment where the worker queue should be created. Run 'astro deployment list' to find valid IDs")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "", "", "Name of the deployment where the worker queue should be created.")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "The name of the worker queue to delete.")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force delete: Don't prompt a user for confirmation")

--- a/cmd/cloud/errors.go
+++ b/cmd/cloud/errors.go
@@ -1,0 +1,14 @@
+package cloud
+
+import "fmt"
+
+// errRequiredFlag returns a standardized error for missing required flags.
+// hint should tell the user how to find valid values (e.g., "astro deployment list").
+//
+//nolint:unparam
+func errRequiredFlag(flag, hint string) error {
+	if hint != "" {
+		return fmt.Errorf("required flag --%s not set. To find valid values, run: %s", flag, hint)
+	}
+	return fmt.Errorf("required flag --%s not set. See --help for usage", flag)
+}


### PR DESCRIPTION
## Summary
- Introduces `errRequiredFlag()` helper in `cmd/cloud/errors.go` for consistent, actionable error formatting
- Replaces 21 instances of bare `"flag --deployment-id is required"` with messages that tell users how to find valid values (e.g., `"required flag --deployment-id not set. To find valid values, run: astro deployment list"`)
- Adds the same hint to all `--deployment-id` flag descriptions
- Fixes `errFlag` message to be more actionable

Part of agent-friendliness improvements. Agents self-correct better when error messages include the correct invocation.

## Test plan
- [x] All existing tests pass (`go test ./cmd/cloud/...`)
- [x] Lint passes
- [ ] Verify `astro deployment team list` (no --deployment-id) shows new error format