### PR TITLE
Fix standalone plugins_folder path

### DIFF
--- a/pkg/airflowrt/env.go
+++ b/pkg/airflowrt/env.go
@@ -40,6 +40,7 @@ func BuildEnv(projectPath, port, envFilePath string) []string {
 	overrides["ASTRONOMER_ENVIRONMENT"] = "local"
 	overrides["AIRFLOW__CORE__LOAD_EXAMPLES"] = "False"
 	overrides["AIRFLOW__CORE__DAGS_FOLDER"] = filepath.Join(projectPath, "dags")
+	overrides["AIRFLOW__CORE__PLUGINS_FOLDER"] = filepath.Join(projectPath, "plugins")
 	overrides["AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS"] = "True"
 	if port != DefaultPort {
 		overrides["AIRFLOW__API__PORT"] = port


### PR DESCRIPTION
## Summary
- AIRFLOW_HOME points to .astro/standalone/, so plugins_folder defaults to .astro/standalone/plugins/ instead of <project>/plugins/
- Dags work because DAGS_FOLDER is explicitly overridden, but plugins_folder was missed
- One-line fix, same pattern as the existing DAGS_FOLDER override

## Test plan
- Create an Astro project with a plugin in plugins/
- Run standalone mode
- Verify plugins are loaded