### PR TITLE
docs: add help examples to all cloud commands

### DIFF
--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -169,6 +169,9 @@ func newDeploymentTeamListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the teams in an Astro Deployment",
 		Long:    "List all the teams in an Astro Deployment",
+		Example: `
+  $ astro deployment team list --deployment-id <deployment-id>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listDeploymentTeam(cmd, out)
 		},
@@ -182,6 +185,9 @@ func newDeploymentTeamRemoveCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Remove a team from an Astro Deployment",
 		Long:    "Remove a team from an Astro Deployment",
+		Example: `
+  $ astro deployment team remove <team-id> --deployment-id <deployment-id>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeDeploymentTeam(cmd, args, out)
 		},
@@ -216,6 +222,9 @@ func newDeploymentTeamAddCmd(out io.Writer) *cobra.Command {
 		Use:   "add [id]",
 		Short: "Add a team to an Astro Deployment with a specific role",
 		Long:  "Add a team to an Astro Deployment with a specific role\n$astro deployment team add [id] --role [DEPLOYMENT_ADMIN or the custom role name].",
+		Example: `
+  $ astro deployment team add <team-id> --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addDeploymentTeam(cmd, args, out)
 		},
@@ -245,6 +254,9 @@ func newDeploymentTeamUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update the role of a team in an Astro Deployment",
 		Long:    "Update the role of a team in an Astro Deployment\n$astro deployment team update [id] --role [DEPLOYMENT_ADMIN or the custom role name].",
+		Example: `
+  $ astro deployment team update <team-id> --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateDeploymentTeam(cmd, args, out)
 		},
@@ -297,6 +309,9 @@ func newDeploymentUserAddCmd(out io.Writer) *cobra.Command {
 		Use:   "add [email]",
 		Short: "Add a user to an Astro Deployment with a specific role",
 		Long:  "Add a user to an Astro Deployment with a specific role\n$astro deployment user add [email] --role [DEPLOYMENT_ADMIN or the custom role name].",
+		Example: `
+  $ astro deployment user add user@company.com --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addDeploymentUser(cmd, args, out)
 		},
@@ -312,6 +327,9 @@ func newDeploymentUserListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the users in an Astro Deployment",
 		Long:    "List all the users in an Astro Deployment",
+		Example: `
+  $ astro deployment user list --deployment-id <deployment-id>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listDeploymentUser(cmd, out)
 		},
@@ -325,6 +343,9 @@ func newDeploymentUserUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update a the role of a user in an Astro Deployment",
 		Long:    "Update the role of a user in an Astro Deployment\n$astro deployment user update [email] --role [DEPLOYMENT_ADMIN or the custom role name].",
+		Example: `
+  $ astro deployment user update user@company.com --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateDeploymentUser(cmd, args, out)
 		},
@@ -340,6 +361,9 @@ func newDeploymentUserRemoveCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Remove a user from an Astro Deployment",
 		Long:    "Remove a user from an Astro Deployment",
+		Example: `
+  $ astro deployment user remove user@company.com --deployment-id <deployment-id>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeDeploymentUser(cmd, args, out)
 		},
@@ -353,6 +377,10 @@ func newDeploymentListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all Deployments running in your Astronomer Workspace",
 		Long:    "List all Deployments running in your Astronomer Workspace. Switch Workspaces to see other Deployments in your Organization.",
