### PR TITLE
fix: propagate non-zero exit codes from `astro dev run`

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -639,7 +639,18 @@ func (d *DockerCompose) Run(args []string, user string) error {
 
 	resp, _ := d.cliClient.ContainerExecAttach(context.Background(), execID, execStartCheck)
 
-	return docker.ExecPipe(resp, os.Stdin, os.Stdout, os.Stderr)
+	if err := docker.ExecPipe(resp, os.Stdin, os.Stdout, os.Stderr); err != nil {
+		return err
+	}
+
+	inspectResp, err := d.cliClient.ContainerExecInspect(context.Background(), execID)
+	if err != nil {
+		return err
+	}
+	if inspectResp.ExitCode != 0 {
+		return fmt.Errorf("command exited with code %d", inspectResp.ExitCode)
+	}
+	return nil
 }
 
 // Pytest creates and runs a container containing the users airflow image, requirments, packages, and volumes(DAGs folder, etc...)

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1098,11 +1098,32 @@ func (s *Suite) TestDockerComposeRun() {
 		mockCLIClient := new(mocks.DockerCLIClient)
 		mockCLIClient.On("ContainerExecCreate", context.Background(), "test-webserver-id", container.ExecOptions{User: "test-user", AttachStdout: true, Cmd: testCmd}).Return(docker_types.IDResponse{ID: "test-exec-id"}, nil).Once()
 		mockCLIClient.On("ContainerExecAttach", context.Background(), "test-exec-id", container.ExecStartOptions{Detach: false}).Return(docker_types.HijackedResponse{Reader: mockResp}, nil).Once()
+		mockCLIClient.On("ContainerExecInspect", context.Background(), "test-exec-id").Return(container.ExecInspect{ExitCode: 0}, nil).Once()
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.cliClient = mockCLIClient
 
 		err := mockDockerCompose.Run(testCmd, "test-user")
 		s.NoError(err)
+		composeMock.AssertExpectations(s.T())
+		mockCLIClient.AssertExpectations(s.T())
+	})
+
+	s.Run("non-zero exit code", func() {
+		testCmd := []string{"test", "command"}
+		str := bytes.NewReader([]byte(`0`))
+		mockResp := bufio.NewReader(str)
+
+		composeMock := new(mocks.DockerComposeAPI)
+		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-webserver-id", Name: "test-webserver", State: "running"}}, nil).Once()
+		mockCLIClient := new(mocks.DockerCLIClient)
+		mockCLIClient.On("ContainerExecCreate", context.Background(), "test-webserver-id", container.ExecOptions{User: "test-user", AttachStdout: true, Cmd: testCmd}).Return(docker_types.IDResponse{ID: "test-exec-id"}, nil).Once()
+		mockCLIClient.On("ContainerExecAttach", context.Background(), "test-exec-id", container.ExecStartOptions{Detach: false}).Return(docker_types.HijackedResponse{Reader: mockResp}, nil).Once()
+		mockCLIClient.On("ContainerExecInspect", context.Background(), "test-exec-id").Return(container.ExecInspect{ExitCode: 1}, nil).Once()
+		mockDockerCompose.composeService = composeMock
+		mockDockerCompose.cliClient = mockCLIClient
+
+		err := mockDockerCompose.Run(testCmd, "test-user")
+		s.EqualError(err, "command exited with code 1")
 		composeMock.AssertExpectations(s.T())
 		mockCLIClient.AssertExpectations(s.T())
 	})


### PR DESCRIPTION
## Summary
- `astro dev run` in Docker mode always returned exit code 0 even when the executed subcommand failed, because the container exec's exit code was never inspected
- After piping I/O via `ExecPipe`, now calls `ContainerExecInspect` to check the actual exit code and returns an error when non-zero
- Standalone mode was not affected (`exec.Command.Run()` already propagates exit errors)

## Test plan
- [x] Added test case for non-zero exit code scenario
- [x] Existing tests pass
- [x] Manual: run `astro dev run airflow dags list` (should exit 0) and `astro dev run airflow bad-command` (should exit non-zero)