### PR TITLE
Move shared request editor and API error logic into pkg/httputil

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,7 @@ linters:
       min-len: 3
       min-occurrences: 3
       ignore-string-values:
-        - '^true$'
+        - 'true'
         - 'Help for '
         - 'Bearer '
         - 'https://'

--- a/airflow/standalone_windows.go
+++ b/airflow/standalone_windows.go
@@ -5,10 +5,11 @@ package airflow
 import (
 	"errors"
 
+	"github.com/pkg/browser"
+
 	"github.com/astronomer/astro-cli/airflow/types"
 	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
-	"github.com/pkg/browser"
 )
 
 var (

--- a/astro-client-core/client.go
+++ b/astro-client-core/client.go
@@ -1,29 +1,13 @@
 package astrocore
 
 import (
-	"bytes"
-	httpContext "context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
-	"net/url"
-	"os"
-	"runtime"
-
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
-	"github.com/astronomer/astro-cli/version"
 )
 
-var (
-	ErrorRequest  = errors.New("failed to perform request")
-	ErrorBaseURL  = errors.New("invalid baseurl")
-	HTTPStatus200 = 200
-	HTTPStatus204 = 204
-)
-
-const TrueString = "true"
+// NormalizeAPIError is a deliberate re-export of httputil.NormalizeAPIError, allowing
+// callers to override error normalization per-client without importing pkg/httputil.
+var NormalizeAPIError = httputil.NormalizeAPIError
 
 // a shorter alias
 type CoreClient = ClientWithResponsesInterface
@@ -31,49 +15,12 @@ type CoreClient = ClientWithResponsesInterface
 // create api client for astro core services
 func NewCoreClient(c *httputil.HTTPClient) *ClientWithResponses {
 	// we append base url in request editor, so set to an empty string here
-	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(CoreRequestEditor))
-	return cl
-}
-
-func NormalizeAPIError(httpResp *http.Response, body []byte) error {
-	if httpResp.StatusCode != HTTPStatus200 && httpResp.StatusCode != HTTPStatus204 {
-		decode := Error{}
-		err := json.NewDecoder(bytes.NewReader(body)).Decode(&decode)
+	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
+		ctx, err := context.GetCurrentContext()
 		if err != nil {
-			return fmt.Errorf("%w, status %d", ErrorRequest, httpResp.StatusCode)
+			return "", "", err
 		}
-		return errors.New(decode.Message)
-	}
-	return nil
-}
-
-func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
-	currentCtx, err := context.GetCurrentContext()
-	if err != nil {
-		return nil
-	}
-	operatingSystem := runtime.GOOS
-	arch := runtime.GOARCH
-	baseURL := currentCtx.GetPublicRESTAPIURL("v1alpha1")
-	requestURL, err := url.Parse(baseURL + req.URL.String())
-	if err != nil {
-		return fmt.Errorf("%w, %s", ErrorBaseURL, baseURL)
-	}
-	req.URL = requestURL
-	req.Header.Add("authorization", currentCtx.Token)
-	switch {
-	case os.Getenv("DEPLOY_ACTION") == TrueString && os.Getenv("GITHUB_ACTIONS") == TrueString:
-		req.Header.Add("x-astro-client-identifier", "deploy-action")
-		req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
-	case os.Getenv("GITHUB_ACTIONS") == TrueString:
-		req.Header.Add("x-astro-client-identifier", "github-action")
-		req.Header.Add("x-astro-client-version", version.CurrVersion)
-	default:
-		req.Header.Add("x-astro-client-identifier", "cli")
-		req.Header.Add("x-astro-client-version", version.CurrVersion)
-	}
-	req.Header.Add("x-astro-client-version", version.CurrVersion)
-	req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)
-	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
-	return nil
+		return ctx.Token, ctx.GetPublicRESTAPIURL("v1alpha1"), nil
+	})))
+	return cl
 }

--- a/astro-client-iam-core/client.go
+++ b/astro-client-iam-core/client.go
@@ -1,77 +1,25 @@
 package astroiamcore
 
 import (
-	"bytes"
-	httpContext "context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
-	"net/url"
-	"os"
-	"runtime"
-
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
-	"github.com/astronomer/astro-cli/version"
 )
 