+		Example: `
+  $ astro deployment list
+  $ astro deployment list --all
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentList(cmd, out)
 		},
@@ -367,7 +395,12 @@ func newDeploymentLogsCmd() *cobra.Command {
 		Aliases: []string{"l"},
 		Short:   "Show an Astro Deployment's Scheduler logs",
 		Long:    "Show an Astro Deployment's Scheduler logs. Use flags to determine what log level to show.",
-		RunE:    deploymentLogs,
+		Example: `
+  $ astro deployment logs <deployment-id>
+  $ astro deployment logs <deployment-id> --error --info --log-count 50
+  $ astro deployment logs --deployment-name my-deployment --keyword "task failed"
+`,
+		RunE: deploymentLogs,
 	}
 	cmd.Flags().BoolVarP(&warnLogs, "warn", "w", false, "Show logs with a log level of 'warning'")
 	cmd.Flags().BoolVarP(&errorLogs, "error", "e", false, "Show logs with a log level of 'error'")
@@ -488,7 +521,11 @@ func newDeploymentDeleteCmd() *cobra.Command {
 		Aliases: []string{"de"},
 		Short:   "Delete an Astro Deployment",
 		Long:    "Delete an Astro Deployment",
-		RunE:    deploymentDelete,
+		Example: `
+  $ astro deployment delete <deployment-id>
+  $ astro deployment delete --deployment-name my-deployment --force
+`,
+		RunE: deploymentDelete,
 	}
 	cmd.Flags().BoolVarP(&forceDelete, "force", "f", false, "Force delete. Don't prompt a user before Deployment deletion")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to delete")
@@ -586,7 +623,13 @@ func newDeploymentHibernateCmd() *cobra.Command {
 		Aliases: []string{"hb"},
 		Short:   "Hibernate an Astro development Deployment",
 		Long:    "Hibernate an Astro development Deployment for a set amount of time. Overrides any existing hibernation schedule and sets the Deployment to hibernate for a specific duration or until a specific time. Use the '--remove-override' flag to remove any existing override and resume the regular hibernation schedule.",
-		RunE:    func(cmd *cobra.Command, args []string) error { return deploymentOverrideHibernation(cmd, args, true) },
+		Example: `
+  $ astro deployment hibernate <deployment-id>
+  $ astro deployment hibernate <deployment-id> --for 2h30m
+  $ astro deployment hibernate <deployment-id> --until 2024-06-01T12:00:00Z
+  $ astro deployment hibernate <deployment-id> --remove-override
+`,
+		RunE: func(cmd *cobra.Command, args []string) error { return deploymentOverrideHibernation(cmd, args, true) },
 	}
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the Deployment to hibernate")
 	cmd.Flags().StringVarP(&until, "until", "u", "", "Specify the hibernation period using an end date and time. Example value: 2021-01-01T00:00:00Z")
@@ -604,7 +647,13 @@ func newDeploymentWakeUpCmd() *cobra.Command {
 		Aliases: []string{"wu"},
 		Short:   "Wake up an Astro development Deployment",
 		Long:    "Wake up an Astro development Deployment from hibernation. Overrides any existing hibernation schedule and sets the Deployment to run for a specific duration or until a specific time. Use the '--remove-override' flag to remove any existing override and resume the regular hibernation schedule.",
-		RunE:    func(cmd *cobra.Command, args []string) error { return deploymentOverrideHibernation(cmd, args, false) },
+		Example: `
+  $ astro deployment wake-up <deployment-id>
+  $ astro deployment wake-up <deployment-id> --for 4h
+  $ astro deployment wake-up <deployment-id> --until 2024-06-01T18:00:00Z
+  $ astro deployment wake-up <deployment-id> --remove-override
+`,
+		RunE: func(cmd *cobra.Command, args []string) error { return deploymentOverrideHibernation(cmd, args, false) },
 	}
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the Deployment to wake up.")
 	cmd.Flags().StringVarP(&until, "until", "u", "", "Specify the awake period using an end date. Example value: 2021-01-01T00:00:00Z")
@@ -1036,6 +1085,9 @@ func newDeploymentTokenListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the API tokens in an Astro Deployment",
 		Long:    "List all the API tokens in an Astro Deployment",
+		Example: `
+  $ astro deployment token list --deployment-id <deployment-id>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listDeploymentToken(cmd, out)
 		},
@@ -1050,6 +1102,10 @@ func newDeploymentTokenCreateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cr"},
 		Short:   "Create an API token in an Astro Deployment",
 		Long:    "Create an API token in an Astro Deployment\n$astro workspace token create --name [token name] --role [Possible values are DEPLOYMENT_ADMIN or a custom role name].",
+		Example: `
+  $ astro deployment token create --name my-token --role DEPLOYMENT_ADMIN --deployment-id <deployment-id>
+  $ astro deployment token create --name my-token --role DEPLOYMENT_ADMIN --deployment-id <deployment-id> --expiration 30
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return createDeploymentToken(cmd, out)
 		},
@@ -1070,6 +1126,9 @@ func newDeploymentTokenUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update a Deployment API token",
 		Long:    "Update a Deployment API token that has a role in an Astro Deployment\n$astro deployment token update [TOKEN_ID] --name [new token name] --role [Possible values are DEPLOYMENT_ADMIN or a custom role name].",
+		Example: `
+  $ astro deployment token update <token-id> --deployment-id <deployment-id> --new-name my-new-token-name --role DEPLOYMENT_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateDeploymentToken(cmd, args, out)
 		},
@@ -1089,6 +1148,10 @@ func newDeploymentTokenRotateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ro"},
 		Short:   "Rotate a Deployment API token",
 		Long:    "Rotate a Deployment API token. You can only rotate Deployment API tokens. You cannot rotate Organization API tokens with this command",
+		Example: `
+  $ astro deployment token rotate <token-id> --deployment-id <deployment-id>
+  $ astro deployment token rotate <token-id> --deployment-id <deployment-id> --force
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rotateDeploymentToken(cmd, args, out)
 		},
@@ -1107,6 +1170,10 @@ func newDeploymentTokenDeleteCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"de"},
 		Short:   "Delete a Deployment API token",
 		Long:    "Delete a Deployment API token",
+		Example: `
+  $ astro deployment token delete <token-id> --deployment-id <deployment-id>
+  $ astro deployment token delete <token-id> --deployment-id <deployment-id> --force
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deleteDeploymentToken(cmd, args, out)
 		},
