### PR TITLE
Support local spec files for --spec-url

### DIFF
--- a/cmd/api/cloud.go
+++ b/cmd/api/cloud.go
@@ -131,7 +131,7 @@ To pass nested values as arrays, declare multiple fields with key[]=value1.`,
 
 	// Other flags
 	cmd.Flags().BoolVar(&opts.GenerateCurl, "generate", false, "Output a curl command instead of executing the request")
-	cmd.PersistentFlags().StringVar(&opts.SpecURL, "spec-url", "", "OpenAPI spec URL (overrides default Cloud API spec)")
+	cmd.PersistentFlags().StringVar(&opts.SpecURL, "spec-url", "", "OpenAPI spec URL or file path (overrides default Cloud API spec)")
 	cmd.PersistentFlags().StringVar(&opts.SpecTokenEnvVar, "spec-token-env-var", "", "Environment variable containing auth token for fetching the spec")
 	//nolint:errcheck
 	cmd.PersistentFlags().MarkHidden("spec-url")
@@ -394,9 +394,19 @@ func initCloudSpecCache(opts *CloudOptions, ctx *config.Context) error {
 		return nil
 	}
 
-	// When --spec-url is provided, use it. If --spec-token-env-var is also set,
-	// read the token from that env var and send it as auth when fetching the spec.
+	// When --spec-url is provided, use it. It can be a remote URL or a local file path.
 	if opts.SpecURL != "" {
+		// Local file: read directly from disk, no caching or auth needed.
+		if openapi.IsLocalSpec(opts.SpecURL) {
+			localPath, err := openapi.ResolveLocalPath(opts.SpecURL)
+			if err != nil {
+				return fmt.Errorf("resolving spec path: %w", err)
+			}
+			opts.specCache = openapi.NewCacheForLocalFile(localPath)
+			return nil
+		}
+
+		// Remote URL: cache with optional auth via --spec-token-env-var.
 		cachePath := filepath.Join(config.HomeConfigPath, openapi.SpecCacheFileName(opts.SpecURL))
 		if opts.SpecTokenEnvVar != "" {
 			token := os.Getenv(opts.SpecTokenEnvVar)

--- a/cmd/api/cloud_test.go
+++ b/cmd/api/cloud_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -512,4 +514,69 @@ func TestInitCloudSpecCache_SpecTokenEnvVar_Empty(t *testing.T) {
 	err := initCloudSpecCache(opts, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `environment variable "NONEXISTENT_VAR_FOR_TEST" is not set`)
+}
+
+// --- --spec-url with local files ---------------------------------------------
+
+func TestInitCloudSpecCache_LocalFile(t *testing.T) {
+	initTestConfig(t)
+
+	specJSON := []byte(`{"openapi":"3.0.0","info":{"title":"Local","version":"1"},"paths":{}}`)
+	tmpFile := filepath.Join(t.TempDir(), "spec.json")
+	require.NoError(t, os.WriteFile(tmpFile, specJSON, 0o600))
+
+	opts := &CloudOptions{SpecURL: tmpFile}
+	ctx := &config.Context{Domain: "example.com", Token: "tok"}
+
+	err := initCloudSpecCache(opts, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, opts.specCache)
+
+	// Verify it can load and parse
+	err = opts.specCache.Load(false)
+	require.NoError(t, err)
+	assert.Equal(t, "Local", opts.specCache.GetDoc().Info.Title)
+}
+
+func TestInitCloudSpecCache_LocalFile_FileURL(t *testing.T) {
+	initTestConfig(t)
+
+	specJSON := []byte(`{"openapi":"3.0.0","info":{"title":"FileURL","version":"1"},"paths":{}}`)
+	tmpFile := filepath.Join(t.TempDir(), "spec.json")
+	require.NoError(t, os.WriteFile(tmpFile, specJSON, 0o600))
+
+	opts := &CloudOptions{SpecURL: "file://" + tmpFile}
+	ctx := &config.Context{Domain: "example.com", Token: "tok"}
+
+	err := initCloudSpecCache(opts, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, opts.specCache)
+
+	err = opts.specCache.Load(false)
+	require.NoError(t, err)
+	assert.Equal(t, "FileURL", opts.specCache.GetDoc().Info.Title)
+}
+
+func TestInitCloudSpecCache_LocalFile_IgnoresSpecTokenEnvVar(t *testing.T) {
+	initTestConfig(t)
+
+	specJSON := []byte(`{"openapi":"3.0.0","info":{"title":"IgnoreToken","version":"1"},"paths":{}}`)
+	tmpFile := filepath.Join(t.TempDir(), "spec.json")
+	require.NoError(t, os.WriteFile(tmpFile, specJSON, 0o600))
+
+	// SpecTokenEnvVar is set to a nonexistent var — for remote URLs this would error,
+	// but for local files it should be silently ignored.
+	opts := &CloudOptions{
+		SpecURL:         tmpFile,
+		SpecTokenEnvVar: "NONEXISTENT_TOKEN_VAR",
+	}
+	ctx := &config.Context{Domain: "example.com"}
+
+	err := initCloudSpecCache(opts, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, opts.specCache)
+
+	err = opts.specCache.Load(false)
+	require.NoError(t, err)
+	assert.Equal(t, "IgnoreToken", opts.specCache.GetDoc().Info.Title)
 }

--- a/pkg/openapi/cache.go
+++ b/pkg/openapi/cache.go
@@ -66,6 +66,7 @@ type CachedSpec struct {
 type Cache struct {
 	specURL     string
 	cachePath   string
+	localPath   string // local file path; when set, Load reads from disk (no HTTP, no caching)
 	stripPrefix string // optional prefix to strip from endpoint paths (e.g. "/api/v2")
 	authToken   string // optional auth token for fetching specs
 	httpClient  *http.Client
@@ -119,10 +120,51 @@ func NewCacheWithAuth(specURL, cachePath, authToken string) *Cache {
 	}
 }
 
+// NewCacheForLocalFile creates a Cache that reads a spec directly from a local
+// file path. The spec is parsed fresh on every Load call; no on-disk caching is
+// performed.
+func NewCacheForLocalFile(path string) *Cache {
+	return &Cache{
+		specURL:   path,
+		localPath: path,
+	}
+}
+
 // SpecCacheFileName returns a deterministic cache file name derived from a spec URL.
 func SpecCacheFileName(specURL string) string {
 	h := sha256.Sum256([]byte(specURL))
 	return fmt.Sprintf("openapi-cache-%x.json", h[:8])
+}
+
+// IsLocalSpec reports whether specURL refers to a local file rather than an
+// HTTP(S) URL.
+func IsLocalSpec(specURL string) bool {
+	lower := strings.ToLower(specURL)
+	return specURL != "" &&
+		!strings.HasPrefix(lower, "http://") &&
+		!strings.HasPrefix(lower, "https://")
+}
+
+// ResolveLocalPath converts a spec URL to an absolute local file path.
+// It handles file:// URLs, ~ home directory expansion, and relative paths.
+func ResolveLocalPath(specURL string) (string, error) {
+	path := specURL
+
+	// Strip file:// scheme
+	if strings.HasPrefix(strings.ToLower(path), "file://") {
+		path = path[len("file://"):]
+	}
+
+	// Expand ~ to home directory
+	if strings.HasPrefix(path, "~/") || path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("expanding home directory: %w", err)
+		}
+		path = filepath.Join(home, path[1:])
+	}
+
+	return filepath.Abs(path)
 }
 
 // NewAirflowCacheForVersion creates a new OpenAPI cache configured for a specific Airflow version.
@@ -153,7 +195,12 @@ func NewAirflowCacheForVersion(version string) (*Cache, error) {
 
 // Load loads the OpenAPI spec, using cache if valid or fetching if needed.
 // If forceRefresh is true, the cache is ignored and a fresh spec is fetched.
+// For local files, the spec is always read fresh from disk.
 func (c *Cache) Load(forceRefresh bool) error {
+	if c.localPath != "" {
+		return c.readLocalFile()
+	}
+
 	if !forceRefresh {
 		// Try to load from cache first
 		if err := c.readCache(); err == nil && !c.isExpired() {
@@ -246,6 +293,25 @@ func (c *Cache) readCache() error {
 	c.v2doc = v2doc
 	c.rawSpec = cached.RawSpec
 	c.fetchedAt = cached.FetchedAt
+	return nil
+}
+
+// readLocalFile reads and parses a spec from the local filesystem.
+func (c *Cache) readLocalFile() error {
+	data, err := os.ReadFile(c.localPath)
+	if err != nil {
+		return fmt.Errorf("reading local spec file: %w", err)
+	}
+
+	v3doc, v2doc, err := parseSpec(data)
+	if err != nil {
+		return fmt.Errorf("parsing local spec file: %w", err)
+	}
+
+	c.doc = v3doc
+	c.v2doc = v2doc
+	c.rawSpec = data
+	c.fetchedAt = time.Now()
 	return nil
 }
 

--- a/pkg/openapi/cache_test.go
+++ b/pkg/openapi/cache_test.go
@@ -606,3 +606,128 @@ func TestGetEndpoints_V2(t *testing.T) {
 	assert.Equal(t, "/orgs", endpoints[0].Path)
 	assert.Equal(t, "ListOrgs", endpoints[0].OperationID)
 }
+
+// --- IsLocalSpec -------------------------------------------------------------
+
+func TestIsLocalSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		specURL  string
+		expected bool
+	}{
+		{"https URL", "https://example.com/spec", false},
+		{"http URL", "http://localhost/spec", false},
+		{"HTTPS uppercase", "HTTPS://example.com/spec", false},
+		{"absolute path", "/tmp/spec.json", true},
+		{"relative path", "./spec.yaml", true},
+		{"parent relative path", "../spec.json", true},
+		{"tilde path", "~/spec.json", true},
+		{"file URL", "file:///tmp/spec.json", true},
+		{"file URL relative", "file://./spec.json", true},
+		{"empty string", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsLocalSpec(tt.specURL))
+		})
+	}
+}
+
+// --- ResolveLocalPath --------------------------------------------------------
+
+func TestResolveLocalPath(t *testing.T) {
+	t.Run("absolute path unchanged", func(t *testing.T) {
+		got, err := ResolveLocalPath("/tmp/spec.json")
+		require.NoError(t, err)
+		assert.Equal(t, "/tmp/spec.json", got)
+	})
+
+	t.Run("file:// stripped to absolute", func(t *testing.T) {
+		got, err := ResolveLocalPath("file:///tmp/spec.json")
+		require.NoError(t, err)
+		assert.Equal(t, "/tmp/spec.json", got)
+	})
+
+	t.Run("tilde expands to home", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+		got, err := ResolveLocalPath("~/spec.json")
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(home, "spec.json"), got)
+	})
+
+	t.Run("relative path made absolute", func(t *testing.T) {
+		got, err := ResolveLocalPath("spec.json")
+		require.NoError(t, err)
+		assert.True(t, filepath.IsAbs(got))
+		assert.True(t, strings.HasSuffix(got, "/spec.json"))
+	})
+}
+
+// --- NewCacheForLocalFile ----------------------------------------------------
+
+func TestNewCacheForLocalFile(t *testing.T) {
+	cache := NewCacheForLocalFile("/tmp/spec.json")
+	assert.Equal(t, "/tmp/spec.json", cache.specURL)
+	assert.Equal(t, "/tmp/spec.json", cache.localPath)
+}
+
+// --- Load with local files ---------------------------------------------------
+
+func TestLoad_LocalFile(t *testing.T) {
+	specJSON := minimalSpecJSON("Local Spec", map[string]map[string]map[string]any{
+		"/items": {"get": {"operationId": "listItems"}},
+	})
+
+	tmpFile := filepath.Join(t.TempDir(), "spec.json")
+	require.NoError(t, os.WriteFile(tmpFile, specJSON, 0o600))
+
+	cache := NewCacheForLocalFile(tmpFile)
+	err := cache.Load(false)
+	require.NoError(t, err)
+	assert.True(t, cache.IsLoaded())
+	assert.Equal(t, "Local Spec", cache.GetDoc().Info.Title)
+
+	endpoints := cache.GetEndpoints()
+	require.Len(t, endpoints, 1)
+	assert.Equal(t, "/items", endpoints[0].Path)
+}
+
+func TestLoad_LocalFile_NotFound(t *testing.T) {
+	cache := NewCacheForLocalFile("/nonexistent/spec.json")
+	err := cache.Load(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading local spec file")
+}
+
+func TestLoad_LocalFile_InvalidSpec(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("<<<not valid>>>"), 0o600))
+
+	cache := NewCacheForLocalFile(tmpFile)
+	err := cache.Load(false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing local spec file")
+}
+
+func TestLoad_LocalFile_AlwaysFresh(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "spec.json")
+
+	// Write version 1
+	v1 := minimalSpecJSON("Version 1", map[string]map[string]map[string]any{})
+	require.NoError(t, os.WriteFile(tmpFile, v1, 0o600))
+
+	cache := NewCacheForLocalFile(tmpFile)
+	err := cache.Load(false)
+	require.NoError(t, err)
+	assert.Equal(t, "Version 1", cache.GetDoc().Info.Title)
+
+	// Overwrite with version 2
+	v2 := minimalSpecJSON("Version 2", map[string]map[string]map[string]any{})
+	require.NoError(t, os.WriteFile(tmpFile, v2, 0o600))
+
+	// Load again without forceRefresh — should still see version 2
+	err = cache.Load(false)
+	require.NoError(t, err)
+	assert.Equal(t, "Version 2", cache.GetDoc().Info.Title)
+}


### PR DESCRIPTION
## Summary
- Allow `--spec-url` to accept local file paths (absolute, relative, `~/`, `file://`) in addition to HTTP URLs
- Local specs are read fresh on every `Load()` call with no caching, ideal for development workflows
- `--spec-token-env-var` is silently ignored for local files since auth is meaningless for local access

## Test plan
- [x] New unit tests for `IsLocalSpec`, `ResolveLocalPath`, `NewCacheForLocalFile`
- [x] New unit tests for `Load` with local files (success, not found, invalid, always-fresh)
- [x] New unit tests for `initCloudSpecCache` with local paths, `file://` URLs, and token env var
- [x] All existing tests pass
- [x] Manual test: `astro api cloud ls --spec-url file:///path/to/spec.yaml`