-var (
-	ErrorRequest  = errors.New("failed to perform request")
-	ErrorBaseURL  = errors.New("invalid baseurl")
-	HTTPStatus200 = 200
-	HTTPStatus204 = 204
-)
-
-const TrueString = "true"
+// NormalizeAPIError is a deliberate re-export of httputil.NormalizeAPIError, allowing
+// callers to override error normalization per-client without importing pkg/httputil.
+var NormalizeAPIError = httputil.NormalizeAPIError
 
 // a shorter alias
 type CoreClient = ClientWithResponsesInterface
 
 func NewIamCoreClient(c *httputil.HTTPClient) *ClientWithResponses {
 	// we append base url in request editor, so set to an empty string here
-	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(CoreRequestEditor))
-	return cl
-}
-
-func NormalizeAPIError(httpResp *http.Response, body []byte) error {
-	if httpResp.StatusCode != HTTPStatus200 && httpResp.StatusCode != HTTPStatus204 {
-		decode := Error{}
-		err := json.NewDecoder(bytes.NewReader(body)).Decode(&decode)
+	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
+		ctx, err := context.GetCurrentContext()
 		if err != nil {
-			return fmt.Errorf("%w, status %d", ErrorRequest, httpResp.StatusCode)
+			return "", "", err
 		}
-		return errors.New(decode.Message)
-	}
-	return nil
-}
-
-func CoreRequestEditor(ctx httpContext.Context, req *http.Request) error {
-	currentCtx, err := context.GetCurrentContext()
-	if err != nil {
-		return nil
-	}
-	operatingSystem := runtime.GOOS
-	arch := runtime.GOARCH
-	baseURL := currentCtx.GetPublicRESTAPIURL("iam/v1beta1")
-	requestURL, err := url.Parse(baseURL + req.URL.String())
-	if err != nil {
-		return fmt.Errorf("%w, %s", ErrorBaseURL, baseURL)
-	}
-	req.URL = requestURL
-	req.Header.Add("authorization", currentCtx.Token)
-	switch {
-	case os.Getenv("DEPLOY_ACTION") == TrueString && os.Getenv("GITHUB_ACTIONS") == TrueString:
-		req.Header.Add("x-astro-client-identifier", "deploy-action")
-		req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
-	case os.Getenv("GITHUB_ACTIONS") == TrueString:
-		req.Header.Add("x-astro-client-identifier", "github-action")
-		req.Header.Add("x-astro-client-version", version.CurrVersion)
-	default:
-		req.Header.Add("x-astro-client-identifier", "cli")
-		req.Header.Add("x-astro-client-version", version.CurrVersion)
-	}
-	req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)
-	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
-	return nil
+		return ctx.Token, ctx.GetPublicRESTAPIURL("iam/v1beta1"), nil
+	})))
+	return cl
 }

--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -1,33 +1,26 @@
 package astroplatformcore
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
+	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
-var (
-	ErrorRequest  = errors.New("failed to perform request")
-	ErrorBaseURL  = errors.New("invalid baseurl")
-	HTTPStatus200 = 200
-	HTTPStatus204 = 204
-)
-
-const TrueString = "true"
+// NormalizeAPIError is a deliberate re-export of httputil.NormalizeAPIError, allowing
+// callers to override error normalization per-client without importing pkg/httputil.
+var NormalizeAPIError = httputil.NormalizeAPIError
 
 // a shorter alias
 type CoreClient = ClientWithResponsesInterface
 
-func NormalizeAPIError(httpResp *http.Response, body []byte) error {
-	if httpResp.StatusCode != HTTPStatus200 && httpResp.StatusCode != HTTPStatus204 {
-		decode := Error{}
-		err := json.NewDecoder(bytes.NewReader(body)).Decode(&decode)
+// create api client for astro platform core services
+func NewPlatformCoreClient(c *httputil.HTTPClient) *ClientWithResponses {
+	// we append base url in request editor, so set to an empty string here
+	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
+		ctx, err := context.GetCurrentContext()
 		if err != nil {
-			return fmt.Errorf("%w, status %d", ErrorRequest, httpResp.StatusCode)
+			return "", "", err
 		}
-		return errors.New(decode.Message)
-	}
-	return nil
+		return ctx.Token, ctx.GetPublicRESTAPIURL("platform/v1beta1"), nil
+	})))
+	return cl
 }