@@ -1156,6 +1223,10 @@ func newAddOrganizationTokenDeploymentRole(out io.Writer) *cobra.Command {
 		Use:   "add [ORG_TOKEN_ID]",
 		Short: "Add an Organization API token to a Deployment",
 		Long:  "Add an Organization API token to a Deployment\n$astro deployment token organization-token add [ORG_TOKEN_ID] --org-token-name [token name] --role [DEPLOYMENT_ADMIN or a custom role name].",
+		Example: `
+  $ astro deployment token organization-token add <org-token-id> --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+  $ astro deployment token organization-token add --org-token-name my-org-token --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addOrgTokenToDeploymentRole(cmd, args, out)
 		},
@@ -1171,6 +1242,10 @@ func newUpdateOrganizationTokenDeploymentRole(out io.Writer) *cobra.Command {
 		Use:   "update [ORG_TOKEN_ID]",
 		Short: "Update an Organization API token's Deployment Role",
 		Long:  "Update an Organization API token's Deployment Role\n$astro deployment token organization-token update [ORG_TOKEN_ID] --org-token-name [token name] --role [DEPLOYMENT_ADMIN or a custom role name].",
+		Example: `
+  $ astro deployment token organization-token update <org-token-id> --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+  $ astro deployment token organization-token update --org-token-name my-org-token --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateOrgTokenToDeploymentRole(cmd, args, out)
 		},
@@ -1186,6 +1261,10 @@ func newAddWorkspaceTokenDeploymentRole(out io.Writer) *cobra.Command {
 		Use:   "add [WORKSPACE_TOKEN_ID]",
 		Short: "Add a Workspace API token's Deployment Role",
 		Long:  "Add a Workspace API token's Deployment Role\n$astro deployment token workspace-token add [WORKSPACE_TOKEN_ID] --workspace-token-name [token name] --role [DEPLOYMENT_ADMIN or a custom role name].",
+		Example: `
+  $ astro deployment token workspace-token add <workspace-token-id> --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+  $ astro deployment token workspace-token add --workspace-token-name my-ws-token --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addWorkspaceTokenDeploymentRole(cmd, args, out)
 		},
@@ -1201,6 +1280,10 @@ func newUpdateWorkspaceTokenDeploymentRole(out io.Writer) *cobra.Command {
 		Use:   "update [WORKSPACE_TOKEN_ID]",
 		Short: "Update a Workspace API token's Deployment Role",
 		Long:  "Update a Workspace API token's Deployment Role\n$astro deployment token workspace-token update [WORKSPACE_TOKEN_ID] --workspace-token-name [token name] --role [DEPLOYMENT_ADMIN or a custom role name].",
+		Example: `
+  $ astro deployment token workspace-token update <workspace-token-id> --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+  $ astro deployment token workspace-token update --workspace-token-name my-ws-token --deployment-id <deployment-id> --role DEPLOYMENT_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateWorkspaceTokenDeploymentRole(cmd, args, out)
 		},
@@ -1290,6 +1373,10 @@ func newRemoveOrganizationTokenDeploymentRole(out io.Writer) *cobra.Command {
 		Use:   "remove [ORG_TOKEN_ID]",
 		Short: "Remove an Organization API token's Deployment Role",
 		Long:  "Remove an Organization API token's Deployment Role\n$astro deployment token organization-token remove [ORG_TOKEN_ID] --org-token-name [token name].",
+		Example: `
+  $ astro deployment token organization-token remove <org-token-id> --deployment-id <deployment-id>
+  $ astro deployment token organization-token remove --org-token-name my-org-token --deployment-id <deployment-id>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeOrgTokenFromDeploymentRole(cmd, args, out)
 		},
@@ -1303,6 +1390,10 @@ func newRemoveWorkspaceTokenDeploymentRole(out io.Writer) *cobra.Command {
 		Use:   "remove [WORKSPACE_TOKEN_ID]",
 		Short: "Remove a Workspace API token's Deployment Role",
 		Long:  "Remove a Workspace API token's Deployment Role\n$astro deployment token workspace-token remove [WORKSPACE_TOKEN_ID] --workspace-token-name [token name].",
+		Example: `
+  $ astro deployment token workspace-token remove <workspace-token-id> --deployment-id <deployment-id>
+  $ astro deployment token workspace-token remove --workspace-token-name my-ws-token --deployment-id <deployment-id>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeWorkspaceTokenDeploymentRole(cmd, args, out)
 		},
@@ -1344,6 +1435,9 @@ func newListOrganizationTokensInDeployment(out io.Writer) *cobra.Command {
 		Use:   "list",
 		Short: "List all Organization API tokens in a deployment",
 		Long:  "List all Organization API tokens in a deployment\n$astro deployment token organization-token list",
+		Example: `
+  $ astro deployment token organization-token list --deployment-id <deployment-id>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listOrganizationTokensInDeployment(cmd, out)
 		},
@@ -1356,6 +1450,9 @@ func newListWorkspaceTokensInDeployment(out io.Writer) *cobra.Command {
 		Use:   "list",
 		Short: "List all Workspace API tokens in a deployment",
 		Long:  "List all Workspace API tokens in a deployment\n$astro deployment token workspace-token list",
+		Example: `
+  $ astro deployment token workspace-token list --deployment-id <deployment-id>
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listWorkspaceTokensInDeployment(cmd, out)
 		},

--- a/cmd/cloud/deployment_inspect.go
+++ b/cmd/cloud/deployment_inspect.go
@@ -22,6 +22,12 @@ func newDeploymentInspectCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"in"},
 		Short:   "Inspect a deployment configuration",
 		Long:    "Inspect an Astro Deployment configuration, which can be useful if you manage deployments as code or use Deployment configuration templates. This command returns the Deployment's configuration as a YAML or JSON output, which includes information about resources, such as cluster ID, region, and Airflow API URL, as well as scheduler and worker queue configurations.",
