### PR TITLE
PLX-273: version-gate Houston airflow deprecations

### DIFF
--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -27,7 +27,7 @@ type ListDeploymentLogsRequest struct {
 type UpdateDeploymentImageRequest struct {
 	ReleaseName    string `json:"releaseName"`
 	Image          string `json:"image"`
-	AirflowVersion string `json:"airflowVersion"`
+	AirflowVersion string `json:"airflowVersion,omitempty"`
 	RuntimeVersion string `json:"runtimeVersion"`
 }
 
@@ -769,17 +769,31 @@ var (
 		}
 	}`
 
-	DeploymentInfoRequest = `
-	query DeploymentInfo {
-		deploymentConfig {
-			airflowImages {
-				version
-				tag
-			}
-			airflowVersions
-			defaultAirflowImageTag
-		}
-	}`
+	DeploymentInfoRequest = queryList{
+		{
+			version: "0.25.0",
+			query: `
+			query DeploymentInfo {
+				deploymentConfig {
+					airflowImages {
+						version
+						tag
+					}
+					airflowVersions
+					defaultAirflowImageTag
+				}
+			}`,
+		},
+		{
+			version: "1.0.1",
+			query: `
+			query DeploymentInfo {
+				deploymentConfig {
+					__typename
+				}
+			}`,
+		},
+	}
 
 	DeploymentLogsGetRequest = `
 	query GetLogs(
@@ -800,24 +814,47 @@ var (
 		}
 	}`
 
-	DeploymentImageUpdateRequest = `
-	mutation updateDeploymentImage(
-		$releaseName:String!,
-		$image:String!,
-		$airflowVersion:String,
-		$runtimeVersion:String,
-	){
-		updateDeploymentImage(
-			releaseName:$releaseName,
-			image:$image,
-			airflowVersion:$airflowVersion,
-			runtimeVersion:$runtimeVersion
-		){
-			releaseName
-			airflowVersion
-			runtimeVersion
-		}
-	}`
+	DeploymentImageUpdateRequest = queryList{
+		{
+			version: "0.25.0",
+			query: `
+			mutation updateDeploymentImage(
+				$releaseName:String!,
+				$image:String!,
+				$airflowVersion:String,
+				$runtimeVersion:String,
+			){
+				updateDeploymentImage(
+					releaseName:$releaseName,
+					image:$image,
+					airflowVersion:$airflowVersion,
+					runtimeVersion:$runtimeVersion
+				){
+					releaseName
+					airflowVersion
+					runtimeVersion
+				}
+			}`,
+		},
+		{
+			version: "1.0.1",
+			query: `
+			mutation updateDeploymentImage(
+				$releaseName:String!,
+				$image:String!,
+				$runtimeVersion:String,
+			){
+				updateDeploymentImage(
+					releaseName:$releaseName,
+					image:$image,
+					runtimeVersion:$runtimeVersion
+				){
+					releaseName
+					runtimeVersion
+				}
+			}`,
+		},
+	}
 
 	UpdateDeploymentRuntimeRequest = `
 	mutation updateDeploymentRuntime($deploymentUuid: Uuid!, $desiredRuntimeVersion: String!) {
@@ -986,8 +1023,9 @@ func (h ClientImplementation) UpdateDeploymentAirflow(variables map[string]inter
 
 // GetDeploymentConfig - get a deployment configuration
 func (h ClientImplementation) GetDeploymentConfig(_ interface{}) (*DeploymentConfig, error) {
+	reqQuery := DeploymentInfoRequest.GreatestLowerBound(version)
 	dReq := Request{
-		Query: DeploymentInfoRequest,
+		Query: reqQuery,
 	}
 
 	resp, err := dReq.DoWithClient(h.client)
@@ -1014,8 +1052,9 @@ func (h ClientImplementation) ListDeploymentLogs(filters ListDeploymentLogsReque
 }
 
 func (h ClientImplementation) UpdateDeploymentImage(updateReq UpdateDeploymentImageRequest) (interface{}, error) {
+	reqQuery := DeploymentImageUpdateRequest.GreatestLowerBound(version)
 	req := Request{
-		Query:     DeploymentImageUpdateRequest,
+		Query:     reqQuery,
 		Variables: updateReq,
 	}
 

--- a/houston/deployment_test.go
+++ b/houston/deployment_test.go
@@ -664,8 +664,7 @@ func (s *Suite) TestUpdateDeploymentImage() {
 		Data: ResponseData{
 			UpdateDeploymentImage: UpdateDeploymentImageResp{
 				ReleaseName:    "prehistoric-gravity-930",
-				AirflowVersion: "2.2.0",
-				RuntimeVersion: "",
+				RuntimeVersion: "6.0.0",
 			},
 		},
 	}
@@ -682,7 +681,7 @@ func (s *Suite) TestUpdateDeploymentImage() {
 		})
 		api := NewClient(client)
 
-		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, AirflowVersion: mockDeployment.Data.UpdateDeploymentImage.AirflowVersion})
+		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, RuntimeVersion: "6.0.0"})
 		s.NoError(err)
 	})
 