--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -276,7 +276,7 @@ func CheckUserSession(c *config.Context, coreClient astrocore.CoreClient, platfo
 	if err != nil {
 		return err
 	}
-	err = astrocore.NormalizeAPIError(orgsResp.HTTPResponse, orgsResp.Body)
+	err = astroplatformcore.NormalizeAPIError(orgsResp.HTTPResponse, orgsResp.Body)
 	if err != nil {
 		return err
 	}

--- a/cloud/deploy/bundle_test.go
+++ b/cloud/deploy/bundle_test.go
@@ -391,7 +391,7 @@ func mockCreateDeploy(client *astrocore_mocks.ClientWithResponsesInterface, bund
 	}
 	response := &astrocore.CreateDeployResponse{
 		HTTPResponse: &http.Response{
-			StatusCode: astrocore.HTTPStatus200,
+			StatusCode: http.StatusOK,
 		},
 		JSON200: &astrocore.Deploy{
 			Id: "test-deploy-id",
@@ -409,7 +409,7 @@ func mockUpdateDeploy(client *astrocore_mocks.ClientWithResponsesInterface, expe
 	}
 	client.On("UpdateDeployWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, request).Return(&astrocore.UpdateDeployResponse{
 		HTTPResponse: &http.Response{
-			StatusCode: astrocore.HTTPStatus200,
+			StatusCode: http.StatusOK,
 		},
 	}, nil)
 }
@@ -417,7 +417,7 @@ func mockUpdateDeploy(client *astrocore_mocks.ClientWithResponsesInterface, expe
 func mockGetDeployment(client *astroplatformcore_mocks.ClientWithResponsesInterface, isDagDeployEnabled, isCicdEnforced bool) {
 	client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.GetDeploymentResponse{
 		HTTPResponse: &http.Response{
-			StatusCode: astrocore.HTTPStatus200,
+			StatusCode: http.StatusOK,
 		},
 		JSON200: &astroplatformcore.Deployment{
 			Id:                 "test-deployment-id",

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -734,7 +734,7 @@ func ListClusterOptions(cloudProvider string, coreClient astrocore.CoreClient) (
 	if err != nil {
 		return nil, err
 	}
-	err = astroplatformcore.NormalizeAPIError(clusterOptions.HTTPResponse, clusterOptions.Body)
+	err = astrocore.NormalizeAPIError(clusterOptions.HTTPResponse, clusterOptions.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -2378,7 +2378,7 @@ func (s *Suite) TestUpdateDeploymentHibernationOverride() {
 			isActive := true
 			mockResponse := astroplatformcore.UpdateDeploymentHibernationOverrideResponse{
 				HTTPResponse: &http.Response{
-					StatusCode: astrocore.HTTPStatus200,
+					StatusCode: http.StatusOK,
 				},
 				JSON200: &astroplatformcore.DeploymentHibernationOverride{
 					IsHibernating: &tt.IsHibernating,
@@ -2403,7 +2403,7 @@ func (s *Suite) TestUpdateDeploymentHibernationOverride() {
 			isActive := true
 			mockResponse := astroplatformcore.UpdateDeploymentHibernationOverrideResponse{
 				HTTPResponse: &http.Response{
-					StatusCode: astrocore.HTTPStatus200,
+					StatusCode: http.StatusOK,
 				},
 				JSON200: &astroplatformcore.DeploymentHibernationOverride{
 					IsHibernating: &tt.IsHibernating,
@@ -2492,7 +2492,7 @@ func (s *Suite) TestDeleteDeploymentHibernationOverride() {
 	s.Run("remove override", func() {
 		mockResponse := astroplatformcore.DeleteDeploymentHibernationOverrideResponse{
 			HTTPResponse: &http.Response{
-				StatusCode: astrocore.HTTPStatus204,
+				StatusCode: http.StatusNoContent,
 			},
 		}
 
@@ -2511,7 +2511,7 @@ func (s *Suite) TestDeleteDeploymentHibernationOverride() {
 	s.Run("remove override with deployment selection", func() {
 		mockResponse := astroplatformcore.DeleteDeploymentHibernationOverrideResponse{
 			HTTPResponse: &http.Response{
-				StatusCode: astrocore.HTTPStatus204,
+				StatusCode: http.StatusNoContent,
 			},
 		}
 

--- a/cloud/platformclient/client.go
+++ b/cloud/platformclient/client.go
@@ -1,52 +1,11 @@
 package platformclient
 
 import (
-	httpContext "context"
-	"fmt"
-	"net/http"
-	"net/url"
-	"os"
-	"runtime"
-
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
-	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
-	"github.com/astronomer/astro-cli/version"
 )
 
 // NewPlatformCoreClient creates an API client for Astro platform core services.
 func NewPlatformCoreClient(c *httputil.HTTPClient) *astroplatformcore.ClientWithResponses {
-	// we append base url in request editor, so set to an empty string here
-	cl, _ := astroplatformcore.NewClientWithResponses("", astroplatformcore.WithHTTPClient(c.HTTPClient), astroplatformcore.WithRequestEditorFn(requestEditor))
-	return cl
-}
-
-func requestEditor(ctx httpContext.Context, req *http.Request) error {
-	currentCtx, err := context.GetCurrentContext()
-	if err != nil {
-		return nil
-	}
-	operatingSystem := runtime.GOOS
-	arch := runtime.GOARCH
-	baseURL := currentCtx.GetPublicRESTAPIURL("platform/v1beta1")
-	requestURL, err := url.Parse(baseURL + req.URL.String())
-	if err != nil {
-		return fmt.Errorf("%w, %s", astroplatformcore.ErrorBaseURL, baseURL)
-	}
-	req.URL = requestURL
-	req.Header.Add("authorization", currentCtx.Token)
-	switch {
-	case os.Getenv("DEPLOY_ACTION") == astroplatformcore.TrueString && os.Getenv("GITHUB_ACTIONS") == astroplatformcore.TrueString:
-		req.Header.Add("x-astro-client-identifier", "deploy-action")
-		req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
-	case os.Getenv("GITHUB_ACTIONS") == astroplatformcore.TrueString:
-		req.Header.Add("x-astro-client-identifier", "github-action")
-		req.Header.Add("x-astro-client-version", version.CurrVersion)
-	default:
-		req.Header.Add("x-astro-client-identifier", "cli")
-		req.Header.Add("x-astro-client-version", version.CurrVersion)
-	}
-	req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)
-	req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
-	return nil
+	return astroplatformcore.NewPlatformCoreClient(c)
 }

--- a/cmd/cloud/dbt_test.go
+++ b/cmd/cloud/dbt_test.go
@@ -240,7 +240,7 @@ func (s *DbtSuite) createDbtProjectFile(path string) {
 func (s *DbtSuite) mockListTestDeployments() {
 	s.mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.ListDeploymentsResponse{
 		HTTPResponse: &http.Response{
-			StatusCode: astrocore.HTTPStatus200,
+			StatusCode: http.StatusOK,
 		},
 		JSON200: &astroplatformcore.DeploymentsPaginated{
 			Deployments: []astroplatformcore.Deployment{
@@ -255,7 +255,7 @@ func (s *DbtSuite) mockListTestDeployments() {
 func (s *DbtSuite) mockGetTestDeployment() {
 	s.mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&astroplatformcore.GetDeploymentResponse{
 		HTTPResponse: &http.Response{
-			StatusCode: astrocore.HTTPStatus200,
+			StatusCode: http.StatusOK,
 		},
 		JSON200: &astroplatformcore.Deployment{
 			Id: "test-deployment-id",

--- a/cmd/cloud/deployment_test.go
+++ b/cmd/cloud/deployment_test.go
@@ -1448,7 +1448,7 @@ func TestDeploymentHibernateAndWakeUp(t *testing.T) {
 			isActive := true
 			mockResponse := astroplatformcore.UpdateDeploymentHibernationOverrideResponse{
 				HTTPResponse: &http.Response{
-					StatusCode: astrocore.HTTPStatus200,
+					StatusCode: http.StatusOK,
 				},
 				JSON200: &astroplatformcore.DeploymentHibernationOverride{
 					IsHibernating: &tt.IsHibernating,
@@ -1478,7 +1478,7 @@ func TestDeploymentHibernateAndWakeUp(t *testing.T) {
 			isActive := true
 			mockResponse := astroplatformcore.UpdateDeploymentHibernationOverrideResponse{
 				HTTPResponse: &http.Response{
-					StatusCode: astrocore.HTTPStatus200,
+					StatusCode: http.StatusOK,
 				},
 				JSON200: &astroplatformcore.DeploymentHibernationOverride{
 					IsHibernating: &tt.IsHibernating,
@@ -1516,7 +1516,7 @@ func TestDeploymentHibernateAndWakeUp(t *testing.T) {
 			isActive := true
 			mockResponse := astroplatformcore.UpdateDeploymentHibernationOverrideResponse{
 				HTTPResponse: &http.Response{
-					StatusCode: astrocore.HTTPStatus200,
+					StatusCode: http.StatusOK,
 				},
 				JSON200: &astroplatformcore.DeploymentHibernationOverride{
 					IsHibernating: &tt.IsHibernating,
@@ -1549,7 +1549,7 @@ func TestDeploymentHibernateAndWakeUp(t *testing.T) {
 
 			mockResponse := astroplatformcore.DeleteDeploymentHibernationOverrideResponse{
 				HTTPResponse: &http.Response{
-					StatusCode: astrocore.HTTPStatus204,
+					StatusCode: http.StatusNoContent,
 				},
 			}
 

--- a/pkg/httputil/request_editor.go
+++ b/pkg/httputil/request_editor.go
@@ -1,0 +1,68 @@
+package httputil
+
+import (
+	"bytes"
+	httpContext "context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+
+	"github.com/astronomer/astro-cli/version"
+)
+
+var ErrorRequest = errors.New("failed to perform request")
+
+type apiError struct {
+	Message string `json:"message"`
+}
+
+func NormalizeAPIError(httpResp *http.Response, body []byte) error {
+	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusNoContent {
+		var decode apiError
+		err := json.NewDecoder(bytes.NewReader(body)).Decode(&decode)
+		if err != nil {
+			return fmt.Errorf("%w, status %d", ErrorRequest, httpResp.StatusCode)
+		}
+		return errors.New(decode.Message)
+	}
+	return nil
+}
+
+// NewRequestEditorFn returns a request editor that sets auth headers and the
+// base URL. getTokenAndURL is called per-request and should return the bearer
+// token and the resolved base URL for the given API path (e.g. from
+// context.GetCurrentContext).
+func NewRequestEditorFn(getTokenAndURL func() (token, baseURL string, err error)) func(httpContext.Context, *http.Request) error {
+	return func(ctx httpContext.Context, req *http.Request) error {
+		token, baseURL, err := getTokenAndURL()
+		if err != nil {
+			return nil
+		}
+		operatingSystem := runtime.GOOS
+		arch := runtime.GOARCH
+		requestURL, err := url.Parse(baseURL + req.URL.String())
+		if err != nil {
+			return fmt.Errorf("%w, %s", ErrorBaseURL, baseURL)
+		}
+		req.URL = requestURL
+		req.Header.Add("authorization", token)
+		switch {
+		case os.Getenv("DEPLOY_ACTION") == "true" && os.Getenv("GITHUB_ACTIONS") == "true":
+			req.Header.Add("x-astro-client-identifier", "deploy-action")
+			req.Header.Add("x-astro-client-version", os.Getenv("DEPLOY_ACTION_VERSION"))
+		case os.Getenv("GITHUB_ACTIONS") == "true":
+			req.Header.Add("x-astro-client-identifier", "github-action")
+			req.Header.Add("x-astro-client-version", version.CurrVersion)
+		default:
+			req.Header.Add("x-astro-client-identifier", "cli")
+			req.Header.Add("x-astro-client-version", version.CurrVersion)
+		}
+		req.Header.Add("x-client-os-identifier", operatingSystem+"-"+arch)
+		req.Header.Add("User-Agent", fmt.Sprintf("astro-cli/%s", version.CurrVersion))
+		return nil
+	}
+}


### PR DESCRIPTION
## Description

Consolidates the duplicated TrueString constant, ErrorRequest/ErrorBaseURL/
HTTPStatus200/HTTPStatus204 vars, NormalizeAPIError function, and request
editor function from all three astro-client-*-core packages into a new
pkg/httputil/request_editor.go. Each client package now re-exports the
vars/const and delegates NormalizeAPIError to httputil, and constructs its
request editor via httputil.NewRequestEditorFn with its API path argument.

Also fixes the double x-astro-client-version header bug in
astro-client-core/client.go. The original code called Header.Add (which
appends, not overwrites) unconditionally after the switch that already set
it -- so every request carried two x-astro-client-version values. In the
deploy-action case the server would see both the deploy action version and
CurrVersion.