+		Example: `
+  $ astro deployment inspect <deployment-id>
+  $ astro deployment inspect <deployment-id> --output json
+  $ astro deployment inspect --deployment-name my-deployment --key configuration.cluster_id
+  $ astro deployment inspect <deployment-id> --template
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentInspect(cmd, args, out)
 		},

--- a/cmd/cloud/deployment_objects.go
+++ b/cmd/cloud/deployment_objects.go
@@ -60,6 +60,10 @@ func newDeploymentConnectionListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"li"},
 		Short:   "list a Deployment's connections",
 		Long:    "list connections for an Astro Deployment",
+		Example: `
+  $ astro deployment connection list --deployment-id <deployment-id>
+  $ astro deployment connection list --deployment-name my-deployment
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentConnectionList(cmd, out)
 		},
@@ -77,6 +81,10 @@ func newDeploymentConnectionCreateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cr"},
 		Short:   "Create connections for a Deployment",
 		Long:    "Create Airflow connections for an Astro Deployment",
+		Example: `
+  $ astro deployment connection create --deployment-id <deployment-id> --conn-id my-conn --conn-type postgres --host localhost --port 5432
+  $ astro deployment connection create --deployment-id <deployment-id> --conn-id my-conn --conn-type http --host https://api.example.com
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentConnectionCreate(cmd, out)
 		},
@@ -103,6 +111,9 @@ func newDeploymentConnectionUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update connections for a Deployment",
 		Long:    "Update existing Airflow connections for an Astro Deployment",
+		Example: `
+  $ astro deployment connection update --deployment-id <deployment-id> --conn-id my-conn --conn-type postgres --host new-host
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentConnectionUpdate(cmd, out)
 		},
@@ -129,6 +140,10 @@ func newDeploymentConnectionCopyCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cp"},
 		Short:   "Copy connections from one Deployment to another",
 		Long:    "Copy Airflow connections from one Astro Deployment to another. Passwords and extra configurations will not copy over. If a connection already exits with same connection ID in the target Deployment, that connection will be updated",
+		Example: `
+  $ astro deployment connection copy --source-id <source-deployment-id> --target-id <target-deployment-id>
+  $ astro deployment connection copy --source-name my-source-deployment --target-name my-target-deployment
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentConnectionCopy(cmd, out)
 		},
@@ -163,6 +178,10 @@ func newDeploymentAirflowVariableListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"li"},
 		Short:   "list a Deployment's Airflow variables",
 		Long:    "list Airflow variables stored in an Astro Deployment's metadata database",
+		Example: `
+  $ astro deployment airflow-variable list --deployment-id <deployment-id>
+  $ astro deployment airflow-variable list --deployment-name my-deployment
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentAirflowVariableList(cmd, out)
 		},
@@ -180,6 +199,10 @@ func newDeploymentAirflowVariableCreateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cr"},
 		Short:   "Create Airflow variables for a Deployment",
 		Long:    "Create Airflow variables for an Astro Deployment",
+		Example: `
+  $ astro deployment airflow-variable create --deployment-id <deployment-id> --key my_var --value my_value
+  $ astro deployment airflow-variable create --deployment-id <deployment-id> --key my_var --value my_value --description "A useful variable"
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentAirflowVariableCreate(cmd, out)
 		},
@@ -200,6 +223,9 @@ func newDeploymentAirflowVariableUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update Airflow variables for a Deployment",
 		Long:    "Update Airflow variables for an Astro Deployment",
+		Example: `
+  $ astro deployment airflow-variable update --deployment-id <deployment-id> --key my_var --value new_value
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentAirflowVariableUpdate(cmd, out)
 		},
@@ -220,6 +246,10 @@ func newDeploymentAirflowVariableCopyCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cp"},
 		Short:   "Copy the Airflow variables from one Deployment to another",
 		Long:    "Copy Airflow variables from one Astro Deployment to another Astro Deployment. If a variable already exits with same Key it will be updated",
+		Example: `
+  $ astro deployment airflow-variable copy --source-id <source-deployment-id> --target-id <target-deployment-id>
+  $ astro deployment airflow-variable copy --source-name my-source-deployment --target-name my-target-deployment
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentAirflowVariableCopy(cmd, out)
 		},
@@ -254,6 +284,10 @@ func newDeploymentPoolListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"li"},
 		Short:   "list a Deployment's Airflow pools",
 		Long:    "list Airflow pools for an Astro Deployment",
+		Example: `
+  $ astro deployment pool list --deployment-id <deployment-id>
+  $ astro deployment pool list --deployment-name my-deployment
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentPoolList(cmd, out)
 		},
@@ -271,6 +305,10 @@ func newDeploymentPoolCreateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cr"},
 		Short:   "Create Airflow pools for an Astro Deployment",
 		Long:    "Create Airflow pools for an Astro Deployment",
