### PR TITLE
fix: add include/ to PYTHONPATH in standalone mode

### DIFF
--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -666,6 +666,14 @@ func (s *Standalone) buildEnv() []string {
 	// Layer 2: Standalone-critical settings — these MUST take precedence over
 	// both inherited env and .env to prevent standalone mode from breaking.
 	overrides["PATH"] = fmt.Sprintf("%s:%s", venvBin, os.Getenv("PATH"))
+	// Add include/ to PYTHONPATH so user modules are importable — mirrors
+	// the Docker image which bakes /usr/local/airflow/include into PYTHONPATH.
+	includePath := filepath.Join(s.airflowHome, "include")
+	if existing := os.Getenv("PYTHONPATH"); existing != "" {
+		overrides["PYTHONPATH"] = fmt.Sprintf("%s:%s", includePath, existing)
+	} else {
+		overrides["PYTHONPATH"] = includePath
+	}
 	overrides["AIRFLOW_HOME"] = standaloneHome
 	overrides["ASTRONOMER_ENVIRONMENT"] = "local"
 	overrides["AIRFLOW__CORE__LOAD_EXAMPLES"] = "False"

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -1614,8 +1614,10 @@ func (s *Suite) TestStandalonePytest_Success() {
 	defer func() { standaloneExec = origExec }()
 
 	var capturedArgs []string
+	var capturedEnv []string
 	standaloneExec = func(dir string, env, args []string, _ io.Reader, _, _ io.Writer) error {
 		capturedArgs = args
+		capturedEnv = env
 		return nil
 	}
 
@@ -1626,6 +1628,19 @@ func (s *Suite) TestStandalonePytest_Success() {
 	s.NoError(err)
 	s.Equal("", exitCode)
 	s.Equal([]string{"pytest", "tests/"}, capturedArgs)
+
+	// Verify PYTHONPATH includes the include/ directory so user modules
+	// in include/ are importable during test runs.
+	expectedInclude := filepath.Join(tmpDir, "include")
+	var pythonPath string
+	for _, kv := range capturedEnv {
+		if strings.HasPrefix(kv, "PYTHONPATH=") {
+			pythonPath = strings.TrimPrefix(kv, "PYTHONPATH=")
+			break
+		}
+	}
+	s.NotEmpty(pythonPath, "PYTHONPATH should be set in pytest env")
+	s.Contains(pythonPath, expectedInclude, "PYTHONPATH should contain include/ directory")
 }
 
 func (s *Suite) TestStandalonePytest_WithFileAndArgs() {


### PR DESCRIPTION
## Summary
- Standalone mode's `buildEnv()` was missing `PYTHONPATH` with the project's `include/` directory, causing import failures for user modules during `astro dev pytest --standalone` (and `start`/`parse`)
- In Docker mode, the Astronomer runtime image bakes `/usr/local/airflow/include` into `PYTHONPATH` — this adds the equivalent for standalone mode
- Preserves any existing `PYTHONPATH` the user may have set

## Test plan
- [x] Updated `TestStandalonePytest_Success` to verify `PYTHONPATH` contains `include/`
- [x] All existing standalone pytest tests pass
- [ ] Manual: `astro dev pytest --standalone` in a project with `include/` imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)