@@ -696,7 +695,7 @@ func (s *Suite) TestUpdateDeploymentImage() {
 		})
 		api := NewClient(client)
 
-		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, AirflowVersion: mockDeployment.Data.UpdateDeploymentImage.AirflowVersion})
+		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, RuntimeVersion: "6.0.0"})
 		s.Contains(err.Error(), "Internal Server Error")
 	})
 }

--- a/houston/types.go
+++ b/houston/types.go
@@ -307,7 +307,6 @@ type AirflowImage struct {
 
 type UpdateDeploymentImageResp struct {
 	ReleaseName    string `json:"releaseName"`
-	AirflowVersion string `json:"airflowVersion"`
 	RuntimeVersion string `json:"runtimeVersion"`
 }
 

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -1234,7 +1234,6 @@ func (s *Suite) TestUpdateDeploymentImage() {
 		}
 		updateDeploymentImageResp := &houston.UpdateDeploymentImageResp{
 			ReleaseName:    releaseName,
-			AirflowVersion: "",
 			RuntimeVersion: runtimeVersion,
 		}
 		deployment := &houston.Deployment{


### PR DESCRIPTION
## Description

Version-gates deprecated Houston API fields (`airflowVersion`, `airflowImages`, `airflowVersions`, `defaultAirflowImageTag`) so the CLI remains compatible when Houston PR #2423 removes them.

**Changes:**
- Converted `DeploymentInfoRequest` and `DeploymentImageUpdateRequest` from standalone GraphQL strings to version-gated `queryList` entries. The 1.0.1+ variants omit all deprecated airflow fields.
- Updated `GetDeploymentConfig()` and `UpdateDeploymentImage()` to resolve the correct query via `GreatestLowerBound(version)`.
- Removed `AirflowVersion` from `UpdateDeploymentImageResp` (unused — the function discards the response).
- Added `omitempty` to `UpdateDeploymentImageRequest.AirflowVersion` so it is not serialized when empty.
- Updated `TestUpdateDeploymentImage` to use runtime-only mock data.

Backward compatibility with older Houston versions is preserved — the pre-1.0.1 query entries still include all airflow fields.

## 🎟 Issue(s)

Related https://linear.app/astronomer/issue/PLX-273/deprecate-astroruntimeenabled
Related astronomer/houston-api#2423

## 🧪 Functional Testing

1. `make test` — all houston, software/deploy, software/deployment, and cmd/software tests pass.
2. `make lint` — no new lint issues.
3. Against Houston < 1.0.1: CLI should use the old queries that include `airflowVersion` fields (backward compat).
4. Against Houston >= 1.0.1: CLI should use the new queries that omit deprecated fields. Deploys (image push, BYO registry, dag-only) should succeed without errors.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