+		Example: `
+  $ astro deployment pool create --deployment-id <deployment-id> --name my-pool --slots 5
+  $ astro deployment pool create --deployment-id <deployment-id> --name my-pool --slots 10 --description "Pool for ML tasks"
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentPoolCreate(cmd, out)
 		},
@@ -292,6 +330,10 @@ func newDeploymentPoolUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update Airflow pools for an Astro Deployment",
 		Long:    "Update Airflow pools for an Astro Deployment",
+		Example: `
+  $ astro deployment pool update --deployment-id <deployment-id> --name my-pool --slots 10
+  $ astro deployment pool update --deployment-id <deployment-id> --name my-pool --slots 10 --description "Updated pool"
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentPoolUpdate(cmd, out)
 		},
@@ -313,6 +355,10 @@ func newDeploymentPoolCopyCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cp"},
 		Short:   "Copy Airflow pools from one Astro Deployment to another",
 		Long:    "Copy Airflow pools from one Astro Deployment to another Astro Deployment. If a pool already exits with same name it will be updated",
+		Example: `
+  $ astro deployment pool copy --source-id <source-deployment-id> --target-id <target-deployment-id>
+  $ astro deployment pool copy --source-name my-source-deployment --target-name my-target-deployment
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentPoolCopy(cmd, out)
 		},

--- a/cmd/cloud/deployment_workerqueue.go
+++ b/cmd/cloud/deployment_workerqueue.go
@@ -40,6 +40,10 @@ func newDeploymentWorkerQueueCreateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cr"},
 		Short:   "Create a Deployment's worker queue",
 		Long:    "Create a worker queue for an Astro Deployment",
+		Example: `
+  $ astro deployment worker-queue create --deployment-id <deployment-id> --name my-queue --worker-type default
+  $ astro deployment worker-queue create --deployment-id <deployment-id> --name my-queue --min-count 2 --max-count 10 --concurrency 16
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentWorkerQueueCreateOrUpdate(cmd, args, out)
 		},
@@ -61,6 +65,10 @@ func newDeploymentWorkerQueueUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update a Deployment's worker queue",
 		Long:    "Update a worker queue for an Astro Deployment",
+		Example: `
+  $ astro deployment worker-queue update --deployment-id <deployment-id> --name my-queue --max-count 20
+  $ astro deployment worker-queue update --deployment-id <deployment-id> --name my-queue --concurrency 32 --force
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentWorkerQueueCreateOrUpdate(cmd, args, out)
 		},
@@ -83,6 +91,10 @@ func newDeploymentWorkerQueueDeleteCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"de"},
 		Short:   "Delete a Deployment's worker queue",
 		Long:    "Delete a worker queue from an Astro Deployment",
+		Example: `
+  $ astro deployment worker-queue delete --deployment-id <deployment-id> --name my-queue
+  $ astro deployment worker-queue delete --deployment-id <deployment-id> --name my-queue --force
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentWorkerQueueDelete(cmd, args, out)
 		},

--- a/cmd/cloud/organization.go
+++ b/cmd/cloud/organization.go
@@ -76,6 +76,9 @@ func newOrganizationListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all Organizations you have access too",
 		Long:    "List all Organizations you have access too",
+		Example: `
+  $ astro organization list
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return organizationList(cmd, out)
 		},
@@ -89,7 +92,12 @@ func newOrganizationSwitchCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"sw"},
 		Short:   "Switch to a different Organization",
 		Long:    "Switch to a different Organization",
-		Args:    cobra.MaximumNArgs(1),
+		Example: `
+  $ astro organization switch
+  $ astro organization switch my-organization
+  $ astro organization switch --login-link --workspace-id ws123456
+`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return organizationSwitch(cmd, out, args)
 		},
@@ -120,6 +128,11 @@ func newOrganizationExportAuditLogs(_ io.Writer) *cobra.Command {
 		Aliases: []string{"e"},
 		Short:   "Export your Organization audit logs in GZIP. Requires Organization Owner permissions.",
 		Long:    "Export your Organization audit logs in GZIP. Requires Organization Owner permissions.",
+		Example: `
+  $ astro organization audit-logs export
+  $ astro organization audit-logs export --output-file audit-logs.gz --include 30
+  $ astro organization audit-logs export --organization-name my-org --include 7
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return organizationExportAuditLogs(cmd)
 		},
@@ -153,6 +166,10 @@ func newOrganizationUserInviteCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"inv"},
 		Short:   "Invite a user to your Astro Organization",
 		Long:    "Invite a user to your Astro Organization\n$astro user invite [email] --role [" + allowedOrganizationRoleNames + "].",
+		Example: `
+  $ astro organization user invite user@company.com
+  $ astro organization user invite user@company.com --role ORGANIZATION_BILLING_ADMIN
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return userInvite(cmd, args, out)
 		},
@@ -168,6 +185,9 @@ func newOrganizationUserListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the users in your Astro Organization",
 		Long:    "List all the users in your Astro Organization",
+		Example: `
+  $ astro organization user list
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listUsers(cmd, out)
 		},
@@ -181,6 +201,10 @@ func newOrganizationUserUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update a the role of a user your in Astro Organization",
 		Long:    "Update the role of a user in your Astro Organization\n$astro user update [email] --role [" + allowedOrganizationRoleNames + "].",
+		Example: `
+  $ astro organization user update user@company.com --role ORGANIZATION_OWNER
+  $ astro organization user update user@company.com --role ORGANIZATION_MEMBER
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return userUpdate(cmd, args, out)
 		},
@@ -288,6 +312,9 @@ func newOrganizationTeamListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the teams in your Astro Organization",
 		Long:    "List all the teams in your Astro Organization",
+		Example: `
+  $ astro organization team list
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listTeams(cmd, out)
 		},
@@ -306,7 +333,12 @@ func newTeamUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update an Astro team",
 		Long:    "Update an Astro team",
-		Args:    cobra.MaximumNArgs(1),
+		Example: `
+  $ astro organization team update team123
+  $ astro organization team update team123 --name "New Team Name" --role ORGANIZATION_MEMBER
+  $ astro organization team update team123 --description "Updated description"
+`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return teamUpdate(cmd, out, args)
 		},
@@ -337,6 +369,11 @@ func newTeamCreateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cr"},
 		Short:   "Create an Astro Team",
 		Long:    "Create an Astro Team",
+		Example: `
+  $ astro organization team create
+  $ astro organization team create --name "My Team" --role ORGANIZATION_MEMBER
+  $ astro organization team create --name "My Team" --description "Data engineering team" --role ORGANIZATION_OWNER
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return teamCreate(cmd, out)
 		},
@@ -368,7 +405,11 @@ func newTeamDeleteCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"de"},
 		Short:   "Delete an Astro Team",
 		Long:    "Delete an Astro Team",
-		Args:    cobra.MaximumNArgs(1),
+		Example: `
+  $ astro organization team delete
+  $ astro organization team delete team123
+`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return teamDelete(cmd, out, args)
 		},
@@ -409,6 +450,9 @@ func newTeamRemoveUserCmd(out io.Writer) *cobra.Command {
 		Use:   "remove",
 		Short: "Remove a user from an Astro Team",
 		Long:  "Remove a user from an Astro Team",
+		Example: `
+  $ astro organization team user remove --team-id team123 --user-id user456
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeTeamUser(cmd, out)
 		},
@@ -428,6 +472,9 @@ func newTeamAddUserCmd(out io.Writer) *cobra.Command {
 		Use:   "add",
 		Short: "Add a user to an Astro Team",
 		Long:  "Add a user to an Astro Team",
+		Example: `
+  $ astro organization team user add --team-id team123 --user-id user456
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addTeamUser(cmd, out)
 		},
@@ -447,6 +494,10 @@ func newTeamListUsersCmd(out io.Writer) *cobra.Command {
 		Use:   "list",
 		Short: "Lists users in an Astro Team",
 		Long:  "Lists users in an Astro Team",
+		Example: `
+  $ astro organization team user list
+  $ astro organization team user list --team-id team123
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listUsersCmd(cmd, out)
 		},
@@ -490,6 +541,10 @@ func newOrganizationTokenListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the API tokens in an Astro Organization",
 		Long:    "List all the API tokens in an Astro Organization",
+		Example: `
+  $ astro organization token list
+  $ astro organization token list --organization-id org123
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listOrganizationToken(cmd, out)
 		},
@@ -503,6 +558,9 @@ func newOrganizationTokenListRolesCmd(out io.Writer) *cobra.Command {
 		Use:   "roles [TOKEN_ID]",
 		Short: "List roles for an organization API token",
 		Long:  "List roles for an organization API token\n$astro organization token roles [TOKEN_ID] ",
+		Example: `
+  $ astro organization token roles token123
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listOrganizationTokenRoles(cmd, args, out)
 		},
@@ -517,6 +575,11 @@ func newOrganizationTokenCreateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cr"},
 		Short:   "Create an API token in an Astro Organization",
 		Long:    "Create an API token in an Astro Organization\n$astro organization token create --name [token name] --role [" + allowedOrganizationRoleNames + "].",
+		Example: `
+  $ astro organization token create
+  $ astro organization token create --name "CI/CD Token" --role ORGANIZATION_MEMBER
+  $ astro organization token create --name "Deploy Token" --role ORGANIZATION_OWNER --expiration 365 --clean-output
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return createOrganizationToken(cmd, out)
 		},
@@ -536,6 +599,11 @@ func newOrganizationTokenUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update a Organization or Organaization API token",
 		Long:    "Update a Organization or Organaization API token that has a role in an Astro Organization\n$astro organization token update [TOKEN_ID] --name [new token name] --role [" + allowedOrganizationRoleNames + "].",
+		Example: `
+  $ astro organization token update token123
+  $ astro organization token update token123 --new-name "Updated Token" --role ORGANIZATION_OWNER
+  $ astro organization token update --name "My Token" --new-name "Renamed Token" --description "Updated desc"
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateOrganizationToken(cmd, args, out)
 		},
@@ -554,6 +622,11 @@ func newOrganizationTokenRotateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ro"},
 		Short:   "Rotate a Organization API token",
 		Long:    "Rotate a Organization API token. You can only rotate Organization API tokens. You cannot rotate Workspace API tokens with this command",
+		Example: `
+  $ astro organization token rotate token123
+  $ astro organization token rotate --name "My Token" --force
+  $ astro organization token rotate token123 --clean-output
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rotateOrganizationToken(cmd, args, out)
 		},
@@ -572,6 +645,10 @@ func newOrganizationTokenDeleteCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"de"},
 		Short:   "Delete a Organization API token or remove an Organization API token from a Organization",
 		Long:    "Delete a Organization API token or remove an Organization API token from a Organization",
+		Example: `
+  $ astro organization token delete token123
+  $ astro organization token delete --name "My Token" --force
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deleteOrganizationToken(cmd, args, out)
 		},
@@ -699,6 +776,10 @@ func newOrganizationRoleListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the roles in your Astro Organization",
 		Long:    "List all the roles in your Astro Organization",
+		Example: `
+  $ astro organization role list
+  $ astro organization role list --include-default-roles
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listRoles(cmd, out)
 		},

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -76,6 +76,9 @@ func newWorkspaceListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all Astro Workspaces in your organization",
 		Long:    "List all Astro Workspaces in your organization.",
+		Example: `
+  $ astro workspace list
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return workspaceList(cmd, out)
 		},
@@ -89,7 +92,11 @@ func newWorkspaceSwitchCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"sw"},
 		Short:   "Switch to a different Astro Workspace",
 		Long:    "Switch to a different Astro Workspace",
-		Args:    cobra.MaximumNArgs(1),
+		Example: `
+  $ astro workspace switch
+  $ astro workspace switch my-workspace
+`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return workspaceSwitch(cmd, out, args)
 		},
@@ -103,6 +110,10 @@ func newWorkspaceCreateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cr"},
 		Short:   "Create an Astro Workspace",
 		Long:    "Create an Astro Workspace",
+		Example: `
+  $ astro workspace create --name "My Workspace" --description "Production pipelines"
+  $ astro workspace create --name "My Workspace" --enforce-cicd ON
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return workspaceCreate(cmd, out)
 		},
@@ -119,7 +130,11 @@ func newWorkspaceUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update an Astro Workspace",
 		Long:    "Update an Astro Workspace",
-		Args:    cobra.MaximumNArgs(1),
+		Example: `
+  $ astro workspace update clxxxxxxxxx --name "New Name"
+  $ astro workspace update clxxxxxxxxx --description "Updated description" --enforce-cicd ON
+`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return workspaceUpdate(cmd, out, args)
 		},
@@ -136,7 +151,11 @@ func newWorkspaceDeleteCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"de"},
 		Short:   "Delete an Astro Workspace",
 		Long:    "Delete an Astro Workspace",
-		Args:    cobra.MaximumNArgs(1),
+		Example: `
+  $ astro workspace delete
+  $ astro workspace delete clxxxxxxxxx
+`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return workspaceDelete(cmd, out, args)
 		},
@@ -168,6 +187,10 @@ func newWorkspaceUserAddCmd(out io.Writer) *cobra.Command {
 		Use:   "add [email]",
 		Short: "Add a user to an Astro Workspace with a specific role",
 		Long:  "Add a user to an Astro Workspace with a specific role\n$astro workspace user add [email] --role [" + allowedWorkspaceRoleNames + "].",
+		Example: `
+  $ astro workspace user add user@company.com --role WORKSPACE_MEMBER
+  $ astro workspace user add user@company.com --role WORKSPACE_OWNER
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addWorkspaceUser(cmd, args, out)
 		},
@@ -183,6 +206,10 @@ func newWorkspaceUserListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the users in an Astro Workspace",
 		Long:    "List all the users in an Astro Workspace",
+		Example: `
+  $ astro workspace user list
+  $ astro workspace user list --workspace-id clxxxxxxxxx
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listWorkspaceUser(cmd, out)
 		},
@@ -196,6 +223,10 @@ func newWorkspaceUserUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update a the role of a user in an Astro Workspace",
 		Long:    "Update the role of a user in an Astro Workspace\n$astro workspace user update [email] --role [" + allowedWorkspaceRoleNames + "].",
+		Example: `
+  $ astro workspace user update user@company.com --role WORKSPACE_OPERATOR
+  $ astro workspace user update user@company.com --role WORKSPACE_OWNER
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateWorkspaceUser(cmd, args, out)
 		},
@@ -211,6 +242,9 @@ func newWorkspaceUserRemoveCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Remove a user from an Astro Workspace",
 		Long:    "Remove a user from an Astro Workspace",
+		Example: `
+  $ astro workspace user remove user@company.com
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeWorkspaceUser(cmd, args, out)
 		},
@@ -247,6 +281,10 @@ func newWorkspaceTokenListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the API tokens in an Astro Workspace",
 		Long:    "List all the API tokens in an Astro Workspace",
+		Example: `
+  $ astro workspace token list
+  $ astro workspace token list --workspace-id clxxxxxxxxx
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listWorkspaceToken(cmd, out)
 		},
@@ -279,6 +317,9 @@ func newWorkspaceTeamListCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all the teams in an Astro Workspace",
 		Long:    "List all the teams in an Astro Workspace",
+		Example: `
+  $ astro workspace team list
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listWorkspaceTeam(cmd, out)
 		},
@@ -293,6 +334,10 @@ func newWorkspaceTokenCreateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"cr"},
 		Short:   "Create an API token in an Astro Workspace",
 		Long:    "Create an API token in an Astro Workspace\n$astro workspace token create --name [token name] --role [" + allowedWorkspaceRoleNames + "].",
+		Example: `
+  $ astro workspace token create --name "My Token" --role WORKSPACE_MEMBER
+  $ astro workspace token create --name "CI Token" --role WORKSPACE_OPERATOR --expiration 30 --clean-output
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return createWorkspaceToken(cmd, out)
 		},
@@ -313,6 +358,10 @@ func newWorkspaceTokenUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update a Workspace or Organaization API token",
 		Long:    "Update a Workspace or Organaization API token that has a role in an Astro Workspace\n$astro workspace token update [TOKEN_ID] --name [new token name] --role [" + allowedWorkspaceRoleNames + "].",
+		Example: `
+  $ astro workspace token update clxxxxxxxxx --new-name "Updated Token" --role WORKSPACE_OPERATOR
+  $ astro workspace token update --name "My Token" --new-name "Renamed Token" --description "Updated description"
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateWorkspaceToken(cmd, args, out)
 		},
@@ -332,6 +381,10 @@ func newWorkspaceTokenRotateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"ro"},
 		Short:   "Rotate a Workspace API token",
 		Long:    "Rotate a Workspace API token. You can only rotate Workspace API tokens. You cannot rotate Organization API tokens with this command",
+		Example: `
+  $ astro workspace token rotate clxxxxxxxxx
+  $ astro workspace token rotate --name "My Token" --force --clean-output
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rotateWorkspaceToken(cmd, args, out)
 		},
@@ -350,6 +403,10 @@ func newWorkspaceTokenDeleteCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"de"},
 		Short:   "Delete a Workspace API token or remove an Organization API token from a Workspace",
 		Long:    "Delete a Workspace API token or remove an Organization API token from a Workspace",
+		Example: `
+  $ astro workspace token delete clxxxxxxxxx
+  $ astro workspace token delete --name "My Token" --force
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deleteWorkspaceToken(cmd, args, out)
 		},
@@ -366,6 +423,10 @@ func newWorkspaceTokenAddOrgTokenCmd(out io.Writer) *cobra.Command {
 		Use:   "add [ORG_TOKEN_ID]",
 		Short: "Add an Organization API token to an Astro Workspace",
 		Long:  "Add an Organization API token to an Astro Workspace\n$astro workspace token add [ORG_TOKEN_ID] --org-token-name [token name] --role [" + allowedWorkspaceRoleNames + "].",
+		Example: `
+  $ astro workspace token add clxxxxxxxxx --role WORKSPACE_MEMBER
+  $ astro workspace token add --org-token-name "My Org Token" --role WORKSPACE_OPERATOR
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addOrgTokenToWorkspace(cmd, args, out)
 		},
@@ -503,6 +564,9 @@ func newWorkspaceTeamRemoveCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Remove a team from an Astro Workspace",
 		Long:    "Remove a team from an Astro Workspace",
+		Example: `
+  $ astro workspace team remove clxxxxxxxxx
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return removeWorkspaceTeam(cmd, args, out)
 		},
@@ -532,6 +596,10 @@ func newWorkspaceTeamAddCmd(out io.Writer) *cobra.Command {
 		Use:   "add [id]",
 		Short: "Add a team to an Astro Workspace with a specific role",
 		Long:  "Add a team to an Astro Workspace with a specific role\n$astro workspace team add [id] --role [" + allowedWorkspaceRoleNames + "].",
+		Example: `
+  $ astro workspace team add clxxxxxxxxx --role WORKSPACE_MEMBER
+  $ astro workspace team add clxxxxxxxxx --role WORKSPACE_OPERATOR --workspace-id clyyyyyyyyy
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addWorkspaceTeam(cmd, args, out)
 		},
@@ -560,6 +628,10 @@ func newWorkspaceTeamUpdateCmd(out io.Writer) *cobra.Command {
 		Aliases: []string{"up"},
 		Short:   "Update a the role of a team in an Astro Workspace",
 		Long:    "Update the role of a team in an Astro Workspace\n$astro workspace team update [id] --role [" + allowedWorkspaceRoleNames + "].",
+		Example: `
+  $ astro workspace team update clxxxxxxxxx --role WORKSPACE_OPERATOR
+  $ astro workspace team update clxxxxxxxxx --role WORKSPACE_OWNER
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateWorkspaceTeam(cmd, args, out)
 		},


### PR DESCRIPTION
## Summary
- Adds Cobra `Example` fields to ~60 leaf commands that were missing them
- Covers workspace, organization, deployment, worker-queue, inspect, connection, airflow-variable, and pool command groups
- Each example shows realistic flag usage so agents and users can pattern-match correct invocations from `--help`

Before: 84% of commands had no examples. After: all leaf commands have examples.

Part of agent-friendliness improvements. Agents rely heavily on `--help` examples to construct correct invocations.

## Test plan
- [x] All existing tests pass (`go test ./cmd/cloud/...`)
- [x] Lint + gofumpt pass
- [ ] Spot-check: `astro workspace list --help`, `astro deployment token create --help`, `astro organization team update --help` all show Example sections