### PR TITLE
Store auth credentials in the OS keychain (macOS + Linux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ testbin/
 testbin/golangci-lint
 upgrade-test*
 vendor/github.com/theupdateframework/notary/Dockerfile
+
+# flock sidecars written next to config files at runtime; disposable
+*.yaml.lock

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,8 @@ linters:
         - "2"
         - "10"
         - "64"
+        - "0o600"
+        - "0o700"
     nolintlint:
       require-explanation: false
       require-specific: false

--- a/airflow-client/airflow-client.go
+++ b/airflow-client/airflow-client.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 
-	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -41,12 +40,14 @@ type Client interface {
 // Client containers the logger and HTTPClient used to communicate with the Astronomer API
 type HTTPClient struct {
 	*httputil.HTTPClient
+	tokenHolder *httputil.TokenHolder
 }
 
-// NewAstroClient returns a new Client with the logger and HTTP client setup.
-func NewAirflowClient(c *httputil.HTTPClient) *HTTPClient {
+// NewAirflowClient returns a new Client with the logger and HTTP client setup.
+func NewAirflowClient(c *httputil.HTTPClient, tokenHolder *httputil.TokenHolder) *HTTPClient {
 	return &HTTPClient{
-		c,
+		HTTPClient:  c,
+		tokenHolder: tokenHolder,
 	}
 }
 
@@ -242,17 +243,14 @@ func checkRetryPolicy(method string) retryablehttp.CheckRetry {
 }
 
 func (c *HTTPClient) DoAirflowClient(doOpts *httputil.DoOptions) (*Response, error) {
-	cl, err := context.GetCurrentContext()
-	if err != nil {
-		return nil, err
-	}
-
-	if cl.Token != "" {
-		doOpts.Headers = map[string]string{
-			"authorization": cl.Token,
+	if c.tokenHolder != nil {
+		if tok := c.tokenHolder.Get(); tok != "" {
+			if doOpts.Headers == nil {
+				doOpts.Headers = map[string]string{}
+			}
+			doOpts.Headers["authorization"] = tok
 		}
 	}
-
 	req, err := retryablehttp.NewRequest(doOpts.Method, doOpts.Path, doOpts.Data)
 	if err != nil {
 		return nil, err

--- a/airflow-client/airflow-client.go
+++ b/airflow-client/airflow-client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -40,14 +41,14 @@ type Client interface {
 // Client containers the logger and HTTPClient used to communicate with the Astronomer API
 type HTTPClient struct {
 	*httputil.HTTPClient
-	tokenHolder *httputil.TokenHolder
+	creds *credentials.CurrentCredentials
 }
 
 // NewAirflowClient returns a new Client with the logger and HTTP client setup.
-func NewAirflowClient(c *httputil.HTTPClient, tokenHolder *httputil.TokenHolder) *HTTPClient {
+func NewAirflowClient(c *httputil.HTTPClient, creds *credentials.CurrentCredentials) *HTTPClient {
 	return &HTTPClient{
-		HTTPClient:  c,
-		tokenHolder: tokenHolder,
+		HTTPClient: c,
+		creds:      creds,
 	}
 }
 
@@ -243,8 +244,8 @@ func checkRetryPolicy(method string) retryablehttp.CheckRetry {
 }
 
 func (c *HTTPClient) DoAirflowClient(doOpts *httputil.DoOptions) (*Response, error) {
-	if c.tokenHolder != nil {
-		if tok := c.tokenHolder.Get(); tok != "" {
+	if c.creds != nil {
+		if tok := c.creds.Get(); tok != "" {
 			if doOpts.Headers == nil {
 				doOpts.Headers = map[string]string{}
 			}

--- a/airflow-client/airflow-client.go
+++ b/airflow-client/airflow-client.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 
-	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -62,12 +62,14 @@ type Client interface {
 // Client containers the logger and HTTPClient used to communicate with the Astronomer API
 type HTTPClient struct {
 	*httputil.HTTPClient
+	creds *credentials.CurrentCredentials
 }
 
-// NewAstroClient returns a new Client with the logger and HTTP client setup.
-func NewAirflowClient(c *httputil.HTTPClient) *HTTPClient {
+// NewAirflowClient returns a new Client with the logger and HTTP client setup.
+func NewAirflowClient(c *httputil.HTTPClient, creds *credentials.CurrentCredentials) *HTTPClient {
 	return &HTTPClient{
-		c,
+		HTTPClient: c,
+		creds:      creds,
 	}
 }
 
@@ -280,17 +282,14 @@ func isRetryableWriteStatus(resp *http.Response) bool {
 }
 
 func (c *HTTPClient) DoAirflowClient(doOpts *httputil.DoOptions) (*Response, error) {
-	cl, err := context.GetCurrentContext()
-	if err != nil {
-		return nil, err
-	}
-
-	if cl.Token != "" {
-		doOpts.Headers = map[string]string{
-			"authorization": cl.Token,
+	if c.creds != nil {
+		if tok := c.creds.Get(); tok != "" {
+			if doOpts.Headers == nil {
+				doOpts.Headers = map[string]string{}
+			}
+			doOpts.Headers["authorization"] = tok
 		}
 	}
-
 	req, err := retryablehttp.NewRequest(doOpts.Method, doOpts.Path, doOpts.Data)
 	if err != nil {
 		return nil, err

--- a/airflow-client/airflow-client_test.go
+++ b/airflow-client/airflow-client_test.go
@@ -32,7 +32,7 @@ func TestAirflowClient(t *testing.T) {
 }
 
 func (s *Suite) TestNew() {
-	client := NewAirflowClient(httputil.NewHTTPClient())
+	client := NewAirflowClient(httputil.NewHTTPClient(), nil)
 	s.NotNil(client, "Can't create new Astro client")
 }
 
@@ -46,7 +46,8 @@ func (s *Suite) TestDoAirflowClient() {
 			Header:     make(http.Header),
 		}
 	})
-	airflowClient := NewAirflowClient(client)
+	th := httputil.NewTokenHolder("token")
+	airflowClient := NewAirflowClient(client, th)
 	doOpts := &httputil.DoOptions{
 		Path: "/test",
 		Headers: map[string]string{
@@ -110,7 +111,8 @@ func (s *Suite) TestGetConnections() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		response, err := airflowClient.GetConnections("test-airflow-url")
 		s.NoError(err)
@@ -126,7 +128,7 @@ func (s *Suite) TestGetConnections() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			_, err := airflowClient.GetConnections("test-airflow-url")
 			s.Error(err)
@@ -141,7 +143,8 @@ func (s *Suite) TestGetConnections() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		_, err := airflowClient.GetConnections("test-airflow-url")
 		s.Error(err)
@@ -174,7 +177,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
 		s.NoError(err)
@@ -188,7 +192,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -203,7 +208,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		// Pass a nil connection to force JSON marshal error
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
@@ -219,7 +225,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -252,7 +259,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.NoError(err)
@@ -266,7 +274,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -281,7 +290,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		// Pass a nil connection to force JSON marshal error
 		err := airflowClient.CreateConnection("test-airflow-url", nil)
@@ -297,7 +307,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -330,7 +341,8 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.CreateVariable("test-airflow-url", *mockVar)
 		s.NoError(err)
@@ -344,7 +356,8 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.CreateVariable("test-airflow-url", *mockVar)
 		s.Error(err)
@@ -359,7 +372,8 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.CreateVariable("test-airflow-url", Variable{Key: "", Value: "test-value"})
 		s.Error(err)
@@ -385,7 +399,8 @@ func (s *Suite) TestGetVariables() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		response, err := airflowClient.GetVariables("test-airflow-url")
 		s.NoError(err)
@@ -401,7 +416,7 @@ func (s *Suite) TestGetVariables() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			_, err := airflowClient.GetVariables("test-airflow-url")
 			s.Error(err)
@@ -435,7 +450,8 @@ func (s *Suite) TestUpdateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.UpdateVariable("test-airflow-url", *mockVar)
 		s.NoError(err)
@@ -449,7 +465,8 @@ func (s *Suite) TestUpdateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.UpdateVariable("test-airflow-url", *mockVar)
 		s.Error(err)
@@ -464,7 +481,8 @@ func (s *Suite) TestUpdateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.UpdateVariable("test-airflow-url", Variable{Key: "", Value: "test-value"})
 		s.Error(err)
@@ -514,7 +532,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.NoError(err)
@@ -528,7 +547,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -543,7 +563,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		// Pass a nil pool to force JSON marshal error
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
@@ -559,7 +580,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -592,7 +614,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.UpdatePool("test-airflow-url", *mockPool)
 		s.NoError(err)
@@ -623,7 +646,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err = airflowClient.UpdatePool("test-airflow-url", defaultPool)
 		s.NoError(err)
@@ -637,7 +661,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.UpdatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -652,7 +677,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		// Pass a nil pool to force JSON marshal error
 		err := airflowClient.UpdatePool("test-airflow-url", Pool{})
@@ -668,7 +694,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		err := airflowClient.UpdatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -693,7 +720,8 @@ func (s *Suite) TestGetPools() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		response, err := airflowClient.GetPools("test-airflow-url")
 		s.NoError(err)
@@ -709,7 +737,7 @@ func (s *Suite) TestGetPools() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			response, err := airflowClient.GetPools("test-airflow-url")
 			s.Error(err)
@@ -726,7 +754,8 @@ func (s *Suite) TestGetPools() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		th := httputil.NewTokenHolder("token")
+		airflowClient := NewAirflowClient(client, th)
 
 		response, err := airflowClient.GetPools("test-airflow-url")
 		s.Error(err)
@@ -759,7 +788,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			doOpts := &httputil.DoOptions{
 				Path:   "/test",
@@ -783,7 +812,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			doOpts := &httputil.DoOptions{
 				Path:   "/test",
@@ -807,7 +836,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		doOpts := &httputil.DoOptions{
 			Path:   "/test",
@@ -829,7 +858,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		doOpts := &httputil.DoOptions{
 			Path:   "/test",
@@ -848,7 +877,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 			callCount++
 			return stdctx.Canceled
 		})
-		airflowClient := NewAirflowClient(cancelTransport)
+		airflowClient := NewAirflowClient(cancelTransport, nil)
 
 		doOpts := &httputil.DoOptions{
 			Path:   "/test",
@@ -897,7 +926,7 @@ func (s *Suite) TestGetConnectionsPagination() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		response, err := airflowClient.GetConnections("test-airflow-url")
 		s.NoError(err)
@@ -941,7 +970,7 @@ func (s *Suite) TestGetVariablesPagination() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		response, err := airflowClient.GetVariables("test-airflow-url")
 		s.NoError(err)
@@ -985,7 +1014,7 @@ func (s *Suite) TestGetPoolsPagination() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		response, err := airflowClient.GetPools("test-airflow-url")
 		s.NoError(err)

--- a/airflow-client/airflow-client_test.go
+++ b/airflow-client/airflow-client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -46,8 +47,8 @@ func (s *Suite) TestDoAirflowClient() {
 			Header:     make(http.Header),
 		}
 	})
-	th := httputil.NewTokenHolder("token")
-	airflowClient := NewAirflowClient(client, th)
+	creds := credentials.New("token")
+	airflowClient := NewAirflowClient(client, creds)
 	doOpts := &httputil.DoOptions{
 		Path: "/test",
 		Headers: map[string]string{
@@ -111,8 +112,8 @@ func (s *Suite) TestGetConnections() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		response, err := airflowClient.GetConnections("test-airflow-url")
 		s.NoError(err)
@@ -143,8 +144,8 @@ func (s *Suite) TestGetConnections() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		_, err := airflowClient.GetConnections("test-airflow-url")
 		s.Error(err)
@@ -177,8 +178,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
 		s.NoError(err)
@@ -192,8 +193,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -208,8 +209,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		// Pass a nil connection to force JSON marshal error
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
@@ -225,8 +226,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -259,8 +260,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.NoError(err)
@@ -274,8 +275,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -290,8 +291,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		// Pass a nil connection to force JSON marshal error
 		err := airflowClient.CreateConnection("test-airflow-url", nil)
@@ -307,8 +308,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -341,8 +342,8 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateVariable("test-airflow-url", *mockVar)
 		s.NoError(err)
@@ -356,8 +357,8 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateVariable("test-airflow-url", *mockVar)
 		s.Error(err)
@@ -372,8 +373,8 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateVariable("test-airflow-url", Variable{Key: "", Value: "test-value"})
 		s.Error(err)
@@ -399,8 +400,8 @@ func (s *Suite) TestGetVariables() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		response, err := airflowClient.GetVariables("test-airflow-url")
 		s.NoError(err)
@@ -450,8 +451,8 @@ func (s *Suite) TestUpdateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateVariable("test-airflow-url", *mockVar)
 		s.NoError(err)
@@ -465,8 +466,8 @@ func (s *Suite) TestUpdateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateVariable("test-airflow-url", *mockVar)
 		s.Error(err)
@@ -481,8 +482,8 @@ func (s *Suite) TestUpdateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateVariable("test-airflow-url", Variable{Key: "", Value: "test-value"})
 		s.Error(err)
@@ -532,8 +533,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.NoError(err)
@@ -547,8 +548,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -563,8 +564,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		// Pass a nil pool to force JSON marshal error
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
@@ -580,8 +581,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -614,8 +615,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdatePool("test-airflow-url", *mockPool)
 		s.NoError(err)
@@ -646,8 +647,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err = airflowClient.UpdatePool("test-airflow-url", defaultPool)
 		s.NoError(err)
@@ -661,8 +662,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -677,8 +678,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		// Pass a nil pool to force JSON marshal error
 		err := airflowClient.UpdatePool("test-airflow-url", Pool{})
@@ -694,8 +695,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -720,8 +721,8 @@ func (s *Suite) TestGetPools() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		response, err := airflowClient.GetPools("test-airflow-url")
 		s.NoError(err)
@@ -754,8 +755,8 @@ func (s *Suite) TestGetPools() {
 				Header:     make(http.Header),
 			}
 		})
-		th := httputil.NewTokenHolder("token")
-		airflowClient := NewAirflowClient(client, th)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		response, err := airflowClient.GetPools("test-airflow-url")
 		s.Error(err)

--- a/airflow-client/airflow-client_test.go
+++ b/airflow-client/airflow-client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -32,7 +33,7 @@ func TestAirflowClient(t *testing.T) {
 }
 
 func (s *Suite) TestNew() {
-	client := NewAirflowClient(httputil.NewHTTPClient())
+	client := NewAirflowClient(httputil.NewHTTPClient(), nil)
 	s.NotNil(client, "Can't create new Astro client")
 }
 
@@ -46,7 +47,8 @@ func (s *Suite) TestDoAirflowClient() {
 			Header:     make(http.Header),
 		}
 	})
-	airflowClient := NewAirflowClient(client)
+	creds := credentials.New("token")
+	airflowClient := NewAirflowClient(client, creds)
 	doOpts := &httputil.DoOptions{
 		Path: "/test",
 		Headers: map[string]string{
@@ -110,7 +112,8 @@ func (s *Suite) TestGetConnections() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		response, err := airflowClient.GetConnections("test-airflow-url")
 		s.NoError(err)
@@ -126,7 +129,7 @@ func (s *Suite) TestGetConnections() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			_, err := airflowClient.GetConnections("test-airflow-url")
 			s.Error(err)
@@ -141,7 +144,8 @@ func (s *Suite) TestGetConnections() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		_, err := airflowClient.GetConnections("test-airflow-url")
 		s.Error(err)
@@ -174,7 +178,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
 		s.NoError(err)
@@ -188,7 +193,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -203,7 +209,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		// Pass a nil connection to force JSON marshal error
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
@@ -219,7 +226,8 @@ func (s *Suite) TestUpdateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -252,7 +260,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.NoError(err)
@@ -266,7 +275,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -281,7 +291,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		// Pass a nil connection to force JSON marshal error
 		err := airflowClient.CreateConnection("test-airflow-url", nil)
@@ -297,7 +308,8 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.Error(err)
@@ -324,7 +336,7 @@ func (s *Suite) TestCreateConnection() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		err := airflowClient.CreateConnection("test-airflow-url", mockConn)
 		s.NoError(err)
@@ -357,7 +369,8 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateVariable("test-airflow-url", *mockVar)
 		s.NoError(err)
@@ -371,7 +384,8 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateVariable("test-airflow-url", *mockVar)
 		s.Error(err)
@@ -386,7 +400,8 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreateVariable("test-airflow-url", Variable{Key: "", Value: "test-value"})
 		s.Error(err)
@@ -413,7 +428,7 @@ func (s *Suite) TestCreateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		err := airflowClient.CreateVariable("test-airflow-url", *mockVar)
 		s.NoError(err)
@@ -439,7 +454,8 @@ func (s *Suite) TestGetVariables() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		response, err := airflowClient.GetVariables("test-airflow-url")
 		s.NoError(err)
@@ -455,7 +471,7 @@ func (s *Suite) TestGetVariables() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			_, err := airflowClient.GetVariables("test-airflow-url")
 			s.Error(err)
@@ -489,7 +505,8 @@ func (s *Suite) TestUpdateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateVariable("test-airflow-url", *mockVar)
 		s.NoError(err)
@@ -503,7 +520,8 @@ func (s *Suite) TestUpdateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateVariable("test-airflow-url", *mockVar)
 		s.Error(err)
@@ -518,7 +536,8 @@ func (s *Suite) TestUpdateVariable() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdateVariable("test-airflow-url", Variable{Key: "", Value: "test-value"})
 		s.Error(err)
@@ -568,7 +587,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.NoError(err)
@@ -582,7 +602,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -597,7 +618,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		// Pass a nil pool to force JSON marshal error
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
@@ -613,7 +635,8 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -640,7 +663,7 @@ func (s *Suite) TestCreatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		err := airflowClient.CreatePool("test-airflow-url", *mockPool)
 		s.NoError(err)
@@ -673,7 +696,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdatePool("test-airflow-url", *mockPool)
 		s.NoError(err)
@@ -704,7 +728,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err = airflowClient.UpdatePool("test-airflow-url", defaultPool)
 		s.NoError(err)
@@ -718,7 +743,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -733,7 +759,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		// Pass a nil pool to force JSON marshal error
 		err := airflowClient.UpdatePool("test-airflow-url", Pool{})
@@ -749,7 +776,8 @@ func (s *Suite) TestUpdatePool() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		err := airflowClient.UpdatePool("test-airflow-url", *mockPool)
 		s.Error(err)
@@ -774,7 +802,8 @@ func (s *Suite) TestGetPools() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		response, err := airflowClient.GetPools("test-airflow-url")
 		s.NoError(err)
@@ -790,7 +819,7 @@ func (s *Suite) TestGetPools() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			response, err := airflowClient.GetPools("test-airflow-url")
 			s.Error(err)
@@ -807,7 +836,8 @@ func (s *Suite) TestGetPools() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		creds := credentials.New("token")
+		airflowClient := NewAirflowClient(client, creds)
 
 		response, err := airflowClient.GetPools("test-airflow-url")
 		s.Error(err)
@@ -840,7 +870,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			doOpts := &httputil.DoOptions{
 				Path:   "/test",
@@ -864,7 +894,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			doOpts := &httputil.DoOptions{
 				Path:   "/test",
@@ -888,7 +918,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		doOpts := &httputil.DoOptions{
 			Path:   "/test",
@@ -921,7 +951,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			doOpts := &httputil.DoOptions{
 				Path:   "/test",
@@ -944,7 +974,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 					Header:     make(http.Header),
 				}
 			})
-			airflowClient := NewAirflowClient(client)
+			airflowClient := NewAirflowClient(client, nil)
 
 			doOpts := &httputil.DoOptions{
 				Path:   "/test",
@@ -968,7 +998,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		doOpts := &httputil.DoOptions{
 			Path:   "/test",
@@ -987,7 +1017,7 @@ func (s *Suite) TestDoAirflowClientRetry() {
 			callCount++
 			return stdctx.Canceled
 		})
-		airflowClient := NewAirflowClient(cancelTransport)
+		airflowClient := NewAirflowClient(cancelTransport, nil)
 
 		doOpts := &httputil.DoOptions{
 			Path:   "/test",
@@ -1036,7 +1066,7 @@ func (s *Suite) TestGetConnectionsPagination() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		response, err := airflowClient.GetConnections("test-airflow-url")
 		s.NoError(err)
@@ -1080,7 +1110,7 @@ func (s *Suite) TestGetVariablesPagination() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		response, err := airflowClient.GetVariables("test-airflow-url")
 		s.NoError(err)
@@ -1124,7 +1154,7 @@ func (s *Suite) TestGetPoolsPagination() {
 				Header:     make(http.Header),
 			}
 		})
-		airflowClient := NewAirflowClient(client)
+		airflowClient := NewAirflowClient(client, nil)
 
 		response, err := airflowClient.GetPools("test-airflow-url")
 		s.NoError(err)

--- a/airflow/container.go
+++ b/airflow/container.go
@@ -18,6 +18,7 @@ import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -40,7 +41,7 @@ type ContainerHandler interface {
 	ComposeExport(settingsFile, composeFile string) error
 	Pytest(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString string) (string, error)
 	Parse(customImageName, deployImageName, buildSecretString string) error
-	UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error
+	UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroPlatformCore astroplatformcore.ClientWithResponsesInterface, store keychain.SecureStore) error
 }
 
 // RegistryHandler defines methods require to handle all operations with registry

--- a/airflow/container.go
+++ b/airflow/container.go
@@ -18,6 +18,7 @@ import (
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -40,7 +41,7 @@ type ContainerHandler interface {
 	ComposeExport(settingsFile, composeFile string) error
 	Pytest(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString string) (string, error)
 	Parse(customImageName, deployImageName, buildSecretString string) error
-	UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroV1Client astrov1.ClientWithResponsesInterface) error
+	UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroV1Client astrov1.ClientWithResponsesInterface, store keychain.SecureStore) error
 }
 
 // RegistryHandler defines methods require to handle all operations with registry

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -42,6 +42,7 @@ import (
 	"github.com/astronomer/astro-cli/docker"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/spinner"
 	"github.com/astronomer/astro-cli/pkg/util"
@@ -701,7 +702,7 @@ func (d *DockerCompose) Pytest(pytestFile, customImageName, deployImageName, pyt
 	return exitCode, errors.New("something went wrong while Pytesting your DAGs")
 }
 
-func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroPlatformCore astroplatformcore.CoreClient) error { //nolint:gocognit,gocyclo
+func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroPlatformCore astroplatformcore.CoreClient, store keychain.SecureStore) error { //nolint:gocognit,gocyclo
 	// figure out which tests to run
 	if !versionTest && !dagTest && !lintTest {
 		versionTest = true
@@ -719,7 +720,7 @@ func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, build
 	}
 	// if user supplies deployment id pull down current image
 	if deploymentID != "" {
-		err := d.pullImageFromDeployment(deploymentID, astroPlatformCore)
+		err := d.pullImageFromDeployment(deploymentID, astroPlatformCore, store)
 		if err != nil {
 			return err
 		}
@@ -806,7 +807,7 @@ func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, build
 	return nil
 }
 
-func (d *DockerCompose) pullImageFromDeployment(deploymentID string, platformCoreClient astroplatformcore.CoreClient) error {
+func (d *DockerCompose) pullImageFromDeployment(deploymentID string, platformCoreClient astroplatformcore.CoreClient, store keychain.SecureStore) error {
 	c, err := config.GetCurrentContext()
 	if err != nil {
 		return err
@@ -817,9 +818,15 @@ func (d *DockerCompose) pullImageFromDeployment(deploymentID string, platformCor
 		return err
 	}
 	deploymentImage := fmt.Sprintf("%s:%s", currentDeployment.ImageRepository, currentDeployment.ImageTag)
-	token := c.Token
+	if store == nil {
+		return fmt.Errorf("no credentials found for %s: credential store unavailable", c.Domain)
+	}
+	creds, err := store.GetCredentials(c.Domain)
+	if err != nil {
+		return fmt.Errorf("no credentials found for %s, please run 'astro login': %w", c.Domain, err)
+	}
 	fmt.Printf("\nPulling image from Astro Deployment %s\n\n", currentDeployment.Name)
-	err = d.imageHandler.Pull(deploymentImage, registryUsername, token)
+	err = d.imageHandler.Pull(deploymentImage, registryUsername, creds.Token)
 	if err != nil {
 		return err
 	}

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -45,6 +45,7 @@ import (
 	"github.com/astronomer/astro-cli/docker"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/spinner"
 	"github.com/astronomer/astro-cli/pkg/util"
@@ -704,7 +705,7 @@ func (d *DockerCompose) Pytest(pytestFile, customImageName, deployImageName, pyt
 	return exitCode, errors.New("something went wrong while Pytesting your DAGs")
 }
 
-func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroV1Client astrov1.APIClient) error { //nolint:gocognit,gocyclo
+func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroV1Client astrov1.APIClient, store keychain.SecureStore) error { //nolint:gocognit,gocyclo
 	// figure out which tests to run
 	if !versionTest && !dagTest && !lintTest {
 		versionTest = true
@@ -722,7 +723,7 @@ func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, build
 	}
 	// if user supplies deployment id pull down current image
 	if deploymentID != "" {
-		err := d.pullImageFromDeployment(deploymentID, astroV1Client)
+		err := d.pullImageFromDeployment(deploymentID, astroV1Client, store)
 		if err != nil {
 			return err
 		}
@@ -809,7 +810,7 @@ func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, build
 	return nil
 }
 
-func (d *DockerCompose) pullImageFromDeployment(deploymentID string, astroV1Client astrov1.APIClient) error {
+func (d *DockerCompose) pullImageFromDeployment(deploymentID string, astroV1Client astrov1.APIClient, store keychain.SecureStore) error {
 	c, err := config.GetCurrentContext()
 	if err != nil {
 		return err
@@ -820,9 +821,15 @@ func (d *DockerCompose) pullImageFromDeployment(deploymentID string, astroV1Clie
 		return err
 	}
 	deploymentImage := fmt.Sprintf("%s:%s", currentDeployment.ImageRepository, currentDeployment.ImageTag)
-	token := c.Token
+	if store == nil {
+		return fmt.Errorf("no credentials found for %s: credential store unavailable", c.Domain)
+	}
+	creds, err := store.GetCredentials(c.Domain)
+	if err != nil {
+		return fmt.Errorf("no credentials found for %s, please run 'astro login': %w", c.Domain, err)
+	}
 	fmt.Printf("\nPulling image from Astro Deployment %s\n\n", currentDeployment.Name)
-	err = d.imageHandler.Pull(deploymentImage, registryUsername, token)
+	err = d.imageHandler.Pull(deploymentImage, registryUsername, creds.Token)
 	if err != nil {
 		return err
 	}

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -26,6 +26,7 @@ import (
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -1255,13 +1256,16 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // All tests enabled by default
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // All tests enabled by default
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("success with deployment id", func() {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		store := keychain.NewTestStore()
+		_ = store.SetCredentials("localhost", keychain.Credentials{Token: "Bearer test-token"})
 		imageHandler := new(mocks.ImageHandler)
 
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
@@ -1275,8 +1279,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("0", nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
-		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", true, true, true, false, false, "", mockPlatformCoreClient) // All tests enabled by default
+		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", true, true, true, false, false, "", mockPlatformCoreClient, store) // All tests enabled by default
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
@@ -1288,7 +1291,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1300,7 +1303,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1313,7 +1316,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1328,7 +1331,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1344,7 +1347,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // dagTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // dagTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1359,7 +1362,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // dagTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // dagTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1370,13 +1373,15 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errMock).Once() // Error on first call
 
 		mockDockerCompose.imageHandler = imageHandler
-		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", mockPlatformCoreClient)
+		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", mockPlatformCoreClient, nil)
 		s.Error(err)
 		// No image handler expectations needed as it fails before pull/build
 	})
 
 	s.Run("image pull failure", func() {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		store := keychain.NewTestStore()
+		_ = store.SetCredentials("localhost", keychain.Credentials{Token: "Bearer test-token"})
 		imageHandler := new(mocks.ImageHandler)
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Twice()
@@ -1384,8 +1389,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		imageHandler.On("Pull", mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker)
 
 		mockDockerCompose.imageHandler = imageHandler
-		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", false, false, false, false, false, "", mockPlatformCoreClient)
+		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", false, false, false, false, false, "", mockPlatformCoreClient, store)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T()) // Only Pull is called
 	})
@@ -1399,7 +1403,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, false, false, "", nil, nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1411,7 +1415,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		s.NoError(err)
 
 		// Add default values for new lint flags
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", nil, nil)
 		s.Error(err) // Expect error due to missing context/domain
 	})
 
@@ -1429,7 +1433,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil, nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1448,7 +1452,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=true, lintFix=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, true, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, true, false, "", nil, nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1482,7 +1486,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		originalWorkingPath := config.WorkingPath
 		config.WorkingPath = cwd
 		defer func() { config.WorkingPath = originalWorkingPath }()
-		err = mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "my-custom-ruff.toml", nil)
+		err = mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "my-custom-ruff.toml", nil, nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1501,7 +1505,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil, nil)
 		s.Error(err)
 		s.Contains(err.Error(), "one of the tests run above failed")
 
@@ -1520,7 +1524,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
 		// Target version is 2.0.0, so lint test should be skipped internally
-		err := mockDockerCompose.UpgradeTest("2.0.0", "", "", "", false, false, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("2.0.0", "", "", "", false, false, true, false, false, "", nil, nil)
 		s.NoError(err) // Should succeed without running lint
 
 		imageHandler.AssertExpectations(s.T())
@@ -1540,7 +1544,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=true, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, true, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, true, "", nil, nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -25,6 +25,7 @@ import (
 	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -1249,13 +1250,16 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // All tests enabled by default
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // All tests enabled by default
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("success with deployment id", func() {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		store := keychain.NewTestStore()
+		_ = store.SetCredentials("localhost", keychain.Credentials{Token: "Bearer test-token"})
 		imageHandler := new(mocks.ImageHandler)
 
 		mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
@@ -1270,7 +1274,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", true, true, true, false, false, "", mockV1Client) // All tests enabled by default
+		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", true, true, true, false, false, "", mockV1Client, store) // All tests enabled by default
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
@@ -1282,7 +1286,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1294,7 +1298,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1307,7 +1311,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1322,7 +1326,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1338,7 +1342,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // dagTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // dagTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1353,7 +1357,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // dagTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil, nil) // dagTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1365,12 +1369,15 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", mockV1Client)
+		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", mockV1Client, nil)
 		s.Error(err)
 		// No image handler expectations needed as it fails before pull/build
 	})
 
 	s.Run("image pull failure", func() {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		store := keychain.NewTestStore()
+		_ = store.SetCredentials("localhost", keychain.Credentials{Token: "Bearer test-token"})
 		imageHandler := new(mocks.ImageHandler)
 		mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Twice()
@@ -1379,7 +1386,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", false, false, false, false, false, "", mockV1Client)
+		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", false, false, false, false, false, "", mockV1Client, store)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T()) // Only Pull is called
 	})
@@ -1393,7 +1400,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, false, false, "", nil, nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1405,7 +1412,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		s.NoError(err)
 
 		// Add default values for new lint flags
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", nil, nil)
 		s.Error(err) // Expect error due to missing context/domain
 	})
 
@@ -1423,7 +1430,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil, nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1442,7 +1449,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=true, lintFix=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, true, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, true, false, "", nil, nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1476,7 +1483,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		originalWorkingPath := config.WorkingPath
 		config.WorkingPath = cwd
 		defer func() { config.WorkingPath = originalWorkingPath }()
-		err = mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "my-custom-ruff.toml", nil)
+		err = mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "my-custom-ruff.toml", nil, nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1495,7 +1502,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil, nil)
 		s.Error(err)
 		s.Contains(err.Error(), "one of the tests run above failed")
 
@@ -1514,7 +1521,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
 		// Target version is 2.0.0, so lint test should be skipped internally
-		err := mockDockerCompose.UpgradeTest("2.0.0", "", "", "", false, false, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("2.0.0", "", "", "", false, false, true, false, false, "", nil, nil)
 		s.NoError(err) // Should succeed without running lint
 
 		imageHandler.AssertExpectations(s.T())
@@ -1534,7 +1541,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=true, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, true, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, true, "", nil, nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())

--- a/airflow/mocks/ContainerHandler.go
+++ b/airflow/mocks/ContainerHandler.go
@@ -5,6 +5,7 @@ package mocks
 import (
 	"github.com/astronomer/astro-cli/airflow/types"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -295,17 +296,17 @@ func (_m *ContainerHandler) Stop(waitForExit bool) error {
 	return r0
 }
 
-// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroPlatformCore
-func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, customImageName string, buildSecretString string, versionTest bool, dagTest bool, lintTest bool, includeLintDeprecations bool, lintFix bool, lintConfigFile string, astroPlatformCore astroplatformcore.ClientWithResponsesInterface) error {
-	ret := _m.Called(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroPlatformCore)
+// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroPlatformCore, store
+func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, customImageName string, buildSecretString string, versionTest bool, dagTest bool, lintTest bool, includeLintDeprecations bool, lintFix bool, lintConfigFile string, astroPlatformCore astroplatformcore.ClientWithResponsesInterface, store keychain.SecureStore) error {
+	ret := _m.Called(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroPlatformCore, store)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpgradeTest")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, bool, bool, bool, string, astroplatformcore.ClientWithResponsesInterface) error); ok {
-		r0 = rf(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroPlatformCore)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, bool, bool, bool, string, astroplatformcore.ClientWithResponsesInterface, keychain.SecureStore) error); ok {
+		r0 = rf(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroPlatformCore, store)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/airflow/mocks/ContainerHandler.go
+++ b/airflow/mocks/ContainerHandler.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	astrov1 "github.com/astronomer/astro-cli/astro-client-v1"
+	keychain "github.com/astronomer/astro-cli/pkg/keychain"
 	mock "github.com/stretchr/testify/mock"
 
 	types "github.com/astronomer/astro-cli/airflow/types"
@@ -295,17 +296,17 @@ func (_m *ContainerHandler) Stop(waitForExit bool) error {
 	return r0
 }
 
-// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client
-func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, customImageName string, buildSecretString string, versionTest bool, dagTest bool, lintTest bool, includeLintDeprecations bool, lintFix bool, lintConfigFile string, astroV1Client astrov1.ClientWithResponsesInterface) error {
-	ret := _m.Called(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client)
+// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client, store
+func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, customImageName string, buildSecretString string, versionTest bool, dagTest bool, lintTest bool, includeLintDeprecations bool, lintFix bool, lintConfigFile string, astroV1Client astrov1.ClientWithResponsesInterface, store keychain.SecureStore) error {
+	ret := _m.Called(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client, store)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpgradeTest")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, bool, bool, bool, string, astrov1.ClientWithResponsesInterface) error); ok {
-		r0 = rf(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, bool, bool, bool, string, astrov1.ClientWithResponsesInterface, keychain.SecureStore) error); ok {
+		r0 = rf(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client, store)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -29,6 +29,7 @@ import (
 	"github.com/astronomer/astro-cli/pkg/airflowrt"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/spinner"
 	"github.com/astronomer/astro-cli/pkg/util"
@@ -990,7 +991,7 @@ func (s *Standalone) Parse(_, _, _ string) error {
 	return nil
 }
 
-func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astroplatformcore.ClientWithResponsesInterface) error {
+func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astroplatformcore.ClientWithResponsesInterface, _ keychain.SecureStore) error {
 	return errors.New("astro dev upgrade-test is not available in standalone mode")
 }
 

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -30,6 +30,7 @@ import (
 	"github.com/astronomer/astro-cli/pkg/airflowrt"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/spinner"
 	"github.com/astronomer/astro-cli/pkg/util"
@@ -1247,7 +1248,7 @@ func (s *Standalone) Parse(_, _, _ string) error {
 	return nil
 }
 
-func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astrov1.ClientWithResponsesInterface) error {
+func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astrov1.ClientWithResponsesInterface, _ keychain.SecureStore) error {
 	return errors.New("astro dev upgrade-test is not available in standalone mode")
 }
 

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -238,7 +238,7 @@ func (s *Suite) TestStandaloneUnsupportedCommands() {
 	s.Error(composeErr)
 	s.Contains(composeErr.Error(), "not available in standalone mode")
 
-	upgradeErr := handler.UpgradeTest("", "", "", "", false, false, false, false, false, "", nil)
+	upgradeErr := handler.UpgradeTest("", "", "", "", false, false, false, false, false, "", nil, nil)
 	s.Error(upgradeErr)
 	s.Contains(upgradeErr.Error(), "not available in standalone mode")
 }

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -295,7 +295,7 @@ func (s *Suite) TestStandaloneUnsupportedCommands() {
 	s.Error(composeErr)
 	s.Contains(composeErr.Error(), "not available in standalone mode")
 
-	upgradeErr := handler.UpgradeTest("", "", "", "", false, false, false, false, false, "", nil)
+	upgradeErr := handler.UpgradeTest("", "", "", "", false, false, false, false, false, "", nil, nil)
 	s.Error(upgradeErr)
 	s.Contains(upgradeErr.Error(), "not available in standalone mode")
 }

--- a/airflow/standalone_windows.go
+++ b/airflow/standalone_windows.go
@@ -10,6 +10,7 @@ import (
 	"github.com/astronomer/astro-cli/airflow/types"
 	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 )
 
 var (
@@ -51,6 +52,6 @@ func (s *Standalone) Pytest(_, _, _, _, _ string) (string, error) {
 	return "", errStandaloneWindows
 }
 func (s *Standalone) Parse(_, _, _ string) error { return errStandaloneWindows }
-func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astroplatformcore.ClientWithResponsesInterface) error {
+func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astroplatformcore.ClientWithResponsesInterface, _ keychain.SecureStore) error {
 	return errStandaloneWindows
 }

--- a/airflow/standalone_windows.go
+++ b/airflow/standalone_windows.go
@@ -10,6 +10,7 @@ import (
 	"github.com/astronomer/astro-cli/airflow/types"
 	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	"github.com/astronomer/astro-cli/astro-client-v1"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 )
 
 var (
@@ -51,6 +52,6 @@ func (s *Standalone) Pytest(_, _, _, _, _ string) (string, error) {
 	return "", errStandaloneWindows
 }
 func (s *Standalone) Parse(_, _, _ string) error { return errStandaloneWindows }
-func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astrov1.ClientWithResponsesInterface) error {
+func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astrov1.ClientWithResponsesInterface, _ keychain.SecureStore) error {
 	return errStandaloneWindows
 }

--- a/astro-client-core/client.go
+++ b/astro-client-core/client.go
@@ -2,6 +2,7 @@ package astrocore
 
 import (
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -13,9 +14,9 @@ var NormalizeAPIError = httputil.NormalizeAPIError
 type CoreClient = ClientWithResponsesInterface
 
 // NewCoreClient creates an API client for astro core services.
-// The provided TokenHolder is read on every request — set it via
-// TokenHolder.Set after credentials are resolved in PersistentPreRunE.
-func NewCoreClient(c *httputil.HTTPClient, holder *httputil.TokenHolder) *ClientWithResponses {
+// The provided CurrentCredentials is read on every request — set it via
+// CurrentCredentials.Set after credentials are resolved in PersistentPreRunE.
+func NewCoreClient(c *httputil.HTTPClient, holder *credentials.CurrentCredentials) *ClientWithResponses {
 	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
 		ctx, err := context.GetCurrentContext()
 		if err != nil {

--- a/astro-client-core/client.go
+++ b/astro-client-core/client.go
@@ -12,15 +12,16 @@ var NormalizeAPIError = httputil.NormalizeAPIError
 // a shorter alias
 type CoreClient = ClientWithResponsesInterface
 
-// create api client for astro core services
-func NewCoreClient(c *httputil.HTTPClient) *ClientWithResponses {
-	// we append base url in request editor, so set to an empty string here
+// NewCoreClient creates an API client for astro core services.
+// The provided TokenHolder is read on every request — set it via
+// TokenHolder.Set after credentials are resolved in PersistentPreRunE.
+func NewCoreClient(c *httputil.HTTPClient, holder *httputil.TokenHolder) *ClientWithResponses {
 	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
 		ctx, err := context.GetCurrentContext()
 		if err != nil {
 			return "", "", err
 		}
-		return ctx.Token, ctx.GetPublicRESTAPIURL("v1alpha1"), nil
+		return holder.Get(), ctx.GetPublicRESTAPIURL("v1alpha1"), nil
 	})))
 	return cl
 }

--- a/astro-client-core/client.test.go
+++ b/astro-client-core/client.test.go
@@ -9,6 +9,6 @@ import (
 )
 
 func TestNewCoreClient(t *testing.T) {
-	client := NewCoreClient(httputil.NewHTTPClient())
+	client := NewCoreClient(httputil.NewHTTPClient(), &httputil.TokenHolder{})
 	assert.NotNil(t, client, "Can't create new Astro Core client")
 }

--- a/astro-client-core/client.test.go
+++ b/astro-client-core/client.test.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
 func TestNewCoreClient(t *testing.T) {
-	client := NewCoreClient(httputil.NewHTTPClient(), &httputil.TokenHolder{})
+	client := NewCoreClient(httputil.NewHTTPClient(), &credentials.CurrentCredentials{})
 	assert.NotNil(t, client, "Can't create new Astro Core client")
 }

--- a/astro-client-iam-core/client.go
+++ b/astro-client-iam-core/client.go
@@ -2,6 +2,7 @@ package astroiamcore
 
 import (
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -12,7 +13,7 @@ var NormalizeAPIError = httputil.NormalizeAPIError
 // a shorter alias
 type CoreClient = ClientWithResponsesInterface
 
-func NewIamCoreClient(c *httputil.HTTPClient, holder *httputil.TokenHolder) *ClientWithResponses {
+func NewIamCoreClient(c *httputil.HTTPClient, holder *credentials.CurrentCredentials) *ClientWithResponses {
 	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
 		ctx, err := context.GetCurrentContext()
 		if err != nil {

--- a/astro-client-iam-core/client.go
+++ b/astro-client-iam-core/client.go
@@ -12,14 +12,13 @@ var NormalizeAPIError = httputil.NormalizeAPIError
 // a shorter alias
 type CoreClient = ClientWithResponsesInterface
 
-func NewIamCoreClient(c *httputil.HTTPClient) *ClientWithResponses {
-	// we append base url in request editor, so set to an empty string here
+func NewIamCoreClient(c *httputil.HTTPClient, holder *httputil.TokenHolder) *ClientWithResponses {
 	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
 		ctx, err := context.GetCurrentContext()
 		if err != nil {
 			return "", "", err
 		}
-		return ctx.Token, ctx.GetPublicRESTAPIURL("iam/v1beta1"), nil
+		return holder.Get(), ctx.GetPublicRESTAPIURL("iam/v1beta1"), nil
 	})))
 	return cl
 }

--- a/astro-client-iam-core/client.test.go
+++ b/astro-client-iam-core/client.test.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
 func TestNewIamCoreClient(t *testing.T) {
-	client := NewIamCoreClient(httputil.NewHTTPClient(), &httputil.TokenHolder{})
+	client := NewIamCoreClient(httputil.NewHTTPClient(), &credentials.CurrentCredentials{})
 	assert.NotNil(t, client, "Can't create new Astro IAM Core client")
 }

--- a/astro-client-iam-core/client.test.go
+++ b/astro-client-iam-core/client.test.go
@@ -9,6 +9,6 @@ import (
 )
 
 func TestNewIamCoreClient(t *testing.T) {
-	client := NewIamCoreClient(httputil.NewHTTPClient())
+	client := NewIamCoreClient(httputil.NewHTTPClient(), &httputil.TokenHolder{})
 	assert.NotNil(t, client, "Can't create new Astro IAM Core client")
 }

--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -2,6 +2,7 @@ package astroplatformcore
 
 import (
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -12,7 +13,7 @@ var NormalizeAPIError = httputil.NormalizeAPIError
 // a shorter alias
 type CoreClient = ClientWithResponsesInterface
 
-func NewPlatformCoreClient(c *httputil.HTTPClient, holder *httputil.TokenHolder) *ClientWithResponses {
+func NewPlatformCoreClient(c *httputil.HTTPClient, holder *credentials.CurrentCredentials) *ClientWithResponses {
 	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
 		ctx, err := context.GetCurrentContext()
 		if err != nil {

--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -12,15 +12,13 @@ var NormalizeAPIError = httputil.NormalizeAPIError
 // a shorter alias
 type CoreClient = ClientWithResponsesInterface
 
-// create api client for astro platform core services
-func NewPlatformCoreClient(c *httputil.HTTPClient) *ClientWithResponses {
-	// we append base url in request editor, so set to an empty string here
+func NewPlatformCoreClient(c *httputil.HTTPClient, holder *httputil.TokenHolder) *ClientWithResponses {
 	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
 		ctx, err := context.GetCurrentContext()
 		if err != nil {
 			return "", "", err
 		}
-		return ctx.Token, ctx.GetPublicRESTAPIURL("platform/v1beta1"), nil
+		return holder.Get(), ctx.GetPublicRESTAPIURL("platform/v1beta1"), nil
 	})))
 	return cl
 }

--- a/astro-client-v1/client.go
+++ b/astro-client-v1/client.go
@@ -2,6 +2,7 @@ package astrov1
 
 import (
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -13,13 +14,15 @@ var NormalizeAPIError = httputil.NormalizeAPIError
 type APIClient = ClientWithResponsesInterface
 
 // NewV1Client creates an API client for the Astro v1 public API.
-func NewV1Client(c *httputil.HTTPClient) *ClientWithResponses {
+// The provided CurrentCredentials is read on every request — set it via
+// CurrentCredentials.Set after credentials are resolved in PersistentPreRunE.
+func NewV1Client(c *httputil.HTTPClient, creds *credentials.CurrentCredentials) *ClientWithResponses {
 	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
 		ctx, err := context.GetCurrentContext()
 		if err != nil {
 			return "", "", err
 		}
-		return ctx.Token, ctx.GetPublicRESTAPIURL("v1"), nil
+		return creds.Get(), ctx.GetPublicRESTAPIURL("v1"), nil
 	})))
 	return cl
 }

--- a/astro-client-v1alpha1/client.go
+++ b/astro-client-v1alpha1/client.go
@@ -2,6 +2,7 @@ package astrov1alpha1
 
 import (
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -14,13 +15,15 @@ type APIClient = ClientWithResponsesInterface
 
 // NewV1Alpha1Client creates an API client for the Astro v1alpha1 public API.
 // v1alpha1 is retained only for endpoints that v1 does not yet cover (Astro IDE).
-func NewV1Alpha1Client(c *httputil.HTTPClient) *ClientWithResponses {
+// The provided CurrentCredentials is read on every request — set it via
+// CurrentCredentials.Set after credentials are resolved in PersistentPreRunE.
+func NewV1Alpha1Client(c *httputil.HTTPClient, creds *credentials.CurrentCredentials) *ClientWithResponses {
 	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
 		ctx, err := context.GetCurrentContext()
 		if err != nil {
 			return "", "", err
 		}
-		return ctx.Token, ctx.GetPublicRESTAPIURL("v1alpha1"), nil
+		return creds.Get(), ctx.GetPublicRESTAPIURL("v1alpha1"), nil
 	})))
 	return cl
 }

--- a/astro-client-v1alpha1/client.test.go
+++ b/astro-client-v1alpha1/client.test.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
 func TestNewV1Alpha1Client(t *testing.T) {
-	client := NewV1Alpha1Client(httputil.NewHTTPClient())
+	client := NewV1Alpha1Client(httputil.NewHTTPClient(), credentials.New(""))
 	assert.NotNil(t, client, "Can't create new Astro v1alpha1 client")
 }

--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -24,6 +24,7 @@ import (
 	"github.com/astronomer/astro-cli/pkg/astroauth"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -340,7 +341,7 @@ func CheckUserSession(c *config.Context, coreClient astrocore.CoreClient, platfo
 }
 
 // Login handles authentication to astronomer api and registry
-func Login(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+func Login(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 	var res Result
 	domain = domainutil.FormatDomain(domain)
 	authConfig, err := FetchDomainAuthConfig(domain)
@@ -387,9 +388,20 @@ func Login(domain, token string, coreClient astrocore.CoreClient, platformCoreCl
 		return err
 	}
 
-	err = res.writeToContext(&c)
-	if err != nil {
-		return err
+	creds := keychain.Credentials{
+		Token:        "Bearer " + res.AccessToken,
+		RefreshToken: res.RefreshToken,
+		UserEmail:    res.UserEmail,
+		ExpiresAt:    time.Now().Add(time.Duration(res.ExpiresIn) * time.Second),
+	}
+	if store == nil {
+		return fmt.Errorf("credential store not available; cannot save login credentials")
+	}
+	if err := store.SetCredentials(domain, creds); err != nil {
+		return fmt.Errorf("storing credentials: %w", err)
+	}
+	if tokenHolder != nil {
+		tokenHolder.Set(creds.Token)
 	}
 
 	fmt.Printf("Logging in as %s\n", ansi.Green(res.UserEmail))
@@ -404,16 +416,11 @@ func Login(domain, token string, coreClient astrocore.CoreClient, platformCoreCl
 }
 
 // Logout logs a user out of the docker registry. Will need to logout of Astro next.
-func Logout(domain string, out io.Writer) {
-	c, _ := context.GetContext(domain)
-
-	err = c.SetContextKey("token", "")
-	if err != nil {
-		return
-	}
-	err = c.SetContextKey("user_email", "")
-	if err != nil {
-		return
+func Logout(domain string, store keychain.SecureStore, out io.Writer) {
+	if store == nil {
+		fmt.Fprintln(out, "Warning: credential store not available; local credentials may not be cleared")
+	} else if err := store.DeleteCredentials(domain); err != nil {
+		fmt.Fprintf(out, "Failed to remove credentials from secure store: %s\n", err.Error())
 	}
 
 	// remove the current context

--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -22,6 +22,7 @@ import (
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/astroauth"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/keychain"
@@ -341,7 +342,7 @@ func CheckUserSession(c *config.Context, coreClient astrocore.CoreClient, platfo
 }
 
 // Login handles authentication to astronomer api and registry
-func Login(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+func Login(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 	var res Result
 	domain = domainutil.FormatDomain(domain)
 	authConfig, err := FetchDomainAuthConfig(domain)
@@ -388,7 +389,7 @@ func Login(domain, token string, store keychain.SecureStore, tokenHolder *httput
 		return err
 	}
 
-	creds := keychain.Credentials{
+	keyCreds := keychain.Credentials{
 		Token:        "Bearer " + res.AccessToken,
 		RefreshToken: res.RefreshToken,
 		UserEmail:    res.UserEmail,
@@ -397,11 +398,11 @@ func Login(domain, token string, store keychain.SecureStore, tokenHolder *httput
 	if store == nil {
 		return fmt.Errorf("credential store not available; cannot save login credentials")
 	}
-	if err := store.SetCredentials(domain, creds); err != nil {
+	if err := store.SetCredentials(domain, keyCreds); err != nil {
 		return fmt.Errorf("storing credentials: %w", err)
 	}
-	if tokenHolder != nil {
-		tokenHolder.Set(creds.Token)
+	if creds != nil {
+		creds.Set(keyCreds.Token)
 	}
 
 	fmt.Printf("Logging in as %s\n", ansi.Green(res.UserEmail))

--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -21,8 +21,10 @@ import (
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/astroauth"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -360,7 +362,7 @@ func CheckUserSession(c *config.Context, astroV1Client astrov1.APIClient, out io
 }
 
 // Login handles authentication to astronomer api and registry
-func Login(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+func Login(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 	var res Result
 	domain = domainutil.FormatDomain(domain)
 	authConfig, err := FetchDomainAuthConfig(domain)
@@ -407,9 +409,20 @@ func Login(domain, token string, astroV1Client astrov1.APIClient, out io.Writer,
 		return err
 	}
 
-	err = res.writeToContext(&c)
-	if err != nil {
-		return err
+	keyCreds := keychain.Credentials{
+		Token:        "Bearer " + res.AccessToken,
+		RefreshToken: res.RefreshToken,
+		UserEmail:    res.UserEmail,
+		ExpiresAt:    time.Now().Add(time.Duration(res.ExpiresIn) * time.Second),
+	}
+	if store == nil {
+		return fmt.Errorf("credential store not available; cannot save login credentials")
+	}
+	if err := store.SetCredentials(domain, keyCreds); err != nil {
+		return fmt.Errorf("storing credentials: %w", err)
+	}
+	if creds != nil {
+		creds.Set(keyCreds.Token)
 	}
 
 	fmt.Printf("Logging in as %s\n", ansi.Green(res.UserEmail))
@@ -424,16 +437,11 @@ func Login(domain, token string, astroV1Client astrov1.APIClient, out io.Writer,
 }
 
 // Logout logs a user out of the docker registry. Will need to logout of Astro next.
-func Logout(domain string, out io.Writer) {
-	c, _ := context.GetContext(domain)
-
-	err = c.SetContextKey("token", "")
-	if err != nil {
-		return
-	}
-	err = c.SetContextKey("user_email", "")
-	if err != nil {
-		return
+func Logout(domain string, store keychain.SecureStore, out io.Writer) {
+	if store == nil {
+		fmt.Fprintln(out, "Warning: credential store not available; local credentials may not be cleared")
+	} else if err := store.DeleteCredentials(domain); err != nil {
+		fmt.Fprintf(out, "Failed to remove credentials from secure store: %s\n", err.Error())
 	}
 
 	// remove the current context

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -12,14 +12,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astrocore_mocks "github.com/astronomer/astro-cli/astro-client-core/mocks"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	"github.com/astronomer/astro-cli/config"
-	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -680,8 +681,12 @@ func TestLogin(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrganizationsResponse, nil).Once()
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
-		err := Login("astronomer.io", "", mockCoreClient, mockPlatformCoreClient, os.Stdout, false)
+		store := keychain.NewTestStore()
+		err := Login("astronomer.io", "", store, nil, mockCoreClient, mockPlatformCoreClient, os.Stdout, false)
 		assert.NoError(t, err)
+		creds, err := store.GetCredentials("astronomer.io")
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer test-token", creds.Token)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
@@ -723,7 +728,7 @@ func TestLogin(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrganizationsResponse, nil).Once()
 
-		err = Login("pr5723.cloud.astronomer-dev.io", "", mockCoreClient, mockPlatformCoreClient, os.Stdout, false)
+		err = Login("pr5723.cloud.astronomer-dev.io", "", keychain.NewTestStore(), nil, mockCoreClient, mockPlatformCoreClient, os.Stdout, false)
 		assert.NoError(t, err)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -752,14 +757,14 @@ func TestLogin(t *testing.T) {
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrganizationsResponse, nil).Once()
 
-		err := Login("astronomer.io", "OAuth Token", mockCoreClient, mockPlatformCoreClient, os.Stdout, false)
+		err := Login("astronomer.io", "OAuth Token", keychain.NewTestStore(), nil, mockCoreClient, mockPlatformCoreClient, os.Stdout, false)
 		assert.NoError(t, err)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
 
 	t.Run("invalid domain", func(t *testing.T) {
-		err := Login("fail.astronomer.io", "", nil, nil, os.Stdout, false)
+		err := Login("fail.astronomer.io", "", nil, nil, nil, nil, os.Stdout, false)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "Invalid domain.")
 	})
@@ -769,7 +774,7 @@ func TestLogin(t *testing.T) {
 			return "", errMock
 		}
 		authenticator = Authenticator{callbackHandler: callbackHandler}
-		err := Login("cloud.astronomer.io", "", nil, nil, os.Stdout, false)
+		err := Login("cloud.astronomer.io", "", nil, nil, nil, nil, os.Stdout, false)
 		assert.ErrorIs(t, err, errMock)
 	})
 
@@ -793,7 +798,7 @@ func TestLogin(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
 		mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 		mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfErrorResponse, nil).Once()
-		err := Login("", "", mockCoreClient, mockPlatformCoreClient, os.Stdout, false)
+		err := Login("", "", keychain.NewTestStore(), nil, mockCoreClient, mockPlatformCoreClient, os.Stdout, false)
 		assert.Contains(t, err.Error(), "failed to fetch self user")
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -827,7 +832,7 @@ func TestLogin(t *testing.T) {
 		// initialize stdin with user email input
 		defer testUtil.MockUserInput(t, "test.user@astronomer.io")()
 		// do the test
-		err = Login("astronomer.io", "", mockCoreClient, mockPlatformCoreClient, os.Stdout, true)
+		err = Login("astronomer.io", "", keychain.NewTestStore(), nil, mockCoreClient, mockPlatformCoreClient, os.Stdout, true)
 		assert.NoError(t, err)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -860,15 +865,13 @@ func TestLogin(t *testing.T) {
 		}
 		// initialize user input with email
 		defer testUtil.MockUserInput(t, "test.user@astronomer.io")()
-		err := Login("astronomer.io", "", mockCoreClient, mockPlatformCoreClient, os.Stdout, true)
+		store := keychain.NewTestStore()
+		err := Login("astronomer.io", "", store, nil, mockCoreClient, mockPlatformCoreClient, os.Stdout, true)
 		assert.NoError(t, err)
-		// assert that everything got set in the right spot
-		domainContext, err := context.GetContext("astronomer.io")
-		assert.NoError(t, err)
-		currentContext, err := context.GetContext("localhost")
-		assert.NoError(t, err)
-		assert.Equal(t, domainContext.Token, "Bearer access_token")
-		assert.Equal(t, currentContext.Token, "token")
+		// assert that credentials were stored in the keychain
+		creds, err := store.GetCredentials("astronomer.io")
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer access_token", creds.Token)
 		mockCoreClient.AssertExpectations(t)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
@@ -878,75 +881,61 @@ func TestLogout(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("success", func(t *testing.T) {
 		buf := new(bytes.Buffer)
-		Logout("astronomer.io", buf)
+		Logout("astronomer.io", keychain.NewTestStore(), buf)
 		assert.Equal(t, "Successfully logged out of Astronomer\n", buf.String())
 	})
 
-	t.Run("success_with_email", func(t *testing.T) {
-		assertions := func(expUserEmail string, expToken string) {
-			contexts, err := config.GetContexts()
-			assert.NoError(t, err)
-			context := contexts.Contexts["localhost"]
-
-			assert.NoError(t, err)
-			assert.Equal(t, expUserEmail, context.UserEmail)
-			assert.Equal(t, expToken, context.Token)
-		}
+	t.Run("success_with_credentials_deleted", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		store := keychain.NewTestStore()
+		err := store.SetCredentials("localhost", keychain.Credentials{
+			Token:     "Bearer some-token",
+			UserEmail: "test.user@astronomer.io",
+		})
+		require.NoError(t, err)
+
 		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("user_email", "test.user@astronomer.io")
-		assert.NoError(t, err)
-		err = c.SetContextKey("token", "Bearer some-token")
-		assert.NoError(t, err)
-		// test before
-		assertions("test.user@astronomer.io", "Bearer some-token")
+		require.NoError(t, err)
+		Logout(c.Domain, store, os.Stdout)
 
-		// log out
-		c, err = config.GetCurrentContext()
-		assert.NoError(t, err)
-		Logout(c.Domain, os.Stdout)
-
-		// test after logout
-		assertions("", "")
+		_, err = store.GetCredentials("localhost")
+		assert.ErrorIs(t, err, keychain.ErrNotFound)
 	})
 }
 
-func Test_writeResultToContext(t *testing.T) {
-	assertConfigContents := func(expToken string, expRefresh string, expExpires time.Time, expUserEmail string) {
-		context, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		// test the output on the config file
-		assert.Equal(t, expToken, context.Token)
-		assert.Equal(t, expRefresh, context.RefreshToken)
-		expiresIn, err := context.GetExpiresIn()
-		assert.NoError(t, err)
-		assert.Equal(t, expExpires.Round(time.Second), expiresIn.Round(time.Second))
-		assert.Equal(t, expUserEmail, context.UserEmail)
-		assert.NoError(t, err)
-	}
+func TestLogin_storesCredentialsInKeychain(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	c, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	err = c.SetContextKey("token", "old_token")
-	assert.NoError(t, err)
-	// test input
-	res := Result{
-		AccessToken:  "new_token",
-		RefreshToken: "new_refresh_token",
-		ExpiresIn:    1234,
-		UserEmail:    "test.user@astronomer.io",
+	mockUserInfo := UserInfo{Email: "test.user@astronomer.io"}
+	userInfoRequester := func(authConfig Config, accessToken string) (UserInfo, error) {
+		return mockUserInfo, nil
 	}
-	// test before changes
-	var timeZero time.Time
-	assertConfigContents("old_token", "", timeZero, "")
+	authenticator = Authenticator{
+		userInfoRequester: userInfoRequester,
+		callbackHandler:   func() (string, error) { return "authorizationCode", nil },
+		tokenRequester: func(authConfig Config, verifier, code string) (Result, error) {
+			return Result{
+				RefreshToken: "new_refresh_token",
+				AccessToken:  "new_access_token",
+				ExpiresIn:    1234,
+			}, nil
+		},
+	}
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+	mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
+	mockCoreClient.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
+	mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, &astroplatformcore.ListOrganizationsParams{}).Return(&mockOrganizationsResponse, nil).Once()
 
-	// apply function
-	c, err = config.GetCurrentContext()
-	assert.NoError(t, err)
-	err = res.writeToContext(&c)
-	assert.NoError(t, err)
+	store := keychain.NewTestStore()
+	err := Login("astronomer.io", "", store, nil, mockCoreClient, mockPlatformCoreClient, os.Stdout, true)
+	require.NoError(t, err)
 
-	// test after changes
-	assertConfigContents("Bearer new_token", "new_refresh_token", time.Now().Add(1234*time.Second), "test.user@astronomer.io")
+	creds, err := store.GetCredentials("astronomer.io")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer new_access_token", creds.Token)
+	assert.Equal(t, "new_refresh_token", creds.RefreshToken)
+	assert.Equal(t, "test.user@astronomer.io", creds.UserEmail)
+	assert.WithinDuration(t, time.Now().Add(1234*time.Second), creds.ExpiresAt, 5*time.Second)
+	mockCoreClient.AssertExpectations(t)
+	mockPlatformCoreClient.AssertExpectations(t)
 }

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -12,12 +12,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
 	"github.com/astronomer/astro-cli/config"
-	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -728,9 +729,12 @@ func TestLogin(t *testing.T) {
 		mockV1Client.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockV1Client.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 		mockV1Client.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
-		err := Login("astronomer.io", "", mockV1Client, os.Stdout, false)
+		store := keychain.NewTestStore()
+		err := Login("astronomer.io", "", store, nil, mockV1Client, os.Stdout, false)
 		assert.NoError(t, err)
-		mockV1Client.AssertExpectations(t)
+		creds, err := store.GetCredentials("astronomer.io")
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer test-token", creds.Token)
 		mockV1Client.AssertExpectations(t)
 	})
 	t.Run("can login to a pr preview environment successfully", func(t *testing.T) {
@@ -770,7 +774,7 @@ func TestLogin(t *testing.T) {
 		mockV1Client.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockV1Client.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 
-		err = Login("pr5723.cloud.astronomer-dev.io", "", mockV1Client, os.Stdout, false)
+		err = Login("pr5723.cloud.astronomer-dev.io", "", keychain.NewTestStore(), nil, mockV1Client, os.Stdout, false)
 		assert.NoError(t, err)
 		mockV1Client.AssertExpectations(t)
 		mockV1Client.AssertExpectations(t)
@@ -798,14 +802,14 @@ func TestLogin(t *testing.T) {
 		mockV1Client.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
 		mockV1Client.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 
-		err := Login("astronomer.io", "OAuth Token", mockV1Client, os.Stdout, false)
+		err := Login("astronomer.io", "OAuth Token", keychain.NewTestStore(), nil, mockV1Client, os.Stdout, false)
 		assert.NoError(t, err)
 		mockV1Client.AssertExpectations(t)
 		mockV1Client.AssertExpectations(t)
 	})
 
 	t.Run("invalid domain", func(t *testing.T) {
-		err := Login("fail.astronomer.io", "", nil, os.Stdout, false)
+		err := Login("fail.astronomer.io", "", nil, nil, nil, os.Stdout, false)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "Invalid domain.")
 	})
@@ -815,7 +819,7 @@ func TestLogin(t *testing.T) {
 			return "", errMock
 		}
 		authenticator = Authenticator{callbackHandler: callbackHandler}
-		err := Login("cloud.astronomer.io", "", nil, os.Stdout, false)
+		err := Login("cloud.astronomer.io", "", nil, nil, nil, os.Stdout, false)
 		assert.ErrorIs(t, err, errMock)
 	})
 
@@ -838,7 +842,7 @@ func TestLogin(t *testing.T) {
 
 		mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
 		mockV1Client.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfErrorResponse, nil).Once()
-		err := Login("", "", mockV1Client, os.Stdout, false)
+		err := Login("", "", keychain.NewTestStore(), nil, mockV1Client, os.Stdout, false)
 		assert.Contains(t, err.Error(), "failed to fetch self user")
 		mockV1Client.AssertExpectations(t)
 		mockV1Client.AssertExpectations(t)
@@ -871,7 +875,7 @@ func TestLogin(t *testing.T) {
 		// initialize stdin with user email input
 		defer testUtil.MockUserInput(t, "test.user@astronomer.io")()
 		// do the test
-		err = Login("astronomer.io", "", mockV1Client, os.Stdout, true)
+		err = Login("astronomer.io", "", keychain.NewTestStore(), nil, mockV1Client, os.Stdout, true)
 		assert.NoError(t, err)
 		mockV1Client.AssertExpectations(t)
 		mockV1Client.AssertExpectations(t)
@@ -903,16 +907,13 @@ func TestLogin(t *testing.T) {
 		}
 		// initialize user input with email
 		defer testUtil.MockUserInput(t, "test.user@astronomer.io")()
-		err := Login("astronomer.io", "", mockV1Client, os.Stdout, true)
+		store := keychain.NewTestStore()
+		err := Login("astronomer.io", "", store, nil, mockV1Client, os.Stdout, true)
 		assert.NoError(t, err)
-		// assert that everything got set in the right spot
-		domainContext, err := context.GetContext("astronomer.io")
-		assert.NoError(t, err)
-		currentContext, err := context.GetContext("localhost")
-		assert.NoError(t, err)
-		assert.Equal(t, domainContext.Token, "Bearer access_token")
-		assert.Equal(t, currentContext.Token, "token")
-		mockV1Client.AssertExpectations(t)
+		// assert that credentials were stored in the keychain
+		creds, err := store.GetCredentials("astronomer.io")
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer access_token", creds.Token)
 		mockV1Client.AssertExpectations(t)
 	})
 }
@@ -921,75 +922,59 @@ func TestLogout(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("success", func(t *testing.T) {
 		buf := new(bytes.Buffer)
-		Logout("astronomer.io", buf)
+		Logout("astronomer.io", keychain.NewTestStore(), buf)
 		assert.Equal(t, "Successfully logged out of Astronomer\n", buf.String())
 	})
 
-	t.Run("success_with_email", func(t *testing.T) {
-		assertions := func(expUserEmail string, expToken string) {
-			contexts, err := config.GetContexts()
-			assert.NoError(t, err)
-			context := contexts.Contexts["localhost"]
-
-			assert.NoError(t, err)
-			assert.Equal(t, expUserEmail, context.UserEmail)
-			assert.Equal(t, expToken, context.Token)
-		}
+	t.Run("success_with_credentials_deleted", func(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		store := keychain.NewTestStore()
+		err := store.SetCredentials("localhost", keychain.Credentials{
+			Token:     "Bearer some-token",
+			UserEmail: "test.user@astronomer.io",
+		})
+		require.NoError(t, err)
+
 		c, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		err = c.SetContextKey("user_email", "test.user@astronomer.io")
-		assert.NoError(t, err)
-		err = c.SetContextKey("token", "Bearer some-token")
-		assert.NoError(t, err)
-		// test before
-		assertions("test.user@astronomer.io", "Bearer some-token")
+		require.NoError(t, err)
+		Logout(c.Domain, store, os.Stdout)
 
-		// log out
-		c, err = config.GetCurrentContext()
-		assert.NoError(t, err)
-		Logout(c.Domain, os.Stdout)
-
-		// test after logout
-		assertions("", "")
+		_, err = store.GetCredentials("localhost")
+		assert.ErrorIs(t, err, keychain.ErrNotFound)
 	})
 }
 
-func Test_writeResultToContext(t *testing.T) {
-	assertConfigContents := func(expToken string, expRefresh string, expExpires time.Time, expUserEmail string) {
-		context, err := config.GetCurrentContext()
-		assert.NoError(t, err)
-		// test the output on the config file
-		assert.Equal(t, expToken, context.Token)
-		assert.Equal(t, expRefresh, context.RefreshToken)
-		expiresIn, err := context.GetExpiresIn()
-		assert.NoError(t, err)
-		assert.Equal(t, expExpires.Round(time.Second), expiresIn.Round(time.Second))
-		assert.Equal(t, expUserEmail, context.UserEmail)
-		assert.NoError(t, err)
-	}
+func TestLogin_storesCredentialsInKeychain(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	c, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	err = c.SetContextKey("token", "old_token")
-	assert.NoError(t, err)
-	// test input
-	res := Result{
-		AccessToken:  "new_token",
-		RefreshToken: "new_refresh_token",
-		ExpiresIn:    1234,
-		UserEmail:    "test.user@astronomer.io",
+	mockUserInfo := UserInfo{Email: "test.user@astronomer.io"}
+	userInfoRequester := func(authConfig Config, accessToken string) (UserInfo, error) {
+		return mockUserInfo, nil
 	}
-	// test before changes
-	var timeZero time.Time
-	assertConfigContents("old_token", "", timeZero, "")
+	authenticator = Authenticator{
+		userInfoRequester: userInfoRequester,
+		callbackHandler:   func() (string, error) { return "authorizationCode", nil },
+		tokenRequester: func(authConfig Config, verifier, code string) (Result, error) {
+			return Result{
+				RefreshToken: "new_refresh_token",
+				AccessToken:  "new_access_token",
+				ExpiresIn:    1234,
+			}, nil
+		},
+	}
+	mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
+	mockV1Client.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Once()
+	mockV1Client.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).Return(&mockGetSelfResponse, nil).Once()
+	mockV1Client.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(&mockOrganizationsResponse, nil).Once()
 
-	// apply function
-	c, err = config.GetCurrentContext()
-	assert.NoError(t, err)
-	err = res.writeToContext(&c)
-	assert.NoError(t, err)
+	store := keychain.NewTestStore()
+	err := Login("astronomer.io", "", store, nil, mockV1Client, os.Stdout, true)
+	require.NoError(t, err)
 
-	// test after changes
-	assertConfigContents("Bearer new_token", "new_refresh_token", time.Now().Add(1234*time.Second), "test.user@astronomer.io")
+	creds, err := store.GetCredentials("astronomer.io")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer new_access_token", creds.Token)
+	assert.Equal(t, "new_refresh_token", creds.RefreshToken)
+	assert.Equal(t, "test.user@astronomer.io", creds.UserEmail)
+	assert.WithinDuration(t, time.Now().Add(1234*time.Second), creds.ExpiresAt, 5*time.Second)
+	mockV1Client.AssertExpectations(t)
 }

--- a/cloud/auth/types.go
+++ b/cloud/auth/types.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/astroauth"
 )
 
@@ -42,27 +41,4 @@ type Result struct {
 type CallbackMessage struct {
 	authorizationCode string
 	errorMessage      string
-}
-
-func (res Result) writeToContext(c *config.Context) error {
-	err = c.SetContextKey("token", "Bearer "+res.AccessToken)
-	if err != nil {
-		return err
-	}
-
-	err = c.SetContextKey("refreshtoken", res.RefreshToken)
-	if err != nil {
-		return err
-	}
-
-	err = c.SetExpiresIn(res.ExpiresIn)
-	if err != nil {
-		return err
-	}
-
-	err = c.SetContextKey("user_email", res.UserEmail)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/cloud/deploy/bundle.go
+++ b/cloud/deploy/bundle.go
@@ -14,6 +14,7 @@ import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/git"
 	"github.com/astronomer/astro-cli/pkg/logger"
@@ -29,6 +30,7 @@ type DeployBundleInput struct {
 	WaitTime           time.Duration
 	PlatformCoreClient astroplatformcore.CoreClient
 	CoreClient         astrocore.CoreClient
+	Creds              *credentials.CurrentCredentials
 }
 
 func DeployBundle(input *DeployBundleInput) error {
@@ -44,7 +46,7 @@ func DeployBundle(input *DeployBundleInput) error {
 	}
 
 	// if CI/CD is enforced, check the subject can deploy
-	if currentDeployment.IsCicdEnforced && !canCiCdDeploy("Bearer "+os.Getenv("ASTRO_API_TOKEN")) {
+	if currentDeployment.IsCicdEnforced && !canCiCdDeploy(input.Creds) {
 		return fmt.Errorf(errCiCdEnforcementUpdate, currentDeployment.Name)
 	}
 

--- a/cloud/deploy/bundle.go
+++ b/cloud/deploy/bundle.go
@@ -44,7 +44,7 @@ func DeployBundle(input *DeployBundleInput) error {
 	}
 
 	// if CI/CD is enforced, check the subject can deploy
-	if currentDeployment.IsCicdEnforced && !canCiCdDeploy(c.Token) {
+	if currentDeployment.IsCicdEnforced && !canCiCdDeploy("Bearer "+os.Getenv("ASTRO_API_TOKEN")) {
 		return fmt.Errorf(errCiCdEnforcementUpdate, currentDeployment.Name)
 	}
 

--- a/cloud/deploy/bundle.go
+++ b/cloud/deploy/bundle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/git"
 	"github.com/astronomer/astro-cli/pkg/logger"
@@ -27,6 +28,7 @@ type DeployBundleInput struct {
 	Wait          bool
 	WaitTime      time.Duration
 	AstroV1Client astrov1.APIClient
+	Creds         *credentials.CurrentCredentials
 }
 
 func DeployBundle(input *DeployBundleInput) error {
@@ -42,7 +44,7 @@ func DeployBundle(input *DeployBundleInput) error {
 	}
 
 	// if CI/CD is enforced, check the subject can deploy
-	if currentDeployment.IsCicdEnforced && !canCiCdDeploy(c.Token) {
+	if currentDeployment.IsCicdEnforced && !canCiCdDeploy(input.Creds) {
 		return fmt.Errorf(errCiCdEnforcementUpdate, currentDeployment.Name)
 	}
 

--- a/cloud/deploy/bundle_test.go
+++ b/cloud/deploy/bundle_test.go
@@ -19,6 +19,7 @@ import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/git"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -40,7 +41,7 @@ func TestBundles(t *testing.T) {
 }
 
 func (s *BundleSuite) TestBundleDeploy_Success() {
-	canCiCdDeploy = func(token string) bool {
+	canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 		return true
 	}
 
@@ -57,6 +58,7 @@ func (s *BundleSuite) TestBundleDeploy_Success() {
 		Description:        "test-description",
 		PlatformCoreClient: s.mockPlatformCoreClient,
 		CoreClient:         s.mockCoreClient,
+		Creds:              &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockPlatformCoreClient, true, true)
@@ -82,7 +84,7 @@ func (s *BundleSuite) TestBundleDeploy_Success() {
 }
 
 func (s *BundleSuite) TestBundleDeploy_CiCdIncompatible() {
-	canCiCdDeploy = func(token string) bool {
+	canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 		return false
 	}
 
@@ -90,6 +92,7 @@ func (s *BundleSuite) TestBundleDeploy_CiCdIncompatible() {
 		DeploymentID:       "test-deployment-id",
 		PlatformCoreClient: s.mockPlatformCoreClient,
 		CoreClient:         s.mockCoreClient,
+		Creds:              &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockPlatformCoreClient, true, true)
@@ -105,6 +108,7 @@ func (s *BundleSuite) TestBundleDeploy_DagDeployDisabled() {
 	input := &DeployBundleInput{
 		PlatformCoreClient: s.mockPlatformCoreClient,
 		CoreClient:         s.mockCoreClient,
+		Creds:              &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockPlatformCoreClient, false, false)
@@ -124,6 +128,7 @@ func (s *BundleSuite) TestBundleDeploy_GitMetadataRetrieved() {
 		BundlePath:         gitPath,
 		PlatformCoreClient: s.mockPlatformCoreClient,
 		CoreClient:         s.mockCoreClient,
+		Creds:              &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockPlatformCoreClient, true, false)
@@ -167,6 +172,7 @@ func (s *BundleSuite) TestBundleDeploy_GitHasUncommittedChanges() {
 		BundlePath:         gitPath,
 		PlatformCoreClient: s.mockPlatformCoreClient,
 		CoreClient:         s.mockCoreClient,
+		Creds:              &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockPlatformCoreClient, true, false)
@@ -206,6 +212,7 @@ func (s *BundleSuite) TestBundleDeploy_GitMetadataDisabledViaConfig() {
 		BundlePath:         gitPath,
 		PlatformCoreClient: s.mockPlatformCoreClient,
 		CoreClient:         s.mockCoreClient,
+		Creds:              &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockPlatformCoreClient, true, false)
@@ -236,6 +243,7 @@ func (s *BundleSuite) TestBundleDeploy_BundleUploadUrlMissing() {
 	input := &DeployBundleInput{
 		PlatformCoreClient: s.mockPlatformCoreClient,
 		CoreClient:         s.mockCoreClient,
+		Creds:              &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockPlatformCoreClient, true, false)

--- a/cloud/deploy/bundle_test.go
+++ b/cloud/deploy/bundle_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/git"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -36,7 +37,7 @@ func TestBundles(t *testing.T) {
 }
 
 func (s *BundleSuite) TestBundleDeploy_Success() {
-	canCiCdDeploy = func(token string) bool {
+	canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 		return true
 	}
 
@@ -52,6 +53,7 @@ func (s *BundleSuite) TestBundleDeploy_Success() {
 		BundleType:    "test-bundle-type",
 		Description:   "test-description",
 		AstroV1Client: s.mockV1Client,
+		Creds:         &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockV1Client, true, true)
@@ -77,13 +79,14 @@ func (s *BundleSuite) TestBundleDeploy_Success() {
 }
 
 func (s *BundleSuite) TestBundleDeploy_CiCdIncompatible() {
-	canCiCdDeploy = func(token string) bool {
+	canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 		return false
 	}
 
 	input := &DeployBundleInput{
 		DeploymentID:  "test-deployment-id",
 		AstroV1Client: s.mockV1Client,
+		Creds:         &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockV1Client, true, true)
@@ -98,6 +101,7 @@ func (s *BundleSuite) TestBundleDeploy_CiCdIncompatible() {
 func (s *BundleSuite) TestBundleDeploy_DagDeployDisabled() {
 	input := &DeployBundleInput{
 		AstroV1Client: s.mockV1Client,
+		Creds:         &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockV1Client, false, false)
@@ -116,6 +120,7 @@ func (s *BundleSuite) TestBundleDeploy_GitMetadataRetrieved() {
 	input := &DeployBundleInput{
 		BundlePath:    gitPath,
 		AstroV1Client: s.mockV1Client,
+		Creds:         &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockV1Client, true, false)
@@ -196,6 +201,7 @@ func (s *BundleSuite) TestBundleDeploy_GitHasUncommittedChanges() {
 	input := &DeployBundleInput{
 		BundlePath:    gitPath,
 		AstroV1Client: s.mockV1Client,
+		Creds:         &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockV1Client, true, false)
@@ -233,6 +239,7 @@ func (s *BundleSuite) TestBundleDeploy_GitMetadataDisabledViaConfig() {
 	input := &DeployBundleInput{
 		BundlePath:    gitPath,
 		AstroV1Client: s.mockV1Client,
+		Creds:         &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockV1Client, true, false)
@@ -261,6 +268,7 @@ func (s *BundleSuite) TestBundleDeploy_GitMetadataDisabledViaConfig() {
 func (s *BundleSuite) TestBundleDeploy_BundleUploadUrlMissing() {
 	input := &DeployBundleInput{
 		AstroV1Client: s.mockV1Client,
+		Creds:         &credentials.CurrentCredentials{},
 	}
 
 	mockGetDeployment(s.mockV1Client, true, false)

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/astronomer/astro-cli/docker"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/azure"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -112,6 +113,7 @@ type InputDeploy struct {
 	Description       string
 	BuildSecretString string
 	Force             bool
+	Creds             *credentials.CurrentCredentials
 }
 
 // InputClientDeploy contains inputs for client image deployments
@@ -121,6 +123,7 @@ type InputClientDeploy struct {
 	Platform          string
 	BuildSecretString string
 	DeploymentID      string
+	Creds             *credentials.CurrentCredentials
 }
 
 const accessYourDeploymentFmt = `
@@ -224,7 +227,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 	}
 
 	if deployInfo.cicdEnforcement {
-		if !canCiCdDeploy("Bearer " + os.Getenv("ASTRO_API_TOKEN")) {
+		if !canCiCdDeploy(deployInput.Creds) {
 			return fmt.Errorf(errCiCdEnforcementUpdate, deployInfo.name) //nolint
 		}
 	}
@@ -413,7 +416,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 
 		imageHandler := airflowImageHandler(deployInfo.deployImage)
 		fmt.Println("Pushing image to Astronomer registry")
-		_, err = imageHandler.Push(remoteImage, registryUsername, "Bearer "+os.Getenv("ASTRO_API_TOKEN"), false)
+		_, err = imageHandler.Push(remoteImage, registryUsername, deployInput.Creds.Get(), false)
 		if err != nil {
 			return err
 		}
@@ -969,7 +972,7 @@ func DeployClientImage(deployInput InputClientDeploy, platformCoreClient astropl
 			}
 			baseImageRegistry := config.CFG.RemoteBaseImageRegistry.GetString()
 			fmt.Printf("Authenticating with base image registry: %s\n", baseImageRegistry)
-			err := airflow.DockerLogin(baseImageRegistry, registryUsername, "Bearer "+os.Getenv("ASTRO_API_TOKEN"))
+			err := airflow.DockerLogin(baseImageRegistry, registryUsername, deployInput.Creds.Get())
 			if err != nil {
 				fmt.Println("Failed to authenticate with Astronomer registry that contains the base agent image used in the Dockerfile.client file.")
 				fmt.Println("This could be because either your token has expired or you don't have permission to pull the base agent image.")

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -224,7 +224,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 	}
 
 	if deployInfo.cicdEnforcement {
-		if !canCiCdDeploy(c.Token) {
+		if !canCiCdDeploy("Bearer " + os.Getenv("ASTRO_API_TOKEN")) {
 			return fmt.Errorf(errCiCdEnforcementUpdate, deployInfo.name) //nolint
 		}
 	}
@@ -413,7 +413,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 
 		imageHandler := airflowImageHandler(deployInfo.deployImage)
 		fmt.Println("Pushing image to Astronomer registry")
-		_, err = imageHandler.Push(remoteImage, registryUsername, c.Token, false)
+		_, err = imageHandler.Push(remoteImage, registryUsername, "Bearer "+os.Getenv("ASTRO_API_TOKEN"), false)
 		if err != nil {
 			return err
 		}
@@ -920,7 +920,7 @@ func setupClientDependencyFiles(buildDir string) error {
 
 // DeployClientImage handles the client deploy functionality
 func DeployClientImage(deployInput InputClientDeploy, platformCoreClient astroplatformcore.CoreClient) error { //nolint:gocritic
-	c, err := config.GetCurrentContext()
+	_, err := config.GetCurrentContext()
 	if err != nil {
 		return errors.Wrap(err, "failed to get current context")
 	}
@@ -969,7 +969,7 @@ func DeployClientImage(deployInput InputClientDeploy, platformCoreClient astropl
 			}
 			baseImageRegistry := config.CFG.RemoteBaseImageRegistry.GetString()
 			fmt.Printf("Authenticating with base image registry: %s\n", baseImageRegistry)
-			err := airflow.DockerLogin(baseImageRegistry, registryUsername, c.Token)
+			err := airflow.DockerLogin(baseImageRegistry, registryUsername, "Bearer "+os.Getenv("ASTRO_API_TOKEN"))
 			if err != nil {
 				fmt.Println("Failed to authenticate with Astronomer registry that contains the base agent image used in the Dockerfile.client file.")
 				fmt.Println("This could be because either your token has expired or you don't have permission to pull the base agent image.")

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/astronomer/astro-cli/docker"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/azure"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -116,6 +117,7 @@ type InputDeploy struct {
 	BuildSecretString string
 	Force             bool
 	DagBundleName     string
+	Creds             *credentials.CurrentCredentials
 }
 
 // InputClientDeploy contains inputs for client image deployments
@@ -125,6 +127,7 @@ type InputClientDeploy struct {
 	Platform          string
 	BuildSecretString string
 	DeploymentID      string
+	Creds             *credentials.CurrentCredentials
 }
 
 const accessYourDeploymentFmt = `
@@ -237,7 +240,7 @@ func Deploy(deployInput InputDeploy, astroV1Client astrov1.APIClient, astroV1Alp
 	}
 
 	if deployInfo.cicdEnforcement {
-		if !canCiCdDeploy(c.Token) {
+		if !canCiCdDeploy(deployInput.Creds) {
 			return fmt.Errorf(errCiCdEnforcementUpdate, deployInfo.name) //nolint
 		}
 	}
@@ -442,7 +445,7 @@ func Deploy(deployInput InputDeploy, astroV1Client astrov1.APIClient, astroV1Alp
 
 		imageHandler := airflowImageHandler(deployInfo.deployImage)
 		fmt.Println("Pushing image to Astronomer registry")
-		_, err = imageHandler.Push(remoteImage, registryUsername, c.Token, false)
+		_, err = imageHandler.Push(remoteImage, registryUsername, deployInput.Creds.Get(), false)
 		if err != nil {
 			return err
 		}
@@ -1049,7 +1052,7 @@ func setupClientDependencyFiles(buildDir string) error {
 
 // DeployClientImage handles the client deploy functionality
 func DeployClientImage(deployInput InputClientDeploy, astroV1Client astrov1.APIClient) error { //nolint:gocritic
-	c, err := config.GetCurrentContext()
+	_, err := config.GetCurrentContext()
 	if err != nil {
 		return errors.Wrap(err, "failed to get current context")
 	}
@@ -1098,7 +1101,7 @@ func DeployClientImage(deployInput InputClientDeploy, astroV1Client astrov1.APIC
 			}
 			baseImageRegistry := config.CFG.RemoteBaseImageRegistry.GetString()
 			fmt.Printf("Authenticating with base image registry: %s\n", baseImageRegistry)
-			err := airflow.DockerLogin(baseImageRegistry, registryUsername, c.Token)
+			err := airflow.DockerLogin(baseImageRegistry, registryUsername, deployInput.Creds.Get())
 			if err != nil {
 				fmt.Println("Failed to authenticate with Astronomer registry that contains the base agent image used in the Dockerfile.client file.")
 				fmt.Println("This could be because either your token has expired or you don't have permission to pull the base agent image.")

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -20,6 +20,7 @@ import (
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
@@ -179,6 +180,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -279,6 +281,7 @@ func TestDeployOnRemoteExecutionDeployment(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -383,10 +386,11 @@ func TestDeployOnCiCdEnforcedDeployment(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
-	canCiCdDeploy = func(astroAPIToken string) bool {
+	canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 		return false
 	}
 
@@ -420,6 +424,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -522,6 +527,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	defer testUtil.MockUserInput(t, "1")()
 	err = Deploy(deployInput, mockPlatformCoreClient, mockCoreClient)
@@ -552,6 +558,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 		Dags:           true,
 		WaitForStatus:  false,
 		DagsPath:       "./testfiles/dags",
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -637,6 +644,7 @@ func TestImageOnlyDeploySuccess(t *testing.T) {
 		Image:          true,
 		WaitForStatus:  false,
 		DagsPath:       "./testfiles/dags",
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -700,6 +708,7 @@ func TestNoDagsDeploy(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           true,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	defer testUtil.MockUserInput(t, "1")()
 	err = Deploy(deployInput, mockPlatformCoreClient, mockCoreClient)
@@ -734,6 +743,7 @@ func TestNoDagsDeployForceSkipsPrompt(t *testing.T) {
 		WsID:      ws,
 		Dags:      true,
 		Force:     true,
+		Creds:     &credentials.CurrentCredentials{},
 	}
 	err = Deploy(deployInput, mockPlatformCoreClient, mockCoreClient)
 	assert.NoError(t, err)
@@ -780,6 +790,7 @@ func TestNoDagsImageDeployForceSkipsPrompt(t *testing.T) {
 		EnvFile:   "./testfiles/.env",
 		Dags:      false,
 		Force:     true,
+		Creds:     &credentials.CurrentCredentials{},
 	}
 	err = Deploy(deployInput, mockPlatformCoreClient, mockCoreClient)
 	assert.NoError(t, err)
@@ -805,6 +816,7 @@ func TestDagsDeployFailed(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           true,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(3)
 	mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(6)
@@ -868,6 +880,7 @@ func TestDeployFailure(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 
 	defer testUtil.MockUserInput(t, "y")()
@@ -945,6 +958,7 @@ func TestDeployMonitoringDAGNonHosted(t *testing.T) {
 		Prompt:         true,
 		Dags:           true,
 		DagsPath:       "./testfiles/dags",
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -1028,6 +1042,7 @@ func TestDeployNoMonitoringDAGHosted(t *testing.T) {
 		Prompt:         true,
 		Dags:           true,
 		DagsPath:       "./testfiles/dags",
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -1428,6 +1443,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              tempDir,
 			BuildSecretString: "",
+			Creds:             credentials.New("Bearer test-token"),
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1458,6 +1474,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              "/test/path",
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1486,6 +1503,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              "/test/path",
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1542,6 +1560,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              tempDir,
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1599,6 +1618,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              tempDir,
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1646,6 +1666,7 @@ func TestDeployClientImage(t *testing.T) {
 			Path:              tempDir,
 			ImageName:         "custom-image:tag",
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -209,7 +209,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
+
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -309,7 +309,7 @@ func TestDeployOnRemoteExecutionDeployment(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
+
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -452,7 +452,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
+
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -681,7 +681,7 @@ func TestNoDagsDeploy(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
+
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -717,7 +717,6 @@ func TestNoDagsDeployForceSkipsPrompt(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -753,7 +752,6 @@ func TestNoDagsImageDeployForceSkipsPrompt(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -1374,6 +1372,8 @@ func TestDeployClientImage(t *testing.T) {
 	}()
 
 	t.Run("successful client deploy", func(t *testing.T) {
+		t.Setenv("ASTRO_API_TOKEN", "test-token")
+
 		// Set up temporary directory with Dockerfile.client
 		tempDir, err := os.MkdirTemp("", "test-deploy-*")
 		assert.NoError(t, err)
@@ -1394,7 +1394,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 		// Mock DockerLogin
@@ -1435,7 +1435,7 @@ func TestDeployClientImage(t *testing.T) {
 		assert.True(t, dockerLoginCalled, "DockerLogin should have been called")
 		assert.Equal(t, "images.astronomer.cloud", capturedRegistry)
 		assert.Equal(t, "cli", capturedUsername)
-		assert.Equal(t, "test-token", capturedToken)
+		assert.Equal(t, "Bearer test-token", capturedToken)
 		mockImageHandler.AssertExpectations(t)
 	})
 
@@ -1444,7 +1444,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 
@@ -1470,7 +1470,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 
@@ -1515,7 +1515,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 
@@ -1571,7 +1571,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 
@@ -1612,7 +1612,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -21,6 +21,7 @@ import (
 	astrov1alpha1_mocks "github.com/astronomer/astro-cli/astro-client-v1alpha1/mocks"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
@@ -180,6 +181,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -208,7 +210,7 @@ func TestDeployWithoutDagsDeploySuccess(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
+
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -278,6 +280,7 @@ func TestDeployOnRemoteExecutionDeployment(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -306,7 +309,7 @@ func TestDeployOnRemoteExecutionDeployment(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
+
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -380,10 +383,11 @@ func TestDeployOnCiCdEnforcedDeployment(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
-	canCiCdDeploy = func(astroAPIToken string) bool {
+	canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 		return false
 	}
 
@@ -416,6 +420,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -448,7 +453,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
+
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -518,6 +523,7 @@ func TestDeployWithDagsDeploySuccess(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	defer testUtil.MockUserInput(t, "1")()
 	err = Deploy(deployInput, mockV1Client, nil)
@@ -547,6 +553,7 @@ func TestDagsDeploySuccess(t *testing.T) {
 		Dags:           true,
 		WaitForStatus:  false,
 		DagsPath:       "./testfiles/dags",
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -631,6 +638,7 @@ func TestImageOnlyDeploySuccess(t *testing.T) {
 		Image:          true,
 		WaitForStatus:  false,
 		DagsPath:       "./testfiles/dags",
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -674,7 +682,7 @@ func TestNoDagsDeploy(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
+
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -693,6 +701,7 @@ func TestNoDagsDeploy(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           true,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	defer testUtil.MockUserInput(t, "1")()
 	err = Deploy(deployInput, mockV1Client, nil)
@@ -709,7 +718,6 @@ func TestNoDagsDeployForceSkipsPrompt(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -727,6 +735,7 @@ func TestNoDagsDeployForceSkipsPrompt(t *testing.T) {
 		WsID:      ws,
 		Dags:      true,
 		Force:     true,
+		Creds:     &credentials.CurrentCredentials{},
 	}
 	err = Deploy(deployInput, mockV1Client, nil)
 	assert.NoError(t, err)
@@ -744,7 +753,6 @@ func TestNoDagsImageDeployForceSkipsPrompt(t *testing.T) {
 
 	ctx, err := config.GetCurrentContext()
 	assert.NoError(t, err)
-	ctx.Token = "test testing"
 	err = ctx.SetContext()
 	assert.NoError(t, err)
 
@@ -773,6 +781,7 @@ func TestNoDagsImageDeployForceSkipsPrompt(t *testing.T) {
 		EnvFile:   "./testfiles/.env",
 		Dags:      false,
 		Force:     true,
+		Creds:     &credentials.CurrentCredentials{},
 	}
 	err = Deploy(deployInput, mockV1Client, nil)
 	assert.NoError(t, err)
@@ -805,12 +814,6 @@ func TestImageDeployOnRemoteExecutionDeploymentSucceedsWithoutDagDeploy(t *testi
 		return mockImageHandler
 	}
 
-	ctx, err := config.GetCurrentContext()
-	assert.NoError(t, err)
-	ctx.Token = "test testing"
-	err = ctx.SetContext()
-	assert.NoError(t, err)
-
 	deployInput := InputDeploy{
 		Path:      "./testfiles/",
 		RuntimeID: deploymentID,
@@ -819,9 +822,10 @@ func TestImageDeployOnRemoteExecutionDeploymentSucceedsWithoutDagDeploy(t *testi
 		ImageName: "custom-image",
 		Image:     true,
 		Force:     true,
+		Creds:     credentials.New("test testing"),
 	}
 
-	err = Deploy(deployInput, mockV1Client, nil)
+	err := Deploy(deployInput, mockV1Client, nil)
 	assert.NoError(t, err)
 	if err != nil {
 		assert.NotContains(t, err.Error(), "DAG-only deploys are not enabled")
@@ -846,6 +850,7 @@ func TestDagsDeployFailed(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           true,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(3)
 	mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(6)
@@ -908,6 +913,7 @@ func TestDeployFailure(t *testing.T) {
 		Prompt:         true,
 		WaitForStatus:  false,
 		Dags:           false,
+		Creds:          &credentials.CurrentCredentials{},
 	}
 
 	defer testUtil.MockUserInput(t, "y")()
@@ -985,6 +991,7 @@ func TestDeployMonitoringDAGNonHosted(t *testing.T) {
 		Prompt:         true,
 		Dags:           true,
 		DagsPath:       "./testfiles/dags",
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -1067,6 +1074,7 @@ func TestDeployNoMonitoringDAGHosted(t *testing.T) {
 		Prompt:         true,
 		Dags:           true,
 		DagsPath:       "./testfiles/dags",
+		Creds:          &credentials.CurrentCredentials{},
 	}
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")
@@ -1425,6 +1433,8 @@ func TestDeployClientImage(t *testing.T) {
 	}()
 
 	t.Run("successful client deploy", func(t *testing.T) {
+		t.Setenv("ASTRO_API_TOKEN", "test-token")
+
 		// Set up temporary directory with Dockerfile.client
 		tempDir, err := os.MkdirTemp("", "test-deploy-*")
 		assert.NoError(t, err)
@@ -1445,7 +1455,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 		// Mock DockerLogin
@@ -1479,6 +1489,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              tempDir,
 			BuildSecretString: "",
+			Creds:             credentials.New("Bearer test-token"),
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1486,7 +1497,7 @@ func TestDeployClientImage(t *testing.T) {
 		assert.True(t, dockerLoginCalled, "DockerLogin should have been called")
 		assert.Equal(t, "images.astronomer.cloud", capturedRegistry)
 		assert.Equal(t, "cli", capturedUsername)
-		assert.Equal(t, "test-token", capturedToken)
+		assert.Equal(t, "Bearer test-token", capturedToken)
 		mockImageHandler.AssertExpectations(t)
 	})
 
@@ -1495,7 +1506,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 
@@ -1509,6 +1520,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              "/test/path",
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1521,7 +1533,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 
@@ -1537,6 +1549,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              "/test/path",
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1566,7 +1579,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 
@@ -1593,6 +1606,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              tempDir,
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1622,7 +1636,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 
@@ -1650,6 +1664,7 @@ func TestDeployClientImage(t *testing.T) {
 		deployInput := InputClientDeploy{
 			Path:              tempDir,
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1663,7 +1678,7 @@ func TestDeployClientImage(t *testing.T) {
 		testUtil.InitTestConfig(testUtil.CloudPlatform)
 		ctx, err := config.GetCurrentContext()
 		assert.NoError(t, err)
-		ctx.Token = "test-token"
+
 		err = ctx.SetContext()
 		assert.NoError(t, err)
 
@@ -1697,6 +1712,7 @@ func TestDeployClientImage(t *testing.T) {
 			Path:              tempDir,
 			ImageName:         "custom-image:tag",
 			BuildSecretString: "",
+			Creds:             &credentials.CurrentCredentials{},
 		}
 
 		err = DeployClientImage(deployInput, nil)

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/astronomer/astro-cli/cloud/workspace"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -125,21 +126,26 @@ func deploymentTableConfig(fromAllWorkspaces bool, ws string) *output.TableConfi
 	)
 }
 
-func CanCiCdDeploy(bearerToken string) bool {
-	token := strings.Split(bearerToken, " ")[1] // Stripping Bearer
-	// Parse the token to peek at the custom claims
-	claims, err := parseToken(token)
+func CanCiCdDeploy(creds *credentials.CurrentCredentials) bool {
+	if creds == nil {
+		return false
+	}
+	bearerToken := creds.Get()
+	if bearerToken == "" {
+		return false
+	}
+	parts := strings.SplitN(bearerToken, " ", 2)
+	if len(parts) < 2 {
+		return false
+	}
+	claims, err := parseToken(parts[1])
 	if err != nil {
 		fmt.Println("Unable to Parse Token")
 		return false
 	}
 
 	// Only API Tokens and API Keys have permissions
-	if len(claims.Permissions) > 0 {
-		return true
-	}
-
-	return false
+	return len(claims.Permissions) > 0
 }
 
 // deploymentToInfo converts a deployment to DeploymentInfo for structured output
@@ -870,7 +876,7 @@ func HealthPoll(deploymentID, ws string, sleepTime, tickNum, timeoutNum int, pla
 }
 
 // TODO (https://github.com/astronomer/astro-cli/issues/1709): move these input arguments to a struct, and drop the nolint
-func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string, schedulerAU, schedulerReplicas int, wQueueList []astroplatformcore.WorkerQueueRequest, hybridQueueList []astroplatformcore.HybridWorkerQueueRequest, newEnvironmentVariables []astroplatformcore.DeploymentEnvironmentVariableRequest, allowedIpAddressRanges *[]string, taskLogBucket *string, taskLogUrlPattern *string, force bool, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient) error { //nolint
+func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string, schedulerAU, schedulerReplicas int, wQueueList []astroplatformcore.WorkerQueueRequest, hybridQueueList []astroplatformcore.HybridWorkerQueueRequest, newEnvironmentVariables []astroplatformcore.DeploymentEnvironmentVariableRequest, allowedIpAddressRanges *[]string, taskLogBucket *string, taskLogUrlPattern *string, force bool, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, creds *credentials.CurrentCredentials) error { //nolint
 	var queueCreateUpdate, confirmWithUser bool
 	// get deployment
 	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, false, nil, platformCoreClient, coreClient)
@@ -893,7 +899,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		isCicdEnforced = true
 	}
 	if !force && isCicdEnforced && dagDeploy != "" {
-		if !canCiCdDeploy("Bearer " + os.Getenv("ASTRO_API_TOKEN")) {
+		if !canCiCdDeploy(creds) {
 			fmt.Printf("\nWarning: You are trying to update the dag deploy setting with ci-cd enforcement enabled. Once the setting is updated, you will not be able to deploy your dags using the CLI. Until you deploy your dags, dags will not be visible in the UI nor will new tasks start." +
 				"\nAfter the setting is updated, either disable cicd enforcement and then deploy your dags OR deploy your dags via CICD or using API Tokens.")
 			y, _ := input.Confirm("\n\nAre you sure you want to continue?")

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -893,7 +893,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		isCicdEnforced = true
 	}
 	if !force && isCicdEnforced && dagDeploy != "" {
-		if !canCiCdDeploy(c.Token) {
+		if !canCiCdDeploy("Bearer " + os.Getenv("ASTRO_API_TOKEN")) {
 			fmt.Printf("\nWarning: You are trying to update the dag deploy setting with ci-cd enforcement enabled. Once the setting is updated, you will not be able to deploy your dags using the CLI. Until you deploy your dags, dags will not be visible in the UI nor will new tasks start." +
 				"\nAfter the setting is updated, either disable cicd enforcement and then deploy your dags OR deploy your dags via CICD or using API Tokens.")
 			y, _ := input.Confirm("\n\nAre you sure you want to continue?")

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -20,6 +20,7 @@ import (
 	"github.com/astronomer/astro-cli/cloud/workspace"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -128,21 +129,26 @@ func deploymentTableConfig(fromAllWorkspaces bool, ws string) *output.TableConfi
 	)
 }
 
-func CanCiCdDeploy(bearerToken string) bool {
-	token := strings.Split(bearerToken, " ")[1] // Stripping Bearer
-	// Parse the token to peek at the custom claims
-	claims, err := parseToken(token)
+func CanCiCdDeploy(creds *credentials.CurrentCredentials) bool {
+	if creds == nil {
+		return false
+	}
+	bearerToken := creds.Get()
+	if bearerToken == "" {
+		return false
+	}
+	parts := strings.SplitN(bearerToken, " ", 2)
+	if len(parts) < 2 {
+		return false
+	}
+	claims, err := parseToken(parts[1])
 	if err != nil {
 		fmt.Println("Unable to Parse Token")
 		return false
 	}
 
 	// Only API Tokens and API Keys have permissions
-	if len(claims.Permissions) > 0 {
-		return true
-	}
-
-	return false
+	return len(claims.Permissions) > 0
 }
 
 // deploymentToInfo converts a deployment to DeploymentInfo for structured output
@@ -865,7 +871,7 @@ func HealthPoll(deploymentID, ws string, sleepTime, tickNum, timeoutNum int, ast
 }
 
 // TODO (https://github.com/astronomer/astro-cli/issues/1709): move these input arguments to a struct, and drop the nolint
-func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string, schedulerAU, schedulerReplicas int, wQueueList []astrov1.WorkerQueueRequest, hybridQueueList []astrov1.HybridWorkerQueueRequest, newEnvironmentVariables []astrov1.DeploymentEnvironmentVariableRequest, allowedIpAddressRanges *[]string, taskLogBucket *string, taskLogUrlPattern *string, force bool, astroV1Client astrov1.APIClient) error { //nolint
+func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCpu, defaultTaskPodMemory, resourceQuotaCpu, resourceQuotaMemory, workloadIdentity string, schedulerAU, schedulerReplicas int, wQueueList []astrov1.WorkerQueueRequest, hybridQueueList []astrov1.HybridWorkerQueueRequest, newEnvironmentVariables []astrov1.DeploymentEnvironmentVariableRequest, allowedIpAddressRanges *[]string, taskLogBucket *string, taskLogUrlPattern *string, force bool, astroV1Client astrov1.APIClient, creds *credentials.CurrentCredentials) error { //nolint
 	var queueCreateUpdate, confirmWithUser bool
 	// get deployment
 	currentDeployment, err := GetDeployment(ws, deploymentID, deploymentName, false, nil, astroV1Client)
@@ -888,7 +894,7 @@ func Update(deploymentID, name, ws, description, deploymentName, dagDeploy, exec
 		isCicdEnforced = true
 	}
 	if !force && isCicdEnforced && dagDeploy != "" {
-		if !canCiCdDeploy(c.Token) {
+		if !canCiCdDeploy(creds) {
 			fmt.Printf("\nWarning: You are trying to update the dag deploy setting with ci-cd enforcement enabled. Once the setting is updated, you will not be able to deploy your dags using the CLI. Until you deploy your dags, dags will not be visible in the UI nor will new tasks start." +
 				"\nAfter the setting is updated, either disable cicd enforcement and then deploy your dags OR deploy your dags via CICD or using API Tokens.")
 			y, _ := input.Confirm("\n\nAre you sure you want to continue?")

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -21,6 +21,7 @@ import (
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	"github.com/astronomer/astro-cli/cloud/organization"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -1591,13 +1592,13 @@ func (s *Suite) TestCanCiCdDeploy() {
 		return &mockClaims, nil
 	}
 
-	canDeploy := CanCiCdDeploy("bearer token")
+	canDeploy := CanCiCdDeploy(credentials.New("bearer token"))
 	s.Equal(canDeploy, false)
 
 	parseToken = func(astroAPIToken string) (*util.CustomClaims, error) {
 		return nil, errMock
 	}
-	canDeploy = CanCiCdDeploy("bearer token")
+	canDeploy = CanCiCdDeploy(credentials.New("bearer token"))
 	s.Equal(canDeploy, false)
 
 	permissions = []string{
@@ -1612,7 +1613,7 @@ func (s *Suite) TestCanCiCdDeploy() {
 		return &mockClaims, nil
 	}
 
-	canDeploy = CanCiCdDeploy("bearer token")
+	canDeploy = CanCiCdDeploy(credentials.New("bearer token"))
 	s.Equal(canDeploy, true)
 }
 
@@ -1668,7 +1669,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with hybrid type in this test nothing is being change just ensuring that dag deploy stays true. Addtionally no deployment id/name is given so user input is needed to select one
-		err := Update("", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, true, mockCoreClient, mockPlatformCoreClient)
+		err := Update("", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, true, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 		s.Equal(deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
 
@@ -1677,7 +1678,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// success updating the kubernetes executor on hybrid type. deployment name is given
-		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// change type to standard
@@ -1689,7 +1690,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// success with standard type and deployment name input and dag deploy stays the same
-		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 		s.Equal(deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
 
@@ -1697,7 +1698,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// success updating to kubernetes executor on standard type
-		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// change type to dedicatd
@@ -1707,7 +1708,7 @@ func (s *Suite) TestUpdate() { //nolint
 		// defer testUtil.MockUserInput(t, "1")()
 
 		// success with dedicated type no changes made asserts that dag deploy stays the same
-		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 		s.Equal(deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
 
@@ -1715,7 +1716,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// success with dedicated updating to kubernetes executor
-		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 	s.Run("successfully update schedulerSize and highAvailability and CICDEnforement", func() {
@@ -1735,7 +1736,7 @@ func (s *Suite) TestUpdate() { //nolint
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "1")()
 		// success with standard type with name
-		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// change type to dedicatd
@@ -1746,20 +1747,20 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with dedicated type
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// success with large scheduler size
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// success with extra large scheduler size
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "extra_large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "extra_large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// success with hybrid type with id
 		deploymentResponse.JSON200.Type = &hybridType
-		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// Mock user input for deployment name
@@ -1767,7 +1768,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		// success with hybrid type with id
 		deploymentResponse.JSON200.Executor = &executorKubernetes
-		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -1785,7 +1786,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with standard type with name
-		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// change type to dedicatd and set development mode to false
@@ -1796,7 +1797,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with dedicated type
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "disable", "enable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "disable", "enable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -1829,7 +1830,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with standard type with name
-		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// mock os.Stdin
@@ -1837,7 +1838,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with standard type
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "enable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, nil, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "enable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, nil, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -1870,7 +1871,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with dedicated type with name
-		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// mock os.Stdin
@@ -1878,7 +1879,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with dedicated type
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "disable", "enable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, nil, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "disable", "enable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, nil, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -1887,35 +1888,35 @@ func (s *Suite) TestUpdate() { //nolint
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(2)
 
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.ErrorIs(err, errMock)
 
 		mockCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		deploymentResponse.JSON200.Type = &hybridType
-		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "10Gi", "2CPU", "10Gi", "", 100, 100, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "10Gi", "2CPU", "10Gi", "", 100, 100, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.ErrorIs(err, ErrInvalidResourceRequest)
 	})
 
 	s.Run("list deployments failure", func() {
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, errMock).Times(1)
 
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.ErrorIs(err, errMock)
 	})
 
 	s.Run("invalid deployment id", func() {
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, errMock).Times(1)
 		// list deployment error
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.ErrorIs(err, errMock)
 
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(3)
 
 		// invalid id
-		err = Update("invalid-id", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("invalid-id", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.ErrorContains(err, "the Deployment specified was not found in this workspace.")
 		// invalid name
-		err = Update("", "", ws, "update", "invalid-name", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "update", "invalid-name", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.ErrorContains(err, "the Deployment specified was not found in this workspace.")
 
 		// mock os.Stdin
@@ -1923,7 +1924,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "0")()
 
 		// invalid selection
-		err = Update("", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.ErrorContains(err, "invalid Deployment selected")
 	})
 
@@ -1938,7 +1939,7 @@ func (s *Suite) TestUpdate() { //nolint
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "n")()
 
-		err := Update("test-id-1", "", ws, "update", "", "disable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "disable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -1949,7 +1950,7 @@ func (s *Suite) TestUpdate() { //nolint
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.ErrorIs(err, errMock)
 		s.NotContains(err.Error(), organization.AstronomerConnectionErrMsg)
 	})
@@ -1959,7 +1960,7 @@ func (s *Suite) TestUpdate() { //nolint
 		deploymentResponse.JSON200.IsDagDeployEnabled = true
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -1967,12 +1968,12 @@ func (s *Suite) TestUpdate() { //nolint
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return false
 		}
 
 		defer testUtil.MockUserInput(s.T(), "n")()
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "enable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "enable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -1981,7 +1982,7 @@ func (s *Suite) TestUpdate() { //nolint
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err := Update("test-id-1", "", ws, "update", "", "disable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "disable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -2002,7 +2003,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 
-		err := Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// change type to standard
@@ -2010,7 +2011,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 		// test update with standard type
-		err = Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// change type to standard
@@ -2018,7 +2019,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 		// test update with standard type
-		err = Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 
 		s.NoError(err)
 	})
@@ -2037,7 +2038,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 		// test update with standard type
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// change type to standard
@@ -2045,14 +2046,14 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 		// test update with standard type
-		err = Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// test update with hybrid type
 		deploymentResponse.JSON200.Type = &hybridType
-		err = Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -2068,7 +2069,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "n")()
 
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -2096,7 +2097,7 @@ func (s *Suite) TestUpdate() { //nolint
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponseWithNoNodePools, nil).Once()
 
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 
@@ -2119,7 +2120,7 @@ func (s *Suite) TestUpdate() { //nolint
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
 
 		// Call the Update function with a non-empty workload ID
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "small", "enable", "", "disable", "", "", "", "", mockWorkloadIdentity, 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, true, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "small", "enable", "", "disable", "", "", "", "", mockWorkloadIdentity, 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, true, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 	s.Run("update deployment to change executor to/from ASTRO executor", func() {
@@ -2134,26 +2135,26 @@ func (s *Suite) TestUpdate() { //nolint
 		// CELERY -> ASTRO
 		deploymentResponse.JSON200.Executor = &executorCelery
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err := Update("test-id-1", "", ws, "", "", "", AstroExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "", "", "", AstroExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// ASTRO -> CELERY
 		astroExecutor := astroplatformcore.DeploymentExecutorASTRO
 		deploymentResponse.JSON200.Executor = &astroExecutor
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// ASTRO -> KUBERNETES
 		deploymentResponse.JSON200.Executor = &astroExecutor
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 
 		// KUBERNETES -> ASTRO
 		deploymentResponse.JSON200.Executor = &executorKubernetes
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err = Update("test-id-1", "", ws, "", "", "", AstroExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient)
+		err = Update("test-id-1", "", ws, "", "", "", AstroExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 	s.Run("update deployment to change remote execution config", func() {
@@ -2176,7 +2177,7 @@ func (s *Suite) TestUpdate() { //nolint
 		newTaskLogURLPattern := "new-task-log-url-pattern"
 		newAllowedIPAddressRanges := []string{"1.2.3.5/32"}
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, &newAllowedIPAddressRanges, &newTaskLogBucket, &newTaskLogURLPattern, false, mockCoreClient, mockPlatformCoreClient)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, &newAllowedIPAddressRanges, &newTaskLogBucket, &newTaskLogURLPattern, false, mockCoreClient, mockPlatformCoreClient, nil)
 		s.NoError(err)
 	})
 }

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -19,6 +19,7 @@ import (
 	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
 	"github.com/astronomer/astro-cli/cloud/organization"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -1733,13 +1734,13 @@ func (s *Suite) TestCanCiCdDeploy() {
 		return &mockClaims, nil
 	}
 
-	canDeploy := CanCiCdDeploy("bearer token")
+	canDeploy := CanCiCdDeploy(credentials.New("bearer token"))
 	s.Equal(canDeploy, false)
 
 	parseToken = func(astroAPIToken string) (*util.CustomClaims, error) {
 		return nil, errMock
 	}
-	canDeploy = CanCiCdDeploy("bearer token")
+	canDeploy = CanCiCdDeploy(credentials.New("bearer token"))
 	s.Equal(canDeploy, false)
 
 	permissions = []string{
@@ -1754,7 +1755,7 @@ func (s *Suite) TestCanCiCdDeploy() {
 		return &mockClaims, nil
 	}
 
-	canDeploy = CanCiCdDeploy("bearer token")
+	canDeploy = CanCiCdDeploy(credentials.New("bearer token"))
 	s.Equal(canDeploy, true)
 }
 
@@ -1810,7 +1811,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with hybrid type in this test nothing is being change just ensuring that dag deploy stays true. Addtionally no deployment id/name is given so user input is needed to select one
-		err := Update("", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, true, mockV1Client)
+		err := Update("", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, true, mockV1Client, nil)
 		s.NoError(err)
 		s.Equal(deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
 
@@ -1819,7 +1820,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// success updating the kubernetes executor on hybrid type. deployment name is given
-		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// change type to standard
@@ -1831,7 +1832,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// success with standard type and deployment name input and dag deploy stays the same
-		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 		s.Equal(deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
 
@@ -1839,7 +1840,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// success updating to kubernetes executor on standard type
-		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// change type to dedicatd
@@ -1849,7 +1850,7 @@ func (s *Suite) TestUpdate() { //nolint
 		// defer testUtil.MockUserInput(t, "1")()
 
 		// success with dedicated type no changes made asserts that dag deploy stays the same
-		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 		s.Equal(deploymentResponse.JSON200.IsDagDeployEnabled, dagDeployEnabled)
 
@@ -1857,7 +1858,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// success with dedicated updating to kubernetes executor
-		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 	s.Run("successfully update schedulerSize and highAvailability and CICDEnforement", func() {
@@ -1877,7 +1878,7 @@ func (s *Suite) TestUpdate() { //nolint
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "1")()
 		// success with standard type with name
-		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// change type to dedicatd
@@ -1888,20 +1889,20 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with dedicated type
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// success with large scheduler size
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// success with extra large scheduler size
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "extra_large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "extra_large", "enable", "", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// success with hybrid type with id
 		deploymentResponse.JSON200.Type = &hybridType
-		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// Mock user input for deployment name
@@ -1909,7 +1910,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		// success with hybrid type with id
 		deploymentResponse.JSON200.Executor = &executorKubernetes
-		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -1927,7 +1928,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with standard type with name
-		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// change type to dedicatd and set development mode to false
@@ -1938,7 +1939,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with dedicated type
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "disable", "enable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "disable", "enable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -1971,7 +1972,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with standard type with name
-		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// mock os.Stdin
@@ -1979,7 +1980,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with standard type
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "enable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, nil, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "enable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, nil, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -2012,7 +2013,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with dedicated type with name
-		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("", "test", ws, "", "", "enable", CeleryExecutor, "medium", "disable", "disable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// mock os.Stdin
@@ -2020,7 +2021,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "1")()
 
 		// success with dedicated type
-		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "disable", "enable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, nil, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("", "", ws, "", "test-1", "enable", CeleryExecutor, "medium", "disable", "enable", "disable", "", "", "2CPU", "2Gi", "", 0, 0, nil, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -2029,35 +2030,35 @@ func (s *Suite) TestUpdate() { //nolint
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(2)
 
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.ErrorIs(err, errMock)
 
 		mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		deploymentResponse.JSON200.Type = &hybridType
-		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "10Gi", "2CPU", "10Gi", "", 100, 100, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "10Gi", "2CPU", "10Gi", "", 100, 100, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.ErrorIs(err, ErrInvalidResourceRequest)
 	})
 
 	s.Run("list deployments failure", func() {
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, errMock).Times(1)
 
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.ErrorIs(err, errMock)
 	})
 
 	s.Run("invalid deployment id", func() {
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, errMock).Times(1)
 		// list deployment error
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.ErrorIs(err, errMock)
 
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(3)
 
 		// invalid id
-		err = Update("invalid-id", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("invalid-id", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.ErrorContains(err, "the Deployment specified was not found in this workspace.")
 		// invalid name
-		err = Update("", "", ws, "update", "invalid-name", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("", "", ws, "update", "invalid-name", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.ErrorContains(err, "the Deployment specified was not found in this workspace.")
 
 		// mock os.Stdin
@@ -2065,7 +2066,7 @@ func (s *Suite) TestUpdate() { //nolint
 		defer testUtil.MockUserInput(s.T(), "0")()
 
 		// invalid selection
-		err = Update("", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.ErrorContains(err, "invalid Deployment selected")
 	})
 
@@ -2080,7 +2081,7 @@ func (s *Suite) TestUpdate() { //nolint
 		// Mock user input for deployment name
 		defer testUtil.MockUserInput(s.T(), "n")()
 
-		err := Update("test-id-1", "", ws, "update", "", "disable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "disable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -2091,7 +2092,7 @@ func (s *Suite) TestUpdate() { //nolint
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Times(1)
 
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.ErrorIs(err, errMock)
 		s.NotContains(err.Error(), organization.AstronomerConnectionErrMsg)
 	})
@@ -2101,7 +2102,7 @@ func (s *Suite) TestUpdate() { //nolint
 		deploymentResponse.JSON200.IsDagDeployEnabled = true
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -2109,12 +2110,12 @@ func (s *Suite) TestUpdate() { //nolint
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return false
 		}
 
 		defer testUtil.MockUserInput(s.T(), "n")()
-		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "enable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "enable", CeleryExecutor, "medium", "enable", "", "enable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -2123,7 +2124,7 @@ func (s *Suite) TestUpdate() { //nolint
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err := Update("test-id-1", "", ws, "update", "", "disable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "disable", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -2144,7 +2145,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 
-		err := Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// change type to standard
@@ -2152,7 +2153,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 		// test update with standard type
-		err = Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// change type to standard
@@ -2160,7 +2161,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 		// test update with standard type
-		err = Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "update", "", "", KubeExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 
 		s.NoError(err)
 	})
@@ -2179,7 +2180,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 		// test update with standard type
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// change type to standard
@@ -2187,14 +2188,14 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 		// test update with standard type
-		err = Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		// test update with hybrid type
 		deploymentResponse.JSON200.Type = &hybridType
-		err = Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -2210,7 +2211,7 @@ func (s *Suite) TestUpdate() { //nolint
 
 		defer testUtil.MockUserInput(s.T(), "n")()
 
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -2238,7 +2239,7 @@ func (s *Suite) TestUpdate() { //nolint
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponseWithNoNodePools, nil).Once()
 
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 
@@ -2261,7 +2262,7 @@ func (s *Suite) TestUpdate() { //nolint
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
 
 		// Call the Update function with a non-empty workload ID
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "small", "enable", "", "disable", "", "", "", "", mockWorkloadIdentity, 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, true, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "small", "enable", "", "disable", "", "", "", "", mockWorkloadIdentity, 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, true, mockV1Client, nil)
 		s.NoError(err)
 	})
 	s.Run("update deployment to change executor to/from ASTRO executor", func() {
@@ -2276,26 +2277,26 @@ func (s *Suite) TestUpdate() { //nolint
 		// CELERY -> ASTRO
 		deploymentResponse.JSON200.Executor = &executorCelery
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err := Update("test-id-1", "", ws, "", "", "", AstroExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "", "", "", AstroExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// ASTRO -> CELERY
 		astroExecutor := astrov1.DeploymentExecutorASTRO
 		deploymentResponse.JSON200.Executor = &astroExecutor
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "", "", "", CeleryExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// ASTRO -> KUBERNETES
 		deploymentResponse.JSON200.Executor = &astroExecutor
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "", "", "", KubeExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 
 		// KUBERNETES -> ASTRO
 		deploymentResponse.JSON200.Executor = &executorKubernetes
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err = Update("test-id-1", "", ws, "", "", "", AstroExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client)
+		err = Update("test-id-1", "", ws, "", "", "", AstroExecutor, "", "", "", "", "", "", "", "", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, nil, nil, nil, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 	s.Run("update deployment to change remote execution config", func() {
@@ -2318,7 +2319,7 @@ func (s *Suite) TestUpdate() { //nolint
 		newTaskLogURLPattern := "new-task-log-url-pattern"
 		newAllowedIPAddressRanges := []string{"1.2.3.5/32"}
 		defer testUtil.MockUserInput(s.T(), "y")()
-		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, &newAllowedIPAddressRanges, &newTaskLogBucket, &newTaskLogURLPattern, false, mockV1Client)
+		err := Update("test-id-1", "", ws, "update", "", "", CeleryExecutor, "medium", "enable", "", "disable", "2CPU", "2Gi", "2CPU", "2Gi", "", 0, 0, workerQueueRequest, hybridQueueList, newEnvironmentVariables, &newAllowedIPAddressRanges, &newTaskLogBucket, &newTaskLogURLPattern, false, mockV1Client, nil)
 		s.NoError(err)
 	})
 }

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -139,7 +139,7 @@ func VariableModify(
 	}
 
 	// update deployment
-	err = Update(currentDeployment.Id, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, []astroplatformcore.WorkerQueueRequest{}, []astroplatformcore.HybridWorkerQueueRequest{}, newEnvironmentVariables, nil, nil, nil, false, coreClient, platformCoreClient)
+	err = Update(currentDeployment.Id, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, []astroplatformcore.WorkerQueueRequest{}, []astroplatformcore.HybridWorkerQueueRequest{}, newEnvironmentVariables, nil, nil, nil, false, coreClient, platformCoreClient, nil)
 	if err != nil {
 		return err
 	}

--- a/cloud/deployment/deployment_variable.go
+++ b/cloud/deployment/deployment_variable.go
@@ -137,7 +137,7 @@ func VariableModify(
 	}
 
 	// update deployment
-	err = Update(currentDeployment.Id, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, []astrov1.WorkerQueueRequest{}, []astrov1.HybridWorkerQueueRequest{}, newEnvironmentVariables, nil, nil, nil, false, astroV1Client)
+	err = Update(currentDeployment.Id, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, []astrov1.WorkerQueueRequest{}, []astrov1.HybridWorkerQueueRequest{}, newEnvironmentVariables, nil, nil, nil, false, astroV1Client, nil)
 	if err != nil {
 		return err
 	}

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -694,11 +694,7 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 		}
 		// update deployment
 		if !force && deploymentFromFile.Deployment.Configuration.APIKeyOnlyDeployments && dagDeploy {
-			c, err := config.GetCurrentContext()
-			if err != nil {
-				return err
-			}
-			if !canCiCdDeploy(c.Token) {
+			if !canCiCdDeploy("Bearer " + os.Getenv("ASTRO_API_TOKEN")) {
 				fmt.Printf("\nWarning: You are trying to update dag deploy setting on a deployment with ci-cd enforcement enabled. You will not be able to deploy your dags using the CLI and that dags will not be visible in the UI and new tasks will not start." +
 					"\nEither disable ci-cd enforcement or please cancel this operation and use API Tokens instead.")
 				y, _ := input.Confirm("\n\nAre you sure you want to continue?")

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -21,6 +21,7 @@ import (
 	"github.com/astronomer/astro-cli/cloud/organization"
 	"github.com/astronomer/astro-cli/cloud/workspace"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/input"
 )
 
@@ -53,7 +54,7 @@ const (
 // CreateOrUpdate takes a file and creates a deployment with the confiuration specified in the file.
 // inputFile can be in yaml or json format
 // It returns an error if any required information is missing or incorrectly specified.
-func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcore.CoreClient, coreClient astrocore.CoreClient, out io.Writer, waitForStatus bool, waitTime time.Duration, force bool) error { //nolint
+func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcore.CoreClient, coreClient astrocore.CoreClient, out io.Writer, waitForStatus bool, waitTime time.Duration, force bool, creds *credentials.CurrentCredentials) error { //nolint
 	var (
 		err                                           error
 		errHelp, clusterID, workspaceID, outputFormat string
@@ -128,7 +129,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 		}
 		// this deployment does not exist so create it
 		// transform formattedDeployment to DeploymentCreateInput
-		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, createAction, &astroplatformcore.Deployment{}, nodePools, dagDeploy, envVars, coreClient, astroPlatformCore, waitForStatus, waitTime, force)
+		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, createAction, &astroplatformcore.Deployment{}, nodePools, dagDeploy, envVars, coreClient, astroPlatformCore, waitForStatus, waitTime, force, creds)
 		if err != nil {
 			return err
 		}
@@ -171,7 +172,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 			return fmt.Errorf("%w \n failed to %s alert emails", err, action)
 		}
 		// transform formattedDeployment to DeploymentUpdateInput
-		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, dagDeploy, envVars, coreClient, astroPlatformCore, waitForStatus, waitTime, force)
+		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, dagDeploy, envVars, coreClient, astroPlatformCore, waitForStatus, waitTime, force, creds)
 		if err != nil {
 			return err
 		}
@@ -196,7 +197,7 @@ func CreateOrUpdate(inputFile, action string, astroPlatformCore astroplatformcor
 // It returns an error if node pool id could not be found for the worker type.
 //
 //nolint:dupl
-func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astroplatformcore.Deployment, nodePools []astroplatformcore.NodePool, dagDeploy bool, envVars []astroplatformcore.DeploymentEnvironmentVariableRequest, coreClient astrocore.CoreClient, astroPlatformCore astroplatformcore.CoreClient, waitForStatus bool, waitTime time.Duration, force bool) error { //nolint
+func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astroplatformcore.Deployment, nodePools []astroplatformcore.NodePool, dagDeploy bool, envVars []astroplatformcore.DeploymentEnvironmentVariableRequest, coreClient astrocore.CoreClient, astroPlatformCore astroplatformcore.CoreClient, waitForStatus bool, waitTime time.Duration, force bool, creds *credentials.CurrentCredentials) error { //nolint
 	var (
 		defaultOptions          astroplatformcore.WorkerQueueOptions
 		configOptions           astroplatformcore.DeploymentOptions
@@ -694,7 +695,7 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 		}
 		// update deployment
 		if !force && deploymentFromFile.Deployment.Configuration.APIKeyOnlyDeployments && dagDeploy {
-			if !canCiCdDeploy("Bearer " + os.Getenv("ASTRO_API_TOKEN")) {
+			if !canCiCdDeploy(creds) {
 				fmt.Printf("\nWarning: You are trying to update dag deploy setting on a deployment with ci-cd enforcement enabled. You will not be able to deploy your dags using the CLI and that dags will not be visible in the UI and new tasks will not start." +
 					"\nEither disable ci-cd enforcement or please cancel this operation and use API Tokens instead.")
 				y, _ := input.Confirm("\n\nAre you sure you want to continue?")

--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -20,6 +20,7 @@ import (
 	"github.com/astronomer/astro-cli/cloud/organization"
 	"github.com/astronomer/astro-cli/cloud/workspace"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/input"
 )
 
@@ -50,7 +51,7 @@ const (
 // CreateOrUpdate takes a file and creates a deployment with the confiuration specified in the file.
 // inputFile can be in yaml or json format
 // It returns an error if any required information is missing or incorrectly specified.
-func CreateOrUpdate(inputFile, action string, astroV1Client astrov1.APIClient, out io.Writer, waitForStatus bool, waitTime time.Duration, force bool) error { //nolint
+func CreateOrUpdate(inputFile, action string, astroV1Client astrov1.APIClient, out io.Writer, waitForStatus bool, waitTime time.Duration, force bool, creds *credentials.CurrentCredentials) error { //nolint
 	var (
 		err                                           error
 		errHelp, clusterID, workspaceID, outputFormat string
@@ -125,7 +126,7 @@ func CreateOrUpdate(inputFile, action string, astroV1Client astrov1.APIClient, o
 		}
 		// this deployment does not exist so create it
 		// transform formattedDeployment to DeploymentCreateInput
-		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, createAction, &astrov1.Deployment{}, nodePools, dagDeploy, envVars, astroV1Client, waitForStatus, waitTime, force)
+		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, createAction, &astrov1.Deployment{}, nodePools, dagDeploy, envVars, astroV1Client, waitForStatus, waitTime, force, creds)
 		if err != nil {
 			return err
 		}
@@ -169,7 +170,7 @@ func CreateOrUpdate(inputFile, action string, astroV1Client astrov1.APIClient, o
 			return fmt.Errorf("%w \n failed to %s alert emails", err, action)
 		}
 		// transform formattedDeployment to DeploymentUpdateInput
-		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, dagDeploy, envVars, astroV1Client, waitForStatus, waitTime, force)
+		err = createOrUpdateDeployment(&formattedDeployment, clusterID, workspaceID, updateAction, &existingDeployment, nodePools, dagDeploy, envVars, astroV1Client, waitForStatus, waitTime, force, creds)
 		if err != nil {
 			return err
 		}
@@ -194,7 +195,7 @@ func CreateOrUpdate(inputFile, action string, astroV1Client astrov1.APIClient, o
 // It returns an error if node pool id could not be found for the worker type.
 //
 //nolint:dupl
-func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astrov1.Deployment, nodePools []astrov1.NodePool, dagDeploy bool, envVars []astrov1.DeploymentEnvironmentVariableRequest, astroV1Client astrov1.APIClient, waitForStatus bool, waitTime time.Duration, force bool) error { //nolint
+func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, clusterID, workspaceID, action string, existingDeployment *astrov1.Deployment, nodePools []astrov1.NodePool, dagDeploy bool, envVars []astrov1.DeploymentEnvironmentVariableRequest, astroV1Client astrov1.APIClient, waitForStatus bool, waitTime time.Duration, force bool, creds *credentials.CurrentCredentials) error { //nolint
 	var (
 		defaultOptions          astrov1.WorkerQueueOptions
 		configOptions           astrov1.DeploymentOptions
@@ -719,11 +720,7 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 		}
 		// update deployment
 		if !force && deploymentFromFile.Deployment.Configuration.APIKeyOnlyDeployments && dagDeploy {
-			c, err := config.GetCurrentContext()
-			if err != nil {
-				return err
-			}
-			if !canCiCdDeploy(c.Token) {
+			if !canCiCdDeploy(creds) {
 				fmt.Printf("\nWarning: You are trying to update dag deploy setting on a deployment with ci-cd enforcement enabled. You will not be able to deploy your dags using the CLI and that dags will not be visible in the UI and new tasks will not start." +
 					"\nEither disable ci-cd enforcement or please cancel this operation and use API Tokens instead.")
 				y, _ := input.Confirm("\n\nAre you sure you want to continue?")

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -18,6 +18,7 @@ import (
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -430,7 +431,7 @@ func (s *Suite) TestCreateOrUpdate() {
 	)
 
 	s.Run("returns an error if file does not exist", func() {
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "open deployment.yaml: no such file or directory")
 	})
 	s.Run("returns an error if file exists but user provides incorrect path", func() {
@@ -439,7 +440,7 @@ func (s *Suite) TestCreateOrUpdate() {
 		err = fileutil.WriteStringToFile(filePath, data)
 		s.NoError(err)
 		defer afero.NewOsFs().RemoveAll("./2")
-		err = CreateOrUpdate("1/deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("1/deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "open 1/deployment.yaml: no such file or directory")
 	})
 	s.Run("returns an error if file is empty", func() {
@@ -447,7 +448,7 @@ func (s *Suite) TestCreateOrUpdate() {
 		data = ""
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errEmptyFile)
 		s.ErrorContains(err, "deployment.yaml has no content")
 	})
@@ -456,7 +457,7 @@ func (s *Suite) TestCreateOrUpdate() {
 		data = "test"
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "error unmarshaling JSON:")
 	})
 	s.Run("returns an error if required fields are missing", func() {
@@ -511,7 +512,7 @@ deployment:
 `
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "missing required field: deployment.configuration.name")
 	})
 	s.Run("returns an error if getting context fails", func() {
@@ -572,7 +573,7 @@ deployment:
 
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "no context set")
 	})
 	s.Run("returns an error if cluster does not exist", func() {
@@ -633,7 +634,7 @@ deployment:
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errNotFound)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -695,7 +696,7 @@ deployment:
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, errTest).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 	})
 	s.Run("returns an error if listing deployment fails", func() {
@@ -758,7 +759,7 @@ deployment:
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, errTest).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -831,7 +832,7 @@ deployment:
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.NotNil(out)
 		mockCoreClient.AssertExpectations(s.T())
@@ -901,7 +902,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.NotNil(out)
 		mockCoreClient.AssertExpectations(s.T())
@@ -985,7 +986,7 @@ deployment:
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, errTest).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1054,7 +1055,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1111,7 +1112,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1184,7 +1185,7 @@ deployment:
       description: hibernation schedule 1
       enabled: true
 `
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return true
 		}
 		fileutil.WriteStringToFile(filePath, data)
@@ -1213,7 +1214,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, "test-deployment-id").Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1277,7 +1278,7 @@ deployment:
     - test1@test.com
     - test2@test.com
 `
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return true
 		}
 		fileutil.WriteStringToFile(filePath, data)
@@ -1302,7 +1303,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, "test-deployment-id").Return(&deploymentResponseRemoteExecution, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1380,7 +1381,7 @@ deployment:
 }`
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return true
 		}
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(2)
@@ -1392,7 +1393,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "\"configuration\": {\n            \"name\": \"test-deployment-label\"")
 		s.Contains(out.String(), "\"metadata\": {\n            \"deployment_id\": \"test-deployment-id\"")
@@ -1492,7 +1493,7 @@ deployment:
 		)).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "\"configuration\": {\n            \"name\": \"test-deployment-label\"")
 		s.Contains(out.String(), "\"metadata\": {\n            \"deployment_id\": \"test-deployment-id\"")
@@ -1594,7 +1595,7 @@ deployment:
 		)).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "\"configuration\": {\n            \"name\": \"test-deployment-label\"")
 		s.Contains(out.String(), "\"metadata\": {\n            \"deployment_id\": \"test-deployment-id\"")
@@ -1660,7 +1661,7 @@ deployment:
 		defer afero.NewOsFs().Remove(filePath)
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&EmptyListWorkspacesResponseOK, errTest).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1723,7 +1724,7 @@ deployment:
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(1)
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "deployment: test-deployment-label already exists: use deployment update --deployment-file deployment.yaml instead")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1802,7 +1803,7 @@ deployment:
 		mockCoreClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.Error(err)
 		s.ErrorContains(err, "worker queue option is invalid: worker concurrency")
 		mockCoreClient.AssertExpectations(s.T())
@@ -1887,7 +1888,7 @@ deployment:
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(1)
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, errCreateFailed).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errCreateFailed)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -1954,7 +1955,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2010,7 +2011,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2098,7 +2099,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2183,7 +2184,7 @@ deployment:
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2258,11 +2259,11 @@ deployment:
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return false
 		}
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		defer testUtil.MockUserInput(s.T(), "n")()
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
@@ -2335,11 +2336,11 @@ deployment:
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return false
 		}
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, true)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, true, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -2425,7 +2426,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockPlatformCoreClient.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "test-deployment-label")
 		s.Contains(out.String(), "description 1")
@@ -2516,7 +2517,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2584,7 +2585,7 @@ deployment:
 		mockPlatformCoreClient.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "deployment: test-deployment-label does not exist: use deployment create --deployment-file deployment.yaml instead")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -2664,7 +2665,7 @@ deployment:
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(2)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.Error(err)
 		s.ErrorContains(err, "worker queue option is invalid: worker concurrency")
 		mockCoreClient.AssertExpectations(s.T())
@@ -2746,7 +2747,7 @@ deployment:
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, errUpdateFailed).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockPlatformCoreClient, mockCoreClient, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errUpdateFailed)
 		s.ErrorContains(err, "failed to update deployment with input")
 		mockCoreClient.AssertExpectations(s.T())
@@ -2819,7 +2820,7 @@ deployment:
 		s.Require().NoError(err)
 
 		// Run createOrUpdateDeployment with waitForStatus=true, allow time for 2 polls
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true, 3*time.Second, false)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true, 3*time.Second, false, nil)
 		s.NoError(err)
 		s.Equal(2, callCount, "expected two polling iterations before becoming healthy")
 	})
@@ -2845,7 +2846,7 @@ deployment:
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Equal(0, callCount, "expected no polling when waitForStatus is false")
 	})
@@ -2876,7 +2877,7 @@ deployment:
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true, 100*time.Millisecond, false)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true, 100*time.Millisecond, false, nil)
 		s.ErrorIs(err, deployment.ErrTimedOut, "expected ErrTimedOut when deployment does not become healthy")
 	})
 
@@ -2907,7 +2908,7 @@ deployment:
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true, 3*time.Second, false)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astroplatformcore.Deployment{}, nil, false, nil, nil, nil, true, 3*time.Second, false, nil)
 		s.ErrorIs(err, apiErr, "expected error returned from CoreGetDeployment to propagate")
 	})
 }
@@ -2966,7 +2967,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "worker_type: test-worker-8 does not exist in cluster: test-cluster")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3012,7 +3013,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "worker queue option is invalid: min worker count")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3058,7 +3059,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, errTest).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3120,7 +3121,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3158,7 +3159,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "don't use 'worker_queues' to update default queue with KubernetesExecutor")
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3175,7 +3176,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, nil, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, nil, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3205,7 +3206,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3271,7 +3272,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astroplatformcore.Deployment{}, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3307,7 +3308,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3328,7 +3329,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			Name:      "test-deployment",
 			ClusterId: &clusterID,
 		}
-		err = createOrUpdateDeployment(&deploymentFromFile, "diff-cluster", workspaceID, "update", &existingDeployment, nil, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, "diff-cluster", workspaceID, "update", &existingDeployment, nil, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errNotPermitted)
 		s.ErrorContains(err, "changing an existing deployment's cluster is not permitted")
 		mockCoreClient.AssertExpectations(s.T())
@@ -3368,7 +3369,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3409,7 +3410,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3459,7 +3460,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3509,7 +3510,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})
@@ -3583,7 +3584,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 
 		mockPlatformCoreClient.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, mockCoreClient, mockPlatformCoreClient, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockCoreClient.AssertExpectations(s.T())
 	})

--- a/cloud/deployment/fromfile/fromfile_test.go
+++ b/cloud/deployment/fromfile/fromfile_test.go
@@ -16,6 +16,7 @@ import (
 	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/cloud/deployment/inspect"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -431,7 +432,7 @@ func (s *Suite) TestCreateOrUpdate() {
 	)
 
 	s.Run("returns an error if file does not exist", func() {
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "open deployment.yaml: no such file or directory")
 	})
 	s.Run("returns an error if file exists but user provides incorrect path", func() {
@@ -440,7 +441,7 @@ func (s *Suite) TestCreateOrUpdate() {
 		err = fileutil.WriteStringToFile(filePath, data)
 		s.NoError(err)
 		defer afero.NewOsFs().RemoveAll("./2")
-		err = CreateOrUpdate("1/deployment.yaml", "create", nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("1/deployment.yaml", "create", nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "open 1/deployment.yaml: no such file or directory")
 	})
 	s.Run("returns an error if file is empty", func() {
@@ -448,7 +449,7 @@ func (s *Suite) TestCreateOrUpdate() {
 		data = ""
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errEmptyFile)
 		s.ErrorContains(err, "deployment.yaml has no content")
 	})
@@ -457,7 +458,7 @@ func (s *Suite) TestCreateOrUpdate() {
 		data = "test"
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "error unmarshaling JSON:")
 	})
 	s.Run("returns an error if required fields are missing", func() {
@@ -512,7 +513,7 @@ deployment:
 `
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", nil, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "missing required field: deployment.configuration.name")
 	})
 	s.Run("returns an error if getting context fails", func() {
@@ -572,7 +573,7 @@ deployment:
 
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "no context set")
 	})
 	s.Run("returns an error if cluster does not exist", func() {
@@ -632,7 +633,7 @@ deployment:
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
 		mockV1Client.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errNotFound)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -693,7 +694,7 @@ deployment:
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
 		mockV1Client.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, errTest).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 	})
 	s.Run("returns an error if listing deployment fails", func() {
@@ -755,7 +756,7 @@ deployment:
 		mockV1Client.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
 		mockV1Client.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, errTest).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -827,7 +828,7 @@ deployment:
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.NotNil(out)
 		mockV1Client.AssertExpectations(s.T())
@@ -896,7 +897,7 @@ deployment:
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.NotNil(out)
 		mockV1Client.AssertExpectations(s.T())
@@ -979,7 +980,7 @@ deployment:
 		mockV1Client.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, errTest).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -1047,7 +1048,7 @@ deployment:
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1103,7 +1104,7 @@ deployment:
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1176,7 +1177,7 @@ deployment:
       description: hibernation schedule 1
       enabled: true
 `
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return true
 		}
 		fileutil.WriteStringToFile(filePath, data)
@@ -1205,7 +1206,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, "test-deployment-id").Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1269,7 +1270,7 @@ deployment:
     - test1@test.com
     - test2@test.com
 `
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return true
 		}
 		fileutil.WriteStringToFile(filePath, data)
@@ -1294,7 +1295,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, "test-deployment-id").Return(&deploymentResponseRemoteExecution, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -1371,7 +1372,7 @@ deployment:
 }`
 		fileutil.WriteStringToFile(filePath, data)
 		defer afero.NewOsFs().Remove(filePath)
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return true
 		}
 		mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(2)
@@ -1383,7 +1384,7 @@ deployment:
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "\"configuration\": {\n            \"name\": \"test-deployment-label\"")
 		s.Contains(out.String(), "\"metadata\": {\n            \"deployment_id\": \"test-deployment-id\"")
@@ -1483,7 +1484,7 @@ deployment:
 		)).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "\"configuration\": {\n            \"name\": \"test-deployment-label\"")
 		s.Contains(out.String(), "\"metadata\": {\n            \"deployment_id\": \"test-deployment-id\"")
@@ -1585,7 +1586,7 @@ deployment:
 		)).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "\"configuration\": {\n            \"name\": \"test-deployment-label\"")
 		s.Contains(out.String(), "\"metadata\": {\n            \"deployment_id\": \"test-deployment-id\"")
@@ -1650,7 +1651,7 @@ deployment:
 		defer afero.NewOsFs().Remove(filePath)
 		mockV1Client.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockV1Client.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&EmptyListWorkspacesResponseOK, errTest).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -1712,7 +1713,7 @@ deployment:
 		mockV1Client.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(1)
 		mockV1Client.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "deployment: test-deployment-label already exists: use deployment update --deployment-file deployment.yaml instead")
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -1790,7 +1791,7 @@ deployment:
 		mockV1Client.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&ListWorkspacesResponseOK, nil).Times(1)
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(1)
 
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.Error(err)
 		s.ErrorContains(err, "worker queue option is invalid: worker concurrency")
 		mockV1Client.AssertExpectations(s.T())
@@ -1874,7 +1875,7 @@ deployment:
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(1)
 		mockV1Client.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, errCreateFailed).Once()
-		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "create", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errCreateFailed)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -1940,7 +1941,7 @@ deployment:
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -1995,7 +1996,7 @@ deployment:
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2082,7 +2083,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2166,7 +2167,7 @@ deployment:
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 		mockV1Client.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2240,11 +2241,11 @@ deployment:
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return false
 		}
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false, nil)
 		defer testUtil.MockUserInput(s.T(), "n")()
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
@@ -2316,11 +2317,11 @@ deployment:
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
 
-		canCiCdDeploy = func(astroAPIToken string) bool {
+		canCiCdDeploy = func(creds *credentials.CurrentCredentials) bool {
 			return false
 		}
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, true)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, true, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "metadata:\n        deployment_id: test-deployment-id")
@@ -2405,7 +2406,7 @@ deployment:
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 		mockV1Client.On("GetClusterWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockGetClusterResponse, nil).Once()
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "test-deployment-label")
 		s.Contains(out.String(), "description 1")
@@ -2495,7 +2496,7 @@ deployment:
 		)).Return(&mockUpdateDeploymentResponse, nil)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(3)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, out, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Contains(out.String(), "configuration:\n        name: test-deployment-label")
 		s.Contains(out.String(), "\n        description: description 1")
@@ -2562,7 +2563,7 @@ deployment:
 		mockV1Client.On("ListClustersWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListClustersResponse, nil).Once()
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Times(2)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "deployment: test-deployment-label does not exist: use deployment create --deployment-file deployment.yaml instead")
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -2641,7 +2642,7 @@ deployment:
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsCreateResponse, nil).Times(2)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.Error(err)
 		s.ErrorContains(err, "worker queue option is invalid: worker concurrency")
 		mockV1Client.AssertExpectations(s.T())
@@ -2722,7 +2723,7 @@ deployment:
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, errUpdateFailed).Times(1)
 		mockV1Client.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Times(1)
 
-		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, nil, false, 0*time.Second, false)
+		err = CreateOrUpdate("deployment.yaml", "update", mockV1Client, nil, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errUpdateFailed)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -2794,7 +2795,7 @@ deployment:
 		s.Require().NoError(err)
 
 		// Run createOrUpdateDeployment with waitForStatus=true, allow time for 2 polls
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astrov1.Deployment{}, nil, false, nil, nil, true, 3*time.Second, false)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astrov1.Deployment{}, nil, false, nil, nil, true, 3*time.Second, false, nil)
 		s.NoError(err)
 		s.Equal(2, callCount, "expected two polling iterations before becoming healthy")
 	})
@@ -2820,7 +2821,7 @@ deployment:
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astrov1.Deployment{}, nil, false, nil, nil, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astrov1.Deployment{}, nil, false, nil, nil, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		s.Equal(0, callCount, "expected no polling when waitForStatus is false")
 	})
@@ -2851,7 +2852,7 @@ deployment:
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astrov1.Deployment{}, nil, false, nil, nil, true, 100*time.Millisecond, false)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astrov1.Deployment{}, nil, false, nil, nil, true, 100*time.Millisecond, false, nil)
 		s.ErrorIs(err, deployment.ErrTimedOut, "expected ErrTimedOut when deployment does not become healthy")
 	})
 
@@ -2882,7 +2883,7 @@ deployment:
 		err := yaml.Unmarshal([]byte(minimalDeploymentYAML), &fd)
 		s.Require().NoError(err)
 
-		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astrov1.Deployment{}, nil, false, nil, nil, true, 3*time.Second, false)
+		err = createOrUpdateDeployment(&fd, "", "ws-id", createAction, &astrov1.Deployment{}, nil, false, nil, nil, true, 3*time.Second, false, nil)
 		s.ErrorIs(err, apiErr, "expected error returned from GetDeploymentByID to propagate")
 	})
 }
@@ -2940,7 +2941,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "worker_type: test-worker-8 does not exist in cluster: test-cluster")
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -2986,7 +2987,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 		mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "worker queue option is invalid: min worker count")
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3032,7 +3033,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 		mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, errTest).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errTest)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3094,7 +3095,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 		mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockV1Client.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3132,7 +3133,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			},
 		}
 		mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.ErrorContains(err, "don't use 'worker_queues' to update default queue with KubernetesExecutor")
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3149,7 +3150,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		deploymentFromFile.Deployment.Configuration.DagDeployEnabled = &dagDeploy
 
 		mockV1Client.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, nil, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, nil, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3179,7 +3180,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockV1Client.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3245,7 +3246,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 
 		mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
 		mockV1Client.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &astrov1.Deployment{}, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3281,7 +3282,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockV1Client.On("CreateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockCreateDeploymentResponse, nil).Once()
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "create", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3302,7 +3303,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 			Name:      "test-deployment",
 			ClusterId: &clusterID,
 		}
-		err = createOrUpdateDeployment(&deploymentFromFile, "diff-cluster", workspaceID, "update", &existingDeployment, nil, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, "diff-cluster", workspaceID, "update", &existingDeployment, nil, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.ErrorIs(err, errNotPermitted)
 		s.ErrorContains(err, "changing an existing deployment's cluster is not permitted")
 		mockV1Client.AssertExpectations(s.T())
@@ -3342,7 +3343,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3383,7 +3384,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3433,7 +3434,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3483,7 +3484,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 		}
 
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})
@@ -3557,7 +3558,7 @@ func (s *Suite) TestGetCreateOrUpdateInput() {
 
 		mockV1Client.On("UpdateDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockUpdateDeploymentResponse, nil).Times(1)
 		mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&GetDeploymentOptionsResponseOK, nil).Times(1)
-		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false)
+		err = createOrUpdateDeployment(&deploymentFromFile, clusterID, workspaceID, "update", &existingDeployment, existingPools, dagDeploy, []astrov1.DeploymentEnvironmentVariableRequest{}, mockV1Client, false, 0*time.Second, false, nil)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
 	})

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -231,7 +231,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 		}
 	}
 	// update the deployment with the new list of worker queues
-	err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, listToCreate, hybridListToCreate, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, coreClient, platformCoreClient)
+	err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, listToCreate, hybridListToCreate, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, coreClient, platformCoreClient, nil)
 	if err != nil {
 		return err
 	}
@@ -558,7 +558,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, platformC
 				}
 			}
 			// update the deployment with the new list
-			err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, workerQueuesToKeep, hybridWorkerQueuesToKeep, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, coreClient, platformCoreClient)
+			err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, workerQueuesToKeep, hybridWorkerQueuesToKeep, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, coreClient, platformCoreClient, nil)
 			if err != nil {
 				return err
 			}
@@ -580,7 +580,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, platformC
 				}
 			}
 			// update the deployment with the new list
-			err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, workerQueuesToKeep, hybridWorkerQueuesToKeep, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, coreClient, platformCoreClient)
+			err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, workerQueuesToKeep, hybridWorkerQueuesToKeep, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, coreClient, platformCoreClient, nil)
 			if err != nil {
 				return err
 			}

--- a/cloud/deployment/workerqueue/workerqueue.go
+++ b/cloud/deployment/workerqueue/workerqueue.go
@@ -229,7 +229,7 @@ func CreateOrUpdate(ws, deploymentID, deploymentName, name, action, workerType s
 		}
 	}
 	// update the deployment with the new list of worker queues
-	err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, listToCreate, hybridListToCreate, []astrov1.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, astroV1Client)
+	err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, listToCreate, hybridListToCreate, []astrov1.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, astroV1Client, nil)
 	if err != nil {
 		return err
 	}
@@ -556,7 +556,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, astroV1Cl
 				}
 			}
 			// update the deployment with the new list
-			err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, workerQueuesToKeep, hybridWorkerQueuesToKeep, []astrov1.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, astroV1Client)
+			err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, workerQueuesToKeep, hybridWorkerQueuesToKeep, []astrov1.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, astroV1Client, nil)
 			if err != nil {
 				return err
 			}
@@ -578,7 +578,7 @@ func Delete(ws, deploymentID, deploymentName, name string, force bool, astroV1Cl
 				}
 			}
 			// update the deployment with the new list
-			err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, workerQueuesToKeep, hybridWorkerQueuesToKeep, []astrov1.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, astroV1Client)
+			err = deployment.Update(requestedDeployment.Id, "", ws, "", "", "", "", "", "", "", "", "", "", "", "", "", 0, 0, workerQueuesToKeep, hybridWorkerQueuesToKeep, []astrov1.DeploymentEnvironmentVariableRequest{}, nil, nil, nil, true, astroV1Client, nil)
 			if err != nil {
 				return err
 			}

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -200,10 +200,6 @@ func SwitchWithContext(domain string, targetOrg *astroplatformcore.Organization,
 		orgProduct = fmt.Sprintf("%s", *targetOrg.Product) //nolint
 	}
 	_ = c.SetOrganizationContext(targetOrg.Id, orgProduct)
-	// need to reset all relevant keys because of https://github.com/spf13/viper/issues/1106 :shrug
-	_ = c.SetContextKey("token", c.Token)
-	_ = c.SetContextKey("refreshtoken", c.RefreshToken)
-	_ = c.SetContextKey("user_email", c.UserEmail)
 	c, _ = context.GetCurrentContext()
 	// call check user session which will trigger workspace switcher flow
 	err := CheckUserSession(&c, coreClient, platformCoreClient, out)

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -189,10 +189,6 @@ func SwitchWithContext(domain string, targetOrg *astrov1.Organization, astroV1Cl
 		orgProduct = fmt.Sprintf("%s", *targetOrg.Product) //nolint
 	}
 	_ = c.SetOrganizationContext(targetOrg.Id, orgProduct)
-	// need to reset all relevant keys because of https://github.com/spf13/viper/issues/1106 :shrug
-	_ = c.SetContextKey("token", c.Token)
-	_ = c.SetContextKey("refreshtoken", c.RefreshToken)
-	_ = c.SetContextKey("user_email", c.UserEmail)
 	c, _ = context.GetCurrentContext()
 	// call check user session which will trigger workspace switcher flow
 	err := CheckUserSession(&c, astroV1Client, out)

--- a/cloud/platformclient/client.go
+++ b/cloud/platformclient/client.go
@@ -6,6 +6,6 @@ import (
 )
 
 // NewPlatformCoreClient creates an API client for Astro platform core services.
-func NewPlatformCoreClient(c *httputil.HTTPClient) *astroplatformcore.ClientWithResponses {
-	return astroplatformcore.NewPlatformCoreClient(c)
+func NewPlatformCoreClient(c *httputil.HTTPClient, holder *httputil.TokenHolder) *astroplatformcore.ClientWithResponses {
+	return astroplatformcore.NewPlatformCoreClient(c, holder)
 }

--- a/cloud/platformclient/client.go
+++ b/cloud/platformclient/client.go
@@ -2,10 +2,11 @@ package platformclient
 
 import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
 // NewPlatformCoreClient creates an API client for Astro platform core services.
-func NewPlatformCoreClient(c *httputil.HTTPClient, holder *httputil.TokenHolder) *astroplatformcore.ClientWithResponses {
+func NewPlatformCoreClient(c *httputil.HTTPClient, holder *credentials.CurrentCredentials) *astroplatformcore.ClientWithResponses {
 	return astroplatformcore.NewPlatformCoreClient(c, holder)
 }

--- a/cloud/platformclient/client_test.go
+++ b/cloud/platformclient/client_test.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
 func TestNewPlatformCoreClient(t *testing.T) {
-	client := NewPlatformCoreClient(httputil.NewHTTPClient(), &httputil.TokenHolder{})
+	client := NewPlatformCoreClient(httputil.NewHTTPClient(), &credentials.CurrentCredentials{})
 	assert.NotNil(t, client, "Can't create new Astro Platform Core client")
 }

--- a/cloud/platformclient/client_test.go
+++ b/cloud/platformclient/client_test.go
@@ -9,6 +9,6 @@ import (
 )
 
 func TestNewPlatformCoreClient(t *testing.T) {
-	client := NewPlatformCoreClient(httputil.NewHTTPClient())
+	client := NewPlatformCoreClient(httputil.NewHTTPClient(), &httputil.TokenHolder{})
 	assert.NotNil(t, client, "Can't create new Astro Platform Core client")
 }

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -29,6 +29,7 @@ import (
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/output"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -150,7 +151,7 @@ astro dev init --remote-execution-enabled --remote-image-repository quay.io/acme
 	proxyPortFlag        string
 )
 
-func newDevRootCmd(platformCoreClient astroplatformcore.CoreClient, astroCoreClient astrocore.CoreClient) *cobra.Command {
+func newDevRootCmd(platformCoreClient astroplatformcore.CoreClient, astroCoreClient astrocore.CoreClient, store keychain.SecureStore) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dev",
 		Aliases: []string{"d"},
@@ -182,7 +183,7 @@ func newDevRootCmd(platformCoreClient astroplatformcore.CoreClient, astroCoreCli
 		newAirflowRestartCmd(astroCoreClient),
 		newAirflowBashCmd(),
 		newAirflowObjectRootCmd(),
-		newAirflowUpgradeTestCmd(platformCoreClient),
+		newAirflowUpgradeTestCmd(platformCoreClient, store),
 		newProxyRootCmd(),
 	)
 	return cmd
@@ -256,14 +257,14 @@ func newAirflowInitCmd() *cobra.Command {
 	return cmd
 }
 
-func newAirflowUpgradeTestCmd(platformCoreClient astroplatformcore.CoreClient) *cobra.Command {
+func newAirflowUpgradeTestCmd(platformCoreClient astroplatformcore.CoreClient, store keychain.SecureStore) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "upgrade-test",
 		Short:   "Test compatibility with a new Airflow or Runtime version",
 		Long:    "Run compatibility tests to check if your environment and DAGs work with a new version of Airflow or Astro Runtime. Produces reports covering dependency version changes, DAG import errors, and Airflow deprecation lint issues. Does not modify your project or local environment.",
 		PreRunE: EnsureRuntime,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return airflowUpgradeTest(cmd, platformCoreClient)
+			return airflowUpgradeTest(cmd, platformCoreClient, store)
 		},
 	}
 	cmd.Flags().StringVarP(&airflowVersion, "airflow-version", "a", "", "The version of Airflow you want to upgrade to. The default is the latest available version. Tests are run against the equivalent Astro Runtime version.")
@@ -757,7 +758,7 @@ func ensureProjectName(args []string, projectName string) (string, error) {
 	return projectName, nil
 }
 
-func airflowUpgradeTest(cmd *cobra.Command, platformCoreClient astroplatformcore.CoreClient) error { //nolint:gocognit
+func airflowUpgradeTest(cmd *cobra.Command, platformCoreClient astroplatformcore.CoreClient, store keychain.SecureStore) error { //nolint:gocognit
 	// Validate runtimeVersion and airflowVersion
 	if airflowVersion != "" && runtimeVersion != "" {
 		return errInvalidBothAirflowAndRuntimeVersionsUpgrade
@@ -800,7 +801,7 @@ func airflowUpgradeTest(cmd *cobra.Command, platformCoreClient astroplatformcore
 
 	buildSecretString = util.GetbuildSecretString(buildSecrets)
 
-	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, lintDeprecations, lintFix, lintConfigFile, platformCoreClient)
+	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, lintDeprecations, lintFix, lintConfigFile, platformCoreClient, store)
 	if err != nil {
 		return err
 	}

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -29,6 +29,7 @@ import (
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/output"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -150,7 +151,7 @@ astro dev init --remote-execution-enabled --remote-image-repository quay.io/acme
 	proxyPortFlag        string
 )
 
-func newDevRootCmd(astroV1Client astrov1.APIClient) *cobra.Command {
+func newDevRootCmd(astroV1Client astrov1.APIClient, store keychain.SecureStore) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dev",
 		Aliases: []string{"d"},
@@ -184,7 +185,7 @@ func newDevRootCmd(astroV1Client astrov1.APIClient) *cobra.Command {
 		newAirflowRestartCmd(astroV1Client),
 		newAirflowBashCmd(),
 		newAirflowObjectRootCmd(),
-		newAirflowUpgradeTestCmd(astroV1Client),
+		newAirflowUpgradeTestCmd(astroV1Client, store),
 		newProxyRootCmd(),
 	)
 	return cmd
@@ -268,14 +269,14 @@ func newAirflowInitCmd() *cobra.Command {
 	return cmd
 }
 
-func newAirflowUpgradeTestCmd(astroV1Client astrov1.APIClient) *cobra.Command {
+func newAirflowUpgradeTestCmd(astroV1Client astrov1.APIClient, store keychain.SecureStore) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "upgrade-test",
 		Short:   "Test compatibility with a new Airflow or Runtime version",
 		Long:    "Run compatibility tests to check if your environment and DAGs work with a new version of Airflow or Astro Runtime. Produces reports covering dependency version changes, DAG import errors, and Airflow deprecation lint issues. Does not modify your project or local environment.",
 		PreRunE: EnsureRuntime,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return airflowUpgradeTest(cmd, astroV1Client)
+			return airflowUpgradeTest(cmd, astroV1Client, store)
 		},
 	}
 	cmd.Flags().StringVarP(&airflowVersion, "airflow-version", "a", "", "The version of Airflow you want to upgrade to. The default is the latest available version. Tests are run against the equivalent Astro Runtime version.")
@@ -769,7 +770,7 @@ func ensureProjectName(args []string, projectName string) (string, error) {
 	return projectName, nil
 }
 
-func airflowUpgradeTest(cmd *cobra.Command, astroV1Client astrov1.APIClient) error { //nolint:gocognit
+func airflowUpgradeTest(cmd *cobra.Command, astroV1Client astrov1.APIClient, store keychain.SecureStore) error { //nolint:gocognit
 	// Validate runtimeVersion and airflowVersion
 	if airflowVersion != "" && runtimeVersion != "" {
 		return errInvalidBothAirflowAndRuntimeVersionsUpgrade
@@ -812,7 +813,7 @@ func airflowUpgradeTest(cmd *cobra.Command, astroV1Client astrov1.APIClient) err
 
 	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
-	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, lintDeprecations, lintFix, lintConfigFile, astroV1Client)
+	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, lintDeprecations, lintFix, lintConfigFile, astroV1Client, store)
 	if err != nil {
 		return err
 	}

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -26,6 +26,7 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/internal/telemetry"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -151,7 +152,32 @@ astro dev init --remote-execution-enabled --remote-image-repository quay.io/acme
 	proxyPortFlag        string
 )
 
-func newDevRootCmd(astroV1Client astrov1.APIClient, store keychain.SecureStore) *cobra.Command {
+// loadDevCredentials populates creds for the `astro dev` sub-commands that
+// reach the Astro API (`--workspace-id` / `--deployment-id`).
+//
+// The root pre-run hook normally does this, but cobra replaces a parent's
+// PersistentPreRunE with the child's rather than chaining them, and dev defines
+// its own to configure the container runtime. Before credentials moved to the
+// secure store this went unnoticed: request editors read the token straight out
+// of config.yaml, so no hook had to run. Now the token only reaches a request
+// via creds, and without this dev would send unauthenticated requests.
+//
+// Deliberately narrower than the root hook: it neither refreshes the token nor
+// prompts for login, matching what dev did when it read config.yaml directly.
+// Plain `astro dev start` targets nothing on Astro and must keep working
+// logged out, so commands without those flags load nothing.
+func loadDevCredentials(store keychain.SecureStore, creds *credentials.CurrentCredentials) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, _ []string) error {
+		wsID, _ := cmd.Flags().GetString("workspace-id")
+		depID, _ := cmd.Flags().GetString("deployment-id")
+		if wsID == "" && depID == "" {
+			return nil
+		}
+		return loadStoredToken(store, creds)
+	}
+}
+
+func newDevRootCmd(astroV1Client astrov1.APIClient, store keychain.SecureStore, creds *credentials.CurrentCredentials) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dev",
 		Aliases: []string{"d"},
@@ -165,6 +191,7 @@ func newDevRootCmd(astroV1Client astrov1.APIClient, store keychain.SecureStore) 
 			SetupLogging,
 			ConfigureContainerRuntime,
 			setDevModeAnnotation,
+			loadDevCredentials(store, creds),
 			telemetry.CreateTrackingHook(),
 		),
 	}

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -148,7 +148,7 @@ func (s *AirflowSuite) TestDevInitCommandSoftware() {
 }
 
 func (s *AirflowSuite) TestNewAirflowDevRootCmd() {
-	cmd := newDevRootCmd(nil, nil)
+	cmd := newDevRootCmd(nil, nil, nil)
 	s.Nil(cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
@@ -761,71 +761,71 @@ func (s *AirflowSuite) TestAirflowStart() {
 
 func (s *AirflowSuite) TestAirflowUpgradeTest() {
 	s.Run("success", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil).Return(nil).Once()
+			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil, nil).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.NoError(err)
 		mockContainerHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("failure", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil).Return(errMock).Once()
+			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil, nil).Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errMock)
 		mockContainerHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("containerHandlerInit failure", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 			return nil, errMock
 		}
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errMock)
 	})
 
 	s.Run("Both airflow and runtime version used", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		airflowVersion = "something"
 		runtimeVersion = "something"
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errInvalidBothAirflowAndRuntimeVersionsUpgrade)
 	})
 
 	s.Run("Both runtime version and custom image used", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		customImageName = "something"
 		runtimeVersion = "something"
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errInvalidBothCustomImageandVersion)
 	})
 
 	s.Run("Both airflow version and custom image used", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		customImageName = "something"
 		airflowVersion = "something"
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errInvalidBothCustomImageandVersion)
 	})
 }
@@ -1919,7 +1919,7 @@ func (s *AirflowSuite) TestDevCommandLocalSubcommandRemoved() {
 
 func (s *AirflowSuite) TestStandaloneDockerFlagsMutuallyExclusive() {
 	// Verify that the flags are registered as mutually exclusive on the dev root command
-	cmd := newDevRootCmd(nil, nil)
+	cmd := newDevRootCmd(nil, nil, nil)
 	s.NotNil(cmd.PersistentFlags().Lookup("standalone"))
 	s.NotNil(cmd.PersistentFlags().Lookup("docker"))
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -148,7 +148,7 @@ func (s *AirflowSuite) TestDevInitCommandSoftware() {
 }
 
 func (s *AirflowSuite) TestNewAirflowDevRootCmd() {
-	cmd := newDevRootCmd(nil, nil)
+	cmd := newDevRootCmd(nil, nil, nil)
 	s.Nil(cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
@@ -1957,7 +1957,7 @@ func (s *AirflowSuite) TestDevCommandLocalSubcommandRemoved() {
 
 func (s *AirflowSuite) TestStandaloneDockerFlagsMutuallyExclusive() {
 	// Verify that the flags are registered as mutually exclusive on the dev root command
-	cmd := newDevRootCmd(nil, nil)
+	cmd := newDevRootCmd(nil, nil, nil)
 	s.NotNil(cmd.PersistentFlags().Lookup("standalone"))
 	s.NotNil(cmd.PersistentFlags().Lookup("docker"))
 

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -148,7 +148,7 @@ func (s *AirflowSuite) TestDevInitCommandSoftware() {
 }
 
 func (s *AirflowSuite) TestNewAirflowDevRootCmd() {
-	cmd := newDevRootCmd(nil)
+	cmd := newDevRootCmd(nil, nil)
 	s.Nil(cmd.PersistentPreRunE(new(cobra.Command), []string{}))
 }
 
@@ -761,71 +761,71 @@ func (s *AirflowSuite) TestAirflowStart() {
 
 func (s *AirflowSuite) TestAirflowUpgradeTest() {
 	s.Run("success", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil).Return(nil).Once()
+			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil, nil).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.NoError(err)
 		mockContainerHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("failure", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil).Return(errMock).Once()
+			mockContainerHandler.On("UpgradeTest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, false, false, false, false, "", nil, nil).Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errMock)
 		mockContainerHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("containerHandlerInit failure", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
 			return nil, errMock
 		}
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errMock)
 	})
 
 	s.Run("Both airflow and runtime version used", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		airflowVersion = "something"
 		runtimeVersion = "something"
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errInvalidBothAirflowAndRuntimeVersionsUpgrade)
 	})
 
 	s.Run("Both runtime version and custom image used", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		customImageName = "something"
 		runtimeVersion = "something"
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errInvalidBothCustomImageandVersion)
 	})
 
 	s.Run("Both airflow version and custom image used", func() {
-		cmd := newAirflowUpgradeTestCmd(nil)
+		cmd := newAirflowUpgradeTestCmd(nil, nil)
 
 		customImageName = "something"
 		airflowVersion = "something"
 
-		err := airflowUpgradeTest(cmd, nil)
+		err := airflowUpgradeTest(cmd, nil, nil)
 		s.ErrorIs(err, errInvalidBothCustomImageandVersion)
 	})
 }
@@ -1957,7 +1957,7 @@ func (s *AirflowSuite) TestDevCommandLocalSubcommandRemoved() {
 
 func (s *AirflowSuite) TestStandaloneDockerFlagsMutuallyExclusive() {
 	// Verify that the flags are registered as mutually exclusive on the dev root command
-	cmd := newDevRootCmd(nil)
+	cmd := newDevRootCmd(nil, nil)
 	s.NotNil(cmd.PersistentFlags().Lookup("standalone"))
 	s.NotNil(cmd.PersistentFlags().Lookup("docker"))
 

--- a/cmd/api/airflow.go
+++ b/cmd/api/airflow.go
@@ -43,18 +43,19 @@ type AirflowOptions struct {
 	// Internal
 	detectedVersion     string // The Airflow version being used (detected or overridden)
 	CredentialsExplicit bool   // true when --username or --password was explicitly passed
+	tokenHolder         *httputil.TokenHolder
 }
 
 // NewAirflowCmd creates the 'astro api airflow' command.
 //
 //nolint:dupl
-func NewAirflowCmd(out io.Writer) *cobra.Command {
+func NewAirflowCmd(out io.Writer, tokenHolder *httputil.TokenHolder) *cobra.Command {
 	opts := &AirflowOptions{
 		RequestOptions: RequestOptions{
 			Out:    out,
 			ErrOut: os.Stderr,
-			// specCache is initialized lazily when we know the Airflow version
 		},
+		tokenHolder: tokenHolder,
 	}
 
 	cmd := &cobra.Command{
@@ -459,7 +460,7 @@ func resolveDeploymentAirflowURL(opts *AirflowOptions) (baseURL, authToken strin
 	}
 
 	// Check for token
-	if ctx.Token == "" {
+	if opts.tokenHolder == nil || opts.tokenHolder.Get() == "" {
 		return "", "", fmt.Errorf("not authenticated. Run 'astro login' to authenticate")
 	}
 
@@ -473,7 +474,7 @@ func resolveDeploymentAirflowURL(opts *AirflowOptions) (baseURL, authToken strin
 	}
 
 	// Create platform client
-	platformCoreClient := platformclient.NewPlatformCoreClient(httputil.NewHTTPClient())
+	platformCoreClient := platformclient.NewPlatformCoreClient(httputil.NewHTTPClient(), opts.tokenHolder)
 
 	// Fetch deployment
 	dep, err := deployment.CoreGetDeployment(orgID, opts.DeploymentID, platformCoreClient)
@@ -492,7 +493,7 @@ func resolveDeploymentAirflowURL(opts *AirflowOptions) (baseURL, authToken strin
 		airflowURL = "https://" + airflowURL
 	}
 
-	return airflowURL, ctx.Token, nil
+	return airflowURL, opts.tokenHolder.Get(), nil
 }
 
 // runAirflowInteractive runs the airflow API command in interactive mode.

--- a/cmd/api/airflow.go
+++ b/cmd/api/airflow.go
@@ -18,6 +18,7 @@ import (
 	"github.com/astronomer/astro-cli/cloud/platformclient"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/openapi"
 )
@@ -43,19 +44,19 @@ type AirflowOptions struct {
 	// Internal
 	detectedVersion     string // The Airflow version being used (detected or overridden)
 	CredentialsExplicit bool   // true when --username or --password was explicitly passed
-	tokenHolder         *httputil.TokenHolder
+	creds               *credentials.CurrentCredentials
 }
 
 // NewAirflowCmd creates the 'astro api airflow' command.
 //
 //nolint:dupl
-func NewAirflowCmd(out io.Writer, tokenHolder *httputil.TokenHolder) *cobra.Command {
+func NewAirflowCmd(out io.Writer, creds *credentials.CurrentCredentials) *cobra.Command {
 	opts := &AirflowOptions{
 		RequestOptions: RequestOptions{
 			Out:    out,
 			ErrOut: os.Stderr,
 		},
-		tokenHolder: tokenHolder,
+		creds: creds,
 	}
 
 	cmd := &cobra.Command{
@@ -460,7 +461,7 @@ func resolveDeploymentAirflowURL(opts *AirflowOptions) (baseURL, authToken strin
 	}
 
 	// Check for token
-	if opts.tokenHolder == nil || opts.tokenHolder.Get() == "" {
+	if opts.creds == nil || opts.creds.Get() == "" {
 		return "", "", fmt.Errorf("not authenticated. Run 'astro login' to authenticate")
 	}
 
@@ -474,7 +475,7 @@ func resolveDeploymentAirflowURL(opts *AirflowOptions) (baseURL, authToken strin
 	}
 
 	// Create platform client
-	platformCoreClient := platformclient.NewPlatformCoreClient(httputil.NewHTTPClient(), opts.tokenHolder)
+	platformCoreClient := platformclient.NewPlatformCoreClient(httputil.NewHTTPClient(), opts.creds)
 
 	// Fetch deployment
 	dep, err := deployment.CoreGetDeployment(orgID, opts.DeploymentID, platformCoreClient)
@@ -493,7 +494,7 @@ func resolveDeploymentAirflowURL(opts *AirflowOptions) (baseURL, authToken strin
 		airflowURL = "https://" + airflowURL
 	}
 
-	return airflowURL, opts.tokenHolder.Get(), nil
+	return airflowURL, opts.creds.Get(), nil
 }
 
 // runAirflowInteractive runs the airflow API command in interactive mode.

--- a/cmd/api/airflow.go
+++ b/cmd/api/airflow.go
@@ -18,6 +18,7 @@ import (
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/openapi"
 )
@@ -43,12 +44,13 @@ type AirflowOptions struct {
 	// Internal
 	detectedVersion     string // The Airflow version being used (detected or overridden)
 	CredentialsExplicit bool   // true when --username or --password was explicitly passed
+	creds               *credentials.CurrentCredentials
 }
 
 // NewAirflowCmd creates the 'astro api airflow' command.
 //
 //nolint:dupl
-func NewAirflowCmd(out io.Writer) *cobra.Command {
+func NewAirflowCmd(out io.Writer, creds *credentials.CurrentCredentials) *cobra.Command {
 	opts := &AirflowOptions{
 		RequestOptions: RequestOptions{
 			Out:             out,
@@ -56,6 +58,7 @@ func NewAirflowCmd(out io.Writer) *cobra.Command {
 			TotalCountField: "total_entries",
 			// specCache is initialized lazily when we know the Airflow version
 		},
+		creds: creds,
 	}
 
 	cmd := &cobra.Command{
@@ -460,7 +463,7 @@ func resolveDeploymentAirflowURL(opts *AirflowOptions) (baseURL, authToken strin
 	}
 
 	// Check for token
-	if ctx.Token == "" {
+	if opts.creds == nil || opts.creds.Get() == "" {
 		return "", "", fmt.Errorf("not authenticated. Run 'astro login' to authenticate")
 	}
 
@@ -474,7 +477,7 @@ func resolveDeploymentAirflowURL(opts *AirflowOptions) (baseURL, authToken strin
 	}
 
 	// Create platform client
-	astroV1Client := astrov1.NewV1Client(httputil.NewHTTPClient())
+	astroV1Client := astrov1.NewV1Client(httputil.NewHTTPClient(), opts.creds)
 
 	// Fetch deployment
 	dep, err := deployment.GetDeploymentByID(orgID, opts.DeploymentID, astroV1Client)
@@ -493,7 +496,7 @@ func resolveDeploymentAirflowURL(opts *AirflowOptions) (baseURL, authToken strin
 		airflowURL = "https://" + airflowURL
 	}
 
-	return airflowURL, ctx.Token, nil
+	return airflowURL, opts.creds.Get(), nil
 }
 
 // runAirflowInteractive runs the airflow API command in interactive mode.

--- a/cmd/api/airflow_test.go
+++ b/cmd/api/airflow_test.go
@@ -14,13 +14,14 @@ import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/openapi"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
 func TestNewAirflowCmd(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewAirflowCmd(out)
+	cmd := NewAirflowCmd(out, nil)
 
 	assert.Equal(t, "airflow <endpoint | operation-id>", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
@@ -39,7 +40,7 @@ func TestNewAirflowCmd(t *testing.T) {
 
 func TestAirflowCmdFlags(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewAirflowCmd(out)
+	cmd := NewAirflowCmd(out, nil)
 
 	// Check airflow-specific flags exist (these are persistent flags so they're inherited by subcommands)
 	assert.NotNil(t, cmd.PersistentFlags().Lookup("api-url"))
@@ -128,7 +129,7 @@ func TestResolveAirflowAPIURL_DeploymentID_NoToken(t *testing.T) {
 	// Set up context without token
 	ctx, err := config.GetCurrentContext()
 	require.NoError(t, err)
-	ctx.Token = ""
+
 	err = ctx.SetContext()
 	require.NoError(t, err)
 
@@ -149,7 +150,7 @@ func TestResolveAirflowAPIURL_DeploymentID_Success(t *testing.T) {
 	// Set up context with token and organization
 	ctx, err := config.GetCurrentContext()
 	require.NoError(t, err)
-	ctx.Token = "test-token"
+
 	ctx.Organization = "test-org"
 	err = ctx.SetContext()
 	require.NoError(t, err)
@@ -168,8 +169,10 @@ func TestResolveAirflowAPIURL_DeploymentID_Success(t *testing.T) {
 		}, nil
 	}
 
+	th := httputil.NewTokenHolder("test-token")
 	opts := &AirflowOptions{
 		DeploymentID: "test-deployment-id",
+		tokenHolder:  th,
 	}
 
 	baseURL, authToken, err := resolveAirflowAPIURL(opts)
@@ -186,7 +189,7 @@ func TestResolveAirflowAPIURL_DeploymentID_WithOrgOverride(t *testing.T) {
 	// Set up context with token but different organization
 	ctx, err := config.GetCurrentContext()
 	require.NoError(t, err)
-	ctx.Token = "test-token"
+
 	ctx.Organization = "context-org"
 	err = ctx.SetContext()
 	require.NoError(t, err)
@@ -206,9 +209,11 @@ func TestResolveAirflowAPIURL_DeploymentID_WithOrgOverride(t *testing.T) {
 		}, nil
 	}
 
+	th := httputil.NewTokenHolder("test-token")
 	opts := &AirflowOptions{
 		DeploymentID:   "test-deployment-id",
 		OrganizationID: "override-org",
+		tokenHolder:    th,
 	}
 
 	baseURL, authToken, err := resolveAirflowAPIURL(opts)
@@ -225,7 +230,7 @@ func TestResolveAirflowAPIURL_DeploymentID_NoAirflowURL(t *testing.T) {
 	// Set up context with token and organization
 	ctx, err := config.GetCurrentContext()
 	require.NoError(t, err)
-	ctx.Token = "test-token"
+
 	ctx.Organization = "test-org"
 	err = ctx.SetContext()
 	require.NoError(t, err)
@@ -241,8 +246,10 @@ func TestResolveAirflowAPIURL_DeploymentID_NoAirflowURL(t *testing.T) {
 		}, nil
 	}
 
+	th := httputil.NewTokenHolder("test-token")
 	opts := &AirflowOptions{
 		DeploymentID: "test-deployment-id",
+		tokenHolder:  th,
 	}
 
 	_, _, err = resolveAirflowAPIURL(opts)

--- a/cmd/api/airflow_test.go
+++ b/cmd/api/airflow_test.go
@@ -14,7 +14,7 @@ import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/config"
-	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/openapi"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -169,10 +169,10 @@ func TestResolveAirflowAPIURL_DeploymentID_Success(t *testing.T) {
 		}, nil
 	}
 
-	th := httputil.NewTokenHolder("test-token")
+	creds := credentials.New("test-token")
 	opts := &AirflowOptions{
 		DeploymentID: "test-deployment-id",
-		tokenHolder:  th,
+		creds:        creds,
 	}
 
 	baseURL, authToken, err := resolveAirflowAPIURL(opts)
@@ -209,11 +209,11 @@ func TestResolveAirflowAPIURL_DeploymentID_WithOrgOverride(t *testing.T) {
 		}, nil
 	}
 
-	th := httputil.NewTokenHolder("test-token")
+	creds := credentials.New("test-token")
 	opts := &AirflowOptions{
 		DeploymentID:   "test-deployment-id",
 		OrganizationID: "override-org",
-		tokenHolder:    th,
+		creds:          creds,
 	}
 
 	baseURL, authToken, err := resolveAirflowAPIURL(opts)
@@ -246,10 +246,10 @@ func TestResolveAirflowAPIURL_DeploymentID_NoAirflowURL(t *testing.T) {
 		}, nil
 	}
 
-	th := httputil.NewTokenHolder("test-token")
+	creds := credentials.New("test-token")
 	opts := &AirflowOptions{
 		DeploymentID: "test-deployment-id",
-		tokenHolder:  th,
+		creds:        creds,
 	}
 
 	_, _, err = resolveAirflowAPIURL(opts)

--- a/cmd/api/airflow_test.go
+++ b/cmd/api/airflow_test.go
@@ -14,13 +14,14 @@ import (
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/openapi"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
 func TestNewAirflowCmd(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewAirflowCmd(out)
+	cmd := NewAirflowCmd(out, nil)
 
 	assert.Equal(t, "airflow <endpoint | operation-id>", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
@@ -39,7 +40,7 @@ func TestNewAirflowCmd(t *testing.T) {
 
 func TestAirflowCmdFlags(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewAirflowCmd(out)
+	cmd := NewAirflowCmd(out, nil)
 
 	// Check airflow-specific flags exist (these are persistent flags so they're inherited by subcommands)
 	assert.NotNil(t, cmd.PersistentFlags().Lookup("api-url"))
@@ -128,7 +129,7 @@ func TestResolveAirflowAPIURL_DeploymentID_NoToken(t *testing.T) {
 	// Set up context without token
 	ctx, err := config.GetCurrentContext()
 	require.NoError(t, err)
-	ctx.Token = ""
+
 	err = ctx.SetContext()
 	require.NoError(t, err)
 
@@ -149,7 +150,7 @@ func TestResolveAirflowAPIURL_DeploymentID_Success(t *testing.T) {
 	// Set up context with token and organization
 	ctx, err := config.GetCurrentContext()
 	require.NoError(t, err)
-	ctx.Token = "test-token"
+
 	ctx.Organization = "test-org"
 	err = ctx.SetContext()
 	require.NoError(t, err)
@@ -168,8 +169,10 @@ func TestResolveAirflowAPIURL_DeploymentID_Success(t *testing.T) {
 		}, nil
 	}
 
+	creds := credentials.New("test-token")
 	opts := &AirflowOptions{
 		DeploymentID: "test-deployment-id",
+		creds:        creds,
 	}
 
 	baseURL, authToken, err := resolveAirflowAPIURL(opts)
@@ -186,7 +189,7 @@ func TestResolveAirflowAPIURL_DeploymentID_WithOrgOverride(t *testing.T) {
 	// Set up context with token but different organization
 	ctx, err := config.GetCurrentContext()
 	require.NoError(t, err)
-	ctx.Token = "test-token"
+
 	ctx.Organization = "context-org"
 	err = ctx.SetContext()
 	require.NoError(t, err)
@@ -206,9 +209,11 @@ func TestResolveAirflowAPIURL_DeploymentID_WithOrgOverride(t *testing.T) {
 		}, nil
 	}
 
+	creds := credentials.New("test-token")
 	opts := &AirflowOptions{
 		DeploymentID:   "test-deployment-id",
 		OrganizationID: "override-org",
+		creds:          creds,
 	}
 
 	baseURL, authToken, err := resolveAirflowAPIURL(opts)
@@ -225,7 +230,7 @@ func TestResolveAirflowAPIURL_DeploymentID_NoAirflowURL(t *testing.T) {
 	// Set up context with token and organization
 	ctx, err := config.GetCurrentContext()
 	require.NoError(t, err)
-	ctx.Token = "test-token"
+
 	ctx.Organization = "test-org"
 	err = ctx.SetContext()
 	require.NoError(t, err)
@@ -241,8 +246,10 @@ func TestResolveAirflowAPIURL_DeploymentID_NoAirflowURL(t *testing.T) {
 		}, nil
 	}
 
+	creds := credentials.New("test-token")
 	opts := &AirflowOptions{
 		DeploymentID: "test-deployment-id",
+		creds:        creds,
 	}
 
 	_, _, err = resolveAirflowAPIURL(opts)

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -7,15 +7,17 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
+	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
 // NewAPICmd creates the parent 'astro api' command.
-func NewAPICmd() *cobra.Command {
-	return NewAPICmdWithOutput(os.Stdout)
+func NewAPICmd(tokenHolder *httputil.TokenHolder) *cobra.Command {
+	return NewAPICmdWithOutput(os.Stdout, tokenHolder)
 }
 
 // NewAPICmdWithOutput creates the parent 'astro api' command with a custom output writer.
-func NewAPICmdWithOutput(out io.Writer) *cobra.Command {
+func NewAPICmdWithOutput(out io.Writer, tokenHolder *httputil.TokenHolder) *cobra.Command {
 	var noColor bool
 
 	cmd := &cobra.Command{
@@ -68,8 +70,8 @@ Use "astro api [command] --help" for more information about a command.`,
 
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorized output")
 
-	cmd.AddCommand(NewAirflowCmd(out))
-	cmd.AddCommand(NewCloudCmd(out))
+	cmd.AddCommand(NewAirflowCmd(out, tokenHolder))
+	cmd.AddCommand(NewCloudCmd(out, tokenHolder))
 	cmd.AddCommand(NewRegistryCmd(out))
 
 	return cmd

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -7,15 +7,17 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
+	"github.com/astronomer/astro-cli/pkg/credentials"
 )
 
 // NewAPICmd creates the parent 'astro api' command.
-func NewAPICmd() *cobra.Command {
-	return NewAPICmdWithOutput(os.Stdout)
+func NewAPICmd(creds *credentials.CurrentCredentials) *cobra.Command {
+	return NewAPICmdWithOutput(os.Stdout, creds)
 }
 
 // NewAPICmdWithOutput creates the parent 'astro api' command with a custom output writer.
-func NewAPICmdWithOutput(out io.Writer) *cobra.Command {
+func NewAPICmdWithOutput(out io.Writer, creds *credentials.CurrentCredentials) *cobra.Command {
 	var noColor bool
 
 	cmd := &cobra.Command{
@@ -68,8 +70,8 @@ Use "astro api [command] --help" for more information about a command.`,
 
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorized output")
 
-	cmd.AddCommand(NewAirflowCmd(out))
-	cmd.AddCommand(NewCloudCmd(out))
+	cmd.AddCommand(NewAirflowCmd(out, creds))
+	cmd.AddCommand(NewCloudCmd(out, creds))
 	cmd.AddCommand(NewRegistryCmd(out))
 
 	return cmd

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -8,16 +8,16 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 )
 
 // NewAPICmd creates the parent 'astro api' command.
-func NewAPICmd(tokenHolder *httputil.TokenHolder) *cobra.Command {
-	return NewAPICmdWithOutput(os.Stdout, tokenHolder)
+func NewAPICmd(creds *credentials.CurrentCredentials) *cobra.Command {
+	return NewAPICmdWithOutput(os.Stdout, creds)
 }
 
 // NewAPICmdWithOutput creates the parent 'astro api' command with a custom output writer.
-func NewAPICmdWithOutput(out io.Writer, tokenHolder *httputil.TokenHolder) *cobra.Command {
+func NewAPICmdWithOutput(out io.Writer, creds *credentials.CurrentCredentials) *cobra.Command {
 	var noColor bool
 
 	cmd := &cobra.Command{
@@ -70,8 +70,8 @@ Use "astro api [command] --help" for more information about a command.`,
 
 	cmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colorized output")
 
-	cmd.AddCommand(NewAirflowCmd(out, tokenHolder))
-	cmd.AddCommand(NewCloudCmd(out, tokenHolder))
+	cmd.AddCommand(NewAirflowCmd(out, creds))
+	cmd.AddCommand(NewCloudCmd(out, creds))
 	cmd.AddCommand(NewRegistryCmd(out))
 
 	return cmd

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -17,7 +17,7 @@ func newRootWithAPI(rootHook func(cmd *cobra.Command, args []string) error) *cob
 		Use:               "astro",
 		PersistentPreRunE: rootHook,
 	}
-	apiCmd := NewAPICmdWithOutput(new(bytes.Buffer))
+	apiCmd := NewAPICmdWithOutput(new(bytes.Buffer), nil)
 	root.AddCommand(apiCmd)
 	return apiCmd
 }
@@ -53,7 +53,7 @@ func TestPersistentPreRunE_RootHookErrorPropagates(t *testing.T) {
 func TestPersistentPreRunE_NoRootHook(t *testing.T) {
 	// Root has no PersistentPreRunE -- should not panic or error.
 	root := &cobra.Command{Use: "astro"}
-	apiCmd := NewAPICmdWithOutput(new(bytes.Buffer))
+	apiCmd := NewAPICmdWithOutput(new(bytes.Buffer), nil)
 	root.AddCommand(apiCmd)
 
 	child := &cobra.Command{Use: "child"}
@@ -77,7 +77,7 @@ func TestPersistentPreRunE_SilenceUsagePropagated(t *testing.T) {
 }
 
 func TestNewAPICmdWithOutput_SubcommandRegistration(t *testing.T) {
-	apiCmd := NewAPICmdWithOutput(new(bytes.Buffer))
+	apiCmd := NewAPICmdWithOutput(new(bytes.Buffer), nil)
 
 	names := make([]string, 0, len(apiCmd.Commands()))
 	for _, sub := range apiCmd.Commands() {
@@ -88,6 +88,6 @@ func TestNewAPICmdWithOutput_SubcommandRegistration(t *testing.T) {
 }
 
 func TestNewAPICmdWithOutput_Flags(t *testing.T) {
-	apiCmd := NewAPICmdWithOutput(new(bytes.Buffer))
+	apiCmd := NewAPICmdWithOutput(new(bytes.Buffer), nil)
 	assert.NotNil(t, apiCmd.PersistentFlags().Lookup("no-color"))
 }

--- a/cmd/api/cloud.go
+++ b/cmd/api/cloud.go
@@ -14,6 +14,7 @@ import (
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
+	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/openapi"
 )
 
@@ -22,18 +23,19 @@ type CloudOptions struct {
 	RequestOptions
 	SpecURL         string // hidden flag: alternative OpenAPI spec URL
 	SpecTokenEnvVar string // hidden flag: env var name containing auth token for spec fetch
+	tokenHolder     *httputil.TokenHolder
 }
 
 // NewCloudCmd creates the 'astro api cloud' command.
 //
 //nolint:dupl
-func NewCloudCmd(out io.Writer) *cobra.Command {
+func NewCloudCmd(out io.Writer, tokenHolder *httputil.TokenHolder) *cobra.Command {
 	opts := &CloudOptions{
 		RequestOptions: RequestOptions{
 			Out:    out,
 			ErrOut: os.Stderr,
-			// specCache is initialized lazily when the domain is known
 		},
+		tokenHolder: tokenHolder,
 	}
 
 	cmd := &cobra.Command{
@@ -159,7 +161,7 @@ func runCloud(opts *CloudOptions) error {
 	}
 
 	// Check for token
-	if ctx.Token == "" {
+	if opts.tokenHolder == nil || opts.tokenHolder.Get() == "" {
 		return fmt.Errorf("not authenticated. Run 'astro login' to authenticate")
 	}
 
@@ -232,11 +234,11 @@ func runCloud(opts *CloudOptions) error {
 
 	// Generate curl command if requested
 	if opts.GenerateCurl {
-		return generateCurl(opts.Out, method, url, ctx.Token, opts.RequestHeaders, params, opts.RequestInputFile)
+		return generateCurl(opts.Out, method, url, opts.tokenHolder.Get(), opts.RequestHeaders, params, opts.RequestInputFile)
 	}
 
 	// Build and execute the request
-	return executeRequest(&opts.RequestOptions, method, url, ctx.Token, params)
+	return executeRequest(&opts.RequestOptions, method, url, opts.tokenHolder.Get(), params)
 }
 
 // isOperationID checks if the input looks like an operation ID rather than a path.

--- a/cmd/api/cloud.go
+++ b/cmd/api/cloud.go
@@ -13,8 +13,8 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
-	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/openapi"
 )
 
@@ -23,19 +23,19 @@ type CloudOptions struct {
 	RequestOptions
 	SpecURL         string // hidden flag: alternative OpenAPI spec URL
 	SpecTokenEnvVar string // hidden flag: env var name containing auth token for spec fetch
-	tokenHolder     *httputil.TokenHolder
+	creds           *credentials.CurrentCredentials
 }
 
 // NewCloudCmd creates the 'astro api cloud' command.
 //
 //nolint:dupl
-func NewCloudCmd(out io.Writer, tokenHolder *httputil.TokenHolder) *cobra.Command {
+func NewCloudCmd(out io.Writer, creds *credentials.CurrentCredentials) *cobra.Command {
 	opts := &CloudOptions{
 		RequestOptions: RequestOptions{
 			Out:    out,
 			ErrOut: os.Stderr,
 		},
-		tokenHolder: tokenHolder,
+		creds: creds,
 	}
 
 	cmd := &cobra.Command{
@@ -161,7 +161,7 @@ func runCloud(opts *CloudOptions) error {
 	}
 
 	// Check for token
-	if opts.tokenHolder == nil || opts.tokenHolder.Get() == "" {
+	if opts.creds == nil || opts.creds.Get() == "" {
 		return fmt.Errorf("not authenticated. Run 'astro login' to authenticate")
 	}
 
@@ -234,11 +234,11 @@ func runCloud(opts *CloudOptions) error {
 
 	// Generate curl command if requested
 	if opts.GenerateCurl {
-		return generateCurl(opts.Out, method, url, opts.tokenHolder.Get(), opts.RequestHeaders, params, opts.RequestInputFile)
+		return generateCurl(opts.Out, method, url, opts.creds.Get(), opts.RequestHeaders, params, opts.RequestInputFile)
 	}
 
 	// Build and execute the request
-	return executeRequest(&opts.RequestOptions, method, url, opts.tokenHolder.Get(), params)
+	return executeRequest(&opts.RequestOptions, method, url, opts.creds.Get(), params)
 }
 
 // isOperationID checks if the input looks like an operation ID rather than a path.

--- a/cmd/api/cloud.go
+++ b/cmd/api/cloud.go
@@ -13,6 +13,7 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
 	"github.com/astronomer/astro-cli/pkg/openapi"
 )
@@ -22,12 +23,13 @@ type CloudOptions struct {
 	RequestOptions
 	SpecURL         string // hidden flag: alternative OpenAPI spec URL
 	SpecTokenEnvVar string // hidden flag: env var name containing auth token for spec fetch
+	creds           *credentials.CurrentCredentials
 }
 
 // NewCloudCmd creates the 'astro api cloud' command.
 //
 //nolint:dupl
-func NewCloudCmd(out io.Writer) *cobra.Command {
+func NewCloudCmd(out io.Writer, creds *credentials.CurrentCredentials) *cobra.Command {
 	opts := &CloudOptions{
 		RequestOptions: RequestOptions{
 			Out:             out,
@@ -35,6 +37,7 @@ func NewCloudCmd(out io.Writer) *cobra.Command {
 			TotalCountField: "totalCount",
 			// specCache is initialized lazily when the domain is known
 		},
+		creds: creds,
 	}
 
 	cmd := &cobra.Command{
@@ -160,7 +163,7 @@ func runCloud(opts *CloudOptions) error {
 	}
 
 	// Check for token
-	if ctx.Token == "" {
+	if opts.creds == nil || opts.creds.Get() == "" {
 		return fmt.Errorf("not authenticated. Run 'astro login' to authenticate")
 	}
 
@@ -233,11 +236,11 @@ func runCloud(opts *CloudOptions) error {
 
 	// Generate curl command if requested
 	if opts.GenerateCurl {
-		return generateCurl(opts.Out, method, url, ctx.Token, opts.RequestHeaders, params, opts.RequestInputFile)
+		return generateCurl(opts.Out, method, url, opts.creds.Get(), opts.RequestHeaders, params, opts.RequestInputFile)
 	}
 
 	// Build and execute the request
-	return executeRequest(&opts.RequestOptions, method, url, ctx.Token, params)
+	return executeRequest(&opts.RequestOptions, method, url, opts.creds.Get(), params)
 }
 
 // isOperationID checks if the input looks like an operation ID rather than a path.

--- a/cmd/api/cloud_test.go
+++ b/cmd/api/cloud_test.go
@@ -36,7 +36,7 @@ contexts:
 
 func TestNewCloudCmd(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 
 	assert.Equal(t, "cloud <endpoint | operation-id>", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
@@ -55,7 +55,7 @@ func TestNewCloudCmd(t *testing.T) {
 
 func TestCloudCmdFlags(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 
 	// Request flags
 	assert.NotNil(t, cmd.Flags().Lookup("method"))
@@ -345,7 +345,7 @@ func TestPlaceholderRE(t *testing.T) {
 
 func TestCloudCmd_NoArgs_ShowsHelp(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 	// Verify Args validator
 	err := cmd.Args(cmd, nil)
 	assert.NoError(t, err) // MaximumNArgs(1) allows 0
@@ -359,7 +359,7 @@ func TestCloudCmd_NoArgs_ShowsHelp(t *testing.T) {
 
 func TestCloudCmdLongDescription(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 	assert.Contains(t, cmd.Long, "Astro Cloud API")
 	assert.Contains(t, cmd.Example, "astro api cloud")
 }
@@ -368,7 +368,7 @@ func TestCloudCmdLongDescription(t *testing.T) {
 
 func TestCloudSpecURLFlag(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 
 	flag := cmd.PersistentFlags().Lookup("spec-url")
 	require.NotNil(t, flag, "--spec-url flag should exist")
@@ -383,7 +383,6 @@ func TestInitCloudSpecCache_SpecURL(t *testing.T) {
 	opts := &CloudOptions{SpecURL: "https://example.com/spec.json"}
 	ctx := &config.Context{
 		Domain: "example.com",
-		Token:  "my-secret-token",
 	}
 
 	err := initCloudSpecCache(opts, ctx)
@@ -421,7 +420,6 @@ func TestRunCloud_SpecURL_BaseURL(t *testing.T) {
 
 	ctx := &config.Context{
 		Domain:       "example.com",
-		Token:        "test-token",
 		Organization: "org-123",
 	}
 
@@ -442,7 +440,7 @@ func TestRunCloud_SpecURL_BaseURL(t *testing.T) {
 
 func TestCloudSpecTokenEnvVarFlag(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 
 	flag := cmd.PersistentFlags().Lookup("spec-token-env-var")
 	require.NotNil(t, flag, "--spec-token-env-var flag should exist")
@@ -460,7 +458,6 @@ func TestInitCloudSpecCache_SpecTokenEnvVar(t *testing.T) {
 	}
 	ctx := &config.Context{
 		Domain: "example.com",
-		Token:  "context-token",
 	}
 
 	err := initCloudSpecCache(opts, ctx)

--- a/cmd/api/cloud_test.go
+++ b/cmd/api/cloud_test.go
@@ -38,7 +38,7 @@ contexts:
 
 func TestNewCloudCmd(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 
 	assert.Equal(t, "cloud <endpoint | operation-id>", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
@@ -57,7 +57,7 @@ func TestNewCloudCmd(t *testing.T) {
 
 func TestCloudCmdFlags(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 
 	// Request flags
 	assert.NotNil(t, cmd.Flags().Lookup("method"))
@@ -347,7 +347,7 @@ func TestPlaceholderRE(t *testing.T) {
 
 func TestCloudCmd_NoArgs_ShowsHelp(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 	// Verify Args validator
 	err := cmd.Args(cmd, nil)
 	assert.NoError(t, err) // MaximumNArgs(1) allows 0
@@ -361,7 +361,7 @@ func TestCloudCmd_NoArgs_ShowsHelp(t *testing.T) {
 
 func TestCloudCmdLongDescription(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 	assert.Contains(t, cmd.Long, "Astro Cloud API")
 	assert.Contains(t, cmd.Example, "astro api cloud")
 }
@@ -370,7 +370,7 @@ func TestCloudCmdLongDescription(t *testing.T) {
 
 func TestCloudSpecURLFlag(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 
 	flag := cmd.PersistentFlags().Lookup("spec-url")
 	require.NotNil(t, flag, "--spec-url flag should exist")
@@ -385,7 +385,6 @@ func TestInitCloudSpecCache_SpecURL(t *testing.T) {
 	opts := &CloudOptions{SpecURL: "https://example.com/spec.json"}
 	ctx := &config.Context{
 		Domain: "example.com",
-		Token:  "my-secret-token",
 	}
 
 	err := initCloudSpecCache(opts, ctx)
@@ -423,7 +422,6 @@ func TestRunCloud_SpecURL_BaseURL(t *testing.T) {
 
 	ctx := &config.Context{
 		Domain:       "example.com",
-		Token:        "test-token",
 		Organization: "org-123",
 	}
 
@@ -444,7 +442,7 @@ func TestRunCloud_SpecURL_BaseURL(t *testing.T) {
 
 func TestCloudSpecTokenEnvVarFlag(t *testing.T) {
 	out := new(bytes.Buffer)
-	cmd := NewCloudCmd(out)
+	cmd := NewCloudCmd(out, nil)
 
 	flag := cmd.PersistentFlags().Lookup("spec-token-env-var")
 	require.NotNil(t, flag, "--spec-token-env-var flag should exist")
@@ -462,7 +460,6 @@ func TestInitCloudSpecCache_SpecTokenEnvVar(t *testing.T) {
 	}
 	ctx := &config.Context{
 		Domain: "example.com",
-		Token:  "context-token",
 	}
 
 	err := initCloudSpecCache(opts, ctx)
@@ -526,7 +523,7 @@ func TestInitCloudSpecCache_LocalFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(tmpFile, specJSON, 0o600))
 
 	opts := &CloudOptions{SpecURL: tmpFile}
-	ctx := &config.Context{Domain: "example.com", Token: "tok"}
+	ctx := &config.Context{Domain: "example.com"}
 
 	err := initCloudSpecCache(opts, ctx)
 	require.NoError(t, err)
@@ -546,7 +543,7 @@ func TestInitCloudSpecCache_LocalFile_FileURL(t *testing.T) {
 	require.NoError(t, os.WriteFile(tmpFile, specJSON, 0o600))
 
 	opts := &CloudOptions{SpecURL: "file://" + tmpFile}
-	ctx := &config.Context{Domain: "example.com", Token: "tok"}
+	ctx := &config.Context{Domain: "example.com"}
 
 	err := initCloudSpecCache(opts, ctx)
 	require.NoError(t, err)

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -55,7 +55,7 @@ func login(cmd *cobra.Command, args []string, store keychain.SecureStore, creds 
 			if context.IsCloudDomain(ctx.Domain) {
 				fmt.Fprintf(out, "To login to Astro Private Cloud follow the instructions below. If you are attempting to login in to Astro cancel the login and run 'astro login'.\n\n")
 			}
-			return softwareLogin(args[0], oAuth, "", "", houstonVersion, store, houstonClient, out)
+			return softwareLogin(args[0], oAuth, "", "", houstonVersion, store, creds, houstonClient, out)
 		}
 		return cloudLogin(args[0], token, store, creds, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
 	}
@@ -67,7 +67,7 @@ func login(cmd *cobra.Command, args []string, store keychain.SecureStore, creds 
 	} else if context.IsCloudDomain(ctx.Domain) {
 		return cloudLogin(ctx.Domain, token, store, creds, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
 	}
-	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, store, houstonClient, out)
+	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, store, creds, houstonClient, out)
 }
 
 func logout(cmd *cobra.Command, args []string, store keychain.SecureStore, out io.Writer) error {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -12,8 +12,8 @@ import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	cloudAuth "github.com/astronomer/astro-cli/cloud/auth"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
-	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	softwareAuth "github.com/astronomer/astro-cli/software/auth"
 )
@@ -30,8 +30,8 @@ var (
 )
 
 // newLoginCommand is a top-level alias for "astro auth login" kept for backward compatibility.
-func newLoginCommand(store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
-	cmd := newAuthLoginCommand(store, tokenHolder, coreClient, platformCoreClient, out)
+func newLoginCommand(store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
+	cmd := newAuthLoginCommand(store, creds, coreClient, platformCoreClient, out)
 	cmd.Long = "Authenticate to Astro or Astro Private Cloud. This is an alias for 'astro auth login'."
 	return cmd
 }
@@ -43,7 +43,7 @@ func newLogoutCommand(store keychain.SecureStore, out io.Writer) *cobra.Command 
 	return cmd
 }
 
-func login(cmd *cobra.Command, args []string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
+func login(cmd *cobra.Command, args []string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
@@ -57,15 +57,15 @@ func login(cmd *cobra.Command, args []string, store keychain.SecureStore, tokenH
 			}
 			return softwareLogin(args[0], oAuth, "", "", houstonVersion, store, houstonClient, out)
 		}
-		return cloudLogin(args[0], token, store, tokenHolder, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
+		return cloudLogin(args[0], token, store, creds, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
 	}
 	// Log back into the current context in case no domain is passed
 	ctx, err := context.GetCurrentContext()
 	if err != nil || ctx.Domain == "" {
 		// Default case when no domain is passed, and error getting current context
-		return cloudLogin(domainutil.DefaultDomain, token, store, tokenHolder, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
+		return cloudLogin(domainutil.DefaultDomain, token, store, creds, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
 	} else if context.IsCloudDomain(ctx.Domain) {
-		return cloudLogin(ctx.Domain, token, store, tokenHolder, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
+		return cloudLogin(ctx.Domain, token, store, creds, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
 	}
 	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, store, houstonClient, out)
 }
@@ -93,28 +93,28 @@ func logout(cmd *cobra.Command, args []string, store keychain.SecureStore, out i
 	return nil
 }
 
-func newAuthRootCmd(store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
+func newAuthRootCmd(store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage authentication to Astronomer",
 		Long:  "Commands for authenticating to Astro or Astro Private Cloud",
 	}
 	cmd.AddCommand(
-		newAuthLoginCommand(store, tokenHolder, coreClient, platformCoreClient, out),
+		newAuthLoginCommand(store, creds, coreClient, platformCoreClient, out),
 		newAuthLogoutCommand(store, out),
 		newAuthTokenCommand(store, out),
 	)
 	return cmd
 }
 
-func newAuthLoginCommand(store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
+func newAuthLoginCommand(store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login [BASEDOMAIN]",
 		Short: "Log in to Astronomer",
 		Long:  "Authenticate to Astro or Astro Private Cloud",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return login(cmd, args, store, tokenHolder, coreClient, platformCoreClient, out)
+			return login(cmd, args, store, creds, coreClient, platformCoreClient, out)
 		},
 	}
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -10,9 +11,10 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	cloudAuth "github.com/astronomer/astro-cli/cloud/auth"
-	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
+	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	softwareAuth "github.com/astronomer/astro-cli/software/auth"
 )
 
@@ -28,20 +30,20 @@ var (
 )
 
 // newLoginCommand is a top-level alias for "astro auth login" kept for backward compatibility.
-func newLoginCommand(coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
-	cmd := newAuthLoginCommand(coreClient, platformCoreClient, out)
+func newLoginCommand(store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
+	cmd := newAuthLoginCommand(store, tokenHolder, coreClient, platformCoreClient, out)
 	cmd.Long = "Authenticate to Astro or Astro Private Cloud. This is an alias for 'astro auth login'."
 	return cmd
 }
 
 // newLogoutCommand is a top-level alias for "astro auth logout" kept for backward compatibility.
-func newLogoutCommand(out io.Writer) *cobra.Command {
-	cmd := newAuthLogoutCommand(out)
+func newLogoutCommand(store keychain.SecureStore, out io.Writer) *cobra.Command {
+	cmd := newAuthLogoutCommand(store, out)
 	cmd.Long = "Log out of Astronomer. This is an alias for 'astro auth logout'."
 	return cmd
 }
 
-func login(cmd *cobra.Command, args []string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
+func login(cmd *cobra.Command, args []string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
@@ -53,22 +55,22 @@ func login(cmd *cobra.Command, args []string, coreClient astrocore.CoreClient, p
 			if context.IsCloudDomain(ctx.Domain) {
 				fmt.Fprintf(out, "To login to Astro Private Cloud follow the instructions below. If you are attempting to login in to Astro cancel the login and run 'astro login'.\n\n")
 			}
-			return softwareLogin(args[0], oAuth, "", "", houstonVersion, houstonClient, out)
+			return softwareLogin(args[0], oAuth, "", "", houstonVersion, store, houstonClient, out)
 		}
-		return cloudLogin(args[0], token, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
+		return cloudLogin(args[0], token, store, tokenHolder, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
 	}
 	// Log back into the current context in case no domain is passed
 	ctx, err := context.GetCurrentContext()
 	if err != nil || ctx.Domain == "" {
 		// Default case when no domain is passed, and error getting current context
-		return cloudLogin(domainutil.DefaultDomain, token, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
+		return cloudLogin(domainutil.DefaultDomain, token, store, tokenHolder, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
 	} else if context.IsCloudDomain(ctx.Domain) {
-		return cloudLogin(ctx.Domain, token, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
+		return cloudLogin(ctx.Domain, token, store, tokenHolder, coreClient, platformCoreClient, out, shouldDisplayLoginLink)
 	}
-	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, houstonClient, out)
+	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, store, houstonClient, out)
 }
 
-func logout(cmd *cobra.Command, args []string, out io.Writer) error {
+func logout(cmd *cobra.Command, args []string, store keychain.SecureStore, out io.Writer) error {
 	var domain string
 	if len(args) == 1 {
 		domain = args[0]
@@ -84,35 +86,35 @@ func logout(cmd *cobra.Command, args []string, out io.Writer) error {
 	cmd.SilenceUsage = true
 
 	if context.IsCloudDomain(domain) {
-		cloudLogout(domain, out)
+		cloudLogout(domain, store, out)
 	} else {
-		softwareLogout(domain)
+		softwareLogout(domain, store)
 	}
 	return nil
 }
 
-func newAuthRootCmd(coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
+func newAuthRootCmd(store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage authentication to Astronomer",
 		Long:  "Commands for authenticating to Astro or Astro Private Cloud",
 	}
 	cmd.AddCommand(
-		newAuthLoginCommand(coreClient, platformCoreClient, out),
-		newAuthLogoutCommand(out),
-		newAuthTokenCommand(out),
+		newAuthLoginCommand(store, tokenHolder, coreClient, platformCoreClient, out),
+		newAuthLogoutCommand(store, out),
+		newAuthTokenCommand(store, out),
 	)
 	return cmd
 }
 
-func newAuthLoginCommand(coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
+func newAuthLoginCommand(store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login [BASEDOMAIN]",
 		Short: "Log in to Astronomer",
 		Long:  "Authenticate to Astro or Astro Private Cloud",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return login(cmd, args, coreClient, platformCoreClient, out)
+			return login(cmd, args, store, tokenHolder, coreClient, platformCoreClient, out)
 		},
 	}
 
@@ -122,20 +124,20 @@ func newAuthLoginCommand(coreClient astrocore.CoreClient, platformCoreClient ast
 	return cmd
 }
 
-func newAuthLogoutCommand(out io.Writer) *cobra.Command {
+func newAuthLogoutCommand(store keychain.SecureStore, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Log out of Astronomer",
 		Long:  "Log out of Astronomer",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return logout(cmd, args, out)
+			return logout(cmd, args, store, out)
 		},
 		Args: cobra.MaximumNArgs(1),
 	}
 	return cmd
 }
 
-func newAuthTokenCommand(out io.Writer) *cobra.Command {
+func newAuthTokenCommand(store keychain.SecureStore, out io.Writer) *cobra.Command {
 	var tokenDomain string
 	cmd := &cobra.Command{
 		Use:   "token",
@@ -143,33 +145,43 @@ func newAuthTokenCommand(out io.Writer) *cobra.Command {
 		Long:  "Print the current authentication token to standard output. This is useful for using the token in scripts or CI/CD pipelines.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return printAuthToken(cmd, tokenDomain, out)
+			return printAuthToken(cmd, store, tokenDomain, out)
 		},
 	}
 	cmd.Flags().StringVarP(&tokenDomain, "domain", "d", "", "Print the token for a specific context domain instead of the current context")
 	return cmd
 }
 
-func printAuthToken(cmd *cobra.Command, contextDomain string, out io.Writer) error {
+func printAuthToken(cmd *cobra.Command, store keychain.SecureStore, contextDomain string, out io.Writer) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	var c config.Context
-	var err error
+	var domain string
 	if contextDomain != "" {
-		c, err = context.GetContext(contextDomain)
+		domain = contextDomain
 	} else {
-		c, err = context.GetCurrentContext()
-	}
-	if err != nil {
-		return err
+		c, err := context.GetCurrentContext()
+		if err != nil {
+			return err
+		}
+		domain = c.Domain
 	}
 
-	if c.Token == "" {
+	if store == nil {
+		return fmt.Errorf("no token found. Please run 'astro login' to authenticate")
+	}
+	creds, err := store.GetCredentials(domain)
+	if err != nil {
+		if errors.Is(err, keychain.ErrNotFound) {
+			return fmt.Errorf("no token found. Please run 'astro login' to authenticate")
+		}
+		return fmt.Errorf("reading credentials: %w", err)
+	}
+	if creds.Token == "" {
 		return fmt.Errorf("no token found. Please run 'astro login' to authenticate")
 	}
 
-	rawToken := strings.TrimPrefix(c.Token, "Bearer ")
+	rawToken := strings.TrimPrefix(creds.Token, "Bearer ")
 	fmt.Fprintln(out, rawToken)
 	return nil
 }

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -54,7 +54,7 @@ func login(cmd *cobra.Command, args []string, store keychain.SecureStore, creds 
 			if context.IsCloudDomain(ctx.Domain) {
 				fmt.Fprintf(out, "To login to Astro Private Cloud follow the instructions below. If you are attempting to login in to Astro cancel the login and run 'astro login'.\n\n")
 			}
-			return softwareLogin(args[0], oAuth, "", "", houstonVersion, store, houstonClient, out)
+			return softwareLogin(args[0], oAuth, "", "", houstonVersion, store, creds, houstonClient, out)
 		}
 		return cloudLogin(args[0], token, store, creds, astroV1Client, out, shouldDisplayLoginLink)
 	}
@@ -66,7 +66,7 @@ func login(cmd *cobra.Command, args []string, store keychain.SecureStore, creds 
 	} else if context.IsCloudDomain(ctx.Domain) {
 		return cloudLogin(ctx.Domain, token, store, creds, astroV1Client, out, shouldDisplayLoginLink)
 	}
-	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, store, houstonClient, out)
+	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, store, creds, houstonClient, out)
 }
 
 func logout(cmd *cobra.Command, args []string, store keychain.SecureStore, out io.Writer) error {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -9,9 +10,10 @@ import (
 
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	cloudAuth "github.com/astronomer/astro-cli/cloud/auth"
-	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/domainutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	softwareAuth "github.com/astronomer/astro-cli/software/auth"
 )
 
@@ -27,20 +29,20 @@ var (
 )
 
 // newLoginCommand is a top-level alias for "astro auth login" kept for backward compatibility.
-func newLoginCommand(astroV1Client astrov1.APIClient, out io.Writer) *cobra.Command {
-	cmd := newAuthLoginCommand(astroV1Client, out)
+func newLoginCommand(store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer) *cobra.Command {
+	cmd := newAuthLoginCommand(store, creds, astroV1Client, out)
 	cmd.Long = "Authenticate to Astro or Astro Private Cloud. This is an alias for 'astro auth login'."
 	return cmd
 }
 
 // newLogoutCommand is a top-level alias for "astro auth logout" kept for backward compatibility.
-func newLogoutCommand(out io.Writer) *cobra.Command {
-	cmd := newAuthLogoutCommand(out)
+func newLogoutCommand(store keychain.SecureStore, out io.Writer) *cobra.Command {
+	cmd := newAuthLogoutCommand(store, out)
 	cmd.Long = "Log out of Astronomer. This is an alias for 'astro auth logout'."
 	return cmd
 }
 
-func login(cmd *cobra.Command, args []string, astroV1Client astrov1.APIClient, out io.Writer) error {
+func login(cmd *cobra.Command, args []string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
@@ -52,22 +54,22 @@ func login(cmd *cobra.Command, args []string, astroV1Client astrov1.APIClient, o
 			if context.IsCloudDomain(ctx.Domain) {
 				fmt.Fprintf(out, "To login to Astro Private Cloud follow the instructions below. If you are attempting to login in to Astro cancel the login and run 'astro login'.\n\n")
 			}
-			return softwareLogin(args[0], oAuth, "", "", houstonVersion, houstonClient, out)
+			return softwareLogin(args[0], oAuth, "", "", houstonVersion, store, houstonClient, out)
 		}
-		return cloudLogin(args[0], token, astroV1Client, out, shouldDisplayLoginLink)
+		return cloudLogin(args[0], token, store, creds, astroV1Client, out, shouldDisplayLoginLink)
 	}
 	// Log back into the current context in case no domain is passed
 	ctx, err := context.GetCurrentContext()
 	if err != nil || ctx.Domain == "" {
 		// Default case when no domain is passed, and error getting current context
-		return cloudLogin(domainutil.DefaultDomain, token, astroV1Client, out, shouldDisplayLoginLink)
+		return cloudLogin(domainutil.DefaultDomain, token, store, creds, astroV1Client, out, shouldDisplayLoginLink)
 	} else if context.IsCloudDomain(ctx.Domain) {
-		return cloudLogin(ctx.Domain, token, astroV1Client, out, shouldDisplayLoginLink)
+		return cloudLogin(ctx.Domain, token, store, creds, astroV1Client, out, shouldDisplayLoginLink)
 	}
-	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, houstonClient, out)
+	return softwareLogin(ctx.Domain, oAuth, "", "", houstonVersion, store, houstonClient, out)
 }
 
-func logout(cmd *cobra.Command, args []string, out io.Writer) error {
+func logout(cmd *cobra.Command, args []string, store keychain.SecureStore, out io.Writer) error {
 	var domain string
 	if len(args) == 1 {
 		domain = args[0]
@@ -83,35 +85,35 @@ func logout(cmd *cobra.Command, args []string, out io.Writer) error {
 	cmd.SilenceUsage = true
 
 	if context.IsCloudDomain(domain) {
-		cloudLogout(domain, out)
+		cloudLogout(domain, store, out)
 	} else {
-		softwareLogout(domain)
+		softwareLogout(domain, store)
 	}
 	return nil
 }
 
-func newAuthRootCmd(astroV1Client astrov1.APIClient, out io.Writer) *cobra.Command {
+func newAuthRootCmd(store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage authentication to Astronomer",
 		Long:  "Commands for authenticating to Astro or Astro Private Cloud",
 	}
 	cmd.AddCommand(
-		newAuthLoginCommand(astroV1Client, out),
-		newAuthLogoutCommand(out),
-		newAuthTokenCommand(out),
+		newAuthLoginCommand(store, creds, astroV1Client, out),
+		newAuthLogoutCommand(store, out),
+		newAuthTokenCommand(store, out),
 	)
 	return cmd
 }
 
-func newAuthLoginCommand(astroV1Client astrov1.APIClient, out io.Writer) *cobra.Command {
+func newAuthLoginCommand(store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login [BASEDOMAIN]",
 		Short: "Log in to Astronomer",
 		Long:  "Authenticate to Astro or Astro Private Cloud",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return login(cmd, args, astroV1Client, out)
+			return login(cmd, args, store, creds, astroV1Client, out)
 		},
 	}
 
@@ -121,20 +123,20 @@ func newAuthLoginCommand(astroV1Client astrov1.APIClient, out io.Writer) *cobra.
 	return cmd
 }
 
-func newAuthLogoutCommand(out io.Writer) *cobra.Command {
+func newAuthLogoutCommand(store keychain.SecureStore, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Log out of Astronomer",
 		Long:  "Log out of Astronomer",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return logout(cmd, args, out)
+			return logout(cmd, args, store, out)
 		},
 		Args: cobra.MaximumNArgs(1),
 	}
 	return cmd
 }
 
-func newAuthTokenCommand(out io.Writer) *cobra.Command {
+func newAuthTokenCommand(store keychain.SecureStore, out io.Writer) *cobra.Command {
 	var tokenDomain string
 	cmd := &cobra.Command{
 		Use:   "token",
@@ -142,33 +144,43 @@ func newAuthTokenCommand(out io.Writer) *cobra.Command {
 		Long:  "Print the current authentication token to standard output. This is useful for using the token in scripts or CI/CD pipelines.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return printAuthToken(cmd, tokenDomain, out)
+			return printAuthToken(cmd, store, tokenDomain, out)
 		},
 	}
 	cmd.Flags().StringVarP(&tokenDomain, "domain", "d", "", "Print the token for a specific context domain instead of the current context")
 	return cmd
 }
 
-func printAuthToken(cmd *cobra.Command, contextDomain string, out io.Writer) error {
+func printAuthToken(cmd *cobra.Command, store keychain.SecureStore, contextDomain string, out io.Writer) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	var c config.Context
-	var err error
+	var domain string
 	if contextDomain != "" {
-		c, err = context.GetContext(contextDomain)
+		domain = contextDomain
 	} else {
-		c, err = context.GetCurrentContext()
-	}
-	if err != nil {
-		return err
+		c, err := context.GetCurrentContext()
+		if err != nil {
+			return err
+		}
+		domain = c.Domain
 	}
 
-	if c.Token == "" {
+	if store == nil {
+		return fmt.Errorf("no token found. Please run 'astro login' to authenticate")
+	}
+	creds, err := store.GetCredentials(domain)
+	if err != nil {
+		if errors.Is(err, keychain.ErrNotFound) {
+			return fmt.Errorf("no token found. Please run 'astro login' to authenticate")
+		}
+		return fmt.Errorf("reading credentials: %w", err)
+	}
+	if creds.Token == "" {
 		return fmt.Errorf("no token found. Please run 'astro login' to authenticate")
 	}
 
-	rawToken := strings.TrimPrefix(c.Token, "Bearer ")
+	rawToken := strings.TrimPrefix(creds.Token, "Bearer ")
 	fmt.Fprintln(out, rawToken)
 	return nil
 }

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -11,7 +11,7 @@ import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/houston"
-	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -28,7 +28,7 @@ func (s *CmdSuite) TestLogin() {
 	cloudDomain := "astronomer.io"
 	softwareDomain := "astronomer_dev.com"
 
-	cloudLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+	cloudLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 		s.Equal(cloudDomain, domain)
 		return nil
 	}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -33,7 +33,7 @@ func (s *CmdSuite) TestLogin() {
 		return nil
 	}
 
-	softwareLogin = func(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, client houston.ClientInterface, out io.Writer) error {
+	softwareLogin = func(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, creds *credentials.CurrentCredentials, client houston.ClientInterface, out io.Writer) error {
 		s.Equal(softwareDomain, domain)
 		return nil
 	}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -11,6 +11,8 @@ import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -26,38 +28,38 @@ func (s *CmdSuite) TestLogin() {
 	cloudDomain := "astronomer.io"
 	softwareDomain := "astronomer_dev.com"
 
-	cloudLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+	cloudLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 		s.Equal(cloudDomain, domain)
 		return nil
 	}
 
-	softwareLogin = func(domain string, oAuthOnly bool, username, password, houstonVersion string, client houston.ClientInterface, out io.Writer) error {
+	softwareLogin = func(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, client houston.ClientInterface, out io.Writer) error {
 		s.Equal(softwareDomain, domain)
 		return nil
 	}
 
 	// cloud login success
-	login(&cobra.Command{}, []string{cloudDomain}, nil, nil, buf)
+	login(&cobra.Command{}, []string{cloudDomain}, nil, nil, nil, nil, buf)
 
 	// software login success
 	testUtil.InitTestConfig(testUtil.Initial)
-	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, buf)
+	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, nil, nil, buf)
 
 	// no domain, cloud login
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	login(&cobra.Command{}, []string{}, nil, nil, buf)
+	login(&cobra.Command{}, []string{}, nil, nil, nil, nil, buf)
 
 	// no domain, software login
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-	login(&cobra.Command{}, []string{}, nil, nil, buf)
+	login(&cobra.Command{}, []string{}, nil, nil, nil, nil, buf)
 
 	// no domain, no current context set
 	config.ResetCurrentContext()
-	login(&cobra.Command{}, []string{}, nil, nil, buf)
+	login(&cobra.Command{}, []string{}, nil, nil, nil, nil, buf)
 
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	softwareDomain = "software.astronomer.io"
-	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, buf)
+	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, nil, nil, buf)
 	s.Contains(buf.String(), "To login to Astro Private Cloud follow the instructions below. If you are attempting to login in to Astro cancel the login and run 'astro login'.\n\n")
 }
 
@@ -65,96 +67,96 @@ func (s *CmdSuite) TestLogout() {
 	localDomain := "localhost"
 	softwareDomain := "astronomer_dev.com"
 
-	cloudLogout = func(domain string, out io.Writer) {
+	cloudLogout = func(domain string, store keychain.SecureStore, out io.Writer) {
 		s.Equal(localDomain, domain)
 	}
-	softwareLogout = func(domain string) {
+	softwareLogout = func(domain string, store keychain.SecureStore) {
 		s.Equal(softwareDomain, domain)
 	}
 
 	// cloud logout success
-	err := logout(&cobra.Command{}, []string{localDomain}, os.Stdout)
+	err := logout(&cobra.Command{}, []string{localDomain}, nil, os.Stdout)
 	s.NoError(err)
 
 	// software logout success
-	err = logout(&cobra.Command{}, []string{softwareDomain}, os.Stdout)
+	err = logout(&cobra.Command{}, []string{softwareDomain}, nil, os.Stdout)
 	s.NoError(err)
 
 	// no domain, cloud logout
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	err = logout(&cobra.Command{}, []string{}, os.Stdout)
+	err = logout(&cobra.Command{}, []string{}, nil, os.Stdout)
 	s.NoError(err)
 
 	// no domain, software logout
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-	err = logout(&cobra.Command{}, []string{}, os.Stdout)
+	err = logout(&cobra.Command{}, []string{}, nil, os.Stdout)
 	s.NoError(err)
 
 	// no domain, no current context set
 	config.ResetCurrentContext()
-	err = logout(&cobra.Command{}, []string{}, os.Stdout)
+	err = logout(&cobra.Command{}, []string{}, nil, os.Stdout)
 	s.EqualError(err, "no context set, have you authenticated to Astro or Astro Private Cloud? Run astro login and try again")
 }
 
 func (s *CmdSuite) TestAuthToken() {
 	buf := new(bytes.Buffer)
-
-	// Test with valid token (with Bearer prefix)
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	c, err := config.GetCurrentContext()
 	s.NoError(err)
 	expectedToken := "test-token-12345"
-	err = c.SetContextKey("token", "Bearer "+expectedToken)
-	s.NoError(err)
 
-	err = printAuthToken(&cobra.Command{}, "", buf)
+	store := keychain.NewTestStore()
+
+	// Test with valid token (with Bearer prefix)
+	s.NoError(store.SetCredentials(c.Domain, keychain.Credentials{Token: "Bearer " + expectedToken}))
+	err = printAuthToken(&cobra.Command{}, store, "", buf)
 	s.NoError(err)
 	s.Equal(expectedToken+"\n", buf.String())
 
 	// Test with token without Bearer prefix
 	buf.Reset()
-	err = c.SetContextKey("token", expectedToken)
-	s.NoError(err)
-
-	err = printAuthToken(&cobra.Command{}, "", buf)
+	s.NoError(store.SetCredentials(c.Domain, keychain.Credentials{Token: expectedToken}))
+	err = printAuthToken(&cobra.Command{}, store, "", buf)
 	s.NoError(err)
 	s.Equal(expectedToken+"\n", buf.String())
 
 	// Test with no token (not authenticated)
 	buf.Reset()
-	err = c.SetContextKey("token", "")
-	s.NoError(err)
+	s.NoError(store.SetCredentials(c.Domain, keychain.Credentials{}))
+	err = printAuthToken(&cobra.Command{}, store, "", buf)
+	s.EqualError(err, "no token found. Please run 'astro login' to authenticate")
 
-	err = printAuthToken(&cobra.Command{}, "", buf)
+	// Test with nil store
+	buf.Reset()
+	err = printAuthToken(&cobra.Command{}, nil, "", buf)
 	s.EqualError(err, "no token found. Please run 'astro login' to authenticate")
 
 	// Test with no current context set
 	buf.Reset()
 	config.ResetCurrentContext()
-	err = printAuthToken(&cobra.Command{}, "", buf)
+	err = printAuthToken(&cobra.Command{}, store, "", buf)
 	s.Error(err)
 }
 
 func (s *CmdSuite) TestAuthTokenWithContext() {
 	buf := new(bytes.Buffer)
-
-	// Set up a specific context with a token
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	c, err := config.GetCurrentContext()
 	s.NoError(err)
 	expectedToken := "context-specific-token"
-	err = c.SetContextKey("token", "Bearer "+expectedToken)
-	s.NoError(err)
+
+	store := keychain.NewTestStore()
+	s.NoError(store.SetCredentials(c.Domain, keychain.Credentials{Token: "Bearer " + expectedToken}))
 
 	// Retrieve token using explicit context domain
-	err = printAuthToken(&cobra.Command{}, c.Domain, buf)
+	err = printAuthToken(&cobra.Command{}, store, c.Domain, buf)
 	s.NoError(err)
 	s.Equal(expectedToken+"\n", buf.String())
 
-	// Test with non-existent context
+	// Test with domain that has no credentials
 	buf.Reset()
-	err = printAuthToken(&cobra.Command{}, "nonexistent.domain.com", buf)
-	s.Error(err)
+	err = printAuthToken(&cobra.Command{}, store, "nonexistent.domain.com", buf)
+	s.EqualError(err, "no token found. Please run 'astro login' to authenticate")
 }
 
 func (s *CmdSuite) TestAuthRootCmd() {

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -32,7 +32,7 @@ func (s *CmdSuite) TestLogin() {
 		return nil
 	}
 
-	softwareLogin = func(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, client houston.ClientInterface, out io.Writer) error {
+	softwareLogin = func(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, creds *credentials.CurrentCredentials, client houston.ClientInterface, out io.Writer) error {
 		s.Equal(softwareDomain, domain)
 		return nil
 	}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/credentials"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -25,38 +27,38 @@ func (s *CmdSuite) TestLogin() {
 	cloudDomain := "astronomer.io"
 	softwareDomain := "astronomer_dev.com"
 
-	cloudLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+	cloudLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 		s.Equal(cloudDomain, domain)
 		return nil
 	}
 
-	softwareLogin = func(domain string, oAuthOnly bool, username, password, houstonVersion string, client houston.ClientInterface, out io.Writer) error {
+	softwareLogin = func(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, client houston.ClientInterface, out io.Writer) error {
 		s.Equal(softwareDomain, domain)
 		return nil
 	}
 
 	// cloud login success
-	login(&cobra.Command{}, []string{cloudDomain}, nil, buf)
+	login(&cobra.Command{}, []string{cloudDomain}, nil, nil, nil, buf)
 
 	// software login success
 	testUtil.InitTestConfig(testUtil.Initial)
-	login(&cobra.Command{}, []string{softwareDomain}, nil, buf)
+	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, nil, buf)
 
 	// no domain, cloud login
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
-	login(&cobra.Command{}, []string{}, nil, buf)
+	login(&cobra.Command{}, []string{}, nil, nil, nil, buf)
 
 	// no domain, software login
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-	login(&cobra.Command{}, []string{}, nil, buf)
+	login(&cobra.Command{}, []string{}, nil, nil, nil, buf)
 
 	// no domain, no current context set
 	config.ResetCurrentContext()
-	login(&cobra.Command{}, []string{}, nil, buf)
+	login(&cobra.Command{}, []string{}, nil, nil, nil, buf)
 
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	softwareDomain = "software.astronomer.io"
-	login(&cobra.Command{}, []string{softwareDomain}, nil, buf)
+	login(&cobra.Command{}, []string{softwareDomain}, nil, nil, nil, buf)
 	s.Contains(buf.String(), "To login to Astro Private Cloud follow the instructions below. If you are attempting to login in to Astro cancel the login and run 'astro login'.\n\n")
 }
 
@@ -64,96 +66,96 @@ func (s *CmdSuite) TestLogout() {
 	localDomain := "localhost"
 	softwareDomain := "astronomer_dev.com"
 
-	cloudLogout = func(domain string, out io.Writer) {
+	cloudLogout = func(domain string, store keychain.SecureStore, out io.Writer) {
 		s.Equal(localDomain, domain)
 	}
-	softwareLogout = func(domain string) {
+	softwareLogout = func(domain string, store keychain.SecureStore) {
 		s.Equal(softwareDomain, domain)
 	}
 
 	// cloud logout success
-	err := logout(&cobra.Command{}, []string{localDomain}, os.Stdout)
+	err := logout(&cobra.Command{}, []string{localDomain}, nil, os.Stdout)
 	s.NoError(err)
 
 	// software logout success
-	err = logout(&cobra.Command{}, []string{softwareDomain}, os.Stdout)
+	err = logout(&cobra.Command{}, []string{softwareDomain}, nil, os.Stdout)
 	s.NoError(err)
 
 	// no domain, cloud logout
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
-	err = logout(&cobra.Command{}, []string{}, os.Stdout)
+	err = logout(&cobra.Command{}, []string{}, nil, os.Stdout)
 	s.NoError(err)
 
 	// no domain, software logout
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
-	err = logout(&cobra.Command{}, []string{}, os.Stdout)
+	err = logout(&cobra.Command{}, []string{}, nil, os.Stdout)
 	s.NoError(err)
 
 	// no domain, no current context set
 	config.ResetCurrentContext()
-	err = logout(&cobra.Command{}, []string{}, os.Stdout)
+	err = logout(&cobra.Command{}, []string{}, nil, os.Stdout)
 	s.EqualError(err, "no context set, have you authenticated to Astro or Astro Private Cloud? Run astro login and try again")
 }
 
 func (s *CmdSuite) TestAuthToken() {
 	buf := new(bytes.Buffer)
-
-	// Test with valid token (with Bearer prefix)
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	c, err := config.GetCurrentContext()
 	s.NoError(err)
 	expectedToken := "test-token-12345"
-	err = c.SetContextKey("token", "Bearer "+expectedToken)
-	s.NoError(err)
 
-	err = printAuthToken(&cobra.Command{}, "", buf)
+	store := keychain.NewTestStore()
+
+	// Test with valid token (with Bearer prefix)
+	s.NoError(store.SetCredentials(c.Domain, keychain.Credentials{Token: "Bearer " + expectedToken}))
+	err = printAuthToken(&cobra.Command{}, store, "", buf)
 	s.NoError(err)
 	s.Equal(expectedToken+"\n", buf.String())
 
 	// Test with token without Bearer prefix
 	buf.Reset()
-	err = c.SetContextKey("token", expectedToken)
-	s.NoError(err)
-
-	err = printAuthToken(&cobra.Command{}, "", buf)
+	s.NoError(store.SetCredentials(c.Domain, keychain.Credentials{Token: expectedToken}))
+	err = printAuthToken(&cobra.Command{}, store, "", buf)
 	s.NoError(err)
 	s.Equal(expectedToken+"\n", buf.String())
 
 	// Test with no token (not authenticated)
 	buf.Reset()
-	err = c.SetContextKey("token", "")
-	s.NoError(err)
+	s.NoError(store.SetCredentials(c.Domain, keychain.Credentials{}))
+	err = printAuthToken(&cobra.Command{}, store, "", buf)
+	s.EqualError(err, "no token found. Please run 'astro login' to authenticate")
 
-	err = printAuthToken(&cobra.Command{}, "", buf)
+	// Test with nil store
+	buf.Reset()
+	err = printAuthToken(&cobra.Command{}, nil, "", buf)
 	s.EqualError(err, "no token found. Please run 'astro login' to authenticate")
 
 	// Test with no current context set
 	buf.Reset()
 	config.ResetCurrentContext()
-	err = printAuthToken(&cobra.Command{}, "", buf)
+	err = printAuthToken(&cobra.Command{}, store, "", buf)
 	s.Error(err)
 }
 
 func (s *CmdSuite) TestAuthTokenWithContext() {
 	buf := new(bytes.Buffer)
-
-	// Set up a specific context with a token
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	c, err := config.GetCurrentContext()
 	s.NoError(err)
 	expectedToken := "context-specific-token"
-	err = c.SetContextKey("token", "Bearer "+expectedToken)
-	s.NoError(err)
+
+	store := keychain.NewTestStore()
+	s.NoError(store.SetCredentials(c.Domain, keychain.Credentials{Token: "Bearer " + expectedToken}))
 
 	// Retrieve token using explicit context domain
-	err = printAuthToken(&cobra.Command{}, c.Domain, buf)
+	err = printAuthToken(&cobra.Command{}, store, c.Domain, buf)
 	s.NoError(err)
 	s.Equal(expectedToken+"\n", buf.String())
 
-	// Test with non-existent context
+	// Test with domain that has no credentials
 	buf.Reset()
-	err = printAuthToken(&cobra.Command{}, "nonexistent.domain.com", buf)
-	s.Error(err)
+	err = printAuthToken(&cobra.Command{}, store, "nonexistent.domain.com", buf)
+	s.EqualError(err, "no token found. Please run 'astro login' to authenticate")
 }
 
 func (s *CmdSuite) TestAuthRootCmd() {

--- a/cmd/cloud/dbt.go
+++ b/cmd/cloud/dbt.go
@@ -138,6 +138,7 @@ func deployDbt(cmd *cobra.Command, args []string) error {
 		WaitTime:           waitTime,
 		PlatformCoreClient: platformCoreClient,
 		CoreClient:         astroCoreClient,
+		Creds:              creds,
 	}
 	return DeployBundle(deployBundleInput)
 }

--- a/cmd/cloud/dbt.go
+++ b/cmd/cloud/dbt.go
@@ -137,6 +137,7 @@ func deployDbt(cmd *cobra.Command, args []string) error {
 		Wait:          waitForDeploy,
 		WaitTime:      waitTime,
 		AstroV1Client: astroV1Client,
+		Creds:         creds,
 	}
 	return DeployBundle(deployBundleInput)
 }

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -169,6 +169,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		Description:       deployDescription,
 		BuildSecretString: BuildSecretString,
 		Force:             forceDeploy,
+		Creds:             creds,
 	}
 
 	return DeployImage(deployInput, platformCoreClient, astroCoreClient)

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -227,6 +227,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		BuildSecretString: BuildSecretString,
 		Force:             forceDeploy,
 		DagBundleName:     dagBundleName,
+		Creds:             creds,
 	}
 
 	return DeployImage(deployInput, astroV1Client, astroV1Alpha1Client)

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -820,7 +820,7 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 		if disallowedFlagSet {
 			return errFlag
 		}
-		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), platformCoreClient, astroCoreClient, out, waitForStatus, waitTimeForDeployment, forceUpdate)
+		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), platformCoreClient, astroCoreClient, out, waitForStatus, waitTimeForDeployment, forceUpdate, creds)
 	}
 
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {
@@ -869,7 +869,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, out io.Writer) error { 
 			// other flags were requested
 			return errFlag
 		}
-		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), platformCoreClient, astroCoreClient, out, false, 0*time.Second, forceUpdate)
+		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), platformCoreClient, astroCoreClient, out, false, 0*time.Second, forceUpdate, creds)
 	}
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {
 		return errors.New("Invalid --dag-deploy value")
@@ -905,7 +905,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, out io.Writer) error { 
 		deploymentID = args[0]
 	}
 
-	return deployment.Update(deploymentID, label, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCPU, defaultTaskPodMemory, resourceQuotaCPU, resourceQuotaMemory, workloadIdentity, updateSchedulerAU, updateSchedulerReplicas, []astroplatformcore.WorkerQueueRequest{}, []astroplatformcore.HybridWorkerQueueRequest{}, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, allowedIPAddressRanges, taskLogBucket, taskLogURLPattern, forceUpdate, astroCoreClient, platformCoreClient)
+	return deployment.Update(deploymentID, label, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCPU, defaultTaskPodMemory, resourceQuotaCPU, resourceQuotaMemory, workloadIdentity, updateSchedulerAU, updateSchedulerReplicas, []astroplatformcore.WorkerQueueRequest{}, []astroplatformcore.HybridWorkerQueueRequest{}, []astroplatformcore.DeploymentEnvironmentVariableRequest{}, allowedIPAddressRanges, taskLogBucket, taskLogURLPattern, forceUpdate, astroCoreClient, platformCoreClient, creds)
 }
 
 func validateCICD() error {

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -826,7 +826,7 @@ func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //n
 		if disallowedFlagSet {
 			return errFlag
 		}
-		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), astroV1Client, out, waitForStatus, waitTimeForDeployment, forceUpdate)
+		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), astroV1Client, out, waitForStatus, waitTimeForDeployment, forceUpdate, creds)
 	}
 
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {
@@ -875,7 +875,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, out io.Writer) error { 
 			// other flags were requested
 			return errFlag
 		}
-		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), astroV1Client, out, false, 0*time.Second, forceUpdate)
+		return fromfile.CreateOrUpdate(inputFile, cmd.Name(), astroV1Client, out, false, 0*time.Second, forceUpdate, creds)
 	}
 	if dagDeploy != "" && !(dagDeploy == enable || dagDeploy == disable) {
 		return errors.New("Invalid --dag-deploy value")
@@ -911,7 +911,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, out io.Writer) error { 
 		deploymentID = args[0]
 	}
 
-	return deployment.Update(deploymentID, label, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCPU, defaultTaskPodMemory, resourceQuotaCPU, resourceQuotaMemory, workloadIdentity, updateSchedulerAU, updateSchedulerReplicas, []astrov1.WorkerQueueRequest{}, []astrov1.HybridWorkerQueueRequest{}, []astrov1.DeploymentEnvironmentVariableRequest{}, allowedIPAddressRanges, taskLogBucket, taskLogURLPattern, forceUpdate, astroV1Client)
+	return deployment.Update(deploymentID, label, ws, description, deploymentName, dagDeploy, executor, schedulerSize, highAvailability, developmentMode, cicdEnforcement, defaultTaskPodCPU, defaultTaskPodMemory, resourceQuotaCPU, resourceQuotaMemory, workloadIdentity, updateSchedulerAU, updateSchedulerReplicas, []astrov1.WorkerQueueRequest{}, []astrov1.HybridWorkerQueueRequest{}, []astrov1.DeploymentEnvironmentVariableRequest{}, allowedIPAddressRanges, taskLogBucket, taskLogURLPattern, forceUpdate, astroV1Client, creds)
 }
 
 func validateCICD() error {

--- a/cmd/cloud/remote.go
+++ b/cmd/cloud/remote.go
@@ -84,6 +84,7 @@ func remoteDeploy(cmd *cobra.Command, args []string) error {
 		Platform:          remotePlatform,
 		BuildSecretString: buildSecretString,
 		DeploymentID:      remoteDeploymentID,
+		Creds:             creds,
 	}
 
 	return cloud.DeployClientImage(deployInput, platformCoreClient)

--- a/cmd/cloud/remote.go
+++ b/cmd/cloud/remote.go
@@ -84,6 +84,7 @@ func remoteDeploy(cmd *cobra.Command, args []string) error {
 		Platform:          remotePlatform,
 		BuildSecretString: buildSecretString,
 		DeploymentID:      remoteDeploymentID,
+		Creds:             creds,
 	}
 
 	return cloud.DeployClientImage(deployInput, astroV1Client)

--- a/cmd/cloud/root.go
+++ b/cmd/cloud/root.go
@@ -9,6 +9,7 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroiamcore "github.com/astronomer/astro-cli/astro-client-iam-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 )
 
 var (
@@ -16,14 +17,16 @@ var (
 	astroCoreIamClient astroiamcore.CoreClient
 	platformCoreClient astroplatformcore.CoreClient
 	airflowAPIClient   airflow.Client
+	creds              *credentials.CurrentCredentials
 )
 
 // AddCmds adds all the command initialized in this package for the cmd package to import
-func AddCmds(astroPlatformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, airflowClient airflow.Client, iamCoreClient astroiamcore.CoreClient, out io.Writer) []*cobra.Command {
+func AddCmds(astroPlatformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient, airflowClient airflow.Client, iamCoreClient astroiamcore.CoreClient, c *credentials.CurrentCredentials, out io.Writer) []*cobra.Command {
 	astroCoreClient = coreClient
 	platformCoreClient = astroPlatformCoreClient
 	astroCoreIamClient = iamCoreClient
 	airflowAPIClient = airflowClient
+	creds = c
 	return []*cobra.Command{
 		NewDeployCmd(),
 		newDeploymentRootCmd(out),

--- a/cmd/cloud/root.go
+++ b/cmd/cloud/root.go
@@ -8,19 +8,22 @@ import (
 	airflow "github.com/astronomer/astro-cli/airflow-client"
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	astrov1alpha1 "github.com/astronomer/astro-cli/astro-client-v1alpha1"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 )
 
 var (
 	astroV1Client       astrov1.APIClient
 	astroV1Alpha1Client astrov1alpha1.APIClient
 	airflowAPIClient    airflow.Client
+	creds               *credentials.CurrentCredentials
 )
 
 // AddCmds adds all the command initialized in this package for the cmd package to import
-func AddCmds(v1Client astrov1.APIClient, airflowClient airflow.Client, v1Alpha1Client astrov1alpha1.APIClient, out io.Writer) []*cobra.Command {
+func AddCmds(v1Client astrov1.APIClient, airflowClient airflow.Client, v1Alpha1Client astrov1alpha1.APIClient, c *credentials.CurrentCredentials, out io.Writer) []*cobra.Command {
 	astroV1Client = v1Client
 	astroV1Alpha1Client = v1Alpha1Client
 	airflowAPIClient = airflowClient
+	creds = c
 	return []*cobra.Command{
 		NewDeployCmd(),
 		newDeploymentRootCmd(out),

--- a/cmd/cloud/root_test.go
+++ b/cmd/cloud/root_test.go
@@ -12,7 +12,7 @@ import (
 func TestAddCmds(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
-	cmds := AddCmds(nil, nil, nil, nil, buf)
+	cmds := AddCmds(nil, nil, nil, nil, nil, buf)
 	for cmdIdx := range cmds {
 		assert.Contains(t, []string{"deployment", "deploy DEPLOYMENT-ID", "workspace", "user", "organization", "dbt", "ide", "remote"}, cmds[cmdIdx].Use)
 	}

--- a/cmd/cloud/root_test.go
+++ b/cmd/cloud/root_test.go
@@ -12,7 +12,7 @@ import (
 func TestAddCmds(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	buf := new(bytes.Buffer)
-	cmds := AddCmds(nil, nil, nil, buf)
+	cmds := AddCmds(nil, nil, nil, nil, buf)
 	for cmdIdx := range cmds {
 		assert.Contains(t, []string{"deployment", "deploy DEPLOYMENT-ID", "env", "workspace", "user", "organization", "dbt", "ide", "remote"}, cmds[cmdIdx].Use)
 	}

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/cloud/organization"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
@@ -66,7 +67,7 @@ type CustomClaims struct {
 }
 
 //nolint:gocognit
-func Setup(cmd *cobra.Command, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+func Setup(cmd *cobra.Command, store keychain.SecureStore, creds *credentials.CurrentCredentials, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
 	// If the user is trying to login or logout no need to go through auth setup.
 	if cmd.CalledAs() == "login" || cmd.CalledAs() == "logout" {
 		return nil
@@ -110,7 +111,7 @@ func Setup(cmd *cobra.Command, store keychain.SecureStore, tokenHolder *httputil
 	}
 
 	// Check for APITokens before API keys or refresh tokens
-	apiToken, err := checkAPIToken(isDeploymentFile, tokenHolder, platformCoreClient)
+	apiToken, err := checkAPIToken(isDeploymentFile, creds, platformCoreClient)
 	if err != nil {
 		return err
 	}
@@ -119,14 +120,14 @@ func Setup(cmd *cobra.Command, store keychain.SecureStore, tokenHolder *httputil
 	}
 
 	// run auth setup for any command that requires auth
-	apiKey, err := checkAPIKeys(platformCoreClient, tokenHolder, isDeploymentFile)
+	apiKey, err := checkAPIKeys(platformCoreClient, creds, isDeploymentFile)
 	if err != nil {
 		return err
 	}
 	if apiKey {
 		return nil
 	}
-	err = checkToken(store, tokenHolder, coreClient, platformCoreClient, os.Stdout)
+	err = checkToken(store, creds, coreClient, platformCoreClient, os.Stdout)
 	if err != nil {
 		return err
 	}
@@ -134,30 +135,30 @@ func Setup(cmd *cobra.Command, store keychain.SecureStore, tokenHolder *httputil
 	return nil
 }
 
-func checkToken(store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
+func checkToken(store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
 	c, err := context.GetCurrentContext()
 	if err != nil {
 		return err
 	}
 
-	creds, err := store.GetCredentials(c.Domain)
-	if err != nil || creds.Token == "" {
-		return authLogin(c.Domain, "", store, tokenHolder, coreClient, platformCoreClient, out, false)
+	keyCreds, err := store.GetCredentials(c.Domain)
+	if err != nil || keyCreds.Token == "" {
+		return authLogin(c.Domain, "", store, creds, coreClient, platformCoreClient, out, false)
 	}
 
-	if isExpired(creds.ExpiresAt, accessTokenExpThreshold) {
+	if isExpired(keyCreds.ExpiresAt, accessTokenExpThreshold) {
 		authConfig, err := auth.FetchDomainAuthConfig(c.Domain)
 		if err != nil {
 			return err
 		}
-		res, err := refresh(creds.RefreshToken, authConfig)
+		res, err := refresh(keyCreds.RefreshToken, authConfig)
 		if err != nil {
-			return authLogin(c.Domain, "", store, tokenHolder, coreClient, platformCoreClient, out, false)
+			return authLogin(c.Domain, "", store, creds, coreClient, platformCoreClient, out, false)
 		}
 		newCreds := keychain.Credentials{
 			Token:        "Bearer " + res.AccessToken,
-			RefreshToken: creds.RefreshToken,
-			UserEmail:    creds.UserEmail,
+			RefreshToken: keyCreds.RefreshToken,
+			UserEmail:    keyCreds.UserEmail,
 			ExpiresAt:    time.Now().Add(time.Duration(res.ExpiresIn) * time.Second),
 		}
 		if res.RefreshToken != "" {
@@ -166,11 +167,11 @@ func checkToken(store keychain.SecureStore, tokenHolder *httputil.TokenHolder, c
 		if err := store.SetCredentials(c.Domain, newCreds); err != nil {
 			return err
 		}
-		tokenHolder.Set(newCreds.Token)
+		creds.Set(newCreds.Token)
 		return nil
 	}
 
-	tokenHolder.Set(creds.Token)
+	creds.Set(keyCreds.Token)
 	return nil
 }
 
@@ -219,7 +220,7 @@ func refresh(refreshToken string, authConfig auth.Config) (TokenResponse, error)
 	return tokenRes, nil
 }
 
-func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, tokenHolder *httputil.TokenHolder, isDeploymentFile bool) (bool, error) {
+func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, creds *credentials.CurrentCredentials, isDeploymentFile bool) (bool, error) {
 	// check os variables
 	astronomerKeyID := os.Getenv("ASTRONOMER_KEY_ID")
 	astronomerKeySecret := os.Getenv("ASTRONOMER_KEY_SECRET")
@@ -300,7 +301,7 @@ func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, tokenHolder *
 		return false, errors.New(tokenRes.ErrorDescription)
 	}
 
-	tokenHolder.Set("Bearer " + tokenRes.AccessToken)
+	creds.Set("Bearer " + tokenRes.AccessToken)
 
 	orgs, err := organization.ListOrganizations(platformCoreClient)
 	if err != nil {
@@ -330,7 +331,7 @@ func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, tokenHolder *
 	return true, nil
 }
 
-func checkAPIToken(isDeploymentFile bool, tokenHolder *httputil.TokenHolder, platformCoreClient astroplatformcore.CoreClient) (bool, error) {
+func checkAPIToken(isDeploymentFile bool, creds *credentials.CurrentCredentials, platformCoreClient astroplatformcore.CoreClient) (bool, error) {
 	// check os variables
 	astroAPIToken := os.Getenv("ASTRO_API_TOKEN")
 	if astroAPIToken == "" {
@@ -367,7 +368,7 @@ func checkAPIToken(isDeploymentFile bool, tokenHolder *httputil.TokenHolder, pla
 		}
 	}
 
-	tokenHolder.Set("Bearer " + astroAPIToken)
+	creds.Set("Bearer " + astroAPIToken)
 
 	// Parse the token to peek at the custom claims
 	claims, err := parseAPIToken(astroAPIToken)

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -22,6 +22,7 @@ import (
 	"github.com/astronomer/astro-cli/cloud/organization"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -47,6 +48,7 @@ type TokenResponse struct {
 	IDToken          string  `json:"id_token"`
 	TokenType        string  `json:"token_type"`
 	ExpiresIn        int64   `json:"expires_in"`
+	RefreshToken     string  `json:"refresh_token,omitempty"`
 	Scope            string  `json:"scope"`
 	Error            *string `json:"error,omitempty"`
 	ErrorDescription string  `json:"error_description,omitempty"`
@@ -64,7 +66,7 @@ type CustomClaims struct {
 }
 
 //nolint:gocognit
-func Setup(cmd *cobra.Command, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+func Setup(cmd *cobra.Command, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
 	// If the user is trying to login or logout no need to go through auth setup.
 	if cmd.CalledAs() == "login" || cmd.CalledAs() == "logout" {
 		return nil
@@ -108,7 +110,7 @@ func Setup(cmd *cobra.Command, platformCoreClient astroplatformcore.CoreClient, 
 	}
 
 	// Check for APITokens before API keys or refresh tokens
-	apiToken, err := checkAPIToken(isDeploymentFile, platformCoreClient)
+	apiToken, err := checkAPIToken(isDeploymentFile, tokenHolder, platformCoreClient)
 	if err != nil {
 		return err
 	}
@@ -117,14 +119,14 @@ func Setup(cmd *cobra.Command, platformCoreClient astroplatformcore.CoreClient, 
 	}
 
 	// run auth setup for any command that requires auth
-	apiKey, err := checkAPIKeys(platformCoreClient, isDeploymentFile)
+	apiKey, err := checkAPIKeys(platformCoreClient, tokenHolder, isDeploymentFile)
 	if err != nil {
 		return err
 	}
 	if apiKey {
 		return nil
 	}
-	err = checkToken(coreClient, platformCoreClient, os.Stdout)
+	err = checkToken(store, tokenHolder, coreClient, platformCoreClient, os.Stdout)
 	if err != nil {
 		return err
 	}
@@ -132,60 +134,43 @@ func Setup(cmd *cobra.Command, platformCoreClient astroplatformcore.CoreClient, 
 	return nil
 }
 
-func checkToken(coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
-	c, err := context.GetCurrentContext() // get current context
+func checkToken(store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer) error {
+	c, err := context.GetCurrentContext()
 	if err != nil {
 		return err
 	}
-	expireTime, _ := c.GetExpiresIn()
-	// check if user is logged in
-	if c.Token == "Bearer " || c.Token == "" || c.Domain == "" {
-		// guide the user through the login process if not logged in
-		err := authLogin(c.Domain, "", coreClient, platformCoreClient, out, false)
-		if err != nil {
-			return err
-		}
 
-		return nil
-	} else if isExpired(expireTime, accessTokenExpThreshold) {
+	creds, err := store.GetCredentials(c.Domain)
+	if err != nil || creds.Token == "" {
+		return authLogin(c.Domain, "", store, tokenHolder, coreClient, platformCoreClient, out, false)
+	}
+
+	if isExpired(creds.ExpiresAt, accessTokenExpThreshold) {
 		authConfig, err := auth.FetchDomainAuthConfig(c.Domain)
 		if err != nil {
 			return err
 		}
-		res, err := refresh(c.RefreshToken, authConfig)
+		res, err := refresh(creds.RefreshToken, authConfig)
 		if err != nil {
-			// guide the user through the login process if refresh doesn't work
-			err := authLogin(c.Domain, "", coreClient, platformCoreClient, out, false)
-			if err != nil {
-				return err
-			}
+			return authLogin(c.Domain, "", store, tokenHolder, coreClient, platformCoreClient, out, false)
 		}
-		// persist the updated context with the renewed access token
-		err = c.SetContextKey("token", "Bearer "+res.AccessToken)
-		if err != nil {
+		newCreds := keychain.Credentials{
+			Token:        "Bearer " + res.AccessToken,
+			RefreshToken: creds.RefreshToken,
+			UserEmail:    creds.UserEmail,
+			ExpiresAt:    time.Now().Add(time.Duration(res.ExpiresIn) * time.Second),
+		}
+		if res.RefreshToken != "" {
+			newCreds.RefreshToken = res.RefreshToken
+		}
+		if err := store.SetCredentials(c.Domain, newCreds); err != nil {
 			return err
 		}
-		err = c.SetExpiresIn(res.ExpiresIn)
-		if err != nil {
-			return err
-		}
-		err = c.SetContextKey("workspace", c.Workspace)
-		if err != nil {
-			return err
-		}
-		err = c.SetContextKey("workspace", c.LastUsedWorkspace)
-		if err != nil {
-			return err
-		}
-		err = c.SetContextKey("organization", c.Organization)
-		if err != nil {
-			return err
-		}
-		err = c.SetContextKey("organization_product", c.OrganizationProduct)
-		if err != nil {
-			return err
-		}
+		tokenHolder.Set(newCreds.Token)
+		return nil
 	}
+
+	tokenHolder.Set(creds.Token)
 	return nil
 }
 
@@ -234,7 +219,7 @@ func refresh(refreshToken string, authConfig auth.Config) (TokenResponse, error)
 	return tokenRes, nil
 }
 
-func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, isDeploymentFile bool) (bool, error) {
+func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, tokenHolder *httputil.TokenHolder, isDeploymentFile bool) (bool, error) {
 	// check os variables
 	astronomerKeyID := os.Getenv("ASTRONOMER_KEY_ID")
 	astronomerKeySecret := os.Getenv("ASTRONOMER_KEY_SECRET")
@@ -315,15 +300,8 @@ func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, isDeploymentF
 		return false, errors.New(tokenRes.ErrorDescription)
 	}
 
-	err = c.SetContextKey("token", "Bearer "+tokenRes.AccessToken)
-	if err != nil {
-		return false, err
-	}
+	tokenHolder.Set("Bearer " + tokenRes.AccessToken)
 
-	err = c.SetExpiresIn(tokenRes.ExpiresIn)
-	if err != nil {
-		return false, err
-	}
 	orgs, err := organization.ListOrganizations(platformCoreClient)
 	if err != nil {
 		return false, err
@@ -352,7 +330,7 @@ func checkAPIKeys(platformCoreClient astroplatformcore.CoreClient, isDeploymentF
 	return true, nil
 }
 
-func checkAPIToken(isDeploymentFile bool, platformCoreClient astroplatformcore.CoreClient) (bool, error) {
+func checkAPIToken(isDeploymentFile bool, tokenHolder *httputil.TokenHolder, platformCoreClient astroplatformcore.CoreClient) (bool, error) {
 	// check os variables
 	astroAPIToken := os.Getenv("ASTRO_API_TOKEN")
 	if astroAPIToken == "" {
@@ -389,15 +367,8 @@ func checkAPIToken(isDeploymentFile bool, platformCoreClient astroplatformcore.C
 		}
 	}
 
-	err = c.SetContextKey("token", "Bearer "+astroAPIToken)
-	if err != nil {
-		return false, err
-	}
+	tokenHolder.Set("Bearer " + astroAPIToken)
 
-	err = c.SetExpiresIn(time.Now().AddDate(1, 0, 0).Unix())
-	if err != nil {
-		return false, err
-	}
 	// Parse the token to peek at the custom claims
 	claims, err := parseAPIToken(astroAPIToken)
 	if err != nil {

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -20,7 +20,9 @@ import (
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/cloud/organization"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -46,6 +48,7 @@ type TokenResponse struct {
 	IDToken          string  `json:"id_token"`
 	TokenType        string  `json:"token_type"`
 	ExpiresIn        int64   `json:"expires_in"`
+	RefreshToken     string  `json:"refresh_token,omitempty"`
 	Scope            string  `json:"scope"`
 	Error            *string `json:"error,omitempty"`
 	ErrorDescription string  `json:"error_description,omitempty"`
@@ -63,7 +66,7 @@ type CustomClaims struct {
 }
 
 //nolint:gocognit
-func Setup(cmd *cobra.Command, astroV1Client astrov1.APIClient) error {
+func Setup(cmd *cobra.Command, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient) error {
 	// If the user is trying to login or logout no need to go through auth setup.
 	if cmd.CalledAs() == "login" || cmd.CalledAs() == "logout" {
 		return nil
@@ -107,7 +110,7 @@ func Setup(cmd *cobra.Command, astroV1Client astrov1.APIClient) error {
 	}
 
 	// Check for APITokens before API keys or refresh tokens
-	apiToken, err := checkAPIToken(isDeploymentFile, astroV1Client)
+	apiToken, err := checkAPIToken(isDeploymentFile, creds, astroV1Client)
 	if err != nil {
 		return err
 	}
@@ -116,14 +119,14 @@ func Setup(cmd *cobra.Command, astroV1Client astrov1.APIClient) error {
 	}
 
 	// run auth setup for any command that requires auth
-	apiKey, err := checkAPIKeys(astroV1Client, isDeploymentFile)
+	apiKey, err := checkAPIKeys(astroV1Client, creds, isDeploymentFile)
 	if err != nil {
 		return err
 	}
 	if apiKey {
 		return nil
 	}
-	err = checkToken(astroV1Client, os.Stdout)
+	err = checkToken(store, creds, astroV1Client, os.Stdout)
 	if err != nil {
 		return err
 	}
@@ -131,60 +134,44 @@ func Setup(cmd *cobra.Command, astroV1Client astrov1.APIClient) error {
 	return nil
 }
 
-func checkToken(astroV1Client astrov1.APIClient, out io.Writer) error {
-	c, err := context.GetCurrentContext() // get current context
+func checkToken(store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer) error {
+	c, err := context.GetCurrentContext()
 	if err != nil {
 		return err
 	}
-	expireTime, _ := c.GetExpiresIn()
-	// check if user is logged in
-	if c.Token == "Bearer " || c.Token == "" || c.Domain == "" {
-		// guide the user through the login process if not logged in
-		err := authLogin(c.Domain, "", astroV1Client, out, false)
-		if err != nil {
-			return err
-		}
 
-		return nil
-	} else if isExpired(expireTime, accessTokenExpThreshold) {
+	keyCreds, err := store.GetCredentials(c.Domain)
+	if err != nil || keyCreds.Token == "" {
+		return authLogin(c.Domain, "", store, creds, astroV1Client, out, false)
+	}
+
+	if isExpired(keyCreds.ExpiresAt, accessTokenExpThreshold) {
 		authConfig, err := auth.FetchDomainAuthConfig(c.Domain)
 		if err != nil {
 			return err
 		}
-		res, err := refresh(c.RefreshToken, authConfig)
+		res, err := refresh(keyCreds.RefreshToken, authConfig)
 		if err != nil {
 			// guide the user through the login process if refresh doesn't work
-			err := authLogin(c.Domain, "", astroV1Client, out, false)
-			if err != nil {
-				return err
-			}
+			return authLogin(c.Domain, "", store, creds, astroV1Client, out, false)
 		}
-		// persist the updated context with the renewed access token
-		err = c.SetContextKey("token", "Bearer "+res.AccessToken)
-		if err != nil {
+		newCreds := keychain.Credentials{
+			Token:        "Bearer " + res.AccessToken,
+			RefreshToken: keyCreds.RefreshToken,
+			UserEmail:    keyCreds.UserEmail,
+			ExpiresAt:    time.Now().Add(time.Duration(res.ExpiresIn) * time.Second),
+		}
+		if res.RefreshToken != "" {
+			newCreds.RefreshToken = res.RefreshToken
+		}
+		if err := store.SetCredentials(c.Domain, newCreds); err != nil {
 			return err
 		}
-		err = c.SetExpiresIn(res.ExpiresIn)
-		if err != nil {
-			return err
-		}
-		err = c.SetContextKey("workspace", c.Workspace)
-		if err != nil {
-			return err
-		}
-		err = c.SetContextKey("workspace", c.LastUsedWorkspace)
-		if err != nil {
-			return err
-		}
-		err = c.SetContextKey("organization", c.Organization)
-		if err != nil {
-			return err
-		}
-		err = c.SetContextKey("organization_product", c.OrganizationProduct)
-		if err != nil {
-			return err
-		}
+		creds.Set(newCreds.Token)
+		return nil
 	}
+
+	creds.Set(keyCreds.Token)
 	return nil
 }
 
@@ -233,7 +220,7 @@ func refresh(refreshToken string, authConfig auth.Config) (TokenResponse, error)
 	return tokenRes, nil
 }
 
-func checkAPIKeys(astroV1Client astrov1.APIClient, isDeploymentFile bool) (bool, error) {
+func checkAPIKeys(astroV1Client astrov1.APIClient, creds *credentials.CurrentCredentials, isDeploymentFile bool) (bool, error) {
 	// check os variables
 	astronomerKeyID := os.Getenv("ASTRONOMER_KEY_ID")
 	astronomerKeySecret := os.Getenv("ASTRONOMER_KEY_SECRET")
@@ -314,15 +301,8 @@ func checkAPIKeys(astroV1Client astrov1.APIClient, isDeploymentFile bool) (bool,
 		return false, errors.New(tokenRes.ErrorDescription)
 	}
 
-	err = c.SetContextKey("token", "Bearer "+tokenRes.AccessToken)
-	if err != nil {
-		return false, err
-	}
+	creds.Set("Bearer " + tokenRes.AccessToken)
 
-	err = c.SetExpiresIn(tokenRes.ExpiresIn)
-	if err != nil {
-		return false, err
-	}
 	orgs, err := organization.ListOrganizations(astroV1Client)
 	if err != nil {
 		return false, err
@@ -351,7 +331,7 @@ func checkAPIKeys(astroV1Client astrov1.APIClient, isDeploymentFile bool) (bool,
 	return true, nil
 }
 
-func checkAPIToken(isDeploymentFile bool, astroV1Client astrov1.APIClient) (bool, error) {
+func checkAPIToken(isDeploymentFile bool, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient) (bool, error) {
 	// check os variables
 	astroAPIToken := os.Getenv("ASTRO_API_TOKEN")
 	if astroAPIToken == "" {
@@ -388,15 +368,8 @@ func checkAPIToken(isDeploymentFile bool, astroV1Client astrov1.APIClient) (bool
 		}
 	}
 
-	err = c.SetContextKey("token", "Bearer "+astroAPIToken)
-	if err != nil {
-		return false, err
-	}
+	creds.Set("Bearer " + astroAPIToken)
 
-	err = c.SetExpiresIn(time.Now().AddDate(1, 0, 0).Unix())
-	if err != nil {
-		return false, err
-	}
 	// Parse the token to peek at the custom claims
 	claims, err := parseAPIToken(astroAPIToken)
 	if err != nil {

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -141,8 +141,15 @@ func checkToken(store keychain.SecureStore, creds *credentials.CurrentCredential
 	}
 
 	keyCreds, err := store.GetCredentials(c.Domain)
-	if err != nil || keyCreds.Token == "" {
+	switch {
+	case errors.Is(err, keychain.ErrNotFound) || (err == nil && keyCreds.Token == ""):
+		// Genuinely not logged in — guide the user through it.
 		return authLogin(c.Domain, "", store, creds, astroV1Client, out, false)
+	case err != nil:
+		// The store exists but wouldn't answer: a locked keychain, a denied ACL
+		// prompt after a binary update, a dead D-Bus. Say so rather than
+		// treating it as a logged-out user and springing a browser login.
+		return fmt.Errorf("could not read stored credentials for %s: %w", c.Domain, err)
 	}
 
 	if isExpired(keyCreds.ExpiresAt, accessTokenExpThreshold) {

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -20,7 +20,7 @@ import (
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
-	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/astronomer/astro-cli/pkg/util"
@@ -69,11 +69,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, nil, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -90,11 +90,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, nil, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -170,11 +170,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "deployment"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, nil, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -190,11 +190,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, nil, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -243,7 +243,7 @@ func TestSetup(t *testing.T) {
 
 		t.Setenv("ASTRO_API_TOKEN", "token")
 
-		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, mockPlatformCoreClient, mockCoreClient)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, mockPlatformCoreClient, mockCoreClient)
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
@@ -267,7 +267,7 @@ func TestSetup(t *testing.T) {
 
 		t.Setenv("ASTRO_API_TOKEN", "bad token")
 
-		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, mockPlatformCoreClient, mockCoreClient)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, mockPlatformCoreClient, mockCoreClient)
 		assert.Error(t, err)
 	})
 
@@ -284,13 +284,13 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
 		t.Setenv("ASTRO_API_TOKEN", "")
 
-		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, mockPlatformCoreClient, mockCoreClient)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, mockPlatformCoreClient, mockCoreClient)
 		assert.NoError(t, err)
 	})
 
@@ -320,7 +320,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -341,7 +341,7 @@ func TestSetup(t *testing.T) {
 				Header:     make(http.Header),
 			}
 		})
-		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, mockPlatformCoreClient, mockCoreClient)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, mockPlatformCoreClient, mockCoreClient)
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -371,7 +371,7 @@ func TestCheckAPIKeys(t *testing.T) {
 		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(&mockOrgsResponse, nil).Once()
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -398,7 +398,7 @@ func TestCheckAPIKeys(t *testing.T) {
 		err = context.Switch(domain)
 		assert.NoError(t, err)
 
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		_, err = checkAPIKeys(mockPlatformCoreClient, holder, false)
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
@@ -411,20 +411,20 @@ func TestCheckToken(t *testing.T) {
 	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 	t.Run("test check token", func(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		err := checkToken(keychain.NewTestStore(), holder, mockCoreClient, mockPlatformCoreClient, nil)
 		assert.NoError(t, err)
 	})
 	t.Run("trigger login when no token is found", func(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return errorLogin
 		}
 
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		err := checkToken(keychain.NewTestStore(), holder, mockCoreClient, mockPlatformCoreClient, nil)
 		assert.Contains(t, err.Error(), "failed to login")
 	})
@@ -434,7 +434,7 @@ func TestCheckToken(t *testing.T) {
 		store := keychain.NewTestStore()
 		_ = store.SetCredentials("astronomer.io", keychain.Credentials{Token: "Bearer tok", ExpiresAt: time.Now().Add(time.Hour)})
 
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		err := checkToken(store, holder, mockCoreClient, mockPlatformCoreClient, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "Bearer tok", holder.Get())
@@ -477,7 +477,7 @@ func TestCheckAPIToken(t *testing.T) {
 	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 
 	t.Run("test context switch", func(t *testing.T) {
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -494,13 +494,13 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.NoError(t, err)
 	})
 
 	t.Run("failed to parse api token", func(t *testing.T) {
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -517,12 +517,12 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.Error(t, err)
 	})
 	t.Run("unable to fetch current context", func(t *testing.T) {
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -536,7 +536,7 @@ func TestCheckAPIToken(t *testing.T) {
 		err := config.ResetCurrentContext()
 		assert.NoError(t, err)
 
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.NoError(t, err)
 	})
@@ -556,7 +556,7 @@ func TestCheckAPIToken(t *testing.T) {
 			},
 		}
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -573,7 +573,7 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		_, err = checkAPIToken(false, holder, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errNotAPIToken)
 	})
@@ -596,7 +596,7 @@ func TestCheckAPIToken(t *testing.T) {
 			},
 		}
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -613,7 +613,7 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errExpiredAPIToken)
 	})
@@ -635,7 +635,7 @@ func TestCheckAPIToken(t *testing.T) {
 			},
 		}
 
-		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -652,7 +652,7 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		holder := &httputil.TokenHolder{}
+		holder := &credentials.CurrentCredentials{}
 		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.NoError(t, err)
 	})

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -20,6 +20,8 @@ import (
 	astroplatformcore_mocks "github.com/astronomer/astro-cli/astro-client-platform-core/mocks"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -38,7 +40,7 @@ func TestSetup(t *testing.T) {
 		cmd := &cobra.Command{Use: "login"}
 		cmd, err := cmd.ExecuteC()
 		assert.NoError(t, err)
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, nil, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -50,7 +52,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, nil, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -67,11 +69,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -88,11 +90,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -104,7 +106,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, nil, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -116,7 +118,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, nil, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -128,7 +130,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, nil, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -140,7 +142,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "context"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, nil, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -152,7 +154,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "completion"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, nil, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -168,11 +170,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "deployment"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -188,11 +190,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, nil, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -216,10 +218,10 @@ func TestSetup(t *testing.T) {
 			RegisteredClaims: jwt.RegisteredClaims{
 				Issuer:    "test-issuer",
 				Subject:   "test-subject",
-				Audience:  jwt.ClaimStrings{"audience1", "audience2"},         // Audience can be a single string or an array of strings
-				ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)), // Set expiration date 24 hours from now
-				NotBefore: jwt.NewNumericDate(time.Now()),                     // Set not before to current time
-				IssuedAt:  jwt.NewNumericDate(time.Now()),                     // Set issued at to current time
+				Audience:  jwt.ClaimStrings{"audience1", "audience2"},
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+				NotBefore: jwt.NewNumericDate(time.Now()),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
 				ID:        "test-id",
 			},
 		}
@@ -241,7 +243,7 @@ func TestSetup(t *testing.T) {
 
 		t.Setenv("ASTRO_API_TOKEN", "token")
 
-		err = Setup(cmd, mockPlatformCoreClient, mockCoreClient)
+		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, mockPlatformCoreClient, mockCoreClient)
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 	})
@@ -265,7 +267,7 @@ func TestSetup(t *testing.T) {
 
 		t.Setenv("ASTRO_API_TOKEN", "bad token")
 
-		err = Setup(cmd, mockPlatformCoreClient, mockCoreClient)
+		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, mockPlatformCoreClient, mockCoreClient)
 		assert.Error(t, err)
 	})
 
@@ -282,13 +284,13 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
 		t.Setenv("ASTRO_API_TOKEN", "")
 
-		err = Setup(cmd, mockPlatformCoreClient, mockCoreClient)
+		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, mockPlatformCoreClient, mockCoreClient)
 		assert.NoError(t, err)
 	})
 
@@ -318,7 +320,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -339,7 +341,7 @@ func TestSetup(t *testing.T) {
 				Header:     make(http.Header),
 			}
 		})
-		err = Setup(cmd, mockPlatformCoreClient, mockCoreClient)
+		err = Setup(cmd, keychain.NewTestStore(), &httputil.TokenHolder{}, mockPlatformCoreClient, mockCoreClient)
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -369,7 +371,7 @@ func TestCheckAPIKeys(t *testing.T) {
 		mockPlatformCoreClient.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(&mockOrgsResponse, nil).Once()
 		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -396,8 +398,8 @@ func TestCheckAPIKeys(t *testing.T) {
 		err = context.Switch(domain)
 		assert.NoError(t, err)
 
-		// run CheckAPIKeys
-		_, err = checkAPIKeys(mockPlatformCoreClient, false)
+		holder := &httputil.TokenHolder{}
+		_, err = checkAPIKeys(mockPlatformCoreClient, holder, false)
 		assert.NoError(t, err)
 		mockPlatformCoreClient.AssertExpectations(t)
 		mockCoreClient.AssertExpectations(t)
@@ -409,25 +411,33 @@ func TestCheckToken(t *testing.T) {
 	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 	t.Run("test check token", func(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
-		// run checkToken
-		err := checkToken(mockCoreClient, mockPlatformCoreClient, nil)
+		holder := &httputil.TokenHolder{}
+		err := checkToken(keychain.NewTestStore(), holder, mockCoreClient, mockPlatformCoreClient, nil)
 		assert.NoError(t, err)
 	})
 	t.Run("trigger login when no token is found", func(t *testing.T) {
 		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return errorLogin
 		}
 
-		ctx, err := context.GetCurrentContext()
-		assert.NoError(t, err)
-		ctx.SetContextKey("token", "")
-		// run checkToken
-		err = checkToken(mockCoreClient, mockPlatformCoreClient, nil)
+		holder := &httputil.TokenHolder{}
+		err := checkToken(keychain.NewTestStore(), holder, mockCoreClient, mockPlatformCoreClient, nil)
 		assert.Contains(t, err.Error(), "failed to login")
+	})
+	t.Run("valid token already in store sets token holder", func(t *testing.T) {
+		mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+
+		store := keychain.NewTestStore()
+		_ = store.SetCredentials("astronomer.io", keychain.Credentials{Token: "Bearer tok", ExpiresAt: time.Now().Add(time.Hour)})
+
+		holder := &httputil.TokenHolder{}
+		err := checkToken(store, holder, mockCoreClient, mockPlatformCoreClient, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "Bearer tok", holder.Get())
 	})
 }
 
@@ -457,17 +467,17 @@ func TestCheckAPIToken(t *testing.T) {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    "test-issuer",
 			Subject:   "test-subject",
-			Audience:  jwt.ClaimStrings{"audience1", "audience2"},         // Audience can be a single string or an array of strings
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)), // Set expiration date 24 hours from now
-			NotBefore: jwt.NewNumericDate(time.Now()),                     // Set not before to current time
-			IssuedAt:  jwt.NewNumericDate(time.Now()),                     // Set issued at to current time
+			Audience:  jwt.ClaimStrings{"audience1", "audience2"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+			NotBefore: jwt.NewNumericDate(time.Now()),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
 			ID:        "test-id",
 		},
 	}
 	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
 
 	t.Run("test context switch", func(t *testing.T) {
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -484,13 +494,13 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		// run checkAPIToken
-		_, err = checkAPIToken(true, mockPlatformCoreClient)
+		holder := &httputil.TokenHolder{}
+		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.NoError(t, err)
 	})
 
 	t.Run("failed to parse api token", func(t *testing.T) {
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -507,12 +517,12 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		// run checkAPIToken
-		_, err = checkAPIToken(true, mockPlatformCoreClient)
+		holder := &httputil.TokenHolder{}
+		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.Error(t, err)
 	})
 	t.Run("unable to fetch current context", func(t *testing.T) {
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -526,8 +536,8 @@ func TestCheckAPIToken(t *testing.T) {
 		err := config.ResetCurrentContext()
 		assert.NoError(t, err)
 
-		// run checkAPIToken
-		_, err = checkAPIToken(true, mockPlatformCoreClient)
+		holder := &httputil.TokenHolder{}
+		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.NoError(t, err)
 	})
 
@@ -546,7 +556,7 @@ func TestCheckAPIToken(t *testing.T) {
 			},
 		}
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -563,8 +573,8 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		// run checkAPIToken
-		_, err = checkAPIToken(false, mockPlatformCoreClient)
+		holder := &httputil.TokenHolder{}
+		_, err = checkAPIToken(false, holder, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errNotAPIToken)
 	})
 
@@ -586,7 +596,7 @@ func TestCheckAPIToken(t *testing.T) {
 			},
 		}
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -603,8 +613,8 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		// run checkAPIToken
-		_, err = checkAPIToken(true, mockPlatformCoreClient)
+		holder := &httputil.TokenHolder{}
+		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.ErrorIs(t, err, errExpiredAPIToken)
 	})
 
@@ -625,7 +635,7 @@ func TestCheckAPIToken(t *testing.T) {
 			},
 		}
 
-		authLogin = func(domain, token string, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, coreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -642,8 +652,8 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
-		// run checkAPIToken
-		_, err = checkAPIToken(true, mockPlatformCoreClient)
+		holder := &httputil.TokenHolder{}
+		_, err = checkAPIToken(true, holder, mockPlatformCoreClient)
 		assert.NoError(t, err)
 	})
 }

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -18,6 +18,8 @@ import (
 	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/astronomer/astro-cli/pkg/util"
 )
@@ -34,7 +36,7 @@ func TestSetup(t *testing.T) {
 		cmd := &cobra.Command{Use: "login"}
 		cmd, err := cmd.ExecuteC()
 		assert.NoError(t, err)
-		err = Setup(cmd, nil)
+		err = Setup(cmd, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -46,7 +48,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -63,11 +65,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, nil)
 		assert.NoError(t, err)
 	})
 
@@ -84,11 +86,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, nil)
 		assert.NoError(t, err)
 	})
 
@@ -100,7 +102,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -112,7 +114,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -124,7 +126,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -136,7 +138,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "context"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -148,7 +150,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "completion"}
 		rootCmd.AddCommand(cmd)
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, nil, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -164,11 +166,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "deployment"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, nil)
 		assert.NoError(t, err)
 	})
 
@@ -184,11 +186,11 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
-		err = Setup(cmd, nil)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, nil)
 		assert.NoError(t, err)
 	})
 
@@ -212,10 +214,10 @@ func TestSetup(t *testing.T) {
 			RegisteredClaims: jwt.RegisteredClaims{
 				Issuer:    "test-issuer",
 				Subject:   "test-subject",
-				Audience:  jwt.ClaimStrings{"audience1", "audience2"},         // Audience can be a single string or an array of strings
-				ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)), // Set expiration date 24 hours from now
-				NotBefore: jwt.NewNumericDate(time.Now()),                     // Set not before to current time
-				IssuedAt:  jwt.NewNumericDate(time.Now()),                     // Set issued at to current time
+				Audience:  jwt.ClaimStrings{"audience1", "audience2"},
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+				NotBefore: jwt.NewNumericDate(time.Now()),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
 				ID:        "test-id",
 			},
 		}
@@ -237,7 +239,7 @@ func TestSetup(t *testing.T) {
 
 		t.Setenv("ASTRO_API_TOKEN", "token")
 
-		err = Setup(cmd, mockV1Client)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, mockV1Client)
 		assert.NoError(t, err)
 		mockV1Client.AssertExpectations(t)
 	})
@@ -261,7 +263,7 @@ func TestSetup(t *testing.T) {
 
 		t.Setenv("ASTRO_API_TOKEN", "bad token")
 
-		err = Setup(cmd, mockV1Client)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, mockV1Client)
 		assert.Error(t, err)
 	})
 
@@ -278,13 +280,13 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
 		t.Setenv("ASTRO_API_TOKEN", "")
 
-		err = Setup(cmd, mockV1Client)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, mockV1Client)
 		assert.NoError(t, err)
 	})
 
@@ -314,7 +316,7 @@ func TestSetup(t *testing.T) {
 		rootCmd := &cobra.Command{Use: "astro"}
 		rootCmd.AddCommand(cmd)
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -335,7 +337,7 @@ func TestSetup(t *testing.T) {
 				Header:     make(http.Header),
 			}
 		})
-		err = Setup(cmd, mockV1Client)
+		err = Setup(cmd, keychain.NewTestStore(), &credentials.CurrentCredentials{}, mockV1Client)
 		assert.NoError(t, err)
 		mockV1Client.AssertExpectations(t)
 		mockV1Client.AssertExpectations(t)
@@ -364,7 +366,7 @@ func TestCheckAPIKeys(t *testing.T) {
 		mockV1Client.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(&mockOrgsResponse, nil).Once()
 		mockV1Client.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -391,8 +393,9 @@ func TestCheckAPIKeys(t *testing.T) {
 		err = context.Switch(domain)
 		assert.NoError(t, err)
 
+		holder := &credentials.CurrentCredentials{}
 		// run CheckAPIKeys
-		_, err = checkAPIKeys(mockV1Client, false)
+		_, err = checkAPIKeys(mockV1Client, holder, false)
 		assert.NoError(t, err)
 		mockV1Client.AssertExpectations(t)
 		mockV1Client.AssertExpectations(t)
@@ -403,25 +406,38 @@ func TestCheckToken(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.CloudPlatform)
 	t.Run("test check token", func(t *testing.T) {
 		mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
+		holder := &credentials.CurrentCredentials{}
 		// run checkToken
-		err := checkToken(mockV1Client, nil)
+		err := checkToken(keychain.NewTestStore(), holder, mockV1Client, nil)
 		assert.NoError(t, err)
 	})
 	t.Run("trigger login when no token is found", func(t *testing.T) {
 		mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return errorLogin
 		}
 
+		holder := &credentials.CurrentCredentials{}
 		ctx, err := context.GetCurrentContext()
 		assert.NoError(t, err)
 		ctx.SetContextKey("token", "")
 		// run checkToken
-		err = checkToken(mockV1Client, nil)
+		err = checkToken(keychain.NewTestStore(), holder, mockV1Client, nil)
 		assert.Contains(t, err.Error(), "failed to login")
+	})
+	t.Run("valid token already in store sets token holder", func(t *testing.T) {
+		mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
+
+		store := keychain.NewTestStore()
+		_ = store.SetCredentials("astronomer.io", keychain.Credentials{Token: "Bearer tok", ExpiresAt: time.Now().Add(time.Hour)})
+
+		holder := &credentials.CurrentCredentials{}
+		err := checkToken(store, holder, mockV1Client, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "Bearer tok", holder.Get())
 	})
 }
 
@@ -451,17 +467,17 @@ func TestCheckAPIToken(t *testing.T) {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    "test-issuer",
 			Subject:   "test-subject",
-			Audience:  jwt.ClaimStrings{"audience1", "audience2"},         // Audience can be a single string or an array of strings
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)), // Set expiration date 24 hours from now
-			NotBefore: jwt.NewNumericDate(time.Now()),                     // Set not before to current time
-			IssuedAt:  jwt.NewNumericDate(time.Now()),                     // Set issued at to current time
+			Audience:  jwt.ClaimStrings{"audience1", "audience2"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+			NotBefore: jwt.NewNumericDate(time.Now()),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
 			ID:        "test-id",
 		},
 	}
 	mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
 
 	t.Run("test context switch", func(t *testing.T) {
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -478,13 +494,14 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
+		holder := &credentials.CurrentCredentials{}
 		// run checkAPIToken
-		_, err = checkAPIToken(true, mockV1Client)
+		_, err = checkAPIToken(true, holder, mockV1Client)
 		assert.NoError(t, err)
 	})
 
 	t.Run("failed to parse api token", func(t *testing.T) {
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -501,12 +518,13 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
+		holder := &credentials.CurrentCredentials{}
 		// run checkAPIToken
-		_, err = checkAPIToken(true, mockV1Client)
+		_, err = checkAPIToken(true, holder, mockV1Client)
 		assert.Error(t, err)
 	})
 	t.Run("unable to fetch current context", func(t *testing.T) {
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -520,8 +538,9 @@ func TestCheckAPIToken(t *testing.T) {
 		err := config.ResetCurrentContext()
 		assert.NoError(t, err)
 
+		holder := &credentials.CurrentCredentials{}
 		// run checkAPIToken
-		_, err = checkAPIToken(true, mockV1Client)
+		_, err = checkAPIToken(true, holder, mockV1Client)
 		assert.NoError(t, err)
 	})
 
@@ -540,7 +559,7 @@ func TestCheckAPIToken(t *testing.T) {
 			},
 		}
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -557,8 +576,9 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
+		holder := &credentials.CurrentCredentials{}
 		// run checkAPIToken
-		_, err = checkAPIToken(false, mockV1Client)
+		_, err = checkAPIToken(false, holder, mockV1Client)
 		assert.ErrorIs(t, err, errNotAPIToken)
 	})
 
@@ -580,7 +600,7 @@ func TestCheckAPIToken(t *testing.T) {
 			},
 		}
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -597,8 +617,9 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
+		holder := &credentials.CurrentCredentials{}
 		// run checkAPIToken
-		_, err = checkAPIToken(true, mockV1Client)
+		_, err = checkAPIToken(true, holder, mockV1Client)
 		assert.ErrorIs(t, err, errExpiredAPIToken)
 	})
 
@@ -619,7 +640,7 @@ func TestCheckAPIToken(t *testing.T) {
 			},
 		}
 
-		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+		authLogin = func(domain, token string, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil
 		}
 
@@ -636,8 +657,9 @@ func TestCheckAPIToken(t *testing.T) {
 		err := context.Switch(domain)
 		assert.NoError(t, err)
 
+		holder := &credentials.CurrentCredentials{}
 		// run checkAPIToken
-		_, err = checkAPIToken(true, mockV1Client)
+		_, err = checkAPIToken(true, holder, mockV1Client)
 		assert.NoError(t, err)
 	})
 }

--- a/cmd/otto.go
+++ b/cmd/otto.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/otto"
 )
 
@@ -29,20 +30,22 @@ func printAstroSubcommands(w io.Writer) {
 	fmt.Fprintln(w)
 }
 
-func newOttoCmd() *cobra.Command {
+func newOttoCmd(creds *credentials.CurrentCredentials) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "otto [flags/args forwarded to Otto]",
 		Short:              "Start the Otto AI agent",
 		Long:               "Start the Otto AI agent for AI-assisted Airflow development and operations.\nAll flags and arguments are forwarded directly to Otto.",
 		SilenceUsage:       true,
 		DisableFlagParsing: true,
-		RunE:               ottoRun,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return ottoRun(args, creds)
+		},
 	}
 
 	return cmd
 }
 
-func ottoRun(cmd *cobra.Command, args []string) error {
+func ottoRun(args []string, creds *credentials.CurrentCredentials) error {
 	// With DisableFlagParsing, cobra won't route to subcommands,
 	// so we dispatch "update" and "version" ourselves. "upgrade" is
 	// aliased to "update" — otherwise it falls through to Otto and gets
@@ -83,7 +86,7 @@ func ottoRun(cmd *cobra.Command, args []string) error {
 	// Same treatment for ErrNotLoggedIn: Start has already printed the sign-up
 	// guidance to stderr, so returning the error to cobra would just tack on a
 	// redundant "Error: not logged in" line.
-	err := otto.Start(args)
+	err := otto.Start(args, creds)
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		os.Exit(exitErr.ExitCode())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,12 +20,14 @@ import (
 	"github.com/astronomer/astro-cli/internal/telemetry"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 )
 
 var (
 	verboseLevel   string
 	houstonClient  houston.ClientInterface
 	houstonVersion string
+	newSecureStore = keychain.New
 )
 
 const (
@@ -36,13 +38,16 @@ const (
 // NewRootCmd adds all of the primary commands for the cli
 func NewRootCmd() *cobra.Command {
 	var err error
-	httpClient := houston.NewHTTPClient()
-	houstonClient = houston.NewClient(httpClient)
+	tokenHolder := &httputil.TokenHolder{}
+	store, storeErr := newSecureStore()
 
-	airflowClient := airflowclient.NewAirflowClient(httputil.NewHTTPClient())
-	astroCoreClient := astrocore.NewCoreClient(httputil.NewHTTPClient())
-	astroCoreIamClient := astroiamcore.NewIamCoreClient(httputil.NewHTTPClient())
-	platformCoreClient := platformclient.NewPlatformCoreClient(httputil.NewHTTPClient())
+	httpClient := houston.NewHTTPClient()
+	houstonClient = houston.NewClient(httpClient, tokenHolder)
+
+	airflowClient := airflowclient.NewAirflowClient(httputil.NewHTTPClient(), tokenHolder)
+	astroCoreClient := astrocore.NewCoreClient(httputil.NewHTTPClient(), tokenHolder)
+	astroCoreIamClient := astroiamcore.NewIamCoreClient(httputil.NewHTTPClient(), tokenHolder)
+	platformCoreClient := platformclient.NewPlatformCoreClient(httputil.NewHTTPClient(), tokenHolder)
 
 	ctx := cloudPlatform
 	isCloudCtx := context.IsCloudContext()
@@ -74,22 +79,22 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 			}
 			return utils.ChainRunEs(
 				SetupLogging,
-				CreateRootPersistentPreRunE(astroCoreClient, platformCoreClient),
+				CreateRootPersistentPreRunE(storeErr, store, tokenHolder, astroCoreClient, platformCoreClient),
 				telemetry.CreateTrackingHook(),
 			)(cmd, args)
 		},
 	}
 
 	rootCmd.AddCommand(
-		newLoginCommand(astroCoreClient, platformCoreClient, os.Stdout),
-		newLogoutCommand(os.Stdout),
-		newAuthRootCmd(astroCoreClient, platformCoreClient, os.Stdout),
+		newLoginCommand(store, tokenHolder, astroCoreClient, platformCoreClient, os.Stdout),
+		newLogoutCommand(store, os.Stdout),
+		newAuthRootCmd(store, tokenHolder, astroCoreClient, platformCoreClient, os.Stdout),
 		newVersionCommand(),
-		newDevRootCmd(platformCoreClient, astroCoreClient),
+		newDevRootCmd(platformCoreClient, astroCoreClient, store),
 		newContextCmd(os.Stdout),
 		newConfigRootCmd(os.Stdout),
 		newRunCommand(),
-		api.NewAPICmd(),
+		api.NewAPICmd(tokenHolder),
 		newTelemetryCmd(os.Stdout),
 		newTelemetrySendCmd(),
 	)
@@ -100,7 +105,7 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 		)
 	} else { // Include all the commands to be exposed for software users
 		rootCmd.AddCommand(
-			softwareCmd.AddCmds(houstonClient, os.Stdout)...,
+			softwareCmd.AddCmds(houstonClient, store, os.Stdout)...,
 		)
 		softwareCmd.VersionMatchCmds(rootCmd, []string{"astro"})
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/internal/telemetry"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 )
@@ -38,16 +39,16 @@ const (
 // NewRootCmd adds all of the primary commands for the cli
 func NewRootCmd() *cobra.Command {
 	var err error
-	tokenHolder := &httputil.TokenHolder{}
+	creds := &credentials.CurrentCredentials{}
 	store, storeErr := newSecureStore()
 
 	httpClient := houston.NewHTTPClient()
-	houstonClient = houston.NewClient(httpClient, tokenHolder)
+	houstonClient = houston.NewClient(httpClient, creds)
 
-	airflowClient := airflowclient.NewAirflowClient(httputil.NewHTTPClient(), tokenHolder)
-	astroCoreClient := astrocore.NewCoreClient(httputil.NewHTTPClient(), tokenHolder)
-	astroCoreIamClient := astroiamcore.NewIamCoreClient(httputil.NewHTTPClient(), tokenHolder)
-	platformCoreClient := platformclient.NewPlatformCoreClient(httputil.NewHTTPClient(), tokenHolder)
+	airflowClient := airflowclient.NewAirflowClient(httputil.NewHTTPClient(), creds)
+	astroCoreClient := astrocore.NewCoreClient(httputil.NewHTTPClient(), creds)
+	astroCoreIamClient := astroiamcore.NewIamCoreClient(httputil.NewHTTPClient(), creds)
+	platformCoreClient := platformclient.NewPlatformCoreClient(httputil.NewHTTPClient(), creds)
 
 	ctx := cloudPlatform
 	isCloudCtx := context.IsCloudContext()
@@ -79,29 +80,29 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 			}
 			return utils.ChainRunEs(
 				SetupLogging,
-				CreateRootPersistentPreRunE(storeErr, store, tokenHolder, astroCoreClient, platformCoreClient),
+				CreateRootPersistentPreRunE(storeErr, store, creds, astroCoreClient, platformCoreClient),
 				telemetry.CreateTrackingHook(),
 			)(cmd, args)
 		},
 	}
 
 	rootCmd.AddCommand(
-		newLoginCommand(store, tokenHolder, astroCoreClient, platformCoreClient, os.Stdout),
+		newLoginCommand(store, creds, astroCoreClient, platformCoreClient, os.Stdout),
 		newLogoutCommand(store, os.Stdout),
-		newAuthRootCmd(store, tokenHolder, astroCoreClient, platformCoreClient, os.Stdout),
+		newAuthRootCmd(store, creds, astroCoreClient, platformCoreClient, os.Stdout),
 		newVersionCommand(),
 		newDevRootCmd(platformCoreClient, astroCoreClient, store),
 		newContextCmd(os.Stdout),
 		newConfigRootCmd(os.Stdout),
 		newRunCommand(),
-		api.NewAPICmd(tokenHolder),
+		api.NewAPICmd(creds),
 		newTelemetryCmd(os.Stdout),
 		newTelemetrySendCmd(),
 	)
 
 	if context.IsCloudContext() { // Include all the commands to be exposed for cloud users
 		rootCmd.AddCommand(
-			cloudCmd.AddCmds(platformCoreClient, astroCoreClient, airflowClient, astroCoreIamClient, os.Stdout)...,
+			cloudCmd.AddCmds(platformCoreClient, astroCoreClient, airflowClient, astroCoreIamClient, creds, os.Stdout)...,
 		)
 	} else { // Include all the commands to be exposed for software users
 		rootCmd.AddCommand(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,13 +18,16 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/internal/telemetry"
 	"github.com/astronomer/astro-cli/pkg/ansi"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 )
 
 var (
 	verboseLevel   string
 	houstonClient  houston.ClientInterface
 	houstonVersion string
+	newSecureStore = keychain.New
 )
 
 const (
@@ -35,12 +38,15 @@ const (
 // NewRootCmd adds all of the primary commands for the cli
 func NewRootCmd() *cobra.Command {
 	var err error
-	httpClient := houston.NewHTTPClient()
-	houstonClient = houston.NewClient(httpClient)
+	creds := &credentials.CurrentCredentials{}
+	store, storeErr := newSecureStore()
 
-	airflowClient := airflowclient.NewAirflowClient(httputil.NewHTTPClient())
-	astroV1Client := astrov1.NewV1Client(httputil.NewHTTPClient())
-	v1Alpha1Client := astrov1alpha1.NewV1Alpha1Client(httputil.NewHTTPClient())
+	httpClient := houston.NewHTTPClient()
+	houstonClient = houston.NewClient(httpClient, creds)
+
+	airflowClient := airflowclient.NewAirflowClient(httputil.NewHTTPClient(), creds)
+	astroV1Client := astrov1.NewV1Client(httputil.NewHTTPClient(), creds)
+	v1Alpha1Client := astrov1alpha1.NewV1Alpha1Client(httputil.NewHTTPClient(), creds)
 
 	ctx := cloudPlatform
 	isCloudCtx := context.IsCloudContext()
@@ -72,34 +78,34 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 			}
 			return utils.ChainRunEs(
 				SetupLogging,
-				CreateRootPersistentPreRunE(astroV1Client),
+				CreateRootPersistentPreRunE(storeErr, store, creds, astroV1Client),
 				telemetry.CreateTrackingHook(),
 			)(cmd, args)
 		},
 	}
 
 	rootCmd.AddCommand(
-		newLoginCommand(astroV1Client, os.Stdout),
-		newLogoutCommand(os.Stdout),
-		newAuthRootCmd(astroV1Client, os.Stdout),
+		newLoginCommand(store, creds, astroV1Client, os.Stdout),
+		newLogoutCommand(store, os.Stdout),
+		newAuthRootCmd(store, creds, astroV1Client, os.Stdout),
 		newVersionCommand(),
-		newDevRootCmd(astroV1Client),
+		newDevRootCmd(astroV1Client, store),
 		newContextCmd(os.Stdout),
 		newConfigRootCmd(os.Stdout),
 		newRunCommand(),
-		api.NewAPICmd(),
+		api.NewAPICmd(creds),
 		newTelemetryCmd(os.Stdout),
 		newTelemetrySendCmd(),
-		newOttoCmd(),
+		newOttoCmd(creds),
 	)
 
 	if context.IsCloudContext() { // Include all the commands to be exposed for cloud users
 		rootCmd.AddCommand(
-			cloudCmd.AddCmds(astroV1Client, airflowClient, v1Alpha1Client, os.Stdout)...,
+			cloudCmd.AddCmds(astroV1Client, airflowClient, v1Alpha1Client, creds, os.Stdout)...,
 		)
 	} else { // Include all the commands to be exposed for software users
 		rootCmd.AddCommand(
-			softwareCmd.AddCmds(houstonClient, os.Stdout)...,
+			softwareCmd.AddCmds(houstonClient, store, os.Stdout)...,
 		)
 		softwareCmd.VersionMatchCmds(rootCmd, []string{"astro"})
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	cloudCmd "github.com/astronomer/astro-cli/cmd/cloud"
 	softwareCmd "github.com/astronomer/astro-cli/cmd/software"
 	"github.com/astronomer/astro-cli/cmd/utils"
+	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/internal/telemetry"
@@ -21,6 +22,7 @@ import (
 	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/keychain"
+	"github.com/astronomer/astro-cli/pkg/util"
 )
 
 var (
@@ -33,13 +35,36 @@ var (
 const (
 	softwarePlatform = "Astro Private Cloud"
 	cloudPlatform    = "Astro"
+
+	// noInsecureFallbackEnv refuses the plaintext credential fallback for a
+	// single invocation. The secure store is constructed before cobra parses
+	// flags, so this cannot be a flag; an env var also suits the CI and
+	// container settings where the fallback actually fires, and matches how
+	// ASTRO_API_TOKEN and ASTRO_DOMAIN are already read.
+	noInsecureFallbackEnv = "ASTRO_NO_INSECURE_FALLBACK"
 )
+
+// allowInsecureCredentialFallback reports whether credentials may be written to
+// a plaintext file when no OS-native secure store is available. It defaults to
+// true, preserving the previous config.yaml posture; users who would rather fail
+// than store secrets in the clear opt out via
+// `astro config set -g no_insecure_fallback true` or ASTRO_NO_INSECURE_FALLBACK.
+//
+// Either source can switch the protection on and neither can switch it off,
+// matching how SkipParse and AutoSelect combine their config and env sources.
+// That direction matters here: CheckEnvBool reports false for anything outside
+// true/1/yes/y/on, so letting the env win outright would mean a typo'd
+// ASTRO_NO_INSECURE_FALLBACK quietly overrode a persisted opt-out and allowed
+// the plaintext write it was set to prevent.
+func allowInsecureCredentialFallback() bool {
+	return !config.CFG.NoInsecureFallback.GetBool() && !util.CheckEnvBool(os.Getenv(noInsecureFallbackEnv))
+}
 
 // NewRootCmd adds all of the primary commands for the cli
 func NewRootCmd() *cobra.Command {
 	var err error
 	creds := &credentials.CurrentCredentials{}
-	store, storeErr := newSecureStore()
+	store, storeErr := newSecureStore(allowInsecureCredentialFallback())
 
 	httpClient := houston.NewHTTPClient()
 	houstonClient = houston.NewClient(httpClient, creds)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,7 +114,7 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 		newLogoutCommand(store, os.Stdout),
 		newAuthRootCmd(store, creds, astroV1Client, os.Stdout),
 		newVersionCommand(),
-		newDevRootCmd(astroV1Client, store),
+		newDevRootCmd(astroV1Client, store, creds),
 		newContextCmd(os.Stdout),
 		newConfigRootCmd(os.Stdout),
 		newRunCommand(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,10 @@ func allowInsecureCredentialFallback() bool {
 func NewRootCmd() *cobra.Command {
 	var err error
 	creds := &credentials.CurrentCredentials{}
+	// Keep the plaintext fallback's file next to config.yaml. pkg/keychain
+	// can't resolve this itself: the path honors ASTRO_HOME and is owned by
+	// package config, which imports pkg/keychain.
+	keychain.SetCredentialsDir(config.HomeConfigPath)
 	store, storeErr := newSecureStore(allowInsecureCredentialFallback())
 
 	httpClient := houston.NewHTTPClient()

--- a/cmd/root_hooks.go
+++ b/cmd/root_hooks.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -15,6 +16,8 @@ import (
 	softwareCmd "github.com/astronomer/astro-cli/cmd/software"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/version"
 )
 
@@ -26,32 +29,68 @@ func SetupLogging(_ *cobra.Command, _ []string) error {
 
 // CreateRootPersistentPreRunE takes clients as arguments and returns a cobra
 // pre-run hook that sets up the context and checks for the latest version.
-func CreateRootPersistentPreRunE(astroCoreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient) func(cmd *cobra.Command, args []string) error {
+func CreateRootPersistentPreRunE(storeErr error, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, astroCoreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// login/logout don't need existing credentials, skip auth setup
+		if cmd.CalledAs() == "login" || cmd.CalledAs() == "logout" {
+			return nil
+		}
+
+		if storeErr != nil {
+			return fmt.Errorf("secure credential store unavailable: %w", storeErr)
+		}
+
 		// Check for latest version
 		if config.CFG.UpgradeMessage.GetBool() {
-			// create http client with 3 second timeout, setting an aggressive timeout since its not mandatory to get a response in each command execution
 			httpClient := &http.Client{Timeout: 3 * time.Second}
-
-			// compare current version to latest
 			err := version.CompareVersions(cmd.Context(), httpClient)
 			if err != nil {
 				softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error comparing CLI versions: "+err.Error())
 			}
 		}
+
+		if migrated, err := config.MigrateLegacyCredentials(store); err != nil {
+			softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "credential migration error: "+err.Error())
+		} else if migrated > 0 {
+			fmt.Printf("Migrated credentials for %d context(s) to your system's secure store.\n", migrated)
+		}
+
 		if context.IsCloudContext() {
-			err := cloudCmd.Setup(cmd, platformCoreClient, astroCoreClient)
-			if err != nil {
-				if strings.Contains(err.Error(), "token is invalid or malformed") {
-					return errors.New("API Token is invalid or malformed") //nolint
-				}
-				if strings.Contains(err.Error(), "the API token given has expired") {
-					return errors.New("API Token is expired") //nolint
-				}
-				softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error during cmd setup: "+err.Error())
+			if err := handleCloudSetup(cmd, store, tokenHolder, platformCoreClient, astroCoreClient); err != nil {
+				return err
 			}
+		} else {
+			loadSoftwareToken(store, tokenHolder)
 		}
 		softwareCmd.PrintDebugLogs()
 		return nil
+	}
+}
+
+func handleCloudSetup(cmd *cobra.Command, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, platformCoreClient astroplatformcore.CoreClient, astroCoreClient astrocore.CoreClient) error {
+	err := cloudCmd.Setup(cmd, store, tokenHolder, platformCoreClient, astroCoreClient)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "token is invalid or malformed") {
+		return errors.New("API Token is invalid or malformed") //nolint
+	}
+	if strings.Contains(err.Error(), "the API token given has expired") {
+		return errors.New("API Token is expired") //nolint
+	}
+	softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error during cmd setup: "+err.Error())
+	return nil
+}
+
+func loadSoftwareToken(store keychain.SecureStore, tokenHolder *httputil.TokenHolder) {
+	if store == nil {
+		return
+	}
+	c, err := context.GetCurrentContext()
+	if err != nil {
+		return
+	}
+	if creds, credErr := store.GetCredentials(c.Domain); credErr == nil {
+		tokenHolder.Set(creds.Token)
 	}
 }

--- a/cmd/root_hooks.go
+++ b/cmd/root_hooks.go
@@ -16,7 +16,7 @@ import (
 	softwareCmd "github.com/astronomer/astro-cli/cmd/software"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
-	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/version"
 )
@@ -29,7 +29,7 @@ func SetupLogging(_ *cobra.Command, _ []string) error {
 
 // CreateRootPersistentPreRunE takes clients as arguments and returns a cobra
 // pre-run hook that sets up the context and checks for the latest version.
-func CreateRootPersistentPreRunE(storeErr error, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, astroCoreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient) func(cmd *cobra.Command, args []string) error {
+func CreateRootPersistentPreRunE(storeErr error, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroCoreClient astrocore.CoreClient, platformCoreClient astroplatformcore.CoreClient) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		// login/logout don't need existing credentials, skip auth setup
 		if cmd.CalledAs() == "login" || cmd.CalledAs() == "logout" {
@@ -56,19 +56,19 @@ func CreateRootPersistentPreRunE(storeErr error, store keychain.SecureStore, tok
 		}
 
 		if context.IsCloudContext() {
-			if err := handleCloudSetup(cmd, store, tokenHolder, platformCoreClient, astroCoreClient); err != nil {
+			if err := handleCloudSetup(cmd, store, creds, platformCoreClient, astroCoreClient); err != nil {
 				return err
 			}
 		} else {
-			loadSoftwareToken(store, tokenHolder)
+			loadSoftwareToken(store, creds)
 		}
 		softwareCmd.PrintDebugLogs()
 		return nil
 	}
 }
 
-func handleCloudSetup(cmd *cobra.Command, store keychain.SecureStore, tokenHolder *httputil.TokenHolder, platformCoreClient astroplatformcore.CoreClient, astroCoreClient astrocore.CoreClient) error {
-	err := cloudCmd.Setup(cmd, store, tokenHolder, platformCoreClient, astroCoreClient)
+func handleCloudSetup(cmd *cobra.Command, store keychain.SecureStore, creds *credentials.CurrentCredentials, platformCoreClient astroplatformcore.CoreClient, astroCoreClient astrocore.CoreClient) error {
+	err := cloudCmd.Setup(cmd, store, creds, platformCoreClient, astroCoreClient)
 	if err == nil {
 		return nil
 	}
@@ -82,7 +82,7 @@ func handleCloudSetup(cmd *cobra.Command, store keychain.SecureStore, tokenHolde
 	return nil
 }
 
-func loadSoftwareToken(store keychain.SecureStore, tokenHolder *httputil.TokenHolder) {
+func loadSoftwareToken(store keychain.SecureStore, creds *credentials.CurrentCredentials) {
 	if store == nil {
 		return
 	}
@@ -90,7 +90,7 @@ func loadSoftwareToken(store keychain.SecureStore, tokenHolder *httputil.TokenHo
 	if err != nil {
 		return
 	}
-	if creds, credErr := store.GetCredentials(c.Domain); credErr == nil {
-		tokenHolder.Set(creds.Token)
+	if keyCreds, credErr := store.GetCredentials(c.Domain); credErr == nil {
+		creds.Set(keyCreds.Token)
 	}
 }

--- a/cmd/root_hooks.go
+++ b/cmd/root_hooks.go
@@ -30,13 +30,21 @@ func SetupLogging(_ *cobra.Command, _ []string) error {
 // pre-run hook that sets up the context and checks for the latest version.
 func CreateRootPersistentPreRunE(storeErr error, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// login/logout don't need existing credentials, skip auth setup
-		if cmd.CalledAs() == "login" || cmd.CalledAs() == "logout" {
+		// logout doesn't need existing credentials, and still has local context
+		// to reset even when the store is broken — let it through either way.
+		if cmd.CalledAs() == "logout" {
 			return nil
 		}
 
+		// Checked before login returns early: login doesn't need existing
+		// credentials, but it does need somewhere to put new ones, and this is
+		// where the reason it can't is worth saying.
 		if storeErr != nil {
 			return fmt.Errorf("secure credential store unavailable: %w", storeErr)
+		}
+
+		if cmd.CalledAs() == "login" {
+			return nil
 		}
 
 		// Check for latest version
@@ -51,15 +59,18 @@ func CreateRootPersistentPreRunE(storeErr error, store keychain.SecureStore, cre
 		if migrated, err := config.MigrateLegacyCredentials(store); err != nil {
 			softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "credential migration error: "+err.Error())
 		} else if migrated > 0 {
-			fmt.Printf("Migrated credentials for %d context(s) to your system's secure store.\n", migrated)
+			// Deliberately doesn't name the destination: on a host with no OS
+			// keyring this store is the plaintext fallback, and claiming a
+			// "secure store" would be a lie. warnInsecureWrite says so instead.
+			fmt.Printf("Moved credentials for %d context(s) out of config.yaml into the credential store.\n", migrated)
 		}
 
 		if context.IsCloudContext() {
 			if err := handleCloudSetup(cmd, store, creds, astroV1Client); err != nil {
 				return err
 			}
-		} else {
-			loadSoftwareToken(store, creds)
+		} else if err := loadSoftwareToken(store, creds); err != nil {
+			return err
 		}
 		softwareCmd.PrintDebugLogs()
 		return nil
@@ -81,15 +92,31 @@ func handleCloudSetup(cmd *cobra.Command, store keychain.SecureStore, creds *cre
 	return nil
 }
 
-func loadSoftwareToken(store keychain.SecureStore, creds *credentials.CurrentCredentials) {
+// loadSoftwareToken populates creds from the secure store for Software
+// (Houston) contexts, which have no checkToken equivalent to do it for them.
+//
+// It distinguishes "nothing stored" from "could not read what is stored". The
+// former is ordinary — the user isn't logged in, so leave creds empty and let
+// whatever needs auth say so. The latter must not be swallowed: a locked
+// keychain, a denied ACL prompt after a binary update, or a dead D-Bus would
+// otherwise leave creds empty and send unauthenticated requests to Houston,
+// surfacing as a baffling 401 rather than the credential problem it is.
+func loadSoftwareToken(store keychain.SecureStore, creds *credentials.CurrentCredentials) error {
 	if store == nil {
-		return
+		return nil
 	}
 	c, err := context.GetCurrentContext()
 	if err != nil {
-		return
+		// No context set yet, so there is nothing to load.
+		return nil
 	}
-	if keyCreds, credErr := store.GetCredentials(c.Domain); credErr == nil {
-		creds.Set(keyCreds.Token)
+	keyCreds, err := store.GetCredentials(c.Domain)
+	switch {
+	case errors.Is(err, keychain.ErrNotFound):
+		return nil
+	case err != nil:
+		return fmt.Errorf("could not read stored credentials for %s: %w", c.Domain, err)
 	}
+	creds.Set(keyCreds.Token)
+	return nil
 }

--- a/cmd/root_hooks.go
+++ b/cmd/root_hooks.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -14,6 +15,8 @@ import (
 	softwareCmd "github.com/astronomer/astro-cli/cmd/software"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/version"
 )
 
@@ -25,32 +28,68 @@ func SetupLogging(_ *cobra.Command, _ []string) error {
 
 // CreateRootPersistentPreRunE takes clients as arguments and returns a cobra
 // pre-run hook that sets up the context and checks for the latest version.
-func CreateRootPersistentPreRunE(astroV1Client astrov1.APIClient) func(cmd *cobra.Command, args []string) error {
+func CreateRootPersistentPreRunE(storeErr error, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// login/logout don't need existing credentials, skip auth setup
+		if cmd.CalledAs() == "login" || cmd.CalledAs() == "logout" {
+			return nil
+		}
+
+		if storeErr != nil {
+			return fmt.Errorf("secure credential store unavailable: %w", storeErr)
+		}
+
 		// Check for latest version
 		if config.CFG.UpgradeMessage.GetBool() {
-			// create http client with 3 second timeout, setting an aggressive timeout since its not mandatory to get a response in each command execution
 			httpClient := &http.Client{Timeout: 3 * time.Second}
-
-			// compare current version to latest
 			err := version.CompareVersions(cmd.Context(), httpClient)
 			if err != nil {
 				softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error comparing CLI versions: "+err.Error())
 			}
 		}
+
+		if migrated, err := config.MigrateLegacyCredentials(store); err != nil {
+			softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "credential migration error: "+err.Error())
+		} else if migrated > 0 {
+			fmt.Printf("Migrated credentials for %d context(s) to your system's secure store.\n", migrated)
+		}
+
 		if context.IsCloudContext() {
-			err := cloudCmd.Setup(cmd, astroV1Client)
-			if err != nil {
-				if strings.Contains(err.Error(), "token is invalid or malformed") {
-					return errors.New("API Token is invalid or malformed") //nolint
-				}
-				if strings.Contains(err.Error(), "the API token given has expired") {
-					return errors.New("API Token is expired") //nolint
-				}
-				softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error during cmd setup: "+err.Error())
+			if err := handleCloudSetup(cmd, store, creds, astroV1Client); err != nil {
+				return err
 			}
+		} else {
+			loadSoftwareToken(store, creds)
 		}
 		softwareCmd.PrintDebugLogs()
 		return nil
+	}
+}
+
+func handleCloudSetup(cmd *cobra.Command, store keychain.SecureStore, creds *credentials.CurrentCredentials, astroV1Client astrov1.APIClient) error {
+	err := cloudCmd.Setup(cmd, store, creds, astroV1Client)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "token is invalid or malformed") {
+		return errors.New("API Token is invalid or malformed") //nolint
+	}
+	if strings.Contains(err.Error(), "the API token given has expired") {
+		return errors.New("API Token is expired") //nolint
+	}
+	softwareCmd.InitDebugLogs = append(softwareCmd.InitDebugLogs, "Error during cmd setup: "+err.Error())
+	return nil
+}
+
+func loadSoftwareToken(store keychain.SecureStore, creds *credentials.CurrentCredentials) {
+	if store == nil {
+		return
+	}
+	c, err := context.GetCurrentContext()
+	if err != nil {
+		return
+	}
+	if keyCreds, credErr := store.GetCredentials(c.Domain); credErr == nil {
+		creds.Set(keyCreds.Token)
 	}
 }

--- a/cmd/root_hooks.go
+++ b/cmd/root_hooks.go
@@ -69,7 +69,7 @@ func CreateRootPersistentPreRunE(storeErr error, store keychain.SecureStore, cre
 			if err := handleCloudSetup(cmd, store, creds, astroV1Client); err != nil {
 				return err
 			}
-		} else if err := loadSoftwareToken(store, creds); err != nil {
+		} else if err := loadStoredToken(store, creds); err != nil {
 			return err
 		}
 		softwareCmd.PrintDebugLogs()
@@ -92,16 +92,18 @@ func handleCloudSetup(cmd *cobra.Command, store keychain.SecureStore, creds *cre
 	return nil
 }
 
-// loadSoftwareToken populates creds from the secure store for Software
-// (Houston) contexts, which have no checkToken equivalent to do it for them.
+// loadStoredToken populates creds with the current context's stored token,
+// without refreshing it or prompting for login. Used by Software contexts,
+// which have no checkToken equivalent to do it for them, and by `astro dev`,
+// whose pre-run hook shadows this one (see loadDevCredentials).
 //
 // It distinguishes "nothing stored" from "could not read what is stored". The
 // former is ordinary — the user isn't logged in, so leave creds empty and let
 // whatever needs auth say so. The latter must not be swallowed: a locked
 // keychain, a denied ACL prompt after a binary update, or a dead D-Bus would
-// otherwise leave creds empty and send unauthenticated requests to Houston,
+// otherwise leave creds empty and send unauthenticated requests,
 // surfacing as a baffling 401 rather than the credential problem it is.
-func loadSoftwareToken(store keychain.SecureStore, creds *credentials.CurrentCredentials) error {
+func loadStoredToken(store keychain.SecureStore, creds *credentials.CurrentCredentials) error {
 	if store == nil {
 		return nil
 	}

--- a/cmd/root_hooks_test.go
+++ b/cmd/root_hooks_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/astro-cli/pkg/credentials"
+	"github.com/astronomer/astro-cli/pkg/keychain"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+)
+
+func TestLoadSoftwareToken_LoadsToken(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	store := keychain.NewTestStore()
+	err := store.SetCredentials("astronomer_dev.com", keychain.Credentials{Token: "test-token"})
+	assert.NoError(t, err)
+
+	holder := &credentials.CurrentCredentials{}
+	loadSoftwareToken(store, holder)
+	assert.Equal(t, "test-token", holder.Get())
+}

--- a/cmd/root_hooks_test.go
+++ b/cmd/root_hooks_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+)
+
+func TestLoadSoftwareToken_LoadsToken(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	store := keychain.NewTestStore()
+	err := store.SetCredentials("astronomer_dev.com", keychain.Credentials{Token: "test-token"})
+	assert.NoError(t, err)
+
+	holder := &httputil.TokenHolder{}
+	loadSoftwareToken(store, holder)
+	assert.Equal(t, "test-token", holder.Get())
+}

--- a/cmd/root_hooks_test.go
+++ b/cmd/root_hooks_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
@@ -16,7 +16,7 @@ func TestLoadSoftwareToken_LoadsToken(t *testing.T) {
 	err := store.SetCredentials("astronomer_dev.com", keychain.Credentials{Token: "test-token"})
 	assert.NoError(t, err)
 
-	holder := &httputil.TokenHolder{}
+	holder := &credentials.CurrentCredentials{}
 	loadSoftwareToken(store, holder)
 	assert.Equal(t, "test-token", holder.Get())
 }

--- a/cmd/root_hooks_test.go
+++ b/cmd/root_hooks_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,42 @@ func TestLoadSoftwareToken_LoadsToken(t *testing.T) {
 	assert.NoError(t, err)
 
 	holder := &credentials.CurrentCredentials{}
-	loadSoftwareToken(store, holder)
+	assert.NoError(t, loadSoftwareToken(store, holder))
 	assert.Equal(t, "test-token", holder.Get())
+}
+
+// errStore fails every read, standing in for a locked keychain, an ACL prompt
+// the user denied after a binary update, or a dead D-Bus session.
+type errStore struct{ err error }
+
+func (e errStore) GetCredentials(string) (keychain.Credentials, error) {
+	return keychain.Credentials{}, e.err
+}
+func (e errStore) SetCredentials(string, keychain.Credentials) error { return e.err }
+func (e errStore) DeleteCredentials(string) error                    { return e.err }
+
+// A store that cannot be read must not look like "not logged in": swallowing
+// the error leaves the token holder empty and sends unauthenticated requests to
+// Houston, which surface as a confusing 401 instead of a credential problem.
+func TestLoadSoftwareToken_ReadFailureIsNotSilent(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	holder := &credentials.CurrentCredentials{}
+	err := loadSoftwareToken(errStore{err: errors.New("keychain is locked")}, holder)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "keychain is locked")
+	assert.Empty(t, holder.Get())
+}
+
+// Not being logged in is ordinary, not an error — leave the holder empty and let
+// whatever actually needs auth report it.
+func TestLoadSoftwareToken_NotFoundIsNotAnError(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+
+	holder := &credentials.CurrentCredentials{}
+	err := loadSoftwareToken(errStore{err: keychain.ErrNotFound}, holder)
+
+	assert.NoError(t, err)
+	assert.Empty(t, holder.Get())
 }

--- a/cmd/root_hooks_test.go
+++ b/cmd/root_hooks_test.go
@@ -4,21 +4,24 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
-func TestLoadSoftwareToken_LoadsToken(t *testing.T) {
+func TestLoadStoredToken_LoadsToken(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
 	store := keychain.NewTestStore()
 	err := store.SetCredentials("astronomer_dev.com", keychain.Credentials{Token: "test-token"})
 	assert.NoError(t, err)
 
 	holder := &credentials.CurrentCredentials{}
-	assert.NoError(t, loadSoftwareToken(store, holder))
+	assert.NoError(t, loadStoredToken(store, holder))
 	assert.Equal(t, "test-token", holder.Get())
 }
 
@@ -35,11 +38,11 @@ func (e errStore) DeleteCredentials(string) error                    { return e.
 // A store that cannot be read must not look like "not logged in": swallowing
 // the error leaves the token holder empty and sends unauthenticated requests to
 // Houston, which surface as a confusing 401 instead of a credential problem.
-func TestLoadSoftwareToken_ReadFailureIsNotSilent(t *testing.T) {
+func TestLoadStoredToken_ReadFailureIsNotSilent(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
 
 	holder := &credentials.CurrentCredentials{}
-	err := loadSoftwareToken(errStore{err: errors.New("keychain is locked")}, holder)
+	err := loadStoredToken(errStore{err: errors.New("keychain is locked")}, holder)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "keychain is locked")
@@ -48,12 +51,51 @@ func TestLoadSoftwareToken_ReadFailureIsNotSilent(t *testing.T) {
 
 // Not being logged in is ordinary, not an error — leave the holder empty and let
 // whatever actually needs auth report it.
-func TestLoadSoftwareToken_NotFoundIsNotAnError(t *testing.T) {
+func TestLoadStoredToken_NotFoundIsNotAnError(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
 
 	holder := &credentials.CurrentCredentials{}
-	err := loadSoftwareToken(errStore{err: keychain.ErrNotFound}, holder)
+	err := loadStoredToken(errStore{err: keychain.ErrNotFound}, holder)
 
 	assert.NoError(t, err)
 	assert.Empty(t, holder.Get())
+}
+
+// `astro dev` defines its own PersistentPreRunE for the container runtime, and
+// cobra replaces the root's rather than chaining them — so the root hook that
+// normally fills creds never runs. Request editors read the token only from
+// creds now, so the dev sub-commands that reach the Astro API must load it
+// themselves or they send unauthenticated requests.
+func TestLoadDevCredentials_LoadsTokenWhenTargetingDeployment(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+	c, err := context.GetCurrentContext()
+	require.NoError(t, err)
+
+	store := keychain.NewTestStore()
+	require.NoError(t, store.SetCredentials(c.Domain, keychain.Credentials{Token: "Bearer dev-token"}))
+
+	cmd := &cobra.Command{Use: "start"}
+	cmd.Flags().String("workspace-id", "", "")
+	cmd.Flags().String("deployment-id", "", "")
+	require.NoError(t, cmd.Flags().Set("deployment-id", "cl-test-deployment"))
+
+	creds := &credentials.CurrentCredentials{}
+	require.NoError(t, loadDevCredentials(store, creds)(cmd, nil))
+	assert.Equal(t, "Bearer dev-token", creds.Get())
+}
+
+// Plain `astro dev start` targets nothing on Astro, so it must keep working
+// logged out — and must not touch the keychain (which on macOS would mean an
+// unprompted-for credential prompt just to start Airflow locally).
+func TestLoadDevCredentials_SkipsWhenNoAstroTarget(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.CloudPlatform)
+
+	cmd := &cobra.Command{Use: "start"}
+	cmd.Flags().String("workspace-id", "", "")
+	cmd.Flags().String("deployment-id", "", "")
+
+	creds := &credentials.CurrentCredentials{}
+	// errStore fails any read; reaching it at all would fail this test.
+	require.NoError(t, loadDevCredentials(errStore{err: errors.New("must not touch the store")}, creds)(cmd, nil))
+	assert.Empty(t, creds.Get())
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,9 +7,16 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/astronomer/astro-cli/version"
 )
+
+func init() {
+	newSecureStore = func() (keychain.SecureStore, error) {
+		return keychain.NewTestStore(), nil
+	}
+}
 
 type CmdSuite struct {
 	suite.Suite

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,18 +2,22 @@ package cmd
 
 import (
 	"bytes"
+	"strconv"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/astronomer/astro-cli/version"
 )
 
 func init() {
-	newSecureStore = func() (keychain.SecureStore, error) {
+	newSecureStore = func(_ bool) (keychain.SecureStore, error) {
 		return keychain.NewTestStore(), nil
 	}
 }
@@ -97,4 +101,34 @@ func (s *CmdSuite) TestRootCommandSoftwareContext() {
 	s.Contains(output, "deployment")
 	s.Contains(output, "run")
 	s.NotContains(output, "Run flow commands")
+}
+
+// Either source can switch the plaintext fallback off; neither can switch it
+// back on. CheckEnvBool reports false for anything outside true/1/yes/y/on, so
+// if the env var won outright a typo would quietly re-allow the plaintext write
+// a persisted opt-out was set to prevent.
+func TestAllowInsecureCredentialFallback(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		config bool
+		env    string
+		want   bool
+	}{
+		{name: "default allows the fallback", want: true},
+		{name: "config opts out", config: true, want: false},
+		{name: "env opts out", env: "true", want: false},
+		{name: "env opts out with 1", env: "1", want: false},
+		{name: "both opt out", config: true, env: "true", want: false},
+		{name: "env cannot re-enable what config disabled", config: true, env: "false", want: false},
+		{name: "a typo cannot re-enable what config disabled", config: true, env: "treu", want: false},
+		{name: "unset env leaves config alone", config: true, env: "", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testUtil.InitTestConfig(testUtil.CloudPlatform)
+			require.NoError(t, config.CFG.NoInsecureFallback.SetHomeString(strconv.FormatBool(tt.config)))
+			t.Setenv("ASTRO_NO_INSECURE_FALLBACK", tt.env)
+
+			assert.Equal(t, tt.want, allowInsecureCredentialFallback())
+		})
+	}
 }

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -114,7 +114,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 	}
 
 	if isDagOnlyDeploy {
-		return DagsOnlyDeploy(houstonClient, ws, deploymentID, config.WorkingPath, nil, true, description)
+		return DagsOnlyDeploy(houstonClient, store, ws, deploymentID, config.WorkingPath, nil, true, description)
 	}
 
 	if imagePresentOnRemote {
@@ -127,7 +127,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		// Since we prompt the user to enter the deploymentID in come cases for DeployAirflowImage, reusing the same  deploymentID for DagsOnlyDeploy
-		deploymentID, err = DeployAirflowImage(houstonClient, config.WorkingPath, deploymentID, ws, ignoreCacheDeploy, forcePrompt, description, isImageOnlyDeploy, imageName)
+		deploymentID, err = DeployAirflowImage(houstonClient, store, config.WorkingPath, deploymentID, ws, ignoreCacheDeploy, forcePrompt, description, isImageOnlyDeploy, imageName)
 		if err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	err = DagsOnlyDeploy(houstonClient, ws, deploymentID, config.WorkingPath, nil, true, description)
+	err = DagsOnlyDeploy(houstonClient, store, ws, deploymentID, config.WorkingPath, nil, true, description)
 	// Don't throw the error if dag-deploy itself is disabled
 	if errors.Is(err, deploy.ErrDagOnlyDeployDisabledInConfig) || errors.Is(err, deploy.ErrDagOnlyDeployNotEnabledForDeployment) {
 		return nil

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -119,7 +119,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 	}
 
 	if isDagOnlyDeploy {
-		return DagsOnlyDeploy(houstonClient, ws, deploymentID, config.WorkingPath, nil, true, description)
+		return DagsOnlyDeploy(houstonClient, store, ws, deploymentID, config.WorkingPath, nil, true, description)
 	}
 
 	if imagePresentOnRemote {
@@ -132,7 +132,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		// Since we prompt the user to enter the deploymentID in come cases for DeployAirflowImage, reusing the same  deploymentID for DagsOnlyDeploy
-		deploymentID, err = DeployAirflowImage(houstonClient, config.WorkingPath, deploymentID, ws, ignoreCacheDeploy, forcePrompt, description, isImageOnlyDeploy, imageName)
+		deploymentID, err = DeployAirflowImage(houstonClient, store, config.WorkingPath, deploymentID, ws, ignoreCacheDeploy, forcePrompt, description, isImageOnlyDeploy, imageName)
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func deployAirflow(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	err = DagsOnlyDeploy(houstonClient, ws, deploymentID, config.WorkingPath, nil, true, description)
+	err = DagsOnlyDeploy(houstonClient, store, ws, deploymentID, config.WorkingPath, nil, true, description)
 	// Don't throw the error if dag-deploy itself is disabled
 	if deploy.IsDagOnlyDeployDisabledInClusterConfig(err) || errors.Is(err, deploy.ErrDagOnlyDeployNotEnabledForDeployment) {
 		return nil

--- a/cmd/software/deploy_test.go
+++ b/cmd/software/deploy_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 	"github.com/astronomer/astro-cli/software/deploy"
 )
@@ -28,14 +29,14 @@ func (s *Suite) TestDeploy() {
 	EnsureProjectDir = func(cmd *cobra.Command, args []string) error {
 		return nil
 	}
-	DeployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+	DeployAirflowImage = func(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 		if description == "" {
 			return deploymentID, fmt.Errorf("description should not be empty")
 		}
 		return deploymentID, nil
 	}
 
-	DagsOnlyDeploy = func(houstonClient houston.ClientInterface, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
+	DagsOnlyDeploy = func(houstonClient houston.ClientInterface, store keychain.SecureStore, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 		return nil
 	}
 
@@ -53,7 +54,7 @@ func (s *Suite) TestDeploy() {
 	s.NoError(err)
 
 	// Test when the default description is used
-	DeployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+	DeployAirflowImage = func(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 		expectedDesc := "Deployed via <astro deploy>"
 		if description != expectedDesc {
 			return deploymentID, fmt.Errorf("expected description to be '%s', but got '%s'", expectedDesc, description)
@@ -68,20 +69,20 @@ func (s *Suite) TestDeploy() {
 	DagsOnlyDeploy = deploy.DagsOnlyDeploy
 
 	s.Run("error should be returned for astro deploy, if DeployAirflowImage throws error", func() {
-		DeployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+		DeployAirflowImage = func(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 			return deploymentID, deploy.ErrNoWorkspaceID
 		}
 
 		err := execDeployCmd([]string{"-f"}...)
 		s.ErrorIs(err, deploy.ErrNoWorkspaceID)
 
-		DeployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+		DeployAirflowImage = func(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 			return deploymentID, nil
 		}
 	})
 
 	s.Run("error should be returned for astro deploy, if dags deploy throws error and the feature is enabled", func() {
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, store keychain.SecureStore, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 			return deploy.ErrNoWorkspaceID
 		}
 		err := execDeployCmd([]string{"-f"}...)
@@ -89,7 +90,7 @@ func (s *Suite) TestDeploy() {
 	})
 
 	s.Run("Test for the flag --dags when the feature is disabled", func() {
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, store keychain.SecureStore, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 			return deploy.ErrDagOnlyDeployDisabledInConfig
 		}
 		err := execDeployCmd([]string{"test-deployment-id", "--dags", "--force"}...)
@@ -102,7 +103,7 @@ func (s *Suite) TestDeploy() {
 	})
 
 	s.Run("Test for the flag --image for image deployment", func() {
-		DeployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+		DeployAirflowImage = func(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 			return deploymentID, deploy.ErrDeploymentTypeIncorrectForImageOnly
 		}
 		err := execDeployCmd([]string{"test-deployment-id", "--image", "--force"}...)
@@ -110,11 +111,11 @@ func (s *Suite) TestDeploy() {
 	})
 
 	s.Run("Test for the flag --image for dags-only deployment", func() {
-		DeployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+		DeployAirflowImage = func(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 			return deploymentID, nil
 		}
 		// This function is not called since --image is passed
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, store keychain.SecureStore, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 			return deploy.ErrNoWorkspaceID
 		}
 		err := execDeployCmd([]string{"test-deployment-id", "--image", "--force"}...)
@@ -123,11 +124,11 @@ func (s *Suite) TestDeploy() {
 
 	s.Run("Test for the flag --image-name", func() {
 		var capturedImageName string
-		DeployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+		DeployAirflowImage = func(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 			capturedImageName = imageName // Capture the imageName
 			return deploymentID, nil
 		}
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, store keychain.SecureStore, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 			return nil
 		}
 		testImageName := "test-image-name" // Set the expected image name
@@ -138,14 +139,14 @@ func (s *Suite) TestDeploy() {
 	})
 
 	s.Run("Test for the flag --image-name with --remote. Dags should be deployed but DeployAirflowImage shouldn't be called", func() {
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, store keychain.SecureStore, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 			return nil
 		}
 		// Create a flag to track if DeployAirflowImage is called
 		deployAirflowImageCalled := false
 
 		// Mock function for DeployAirflowImage
-		DeployAirflowImage = func(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+		DeployAirflowImage = func(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 			deployAirflowImageCalled = true // Set the flag if this function is called
 			return deploymentID, nil
 		}
@@ -177,7 +178,7 @@ func (s *Suite) TestDeploy() {
 	})
 
 	s.Run("error should be returned if BYORegistryEnabled is true but BYORegistryDomain is empty", func() {
-		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
+		DagsOnlyDeploy = func(houstonClient houston.ClientInterface, store keychain.SecureStore, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 			return deploy.ErrBYORegistryDomainNotSet
 		}
 		err := execDeployCmd([]string{"-f"}...)

--- a/cmd/software/deployment_logs.go
+++ b/cmd/software/deployment_logs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/software/deployment"
 )
 
@@ -144,7 +145,16 @@ astro deployment logs triggerer YOU_DEPLOYMENT_ID -s string-to-find
 
 func fetchRemoteLogs(component string, args []string, out io.Writer) error {
 	if follow {
-		return deployment.SubscribeDeploymentLog(args[0], component, search, since)
+		var token string
+		if store != nil {
+			c, err := config.GetCurrentContext()
+			if err == nil {
+				if creds, credErr := store.GetCredentials(c.Domain); credErr == nil {
+					token = creds.Token
+				}
+			}
+		}
+		return deployment.SubscribeDeploymentLog(args[0], component, search, token, since)
 	}
 	return deployment.Log(args[0], component, search, since, houstonClient, out)
 }

--- a/cmd/software/deployment_teams_test.go
+++ b/cmd/software/deployment_teams_test.go
@@ -101,7 +101,7 @@ func (s *Suite) TestDeploymentTeamsListCmd() {
 			Header:     make(http.Header),
 		}
 	})
-	houstonClient = houston.NewClient(client)
+	houstonClient = houston.NewClient(client, nil)
 	buf := new(bytes.Buffer)
 	cmd := newDeploymentTeamListCmd(buf)
 	s.NotNil(cmd)

--- a/cmd/software/deployment_teams_test.go
+++ b/cmd/software/deployment_teams_test.go
@@ -103,7 +103,7 @@ func (s *Suite) TestDeploymentTeamsListCmd() {
 			Header:     make(http.Header),
 		}
 	})
-	houstonClient = houston.NewClient(client)
+	houstonClient = houston.NewClient(client, nil)
 	buf := new(bytes.Buffer)
 	cmd := newDeploymentTeamListCmd(buf)
 	s.NotNil(cmd)

--- a/cmd/software/root.go
+++ b/cmd/software/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 )
 
@@ -19,14 +20,16 @@ var (
 	houstonClient  houston.ClientInterface
 	appConfig      *houston.AppConfig
 	houstonVersion string
+	store          keychain.SecureStore
 
 	workspaceID string
 	teamID      string
 )
 
 // AddCmds adds all the command initialized in this package for the cmd package to import
-func AddCmds(client houston.ClientInterface, out io.Writer) []*cobra.Command {
+func AddCmds(client houston.ClientInterface, s keychain.SecureStore, out io.Writer) []*cobra.Command {
 	houstonClient = client
+	store = s
 
 	var err error
 	// There is no clusterID in the GetAppConfig call at this point of lifecycle, so we are getting the app config for the default cluster

--- a/cmd/software/root_test.go
+++ b/cmd/software/root_test.go
@@ -44,7 +44,7 @@ func (s *AddCmdSuite) TestAddCmds() {
 	houstonMock.On("GetAppConfig", "").Return(appConfig, nil)
 	houstonMock.On("GetPlatformVersion", nil).Return("0.30.0", nil)
 	buf := new(bytes.Buffer)
-	cmds := AddCmds(houstonMock, buf)
+	cmds := AddCmds(houstonMock, nil, buf)
 	for cmdIdx := range cmds {
 		s.Contains([]string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace", "team"}, cmds[cmdIdx].Use)
 	}
@@ -56,7 +56,7 @@ func (s *AddCmdSuite) TestAppConfigFailure() {
 	houstonMock.On("GetAppConfig", "").Return(nil, errMock)
 	houstonMock.On("GetPlatformVersion", nil).Return("0.30.0", nil)
 	buf := new(bytes.Buffer)
-	cmds := AddCmds(houstonMock, buf)
+	cmds := AddCmds(houstonMock, nil, buf)
 	for cmdIdx := range cmds {
 		s.Contains([]string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace", "team"}, cmds[cmdIdx].Use)
 	}
@@ -75,7 +75,7 @@ func (s *AddCmdSuite) TestPlatformVersionFailure() {
 	houstonMock.On("GetAppConfig", "").Return(appConfig, nil)
 	houstonMock.On("GetPlatformVersion", nil).Return("", errMock)
 	buf := new(bytes.Buffer)
-	cmds := AddCmds(houstonMock, buf)
+	cmds := AddCmds(houstonMock, nil, buf)
 	for cmdIdx := range cmds {
 		s.Contains([]string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace", "team"}, cmds[cmdIdx].Use)
 	}

--- a/cmd/software/root_test.go
+++ b/cmd/software/root_test.go
@@ -45,7 +45,7 @@ func (s *AddCmdSuite) TestAddCmds() {
 	houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil)
 	houstonMock.On("GetPlatformVersion", nil).Return("0.30.0", nil)
 	buf := new(bytes.Buffer)
-	cmds := AddCmds(houstonMock, buf)
+	cmds := AddCmds(houstonMock, nil, buf)
 	for cmdIdx := range cmds {
 		s.Contains([]string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace", "team"}, cmds[cmdIdx].Use)
 	}
@@ -57,7 +57,7 @@ func (s *AddCmdSuite) TestAppConfigFailure() {
 	houstonMock.On("GetAppConfig", mock.Anything).Return(nil, errMock)
 	houstonMock.On("GetPlatformVersion", nil).Return("0.30.0", nil)
 	buf := new(bytes.Buffer)
-	cmds := AddCmds(houstonMock, buf)
+	cmds := AddCmds(houstonMock, nil, buf)
 	for cmdIdx := range cmds {
 		s.Contains([]string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace", "team"}, cmds[cmdIdx].Use)
 	}
@@ -76,7 +76,7 @@ func (s *AddCmdSuite) TestPlatformVersionFailure() {
 	houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil)
 	houstonMock.On("GetPlatformVersion", nil).Return("", errMock)
 	buf := new(bytes.Buffer)
-	cmds := AddCmds(houstonMock, buf)
+	cmds := AddCmds(houstonMock, nil, buf)
 	for cmdIdx := range cmds {
 		s.Contains([]string{"deployment", "deploy [DEPLOYMENT ID]", "user", "workspace", "team"}, cmds[cmdIdx].Use)
 	}

--- a/cmd/software/utils_test.go
+++ b/cmd/software/utils_test.go
@@ -18,7 +18,7 @@ func (s *Suite) TestVersionMatchCmds() {
 		mockAPI.On("GetAppConfig", "").Return(&houston.AppConfig{Version: "0.27.0"}, nil)
 		mockAPI.On("GetPlatformVersion", nil).Return("0.27.0", nil)
 		cmd := &cobra.Command{Use: "astro"}
-		childCMDs := AddCmds(mockAPI, buf)
+		childCMDs := AddCmds(mockAPI, nil, buf)
 		cmd.AddCommand(childCMDs...)
 
 		VersionMatchCmds(cmd, []string{"astro"})
@@ -46,7 +46,7 @@ func (s *Suite) TestVersionMatchCmds() {
 		mockAPI.On("GetAppConfig", "").Return(&houston.AppConfig{Version: "0.30.0"}, nil)
 		mockAPI.On("GetPlatformVersion", nil).Return("0.30.0", nil)
 		cmd := &cobra.Command{Use: "astro"}
-		childCMDs := AddCmds(mockAPI, buf)
+		childCMDs := AddCmds(mockAPI, nil, buf)
 		cmd.AddCommand(childCMDs...)
 
 		VersionMatchCmds(cmd, []string{"astro"})

--- a/cmd/software/utils_test.go
+++ b/cmd/software/utils_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/astronomer/astro-cli/houston"
 	houston_mocks "github.com/astronomer/astro-cli/houston/mocks"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 )
 
 func (s *Suite) TestVersionMatchCmds() {
@@ -19,7 +20,7 @@ func (s *Suite) TestVersionMatchCmds() {
 		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "0.27.0"}, nil)
 		mockAPI.On("GetPlatformVersion", nil).Return("0.27.0", nil)
 		cmd := &cobra.Command{Use: "astro"}
-		childCMDs := AddCmds(mockAPI, buf)
+		childCMDs := AddCmds(mockAPI, nil, buf)
 		cmd.AddCommand(childCMDs...)
 
 		VersionMatchCmds(cmd, []string{"astro"})
@@ -51,7 +52,7 @@ func (s *Suite) TestVersionMatchCmds() {
 		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "0.29.0"}, nil)
 		mockAPI.On("GetPlatformVersion", nil).Return("0.29.0", nil)
 		cmd := &cobra.Command{Use: "astro"}
-		childCMDs := AddCmds(mockAPI, buf)
+		childCMDs := AddCmds(mockAPI, keychain.NewTestStore(), buf)
 		cmd.AddCommand(childCMDs...)
 
 		VersionMatchCmds(cmd, []string{"astro"})
@@ -79,7 +80,7 @@ func (s *Suite) TestVersionMatchCmds() {
 		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "0.30.0"}, nil)
 		mockAPI.On("GetPlatformVersion", nil).Return("0.30.0", nil)
 		cmd := &cobra.Command{Use: "astro"}
-		childCMDs := AddCmds(mockAPI, buf)
+		childCMDs := AddCmds(mockAPI, nil, buf)
 		cmd.AddCommand(childCMDs...)
 
 		VersionMatchCmds(cmd, []string{"astro"})
@@ -107,7 +108,7 @@ func (s *Suite) TestVersionMatchCmds() {
 		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "1.0.1"}, nil)
 		mockAPI.On("GetPlatformVersion", nil).Return("1.0.1", nil)
 		cmd := &cobra.Command{Use: "astro"}
-		childCMDs := AddCmds(mockAPI, buf)
+		childCMDs := AddCmds(mockAPI, keychain.NewTestStore(), buf)
 		cmd.AddCommand(childCMDs...)
 
 		VersionMatchCmds(cmd, []string{"astro"})
@@ -135,7 +136,7 @@ func (s *Suite) TestVersionMatchCmds() {
 		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "2.1.0"}, nil)
 		mockAPI.On("GetPlatformVersion", nil).Return("2.1.0", nil)
 		cmd := &cobra.Command{Use: "astro"}
-		childCMDs := AddCmds(mockAPI, buf)
+		childCMDs := AddCmds(mockAPI, keychain.NewTestStore(), buf)
 		cmd.AddCommand(childCMDs...)
 
 		VersionMatchCmds(cmd, []string{"astro"})
@@ -163,7 +164,7 @@ func (s *Suite) TestVersionMatchCmds() {
 		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "1.0.1"}, nil)
 		mockAPI.On("GetPlatformVersion", nil).Return("1.0.1", nil)
 		cmd := &cobra.Command{Use: "astro"}
-		childCMDs := AddCmds(mockAPI, buf)
+		childCMDs := AddCmds(mockAPI, keychain.NewTestStore(), buf)
 		cmd.AddCommand(childCMDs...)
 
 		VersionMatchCmds(cmd, []string{"astro"})
@@ -191,7 +192,7 @@ func (s *Suite) TestVersionMatchCmds() {
 		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "2.1.0"}, nil)
 		mockAPI.On("GetPlatformVersion", nil).Return("2.1.0", nil)
 		cmd := &cobra.Command{Use: "astro"}
-		childCMDs := AddCmds(mockAPI, buf)
+		childCMDs := AddCmds(mockAPI, keychain.NewTestStore(), buf)
 		cmd.AddCommand(childCMDs...)
 
 		VersionMatchCmds(cmd, []string{"astro"})

--- a/cmd/software/workspace_teams_test.go
+++ b/cmd/software/workspace_teams_test.go
@@ -102,7 +102,7 @@ func (s *Suite) TestWorkspaceTeamsListCmd() {
 			Header:     make(http.Header),
 		}
 	})
-	houstonClient = houston.NewClient(client)
+	houstonClient = houston.NewClient(client, nil)
 	buf := new(bytes.Buffer)
 	cmd := newWorkspaceTeamsListCmd(buf)
 	s.NotNil(cmd)

--- a/cmd/software/workspace_teams_test.go
+++ b/cmd/software/workspace_teams_test.go
@@ -104,7 +104,7 @@ func (s *Suite) TestWorkspaceTeamsListCmd() {
 			Header:     make(http.Header),
 		}
 	})
-	houstonClient = houston.NewClient(client)
+	houstonClient = houston.NewClient(client, nil)
 	buf := new(bytes.Buffer)
 	cmd := newWorkspaceTeamsListCmd(buf)
 	s.NotNil(cmd)

--- a/cmd/software/workspace_user_test.go
+++ b/cmd/software/workspace_user_test.go
@@ -59,7 +59,7 @@ func (s *Suite) TestNewWorkspaceUserListCmd() {
 			Header:     make(http.Header),
 		}
 	})
-	houstonClient = houston.NewClient(client)
+	houstonClient = houston.NewClient(client, nil)
 	buf := new(bytes.Buffer)
 	cmd := newWorkspaceUserListCmd(buf)
 	s.NotNil(cmd)

--- a/config/config.go
+++ b/config/config.go
@@ -97,6 +97,7 @@ var (
 		DevMode:                 newCfg("dev.mode", "docker"),
 		DevBuildSecrets:         newCfg("dev.build_secrets", ""),
 		TelemetryEnabled:        newCfg("telemetry.enabled", "true"),
+		NoInsecureFallback:      newCfg("no_insecure_fallback", "false"),
 		TelemetryAnonymousID:    newCfg("telemetry.anonymous_id", ""),
 		TelemetryNoticeShown:    newCfg("telemetry.notice_shown", ""),
 		ProxyPort:               newCfg("proxy.port", "6563"),

--- a/config/context.go
+++ b/config/context.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
+
+	"github.com/astronomer/astro-cli/pkg/keychain"
 )
 
 var (
@@ -31,9 +32,6 @@ type Context struct {
 	OrganizationProduct string `mapstructure:"organization_product"`
 	Workspace           string `mapstructure:"workspace"`
 	LastUsedWorkspace   string `mapstructure:"last_used_workspace"`
-	Token               string `mapstructure:"token"`
-	RefreshToken        string `mapstructure:"refreshtoken"`
-	UserEmail           string `mapstructure:"user_email"`
 }
 
 // GetCurrentContext looks up current context and gets corresponding Context struct
@@ -123,14 +121,11 @@ func (c *Context) SetContext() error {
 	}
 
 	context := map[string]string{
-		"token":                c.Token,
 		"domain":               c.Domain,
 		"organization":         c.Organization,
 		"organization_product": c.OrganizationProduct,
 		"workspace":            c.Workspace,
 		"last_used_workspace":  c.Workspace,
-		"refreshtoken":         c.RefreshToken,
-		"user_email":           c.UserEmail,
 	}
 
 	viperHome.Set(contextsKey+"."+key, context)
@@ -207,30 +202,56 @@ func (c *Context) DeleteContext() error {
 	return nil
 }
 
-func (c *Context) SetExpiresIn(value int64) error {
-	cKey, err := c.GetContextKey()
+// MigrateLegacyCredentials reads credential fields (token, refreshtoken,
+// user_email, ExpiresIn) directly from viper across all contexts and moves
+// them to the provided SecureStore. Each context is migrated atomically:
+// if the keychain write fails the context is left in config.yaml and retried
+// on the next invocation. Returns the number of contexts migrated.
+//
+// These viper key names are the legacy field names and must not appear anywhere
+// else in the codebase — this function is the only sanctioned reader of them.
+func MigrateLegacyCredentials(store keychain.SecureStore) (int, error) {
+	contexts, err := GetContexts()
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	expiretime := time.Now().Add(time.Duration(value) * time.Second)
+	migrated := 0
+	for contextKey, ctx := range contexts.Contexts {
+		token := viperHome.GetString(fmt.Sprintf("%s.%s.token", contextsKey, contextKey))
+		refreshToken := viperHome.GetString(fmt.Sprintf("%s.%s.refreshtoken", contextsKey, contextKey))
+		userEmail := viperHome.GetString(fmt.Sprintf("%s.%s.user_email", contextsKey, contextKey))
+		expiresAt := viperHome.GetTime(fmt.Sprintf("%s.%s.ExpiresIn", contextsKey, contextKey))
 
-	cfgPath := fmt.Sprintf("%s.%s.%s", contextsKey, cKey, "ExpiresIn")
-	viperHome.Set(cfgPath, expiretime)
-	err = saveConfig(viperHome, HomeConfigFile)
-	if err != nil {
-		return err
+		if token == "" && refreshToken == "" {
+			continue
+		}
+
+		creds := keychain.Credentials{
+			Token:        token,
+			RefreshToken: refreshToken,
+			UserEmail:    userEmail,
+			ExpiresAt:    expiresAt,
+		}
+
+		if err := store.SetCredentials(ctx.Domain, creds); err != nil {
+			// Don't scrub on failure — will retry next invocation.
+			continue
+		}
+
+		// Scrub credential fields from the config map entirely so they don't
+		// linger as empty strings in the YAML file.
+		ctxPath := fmt.Sprintf("%s.%s", contextsKey, contextKey)
+		ctxMap := viperHome.GetStringMap(ctxPath)
+		for _, field := range []string{"token", "refreshtoken", "user_email", "expiresin"} {
+			delete(ctxMap, field)
+		}
+		viperHome.Set(ctxPath, ctxMap)
+		if err := saveConfig(viperHome, HomeConfigFile); err != nil {
+			return migrated, err
+		}
+		migrated++
 	}
 
-	return nil
-}
-
-func (c *Context) GetExpiresIn() (time.Time, error) {
-	cKey, err := c.GetContextKey()
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	cfgPath := fmt.Sprintf("%s.%s.%s", contextsKey, cKey, "ExpiresIn")
-	return viperHome.GetTime(cfgPath), nil
+	return migrated, nil
 }

--- a/config/context.go
+++ b/config/context.go
@@ -237,6 +237,17 @@ func MigrateLegacyCredentials(store keychain.SecureStore) (int, error) {
 			continue
 		}
 
+		// A context entry's `domain:` field is optional — GetCurrentContext fills
+		// Domain in from the top-level `context:` key instead, so entries written
+		// without it still resolve at runtime. Here we're walking every context,
+		// not just the current one, so recover the domain from the context key
+		// (the domain with dots replaced by underscores). Without this, every
+		// domain-less context migrates under "" and they overwrite each other.
+		domain := ctx.Domain
+		if domain == "" {
+			domain = strings.ReplaceAll(contextKey, "_", ".")
+		}
+
 		creds := keychain.Credentials{
 			Token:        token,
 			RefreshToken: refreshToken,
@@ -244,7 +255,7 @@ func MigrateLegacyCredentials(store keychain.SecureStore) (int, error) {
 			ExpiresAt:    expiresAt,
 		}
 
-		if err := store.SetCredentials(ctx.Domain, creds); err != nil {
+		if err := store.SetCredentials(domain, creds); err != nil {
 			// Don't scrub on failure — will retry next invocation.
 			continue
 		}

--- a/config/context.go
+++ b/config/context.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
+
+	"github.com/astronomer/astro-cli/pkg/keychain"
 )
 
 var (
@@ -31,9 +32,6 @@ type Context struct {
 	OrganizationProduct string `mapstructure:"organization_product"`
 	Workspace           string `mapstructure:"workspace"`
 	LastUsedWorkspace   string `mapstructure:"last_used_workspace"`
-	Token               string `mapstructure:"token"`
-	RefreshToken        string `mapstructure:"refreshtoken"`
-	UserEmail           string `mapstructure:"user_email"`
 }
 
 // GetCurrentContext looks up current context and gets corresponding Context struct
@@ -123,14 +121,11 @@ func (c *Context) SetContext() error {
 	}
 
 	context := map[string]string{
-		"token":                c.Token,
 		"domain":               c.Domain,
 		"organization":         c.Organization,
 		"organization_product": c.OrganizationProduct,
 		"workspace":            c.Workspace,
 		"last_used_workspace":  c.Workspace,
-		"refreshtoken":         c.RefreshToken,
-		"user_email":           c.UserEmail,
 	}
 
 	viperHome.Set(contextsKey+"."+key, context)
@@ -217,21 +212,56 @@ func (c *Context) DeleteContext() error {
 	return nil
 }
 
-func (c *Context) SetExpiresIn(value int64) error {
-	cKey, err := c.GetContextKey()
+// MigrateLegacyCredentials reads credential fields (token, refreshtoken,
+// user_email, ExpiresIn) directly from viper across all contexts and moves
+// them to the provided SecureStore. Each context is migrated atomically:
+// if the keychain write fails the context is left in config.yaml and retried
+// on the next invocation. Returns the number of contexts migrated.
+//
+// These are the legacy viper context keys; this is the only code that reads
+// them.
+func MigrateLegacyCredentials(store keychain.SecureStore) (int, error) {
+	contexts, err := GetContexts()
 	if err != nil {
-		return err
-	}
-	expiretime := time.Now().Add(time.Duration(value) * time.Second)
-	return setContextField(cKey, "ExpiresIn", expiretime)
-}
-
-func (c *Context) GetExpiresIn() (time.Time, error) {
-	cKey, err := c.GetContextKey()
-	if err != nil {
-		return time.Time{}, err
+		return 0, err
 	}
 
-	cfgPath := fmt.Sprintf("%s.%s.%s", contextsKey, cKey, "ExpiresIn")
-	return viperHome.GetTime(cfgPath), nil
+	migrated := 0
+	for contextKey, ctx := range contexts.Contexts {
+		token := viperHome.GetString(fmt.Sprintf("%s.%s.token", contextsKey, contextKey))
+		refreshToken := viperHome.GetString(fmt.Sprintf("%s.%s.refreshtoken", contextsKey, contextKey))
+		userEmail := viperHome.GetString(fmt.Sprintf("%s.%s.user_email", contextsKey, contextKey))
+		expiresAt := viperHome.GetTime(fmt.Sprintf("%s.%s.ExpiresIn", contextsKey, contextKey))
+
+		if token == "" && refreshToken == "" {
+			continue
+		}
+
+		creds := keychain.Credentials{
+			Token:        token,
+			RefreshToken: refreshToken,
+			UserEmail:    userEmail,
+			ExpiresAt:    expiresAt,
+		}
+
+		if err := store.SetCredentials(ctx.Domain, creds); err != nil {
+			// Don't scrub on failure — will retry next invocation.
+			continue
+		}
+
+		// Scrub credential fields from the config map entirely so they don't
+		// linger as empty strings in the YAML file.
+		ctxPath := fmt.Sprintf("%s.%s", contextsKey, contextKey)
+		ctxMap := viperHome.GetStringMap(ctxPath)
+		for _, field := range []string{"token", "refreshtoken", "user_email", "expiresin"} {
+			delete(ctxMap, field)
+		}
+		viperHome.Set(ctxPath, ctxMap)
+		if err := saveConfig(viperHome, HomeConfigFile); err != nil {
+			return migrated, err
+		}
+		migrated++
+	}
+
+	return migrated, nil
 }

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"time"
 
 	"github.com/spf13/afero"
 )
@@ -40,7 +39,6 @@ context: example_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
 `)
@@ -48,7 +46,6 @@ contexts:
 	InitConfig(fs)
 
 	ctx := Context{
-		Token:             "token",
 		LastUsedWorkspace: "ck05r3bor07h40d02y2hw4n4v",
 		Workspace:         "ck05r3bor07h40d02y2hw4n4v",
 		Domain:            "example.com",
@@ -74,7 +71,6 @@ context: example_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace:
 `)
@@ -82,7 +78,6 @@ contexts:
 	InitConfig(fs)
 
 	ctx := Context{
-		Token:             "token",
 		LastUsedWorkspace: "ck05r3bor07h40d02y2hw4n4v",
 		Workspace:         "",
 		Domain:            "example.com",
@@ -108,7 +103,6 @@ context: example_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
 `)
@@ -117,7 +111,6 @@ contexts:
 	ctx, err := GetCurrentContext()
 	s.NoError(err)
 	s.Equal("example.com", ctx.Domain)
-	s.Equal("token", ctx.Token)
 	s.Equal("ck05r3bor07h40d02y2hw4n4v", ctx.Workspace)
 }
 
@@ -135,12 +128,10 @@ context: example_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
   stage_example_com:
     domain: stage.example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4w
     workspace: ck05r3bor07h40d02y2hw4n4w
 `)
@@ -150,7 +141,6 @@ contexts:
 	ctx, err := GetCurrentContext()
 	s.NoError(err)
 	s.Equal("stage.example.com", ctx.Domain)
-	s.Equal("token", ctx.Token)
 	s.Equal("ck05r3bor07h40d02y2hw4n4w", ctx.Workspace)
 }
 
@@ -161,13 +151,11 @@ context: test_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
     organization: test-org-id
   test_com:
     domain: test.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
     organization: test-org-id
@@ -196,16 +184,21 @@ func (s *Suite) TestGetContexts() {
 	initTestConfig()
 	ctxs, err := GetContexts()
 	s.NoError(err)
-	s.Equal(Contexts{Contexts: map[string]Context{"test_com": {"test.com", "test-org-id", "", "ck05r3bor07h40d02y2hw4n4v", "ck05r3bor07h40d02y2hw4n4v", "token", "", ""}, "example_com": {"example.com", "test-org-id", "", "ck05r3bor07h40d02y2hw4n4v", "ck05r3bor07h40d02y2hw4n4v", "token", "", ""}}}, ctxs)
+	s.Equal(Contexts{Contexts: map[string]Context{
+		"test_com":    {Domain: "test.com", Organization: "test-org-id", Workspace: "ck05r3bor07h40d02y2hw4n4v", LastUsedWorkspace: "ck05r3bor07h40d02y2hw4n4v"},
+		"example_com": {Domain: "example.com", Organization: "test-org-id", Workspace: "ck05r3bor07h40d02y2hw4n4v", LastUsedWorkspace: "ck05r3bor07h40d02y2hw4n4v"},
+	}}, ctxs)
 }
 
 func (s *Suite) TestSetContextKey() {
 	initTestConfig()
 	ctx := Context{Domain: "localhost"}
-	ctx.SetContextKey("token", "test")
+	err := ctx.SetContextKey("workspace", "ws-123")
+	s.NoError(err)
 	outCtx, err := ctx.GetContext()
 	s.NoError(err)
-	s.Equal("test", outCtx.Token)
+	s.Equal("localhost", outCtx.Domain)
+	s.Equal("ws-123", outCtx.Workspace)
 }
 
 func (s *Suite) TestSetOrganizationContext() {
@@ -226,30 +219,4 @@ func (s *Suite) TestSetOrganizationContext() {
 		s.Error(err)
 		s.Contains(err.Error(), "context config invalid, no domain specified")
 	})
-}
-
-func (s *Suite) TestExpiresIn() {
-	initTestConfig()
-	ctx := Context{Domain: "localhost"}
-	err := ctx.SetExpiresIn(12)
-	s.NoError(err)
-
-	outCtx, err := ctx.GetContext()
-	s.NoError(err)
-
-	val, err := outCtx.GetExpiresIn()
-	s.NoError(err)
-	s.Equal("localhost", outCtx.Domain)
-	s.True(time.Now().Add(time.Duration(12) * time.Second).After(val)) // now + 12 seconds will always be after expire time, since that is set before
-}
-
-func (s *Suite) TestExpiresInFailure() {
-	initTestConfig()
-	ctx := Context{}
-	err := ctx.SetExpiresIn(1)
-	s.ErrorIs(err, ErrCtxConfigErr)
-
-	val, err := ctx.GetExpiresIn()
-	s.ErrorIs(err, ErrCtxConfigErr)
-	s.Equal(time.Time{}, val)
 }

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"time"
 
 	"github.com/spf13/afero"
 )
@@ -40,7 +39,6 @@ context: example_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
 `)
@@ -48,7 +46,6 @@ contexts:
 	InitConfig(fs)
 
 	ctx := Context{
-		Token:             "token",
 		LastUsedWorkspace: "ck05r3bor07h40d02y2hw4n4v",
 		Workspace:         "ck05r3bor07h40d02y2hw4n4v",
 		Domain:            "example.com",
@@ -74,7 +71,6 @@ context: example_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace:
 `)
@@ -82,7 +78,6 @@ contexts:
 	InitConfig(fs)
 
 	ctx := Context{
-		Token:             "token",
 		LastUsedWorkspace: "ck05r3bor07h40d02y2hw4n4v",
 		Workspace:         "",
 		Domain:            "example.com",
@@ -108,7 +103,6 @@ context: example_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
 `)
@@ -117,7 +111,6 @@ contexts:
 	ctx, err := GetCurrentContext()
 	s.NoError(err)
 	s.Equal("example.com", ctx.Domain)
-	s.Equal("token", ctx.Token)
 	s.Equal("ck05r3bor07h40d02y2hw4n4v", ctx.Workspace)
 }
 
@@ -135,12 +128,10 @@ context: example_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
   stage_example_com:
     domain: stage.example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4w
     workspace: ck05r3bor07h40d02y2hw4n4w
 `)
@@ -150,7 +141,6 @@ contexts:
 	ctx, err := GetCurrentContext()
 	s.NoError(err)
 	s.Equal("stage.example.com", ctx.Domain)
-	s.Equal("token", ctx.Token)
 	s.Equal("ck05r3bor07h40d02y2hw4n4w", ctx.Workspace)
 }
 
@@ -161,13 +151,11 @@ context: test_com
 contexts:
   example_com:
     domain: example.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
     organization: test-org-id
   test_com:
     domain: test.com
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
     organization: test-org-id
@@ -196,16 +184,21 @@ func (s *Suite) TestGetContexts() {
 	initTestConfig()
 	ctxs, err := GetContexts()
 	s.NoError(err)
-	s.Equal(Contexts{Contexts: map[string]Context{"test_com": {"test.com", "test-org-id", "", "ck05r3bor07h40d02y2hw4n4v", "ck05r3bor07h40d02y2hw4n4v", "token", "", ""}, "example_com": {"example.com", "test-org-id", "", "ck05r3bor07h40d02y2hw4n4v", "ck05r3bor07h40d02y2hw4n4v", "token", "", ""}}}, ctxs)
+	s.Equal(Contexts{Contexts: map[string]Context{
+		"test_com":    {Domain: "test.com", Organization: "test-org-id", Workspace: "ck05r3bor07h40d02y2hw4n4v", LastUsedWorkspace: "ck05r3bor07h40d02y2hw4n4v"},
+		"example_com": {Domain: "example.com", Organization: "test-org-id", Workspace: "ck05r3bor07h40d02y2hw4n4v", LastUsedWorkspace: "ck05r3bor07h40d02y2hw4n4v"},
+	}}, ctxs)
 }
 
 func (s *Suite) TestSetContextKey() {
 	initTestConfig()
 	ctx := Context{Domain: "localhost"}
-	ctx.SetContextKey("token", "test")
+	err := ctx.SetContextKey("workspace", "ws-123")
+	s.NoError(err)
 	outCtx, err := ctx.GetContext()
 	s.NoError(err)
-	s.Equal("test", outCtx.Token)
+	s.Equal("localhost", outCtx.Domain)
+	s.Equal("ws-123", outCtx.Workspace)
 }
 
 // Regression: viper's Set on a nested path populates its override layer with
@@ -218,9 +211,8 @@ context: example.com
 contexts:
   example_com:
     domain: example.com
-    token: Bearer old
-    refreshtoken: original-refresh-token
     organization: org-id
+    last_used_workspace: ws-previous
     workspace: ws-id
 `)
 	err = afero.WriteFile(fs, HomeConfigFile, configRaw, 0o777)
@@ -229,15 +221,13 @@ contexts:
 
 	ctx, err := GetCurrentContext()
 	s.Require().NoError(err)
-	s.Require().NoError(ctx.SetContextKey("token", "Bearer new"))
-	s.Require().NoError(ctx.SetExpiresIn(3600))
+	s.Require().NoError(ctx.SetContextKey("workspace", "ws-new"))
 
 	reread, err := GetCurrentContext()
 	s.Require().NoError(err)
-	s.Equal("Bearer new", reread.Token)
-	s.Equal("original-refresh-token", reread.RefreshToken)
+	s.Equal("ws-new", reread.Workspace)
+	s.Equal("ws-previous", reread.LastUsedWorkspace)
 	s.Equal("org-id", reread.Organization)
-	s.Equal("ws-id", reread.Workspace)
 	s.Equal("example.com", reread.Domain)
 }
 
@@ -259,30 +249,4 @@ func (s *Suite) TestSetOrganizationContext() {
 		s.Error(err)
 		s.Contains(err.Error(), "context config invalid, no domain specified")
 	})
-}
-
-func (s *Suite) TestExpiresIn() {
-	initTestConfig()
-	ctx := Context{Domain: "localhost"}
-	err := ctx.SetExpiresIn(12)
-	s.NoError(err)
-
-	outCtx, err := ctx.GetContext()
-	s.NoError(err)
-
-	val, err := outCtx.GetExpiresIn()
-	s.NoError(err)
-	s.Equal("localhost", outCtx.Domain)
-	s.True(time.Now().Add(time.Duration(12) * time.Second).After(val)) // now + 12 seconds will always be after expire time, since that is set before
-}
-
-func (s *Suite) TestExpiresInFailure() {
-	initTestConfig()
-	ctx := Context{}
-	err := ctx.SetExpiresIn(1)
-	s.ErrorIs(err, ErrCtxConfigErr)
-
-	val, err := ctx.GetExpiresIn()
-	s.ErrorIs(err, ErrCtxConfigErr)
-	s.Equal(time.Time{}, val)
 }

--- a/config/migrate_test.go
+++ b/config/migrate_test.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/astronomer/astro-cli/pkg/keychain"
+)
+
+func TestMigrateLegacyCredentials_NothingToMigrate(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configRaw := []byte(`
+context: astronomer_io
+contexts:
+  astronomer_io:
+    domain: astronomer.io
+    workspace: ws-1
+`)
+	err := afero.WriteFile(fs, HomeConfigFile, configRaw, 0o777)
+	require.NoError(t, err)
+	InitConfig(fs)
+
+	store := keychain.NewTestStore()
+	migrated, err := MigrateLegacyCredentials(store)
+	require.NoError(t, err)
+	assert.Equal(t, 0, migrated)
+
+	_, err = store.GetCredentials("astronomer.io")
+	assert.ErrorIs(t, err, keychain.ErrNotFound)
+}
+
+func TestMigrateLegacyCredentials_SingleContext(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configRaw := []byte(`
+context: astronomer_io
+contexts:
+  astronomer_io:
+    domain: astronomer.io
+    token: "Bearer old-token"
+    refreshtoken: "old-refresh"
+    user_email: "user@example.com"
+    workspace: ws-1
+`)
+	err := afero.WriteFile(fs, HomeConfigFile, configRaw, 0o777)
+	require.NoError(t, err)
+	InitConfig(fs)
+
+	store := keychain.NewTestStore()
+	migrated, err := MigrateLegacyCredentials(store)
+	require.NoError(t, err)
+	assert.Equal(t, 1, migrated)
+
+	creds, err := store.GetCredentials("astronomer.io")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer old-token", creds.Token)
+	assert.Equal(t, "old-refresh", creds.RefreshToken)
+	assert.Equal(t, "user@example.com", creds.UserEmail)
+
+	// Confirm credential fields are fully removed (not just empty strings)
+	ctxMap := viperHome.GetStringMap("contexts.astronomer_io")
+	assert.NotContains(t, ctxMap, "token")
+	assert.NotContains(t, ctxMap, "refreshtoken")
+	assert.NotContains(t, ctxMap, "user_email")
+	assert.NotContains(t, ctxMap, "expiresin")
+	// Non-credential fields survive
+	assert.Contains(t, ctxMap, "domain")
+	assert.Contains(t, ctxMap, "workspace")
+}
+
+func TestMigrateLegacyCredentials_MultipleContexts(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configRaw := []byte(`
+context: astronomer_io
+contexts:
+  astronomer_io:
+    domain: astronomer.io
+    token: "Bearer token-a"
+    refreshtoken: "refresh-a"
+    user_email: "a@example.com"
+  astronomer_stage_io:
+    domain: astronomer-stage.io
+    token: "Bearer token-b"
+    refreshtoken: "refresh-b"
+    user_email: "b@example.com"
+`)
+	err := afero.WriteFile(fs, HomeConfigFile, configRaw, 0o777)
+	require.NoError(t, err)
+	InitConfig(fs)
+
+	store := keychain.NewTestStore()
+	migrated, err := MigrateLegacyCredentials(store)
+	require.NoError(t, err)
+	assert.Equal(t, 2, migrated)
+
+	credsA, err := store.GetCredentials("astronomer.io")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-a", credsA.Token)
+
+	credsB, err := store.GetCredentials("astronomer-stage.io")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-b", credsB.Token)
+}
+
+func TestMigrateLegacyCredentials_Idempotent(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configRaw := []byte(`
+context: astronomer_io
+contexts:
+  astronomer_io:
+    domain: astronomer.io
+    token: "Bearer old-token"
+    refreshtoken: "old-refresh"
+    user_email: "user@example.com"
+`)
+	err := afero.WriteFile(fs, HomeConfigFile, configRaw, 0o777)
+	require.NoError(t, err)
+	InitConfig(fs)
+
+	store := keychain.NewTestStore()
+	migrated, err := MigrateLegacyCredentials(store)
+	require.NoError(t, err)
+	assert.Equal(t, 1, migrated)
+
+	// Second call: nothing in config.yaml to migrate
+	migrated, err = MigrateLegacyCredentials(store)
+	require.NoError(t, err)
+	assert.Equal(t, 0, migrated)
+}

--- a/config/migrate_test.go
+++ b/config/migrate_test.go
@@ -104,6 +104,47 @@ contexts:
 	assert.Equal(t, "Bearer token-b", credsB.Token)
 }
 
+// A context entry's `domain:` field is optional — real config.yaml files have
+// entries without it, and they resolve at runtime because GetCurrentContext
+// fills Domain in from the top-level `context:` key. Migration walks every
+// context rather than just the current one, so it must recover the domain from
+// the context key; otherwise all such contexts land under "" and clobber each
+// other, silently logging the user out of all but one.
+func TestMigrateLegacyCredentials_ContextsWithoutDomainField(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configRaw := []byte(`
+context: astronomer-stage.io
+contexts:
+  astronomer-dev_io:
+    token: "Bearer token-dev"
+    refreshtoken: "refresh-dev"
+  astronomer-stage_io:
+    token: "Bearer token-stage"
+    refreshtoken: "refresh-stage"
+`)
+	err := afero.WriteFile(fs, HomeConfigFile, configRaw, 0o777)
+	require.NoError(t, err)
+	InitConfig(fs)
+
+	store := keychain.NewTestStore()
+	migrated, err := MigrateLegacyCredentials(store)
+	require.NoError(t, err)
+	assert.Equal(t, 2, migrated)
+
+	credsDev, err := store.GetCredentials("astronomer-dev.io")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-dev", credsDev.Token)
+	assert.Equal(t, "refresh-dev", credsDev.RefreshToken)
+
+	credsStage, err := store.GetCredentials("astronomer-stage.io")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-stage", credsStage.Token)
+	assert.Equal(t, "refresh-stage", credsStage.RefreshToken)
+
+	_, err = store.GetCredentials("")
+	assert.Error(t, err, "no credentials should be filed under an empty domain")
+}
+
 func TestMigrateLegacyCredentials_Idempotent(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	configRaw := []byte(`

--- a/config/types.go
+++ b/config/types.go
@@ -59,6 +59,7 @@ type cfgs struct {
 	DevMode                 cfg
 	DevBuildSecrets         cfg
 	TelemetryEnabled        cfg
+	NoInsecureFallback      cfg
 	TelemetryAnonymousID    cfg
 	TelemetryNoticeShown    cfg
 	ProxyPort               cfg

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -36,10 +36,9 @@ func (s *Suite) TestGetCurrentContext() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	cluster, err := GetCurrentContext()
 	s.NoError(err)
-	s.Equal(cluster.Domain, testUtil.GetEnv("HOST", "localhost"))
+	s.Equal("localhost", cluster.Domain)
 	s.Equal(cluster.Workspace, "ck05r3bor07h40d02y2hw4n4v")
 	s.Equal(cluster.LastUsedWorkspace, "ck05r3bor07h40d02y2hw4n4v")
-	s.Equal(cluster.Token, "token")
 }
 
 func (s *Suite) TestGetContextKeyValidContextConfig() {

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,8 @@ require (
 	4d63.com/gochecknoglobals v0.2.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/4meepo/tagalign v1.3.4 // indirect
+	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
+	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/Abirdcfly/dupword v0.1.3 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/Antonboom/errname v1.0.0 // indirect
@@ -128,10 +130,12 @@ require (
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/daixiang0/gci v0.13.5 // indirect
+	github.com/danieljoos/wincred v1.2.1 // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/docker/cli-docs-tool v0.8.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
+	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
@@ -160,6 +164,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a // indirect
 	github.com/golangci/go-printf-func-name v0.1.0 // indirect
@@ -178,6 +183,7 @@ require (
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
 	github.com/gostaticanalysis/testutil v0.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 // indirect
+	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
@@ -221,6 +227,7 @@ require (
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/moricho/tparallel v0.3.2 // indirect
+	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 )
 
 require (
+	github.com/99designs/keyring v1.2.2
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.7.0
 	github.com/astronomer/astro-cli/pkg/airflowrt v0.0.0-00010101000000-000000000000
 	github.com/astronomer/astro-cli/pkg/astroauth v0.0.0-00010101000000-000000000000
@@ -68,6 +69,7 @@ require (
 	4d63.com/gocheckcompilerdirectives v1.2.1 // indirect
 	4d63.com/gochecknoglobals v0.2.1 // indirect
 	github.com/4meepo/tagalign v1.3.4 // indirect
+	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/Abirdcfly/dupword v0.1.3 // indirect
 	github.com/Antonboom/errname v1.0.0 // indirect
 	github.com/Antonboom/nilnil v1.0.0 // indirect
@@ -132,10 +134,12 @@ require (
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/daixiang0/gci v0.13.5 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/docker/cli-docs-tool v0.11.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
+	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
@@ -175,6 +179,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a // indirect
@@ -194,6 +199,7 @@ require (
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
 	github.com/gostaticanalysis/testutil v0.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
@@ -240,6 +246,7 @@ require (
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/moricho/tparallel v0.3.2 // indirect
+	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect
 	github.com/nishanths/exhaustive v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,10 @@ filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/4meepo/tagalign v1.3.4 h1:P51VcvBnf04YkHzjfclN6BbsopfJR5rxs1n+5zHt+w8=
 github.com/4meepo/tagalign v1.3.4/go.mod h1:M+pnkHH2vG8+qhE5bVc/zeP7HS/j910Fwa9TUSyZVI0=
+github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
+github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
+github.com/99designs/keyring v1.2.2 h1:pZd3neh/EmUzWONb35LxQfvuY7kiSXAq3HQd97+XBn0=
+github.com/99designs/keyring v1.2.2/go.mod h1:wes/FrByc8j7lFOAGLGSNEg8f/PaI3cgTBqhFkHUrPk=
 github.com/Abirdcfly/dupword v0.1.3 h1:9Pa1NuAsZvpFPi9Pqkd93I7LIYRURj+A//dFd5tgBeE=
 github.com/Abirdcfly/dupword v0.1.3/go.mod h1:8VbB2t7e10KRNdwTVoxdBaxla6avbhGzb8sCTygUMhw=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -243,6 +247,8 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
 github.com/daixiang0/gci v0.13.5 h1:kThgmH1yBmZSBCh1EJVxQ7JsHpm5Oms0AMed/0LaH4c=
 github.com/daixiang0/gci v0.13.5/go.mod h1:12etP2OniiIdP4q+kjUGrC/rUagga7ODbqsom5Eo5Yk=
+github.com/danieljoos/wincred v1.2.1 h1:dl9cBrupW8+r5250DYkYxocLeZ1Y4vB1kxgtjxw8GQs=
+github.com/danieljoos/wincred v1.2.1/go.mod h1:uGaFL9fDn3OLTvzCGulzE+SzjEe5NGlh5FdCcyfPwps=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -286,6 +292,8 @@ github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960/go.mod h1:9HQzr9D/
 github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 h1:PRxIJD8XjimM5aTknUK9w6DHLDox2r2M3DI4i2pnd3w=
 github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936/go.mod h1:ttYvX5qlB+mlV1okblJqcSMtR4c52UKxDiX9GRBS8+Q=
 github.com/dvsekhvalnov/jose2go v0.0.0-20170216131308-f21a8cedbbae/go.mod h1:7BvyPhdbLxMXIYTFPLsyJRFMsKmOZnQmzh6Gb+uquuM=
+github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
+github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -390,6 +398,8 @@ github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUW
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
+github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
@@ -500,6 +510,8 @@ github.com/gostaticanalysis/testutil v0.5.0 h1:Dq4wT1DdTwTGCQQv3rl3IvD5Ld0E6HiY+
 github.com/gostaticanalysis/testutil v0.5.0/go.mod h1:OLQSbuM6zw2EvCcXTz1lVq5unyoNft372msDY0nY5Hs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 h1:TmHmbvxPmaegwhDubVz0lICL0J5Ka2vwTzhoePEXsGE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0/go.mod h1:qztMSjm835F2bXf+5HKAPIS5qsmQDqZna/PgVt4rWtI=
+github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
+github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -716,6 +728,8 @@ github.com/moricho/tparallel v0.3.2/go.mod h1:OQ+K3b4Ln3l2TZveGCywybl68glfLEwFGq
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=
+github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
+github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -1334,6 +1348,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,10 @@ filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/4meepo/tagalign v1.3.4 h1:P51VcvBnf04YkHzjfclN6BbsopfJR5rxs1n+5zHt+w8=
 github.com/4meepo/tagalign v1.3.4/go.mod h1:M+pnkHH2vG8+qhE5bVc/zeP7HS/j910Fwa9TUSyZVI0=
+github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
+github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
+github.com/99designs/keyring v1.2.2 h1:pZd3neh/EmUzWONb35LxQfvuY7kiSXAq3HQd97+XBn0=
+github.com/99designs/keyring v1.2.2/go.mod h1:wes/FrByc8j7lFOAGLGSNEg8f/PaI3cgTBqhFkHUrPk=
 github.com/Abirdcfly/dupword v0.1.3 h1:9Pa1NuAsZvpFPi9Pqkd93I7LIYRURj+A//dFd5tgBeE=
 github.com/Abirdcfly/dupword v0.1.3/go.mod h1:8VbB2t7e10KRNdwTVoxdBaxla6avbhGzb8sCTygUMhw=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -242,6 +246,8 @@ github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
 github.com/daixiang0/gci v0.13.5 h1:kThgmH1yBmZSBCh1EJVxQ7JsHpm5Oms0AMed/0LaH4c=
 github.com/daixiang0/gci v0.13.5/go.mod h1:12etP2OniiIdP4q+kjUGrC/rUagga7ODbqsom5Eo5Yk=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -285,6 +291,8 @@ github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960/go.mod h1:9HQzr9D/
 github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 h1:PRxIJD8XjimM5aTknUK9w6DHLDox2r2M3DI4i2pnd3w=
 github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936/go.mod h1:ttYvX5qlB+mlV1okblJqcSMtR4c52UKxDiX9GRBS8+Q=
 github.com/dvsekhvalnov/jose2go v0.0.0-20170216131308-f21a8cedbbae/go.mod h1:7BvyPhdbLxMXIYTFPLsyJRFMsKmOZnQmzh6Gb+uquuM=
+github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
+github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -417,6 +425,8 @@ github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUW
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
+github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
 github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
@@ -523,6 +533,8 @@ github.com/gostaticanalysis/testutil v0.5.0 h1:Dq4wT1DdTwTGCQQv3rl3IvD5Ld0E6HiY+
 github.com/gostaticanalysis/testutil v0.5.0/go.mod h1:OLQSbuM6zw2EvCcXTz1lVq5unyoNft372msDY0nY5Hs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
+github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
+github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -739,6 +751,8 @@ github.com/moricho/tparallel v0.3.2/go.mod h1:OQ+K3b4Ln3l2TZveGCywybl68glfLEwFGq
 github.com/morikuni/aec v1.1.0 h1:vBBl0pUnvi/Je71dsRrhMBtreIqNMYErSAbEeb8jrXQ=
 github.com/morikuni/aec v1.1.0/go.mod h1:xDRgiq/iw5l+zkao76YTKzKttOp2cwPEne25HDkJnBw=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=
+github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
+github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -1358,6 +1372,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnfEbYzo=

--- a/houston/app_test.go
+++ b/houston/app_test.go
@@ -45,7 +45,7 @@ func (s *Suite) TestGetAppConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		config, err := api.GetAppConfig("")
 		s.NoError(err)
@@ -68,7 +68,7 @@ func (s *Suite) TestGetAppConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		// reset the local variables
 		appConfig = nil
@@ -98,7 +98,7 @@ func (s *Suite) TestGetAppConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetAppConfig("")
 		s.EqualError(err, ErrFieldsNotAvailable{}.Error())
@@ -127,7 +127,7 @@ func (s *Suite) TestGetAvailableNamespaces() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		namespaces, err := api.GetAvailableNamespaces(nil)
 		s.NoError(err)
@@ -142,7 +142,7 @@ func (s *Suite) TestGetAvailableNamespaces() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetAvailableNamespaces(nil)
 		s.Contains(err.Error(), "Internal Server Error")
@@ -168,7 +168,7 @@ func (s *Suite) TestGetPlatformVersion() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 		version = "0.30.0"
 		versionErr = nil
 		resp, err := api.GetPlatformVersion(nil)
@@ -184,7 +184,7 @@ func (s *Suite) TestGetPlatformVersion() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 		version = ""
 		versionErr = errMockHouston
 		resp, err := api.GetPlatformVersion(nil)
@@ -200,7 +200,7 @@ func (s *Suite) TestGetPlatformVersion() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 		version = ""
 		versionErr = nil
 		platformVersion, err := api.GetPlatformVersion(nil)
@@ -216,7 +216,7 @@ func (s *Suite) TestGetPlatformVersion() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 		version = ""
 		versionErr = nil
 		_, err := api.GetPlatformVersion(nil)

--- a/houston/app_test.go
+++ b/houston/app_test.go
@@ -45,7 +45,7 @@ func (s *Suite) TestGetAppConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		config, err := api.GetAppConfig(GetAppConfigRequest{})
 		s.NoError(err)
@@ -68,7 +68,7 @@ func (s *Suite) TestGetAppConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		// reset the local variables
 		appConfig = nil
@@ -98,7 +98,7 @@ func (s *Suite) TestGetAppConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetAppConfig(GetAppConfigRequest{})
 		s.ErrorAs(err, &ErrFieldsNotAvailable{})
@@ -128,7 +128,7 @@ func (s *Suite) TestGetAvailableNamespaces() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		namespaces, err := api.GetAvailableNamespaces(nil)
 		s.NoError(err)
@@ -143,7 +143,7 @@ func (s *Suite) TestGetAvailableNamespaces() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetAvailableNamespaces(nil)
 		s.Contains(err.Error(), "Internal Server Error")
@@ -169,7 +169,7 @@ func (s *Suite) TestGetPlatformVersion() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 		version = "0.30.0"
 		versionErr = nil
 		resp, err := api.GetPlatformVersion(nil)
@@ -185,7 +185,7 @@ func (s *Suite) TestGetPlatformVersion() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 		version = ""
 		versionErr = errMockHouston
 		resp, err := api.GetPlatformVersion(nil)
@@ -201,7 +201,7 @@ func (s *Suite) TestGetPlatformVersion() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 		version = ""
 		versionErr = nil
 		platformVersion, err := api.GetPlatformVersion(nil)
@@ -217,7 +217,7 @@ func (s *Suite) TestGetPlatformVersion() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 		version = ""
 		versionErr = nil
 		_, err := api.GetPlatformVersion(nil)

--- a/houston/auth_test.go
+++ b/houston/auth_test.go
@@ -36,7 +36,7 @@ func (s *Suite) TestAuthenticateWithBasicAuth() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		token, err := api.AuthenticateWithBasicAuth(BasicAuthRequest{"username", "password", &ctx})
 		s.NoError(err)
@@ -51,7 +51,7 @@ func (s *Suite) TestAuthenticateWithBasicAuth() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.AuthenticateWithBasicAuth(BasicAuthRequest{"username", "password", &ctx})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -83,7 +83,7 @@ func (s *Suite) TestGetAuthConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		authConfig, err := api.GetAuthConfig(&ctx)
 		s.NoError(err)
@@ -98,7 +98,7 @@ func (s *Suite) TestGetAuthConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetAuthConfig(&ctx)
 		s.Contains(err.Error(), "Internal Server Error")

--- a/houston/decorator.go
+++ b/houston/decorator.go
@@ -152,7 +152,7 @@ func getVersion() string {
 
 	// fallback case in which somehow we reach here without getting houston version
 	httpClient := NewHTTPClient()
-	client := NewClient(httpClient)
+	client := NewClient(httpClient, nil)
 
 	version, versionErr = client.GetPlatformVersion(nil)
 	return version

--- a/houston/deployment_teams_test.go
+++ b/houston/deployment_teams_test.go
@@ -37,7 +37,7 @@ func (s *Suite) TestAddDeploymentTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.AddDeploymentTeam(AddDeploymentTeamRequest{"deployment-id", "team-id", "role"})
 		s.NoError(err)
@@ -52,7 +52,7 @@ func (s *Suite) TestAddDeploymentTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.AddDeploymentTeam(AddDeploymentTeamRequest{"deployment-id", "team-id", "role"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -87,7 +87,7 @@ func (s *Suite) TestDeleteDeploymentTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.RemoveDeploymentTeam(RemoveDeploymentTeamRequest{"deployment-id", "team-id"})
 		s.NoError(err)
@@ -102,7 +102,7 @@ func (s *Suite) TestDeleteDeploymentTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.RemoveDeploymentTeam(RemoveDeploymentTeamRequest{"deployment-id", "team-id"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -134,7 +134,7 @@ func (s *Suite) TestListDeploymentTeamsAndRoles() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ListDeploymentTeamsAndRoles("deployment-id")
 		s.NoError(err)
@@ -149,7 +149,7 @@ func (s *Suite) TestListDeploymentTeamsAndRoles() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListDeploymentTeamsAndRoles("deploymeny-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -184,7 +184,7 @@ func (s *Suite) TestUpdateDeploymentTeamAndRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.UpdateDeploymentTeamRole(UpdateDeploymentTeamRequest{"deployment-id", "team-id", DeploymentAdminRole})
 		s.NoError(err)
@@ -199,7 +199,7 @@ func (s *Suite) TestUpdateDeploymentTeamAndRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentTeamRole(UpdateDeploymentTeamRequest{"deployment-id", "team-id", "role"})
 		s.Contains(err.Error(), "Internal Server Error")

--- a/houston/deployment_test.go
+++ b/houston/deployment_test.go
@@ -47,7 +47,7 @@ func (s *Suite) TestCreateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.CreateDeployment(map[string]interface{}{})
 		s.NoError(err)
@@ -88,7 +88,7 @@ func (s *Suite) TestCreateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.CreateDeployment(map[string]interface{}{})
 		s.NoError(err)
@@ -103,7 +103,7 @@ func (s *Suite) TestCreateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.CreateDeployment(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -147,7 +147,7 @@ func (s *Suite) TestDeleteDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.DeleteDeployment(DeleteDeploymentRequest{"deployment-id", false})
 		s.NoError(err)
@@ -162,7 +162,7 @@ func (s *Suite) TestDeleteDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.DeleteDeployment(DeleteDeploymentRequest{"deployment-id", false})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -208,7 +208,7 @@ func (s *Suite) TestListDeployments() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deploymentList, err := api.ListDeployments(ListDeploymentsRequest{})
 		s.NoError(err)
@@ -223,7 +223,7 @@ func (s *Suite) TestListDeployments() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListDeployments(ListDeploymentsRequest{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -267,7 +267,7 @@ func (s *Suite) TestUpdateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.UpdateDeployment(map[string]interface{}{})
 		s.NoError(err)
@@ -308,7 +308,7 @@ func (s *Suite) TestUpdateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.UpdateDeployment(map[string]interface{}{})
 		s.NoError(err)
@@ -323,7 +323,7 @@ func (s *Suite) TestUpdateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeployment(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -367,7 +367,7 @@ func (s *Suite) TestGetDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.GetDeployment("deployment-id")
 		s.NoError(err)
@@ -382,7 +382,7 @@ func (s *Suite) TestGetDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetDeployment("deployment-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -426,7 +426,7 @@ func (s *Suite) TestUpdateDeploymentAirflow() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.UpdateDeploymentAirflow(map[string]interface{}{})
 		s.NoError(err)
@@ -441,7 +441,7 @@ func (s *Suite) TestUpdateDeploymentAirflow() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentAirflow(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -479,7 +479,7 @@ func (s *Suite) TestGetDeploymentConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deploymentConfig, err := api.GetDeploymentConfig(nil)
 		s.NoError(err)
@@ -494,7 +494,7 @@ func (s *Suite) TestGetDeploymentConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetDeploymentConfig(nil)
 		s.Contains(err.Error(), "Internal Server Error")
@@ -524,7 +524,7 @@ func (s *Suite) TestListDeploymentLogs() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		logs, err := api.ListDeploymentLogs(ListDeploymentLogsRequest{})
 		s.NoError(err)
@@ -539,7 +539,7 @@ func (s *Suite) TestListDeploymentLogs() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListDeploymentLogs(ListDeploymentLogsRequest{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -586,7 +586,7 @@ func (s *Suite) TestUpdateDeploymentRuntime() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.UpdateDeploymentRuntime(map[string]interface{}{})
 		s.NoError(err)
@@ -601,7 +601,7 @@ func (s *Suite) TestUpdateDeploymentRuntime() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentRuntime(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -635,7 +635,7 @@ func (s *Suite) TestCancelUpdateDeploymentRuntime() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.CancelUpdateDeploymentRuntime(map[string]interface{}{})
 		s.NoError(err)
@@ -650,7 +650,7 @@ func (s *Suite) TestCancelUpdateDeploymentRuntime() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.CancelUpdateDeploymentRuntime(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -680,7 +680,7 @@ func (s *Suite) TestUpdateDeploymentImage() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, AirflowVersion: mockDeployment.Data.UpdateDeploymentImage.AirflowVersion})
 		s.NoError(err)
@@ -694,7 +694,7 @@ func (s *Suite) TestUpdateDeploymentImage() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, AirflowVersion: mockDeployment.Data.UpdateDeploymentImage.AirflowVersion})
 		s.Contains(err.Error(), "Internal Server Error")

--- a/houston/deployment_test.go
+++ b/houston/deployment_test.go
@@ -47,7 +47,7 @@ func (s *Suite) TestCreateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.CreateDeployment(map[string]interface{}{})
 		s.NoError(err)
@@ -88,7 +88,7 @@ func (s *Suite) TestCreateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.CreateDeployment(map[string]interface{}{})
 		s.NoError(err)
@@ -103,7 +103,7 @@ func (s *Suite) TestCreateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.CreateDeployment(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -147,7 +147,7 @@ func (s *Suite) TestDeleteDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.DeleteDeployment(DeleteDeploymentRequest{"deployment-id", false})
 		s.NoError(err)
@@ -162,7 +162,7 @@ func (s *Suite) TestDeleteDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.DeleteDeployment(DeleteDeploymentRequest{"deployment-id", false})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -205,7 +205,7 @@ func (s *Suite) TestAdoptDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.AdoptDeployment(req)
 		s.NoError(err)
@@ -220,7 +220,7 @@ func (s *Suite) TestAdoptDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.AdoptDeployment(req)
 		s.Contains(err.Error(), "Internal Server Error")
@@ -255,7 +255,7 @@ func (s *Suite) TestUnadoptDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.UnadoptDeployment(UnadoptDeploymentRequest{DeploymentID: "deployment-test-id"})
 		s.NoError(err)
@@ -270,7 +270,7 @@ func (s *Suite) TestUnadoptDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UnadoptDeployment(UnadoptDeploymentRequest{DeploymentID: "deployment-test-id"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -316,7 +316,7 @@ func (s *Suite) TestListDeployments() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deploymentList, err := api.ListDeployments(ListDeploymentsRequest{})
 		s.NoError(err)
@@ -331,7 +331,7 @@ func (s *Suite) TestListDeployments() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListDeployments(ListDeploymentsRequest{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -375,7 +375,7 @@ func (s *Suite) TestUpdateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.UpdateDeployment(map[string]interface{}{})
 		s.NoError(err)
@@ -416,7 +416,7 @@ func (s *Suite) TestUpdateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.UpdateDeployment(map[string]interface{}{})
 		s.NoError(err)
@@ -431,7 +431,7 @@ func (s *Suite) TestUpdateDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeployment(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -475,7 +475,7 @@ func (s *Suite) TestGetDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.GetDeployment("deployment-id")
 		s.NoError(err)
@@ -490,7 +490,7 @@ func (s *Suite) TestGetDeployment() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetDeployment("deployment-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -534,7 +534,7 @@ func (s *Suite) TestUpdateDeploymentAirflow() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.UpdateDeploymentAirflow(map[string]interface{}{})
 		s.NoError(err)
@@ -549,7 +549,7 @@ func (s *Suite) TestUpdateDeploymentAirflow() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentAirflow(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -587,7 +587,7 @@ func (s *Suite) TestGetDeploymentConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deploymentConfig, err := api.GetDeploymentConfig(nil)
 		s.NoError(err)
@@ -602,7 +602,7 @@ func (s *Suite) TestGetDeploymentConfig() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetDeploymentConfig(nil)
 		s.Contains(err.Error(), "Internal Server Error")
@@ -632,7 +632,7 @@ func (s *Suite) TestListDeploymentLogs() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		logs, err := api.ListDeploymentLogs(ListDeploymentLogsRequest{})
 		s.NoError(err)
@@ -647,7 +647,7 @@ func (s *Suite) TestListDeploymentLogs() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListDeploymentLogs(ListDeploymentLogsRequest{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -694,7 +694,7 @@ func (s *Suite) TestUpdateDeploymentRuntime() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.UpdateDeploymentRuntime(map[string]interface{}{})
 		s.NoError(err)
@@ -709,7 +709,7 @@ func (s *Suite) TestUpdateDeploymentRuntime() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentRuntime(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -743,7 +743,7 @@ func (s *Suite) TestCancelUpdateDeploymentRuntime() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		deployment, err := api.CancelUpdateDeploymentRuntime(map[string]interface{}{})
 		s.NoError(err)
@@ -758,7 +758,7 @@ func (s *Suite) TestCancelUpdateDeploymentRuntime() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.CancelUpdateDeploymentRuntime(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -787,7 +787,7 @@ func (s *Suite) TestUpdateDeploymentImage() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, RuntimeVersion: "6.0.0"})
 		s.NoError(err)
@@ -801,7 +801,7 @@ func (s *Suite) TestUpdateDeploymentImage() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{ReleaseName: mockDeployment.Data.UpdateDeploymentImage.ReleaseName, RuntimeVersion: "6.0.0"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -822,7 +822,7 @@ func (s *Suite) TestUpdateDeploymentImage() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{
 			ReleaseName:    mockDeployment.Data.UpdateDeploymentImage.ReleaseName,
@@ -849,7 +849,7 @@ func (s *Suite) TestUpdateDeploymentImage() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentImage(UpdateDeploymentImageRequest{
 			ReleaseName:    mockDeployment.Data.UpdateDeploymentImage.ReleaseName,

--- a/houston/deployment_user_test.go
+++ b/houston/deployment_user_test.go
@@ -40,7 +40,7 @@ func (s *Suite) TestListDeploymentUsers() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ListDeploymentUsers(ListDeploymentUsersRequest{})
 		s.NoError(err)
@@ -55,7 +55,7 @@ func (s *Suite) TestListDeploymentUsers() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListDeploymentUsers(ListDeploymentUsersRequest{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -94,7 +94,7 @@ func (s *Suite) TestAddDeploymentUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.AddDeploymentUser(UpdateDeploymentUserRequest{})
 		s.NoError(err)
@@ -110,7 +110,7 @@ func (s *Suite) TestAddDeploymentUser() {
 			}
 		})
 
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.AddDeploymentUser(UpdateDeploymentUserRequest{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -149,7 +149,7 @@ func (s *Suite) TestUpdateDeploymentUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.UpdateDeploymentUser(UpdateDeploymentUserRequest{})
 		s.NoError(err)
@@ -164,7 +164,7 @@ func (s *Suite) TestUpdateDeploymentUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateDeploymentUser(UpdateDeploymentUserRequest{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -203,7 +203,7 @@ func (s *Suite) TestDeleteDeploymentUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.DeleteDeploymentUser(DeleteDeploymentUserRequest{"deployment-id", "email"})
 		s.NoError(err)
@@ -218,7 +218,7 @@ func (s *Suite) TestDeleteDeploymentUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.DeleteDeploymentUser(DeleteDeploymentUserRequest{"deployment-id", "email"})
 		s.Contains(err.Error(), "Internal Server Error")

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -107,8 +107,8 @@ type ClientImplementation struct {
 
 // NewClient - initialized the Houston Client object with proper HTTP Client configuration
 // set as a variable so we can change it to return mock houston clients in tests
-var NewClient = func(c *httputil.HTTPClient) ClientInterface {
-	client := newInternalClient(c)
+var NewClient = func(c *httputil.HTTPClient, tokenHolder *httputil.TokenHolder) ClientInterface {
+	client := newInternalClient(c, tokenHolder)
 	return &ClientImplementation{
 		client: client,
 	}
@@ -116,7 +116,8 @@ var NewClient = func(c *httputil.HTTPClient) ClientInterface {
 
 // Client containers the logger and HTTPClient used to communicate with the HoustonAPI
 type Client struct {
-	HTTPClient *httputil.HTTPClient
+	HTTPClient  *httputil.HTTPClient
+	tokenHolder *httputil.TokenHolder
 }
 
 func NewHTTPClient() *httputil.HTTPClient {
@@ -135,9 +136,10 @@ func NewHTTPClient() *httputil.HTTPClient {
 }
 
 // newInternalClient returns a new Client with the logger and HTTP Client setup.
-func newInternalClient(c *httputil.HTTPClient) *Client {
+func newInternalClient(c *httputil.HTTPClient, tokenHolder *httputil.TokenHolder) *Client {
 	return &Client{
-		HTTPClient: c,
+		HTTPClient:  c,
+		tokenHolder: tokenHolder,
 	}
 }
 
@@ -164,7 +166,7 @@ func (r *Request) DoWithClient(api *Client) (*Response, error) {
 
 // Do (request) is a wrapper to more easily pass variables to a Client.Do request
 func (r *Request) Do() (*Response, error) {
-	return r.DoWithClient(newInternalClient(httputil.NewHTTPClient()))
+	return r.DoWithClient(newInternalClient(httputil.NewHTTPClient(), nil))
 }
 
 // Do fetches the current context, and returns Houston API response, error
@@ -180,8 +182,10 @@ func (c *Client) Do(doOpts *httputil.DoOptions) (*Response, error) {
 // DoWithContext executes a query against the Houston API, logging out any errors contained in the response object
 func (c *Client) DoWithContext(doOpts *httputil.DoOptions, ctx *config.Context) (*Response, error) {
 	// set headers
-	if ctx.Token != "" {
-		doOpts.Headers["authorization"] = ctx.Token
+	if c.tokenHolder != nil {
+		if tok := c.tokenHolder.Get(); tok != "" {
+			doOpts.Headers["authorization"] = tok
+		}
 	}
 	newLogger.Debugf("Request Data: %v\n", string(doOpts.Data))
 	doOpts.Method = http.MethodPost

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -107,8 +108,8 @@ type ClientImplementation struct {
 
 // NewClient - initialized the Houston Client object with proper HTTP Client configuration
 // set as a variable so we can change it to return mock houston clients in tests
-var NewClient = func(c *httputil.HTTPClient, tokenHolder *httputil.TokenHolder) ClientInterface {
-	client := newInternalClient(c, tokenHolder)
+var NewClient = func(c *httputil.HTTPClient, creds *credentials.CurrentCredentials) ClientInterface {
+	client := newInternalClient(c, creds)
 	return &ClientImplementation{
 		client: client,
 	}
@@ -116,8 +117,8 @@ var NewClient = func(c *httputil.HTTPClient, tokenHolder *httputil.TokenHolder) 
 
 // Client containers the logger and HTTPClient used to communicate with the HoustonAPI
 type Client struct {
-	HTTPClient  *httputil.HTTPClient
-	tokenHolder *httputil.TokenHolder
+	HTTPClient *httputil.HTTPClient
+	creds      *credentials.CurrentCredentials
 }
 
 func NewHTTPClient() *httputil.HTTPClient {
@@ -136,10 +137,10 @@ func NewHTTPClient() *httputil.HTTPClient {
 }
 
 // newInternalClient returns a new Client with the logger and HTTP Client setup.
-func newInternalClient(c *httputil.HTTPClient, tokenHolder *httputil.TokenHolder) *Client {
+func newInternalClient(c *httputil.HTTPClient, creds *credentials.CurrentCredentials) *Client {
 	return &Client{
-		HTTPClient:  c,
-		tokenHolder: tokenHolder,
+		HTTPClient: c,
+		creds:      creds,
 	}
 }
 
@@ -182,8 +183,8 @@ func (c *Client) Do(doOpts *httputil.DoOptions) (*Response, error) {
 // DoWithContext executes a query against the Houston API, logging out any errors contained in the response object
 func (c *Client) DoWithContext(doOpts *httputil.DoOptions, ctx *config.Context) (*Response, error) {
 	// set headers
-	if c.tokenHolder != nil {
-		if tok := c.tokenHolder.Get(); tok != "" {
+	if c.creds != nil {
+		if tok := c.creds.Get(); tok != "" {
 			doOpts.Headers["authorization"] = tok
 		}
 	}

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
@@ -109,8 +110,8 @@ type ClientImplementation struct {
 
 // NewClient - initialized the Houston Client object with proper HTTP Client configuration
 // set as a variable so we can change it to return mock houston clients in tests
-var NewClient = func(c *httputil.HTTPClient) ClientInterface {
-	client := newInternalClient(c)
+var NewClient = func(c *httputil.HTTPClient, creds *credentials.CurrentCredentials) ClientInterface {
+	client := newInternalClient(c, creds)
 	return &ClientImplementation{
 		client: client,
 	}
@@ -119,6 +120,7 @@ var NewClient = func(c *httputil.HTTPClient) ClientInterface {
 // Client containers the logger and HTTPClient used to communicate with the HoustonAPI
 type Client struct {
 	HTTPClient *httputil.HTTPClient
+	creds      *credentials.CurrentCredentials
 }
 
 func NewHTTPClient() *httputil.HTTPClient {
@@ -137,9 +139,10 @@ func NewHTTPClient() *httputil.HTTPClient {
 }
 
 // newInternalClient returns a new Client with the logger and HTTP Client setup.
-func newInternalClient(c *httputil.HTTPClient) *Client {
+func newInternalClient(c *httputil.HTTPClient, creds *credentials.CurrentCredentials) *Client {
 	return &Client{
 		HTTPClient: c,
+		creds:      creds,
 	}
 }
 
@@ -166,7 +169,7 @@ func (r *Request) DoWithClient(api *Client) (*Response, error) {
 
 // Do (request) is a wrapper to more easily pass variables to a Client.Do request
 func (r *Request) Do() (*Response, error) {
-	return r.DoWithClient(newInternalClient(httputil.NewHTTPClient()))
+	return r.DoWithClient(newInternalClient(httputil.NewHTTPClient(), nil))
 }
 
 // Do fetches the current context, and returns Houston API response, error
@@ -182,8 +185,10 @@ func (c *Client) Do(doOpts *httputil.DoOptions) (*Response, error) {
 // DoWithContext executes a query against the Houston API, logging out any errors contained in the response object
 func (c *Client) DoWithContext(doOpts *httputil.DoOptions, ctx *config.Context) (*Response, error) {
 	// set headers
-	if ctx.Token != "" {
-		doOpts.Headers["authorization"] = ctx.Token
+	if c.creds != nil {
+		if tok := c.creds.Get(); tok != "" {
+			doOpts.Headers["authorization"] = tok
+		}
 	}
 	newLogger.Debugf("Request Data: %v\n", string(doOpts.Data))
 	doOpts.Method = http.MethodPost

--- a/houston/houston_test.go
+++ b/houston/houston_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *Suite) TestNewHoustonClient() {
-	client := newInternalClient(httputil.NewHTTPClient())
+	client := newInternalClient(httputil.NewHTTPClient(), nil)
 	s.NotNil(client, "Can't create new houston Client")
 }
 

--- a/houston/runtime_test.go
+++ b/houston/runtime_test.go
@@ -30,7 +30,7 @@ func (s *Suite) TestGetRuntimeReleases() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		vars := make(map[string]interface{})
 		resp, err := api.GetRuntimeReleases(vars)
@@ -46,7 +46,7 @@ func (s *Suite) TestGetRuntimeReleases() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		vars := make(map[string]interface{})
 		vars["clusterId"] = "test-cluster-id"
@@ -63,7 +63,7 @@ func (s *Suite) TestGetRuntimeReleases() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		vars := make(map[string]interface{})
 		vars["airflowVersion"] = "2.2.4"
@@ -80,7 +80,7 @@ func (s *Suite) TestGetRuntimeReleases() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		vars := make(map[string]interface{})
 		_, err := api.GetRuntimeReleases(vars)

--- a/houston/service_account_test.go
+++ b/houston/service_account_test.go
@@ -39,7 +39,7 @@ func (s *Suite) TestCreateDeploymentServiceAccount() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.CreateDeploymentServiceAccount(&CreateServiceAccountRequest{})
 		s.NoError(err)
@@ -54,7 +54,7 @@ func (s *Suite) TestCreateDeploymentServiceAccount() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.CreateDeploymentServiceAccount(&CreateServiceAccountRequest{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -91,7 +91,7 @@ func (s *Suite) TestCreateWorkspaceServiceAccount() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.CreateWorkspaceServiceAccount(&CreateServiceAccountRequest{})
 		s.NoError(err)
@@ -106,7 +106,7 @@ func (s *Suite) TestCreateWorkspaceServiceAccount() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.CreateWorkspaceServiceAccount(&CreateServiceAccountRequest{})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -141,7 +141,7 @@ func (s *Suite) TestDeleteDeploymentServiceAccount() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.DeleteDeploymentServiceAccount(DeleteServiceAccountRequest{"", "deployment-id", "sa-id"})
 		s.NoError(err)
@@ -156,7 +156,7 @@ func (s *Suite) TestDeleteDeploymentServiceAccount() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.DeleteDeploymentServiceAccount(DeleteServiceAccountRequest{"", "deployment-id", "sa-id"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -191,7 +191,7 @@ func (s *Suite) TestDeleteWorkspaceServiceAccount() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.DeleteWorkspaceServiceAccount(DeleteServiceAccountRequest{"workspace-id", "", "sa-id"})
 		s.NoError(err)
@@ -206,7 +206,7 @@ func (s *Suite) TestDeleteWorkspaceServiceAccount() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.DeleteWorkspaceServiceAccount(DeleteServiceAccountRequest{"workspace-id", "", "sa-id"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -253,7 +253,7 @@ func (s *Suite) TestListDeploymentServiceAccounts() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ListDeploymentServiceAccounts("deployment-id")
 		s.NoError(err)
@@ -268,7 +268,7 @@ func (s *Suite) TestListDeploymentServiceAccounts() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListDeploymentServiceAccounts("deployment-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -315,7 +315,7 @@ func (s *Suite) TestListWorkspaceServiceAccounts() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ListWorkspaceServiceAccounts("workspace-id")
 		s.NoError(err)
@@ -330,7 +330,7 @@ func (s *Suite) TestListWorkspaceServiceAccounts() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListWorkspaceServiceAccounts("workspace-id")
 		s.Contains(err.Error(), "Internal Server Error")

--- a/houston/teams_test.go
+++ b/houston/teams_test.go
@@ -30,7 +30,7 @@ func (s *Suite) TestGetTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.GetTeam("team-id")
 		s.NoError(err)
@@ -45,7 +45,7 @@ func (s *Suite) TestGetTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetTeam("team-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -75,7 +75,7 @@ func (s *Suite) TestGetTeamUsers() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.GetTeamUsers("team-id")
 		s.NoError(err)
@@ -90,7 +90,7 @@ func (s *Suite) TestGetTeamUsers() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetTeamUsers("team-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -123,7 +123,7 @@ func (s *Suite) TestListTeams() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ListTeams(ListTeamsRequest{"", 1})
 		s.NoError(err)
@@ -138,7 +138,7 @@ func (s *Suite) TestListTeams() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListTeams(ListTeamsRequest{"", 1})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -165,7 +165,7 @@ func (s *Suite) TestCreateTeamSystemRoleBinding() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.CreateTeamSystemRoleBinding(SystemRoleBindingRequest{"test-id", SystemAdminRole})
 		s.NoError(err)
@@ -180,7 +180,7 @@ func (s *Suite) TestCreateTeamSystemRoleBinding() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.CreateTeamSystemRoleBinding(SystemRoleBindingRequest{"test-id", SystemAdminRole})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -207,7 +207,7 @@ func (s *Suite) TestDeleteTeamSystemRoleBinding() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.DeleteTeamSystemRoleBinding(SystemRoleBindingRequest{"test-id", SystemAdminRole})
 		s.NoError(err)
@@ -222,7 +222,7 @@ func (s *Suite) TestDeleteTeamSystemRoleBinding() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.DeleteTeamSystemRoleBinding(SystemRoleBindingRequest{"test-id", SystemAdminRole})
 		s.Contains(err.Error(), "Internal Server Error")

--- a/houston/user_test.go
+++ b/houston/user_test.go
@@ -40,7 +40,7 @@ func (s *Suite) TestCreateUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.CreateUser(CreateUserRequest{"email", "password"})
 		s.NoError(err)
@@ -55,7 +55,7 @@ func (s *Suite) TestCreateUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.CreateUser(CreateUserRequest{"email", "password"})
 		s.Contains(err.Error(), "Internal Server Error")

--- a/houston/workspace_teams_test.go
+++ b/houston/workspace_teams_test.go
@@ -34,7 +34,7 @@ func (s *Suite) TestAddWorkspaceTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.AddWorkspaceTeam(AddWorkspaceTeamRequest{"workspace-id", "team-id", "role"})
 		s.NoError(err)
@@ -49,7 +49,7 @@ func (s *Suite) TestAddWorkspaceTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.AddWorkspaceTeam(AddWorkspaceTeamRequest{"workspace-id", "team-id", "role"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -81,7 +81,7 @@ func (s *Suite) TestDeleteWorkspaceTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.DeleteWorkspaceTeam(DeleteWorkspaceTeamRequest{"workspace-id", "user-id"})
 		s.NoError(err)
@@ -96,7 +96,7 @@ func (s *Suite) TestDeleteWorkspaceTeam() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.DeleteWorkspaceTeam(DeleteWorkspaceTeamRequest{"workspace-id", "user-id"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -128,7 +128,7 @@ func (s *Suite) TestListWorkspaceTeamsAndRoles() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ListWorkspaceTeamsAndRoles("workspace-id")
 		s.NoError(err)
@@ -143,7 +143,7 @@ func (s *Suite) TestListWorkspaceTeamsAndRoles() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListWorkspaceTeamsAndRoles("workspace-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -169,7 +169,7 @@ func (s *Suite) TestUpdateWorkspaceTeamAndRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.UpdateWorkspaceTeamRole(UpdateWorkspaceTeamRoleRequest{"workspace-id", "team-id", WorkspaceAdminRole})
 		s.NoError(err)
@@ -184,7 +184,7 @@ func (s *Suite) TestUpdateWorkspaceTeamAndRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateWorkspaceTeamRole(UpdateWorkspaceTeamRoleRequest{"workspace-id", "team-id", "role"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -206,7 +206,7 @@ func (s *Suite) TestGetWorkspaceTeamRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.GetWorkspaceTeamRole(GetWorkspaceTeamRoleRequest{"workspace-id", "team-id"})
 		s.NoError(err)
@@ -221,7 +221,7 @@ func (s *Suite) TestGetWorkspaceTeamRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetWorkspaceTeamRole(GetWorkspaceTeamRoleRequest{"workspace-id", "team-id"})
 		s.Contains(err.Error(), "Internal Server Error")

--- a/houston/workspace_test.go
+++ b/houston/workspace_test.go
@@ -44,7 +44,7 @@ func (s *Suite) TestCreateWorkspace() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.CreateWorkspace(CreateWorkspaceRequest{"label", "description"})
 		s.NoError(err)
@@ -59,7 +59,7 @@ func (s *Suite) TestCreateWorkspace() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.CreateWorkspace(CreateWorkspaceRequest{"label", "description"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -120,7 +120,7 @@ func (s *Suite) TestListWorkspaces() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ListWorkspaces(nil)
 		s.NoError(err)
@@ -135,7 +135,7 @@ func (s *Suite) TestListWorkspaces() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListWorkspaces(nil)
 		s.Contains(err.Error(), "Internal Server Error")
@@ -196,7 +196,7 @@ func (s *Suite) TestPaginatedListWorkspaces() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.PaginatedListWorkspaces(PaginatedListWorkspaceRequest{10, 0})
 		s.NoError(err)
@@ -211,7 +211,7 @@ func (s *Suite) TestPaginatedListWorkspaces() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.PaginatedListWorkspaces(PaginatedListWorkspaceRequest{10, 0})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -253,7 +253,7 @@ func (s *Suite) TestDeleteWorkspace() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.DeleteWorkspace("workspace-id")
 		s.NoError(err)
@@ -268,7 +268,7 @@ func (s *Suite) TestDeleteWorkspace() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.DeleteWorkspace("workspace-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -310,7 +310,7 @@ func (s *Suite) TestGetWorkspace() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.GetWorkspace("workspace-id")
 		s.NoError(err)
@@ -325,7 +325,7 @@ func (s *Suite) TestGetWorkspace() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetWorkspace("workspace-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -357,7 +357,7 @@ func (s *Suite) TestValidateWorkspaceID() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ValidateWorkspaceID("workspace-id")
 		s.NoError(err)
@@ -372,7 +372,7 @@ func (s *Suite) TestValidateWorkspaceID() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ValidateWorkspaceID("workspace-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -414,7 +414,7 @@ func (s *Suite) TestUpdateWorkspace() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.UpdateWorkspace(UpdateWorkspaceRequest{"workspace-id", map[string]string{}})
 		s.NoError(err)
@@ -429,7 +429,7 @@ func (s *Suite) TestUpdateWorkspace() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateWorkspace(UpdateWorkspaceRequest{"workspace-id", map[string]string{}})
 		s.Contains(err.Error(), "Internal Server Error")

--- a/houston/workspace_users_test.go
+++ b/houston/workspace_users_test.go
@@ -43,7 +43,7 @@ func (s *Suite) TestAddWorkspaceUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.AddWorkspaceUser(AddWorkspaceUserRequest{"workspace-id", "email", "role"})
 		s.NoError(err)
@@ -58,7 +58,7 @@ func (s *Suite) TestAddWorkspaceUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.AddWorkspaceUser(AddWorkspaceUserRequest{"workspace-id", "email", "role"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -99,7 +99,7 @@ func (s *Suite) TestDeleteWorkspaceUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.DeleteWorkspaceUser(DeleteWorkspaceUserRequest{"workspace-id", "user-id"})
 		s.NoError(err)
@@ -114,7 +114,7 @@ func (s *Suite) TestDeleteWorkspaceUser() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.DeleteWorkspaceUser(DeleteWorkspaceUserRequest{"workspace-id", "user-id"})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -152,7 +152,7 @@ func (s *Suite) TestListWorkspaceUserAndRoles() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ListWorkspaceUserAndRoles("workspace-id")
 		s.NoError(err)
@@ -167,7 +167,7 @@ func (s *Suite) TestListWorkspaceUserAndRoles() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListWorkspaceUserAndRoles("workspace-id")
 		s.Contains(err.Error(), "Internal Server Error")
@@ -205,7 +205,7 @@ func (s *Suite) TestListWorkspacePaginatedUserAndRoles() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.ListWorkspacePaginatedUserAndRoles(PaginatedWorkspaceUserRolesRequest{"workspace-id", "cursor-id", 100})
 		s.NoError(err)
@@ -220,7 +220,7 @@ func (s *Suite) TestListWorkspacePaginatedUserAndRoles() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.ListWorkspacePaginatedUserAndRoles(PaginatedWorkspaceUserRolesRequest{"workspace-id", "cursor-id", 100})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -246,7 +246,7 @@ func (s *Suite) TestUpdateWorkspaceUserAndRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.UpdateWorkspaceUserRole(UpdateWorkspaceUserRoleRequest{"workspace-id", "test@test.com", WorkspaceAdminRole})
 		s.NoError(err)
@@ -261,7 +261,7 @@ func (s *Suite) TestUpdateWorkspaceUserAndRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.UpdateWorkspaceUserRole(UpdateWorkspaceUserRoleRequest{"workspace-id", "test@test.com", WorkspaceAdminRole})
 		s.Contains(err.Error(), "Internal Server Error")
@@ -296,7 +296,7 @@ func (s *Suite) TestGetWorkspaceUserRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		response, err := api.GetWorkspaceUserRole(GetWorkspaceUserRoleRequest{"workspace-id", "email"})
 		s.NoError(err)
@@ -311,7 +311,7 @@ func (s *Suite) TestGetWorkspaceUserRole() {
 				Header:     make(http.Header),
 			}
 		})
-		api := NewClient(client)
+		api := NewClient(client, nil)
 
 		_, err := api.GetWorkspaceUserRole(GetWorkspaceUserRoleRequest{"workspace-id", "email"})
 		s.Contains(err.Error(), "Internal Server Error")

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -1,0 +1,34 @@
+package credentials
+
+import "sync"
+
+// CurrentCredentials holds the current auth token in memory for the duration of a
+// command invocation. It is populated by PersistentPreRunE after credentials
+// are resolved from the secure store, and read by API client request editors
+// on every outbound request.
+//
+// It is constructed once in NewRootCmd and passed by pointer to both the API
+// clients and CreateRootPersistentPreRunE. There is no global state.
+type CurrentCredentials struct {
+	mu    sync.RWMutex
+	token string
+}
+
+// New creates a CurrentCredentials with an initial token value.
+func New(token string) *CurrentCredentials {
+	return &CurrentCredentials{token: token}
+}
+
+// Set stores the token.
+func (h *CurrentCredentials) Set(token string) {
+	h.mu.Lock()
+	h.token = token
+	h.mu.Unlock()
+}
+
+// Get returns the current token.
+func (h *CurrentCredentials) Get() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.token
+}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -1,33 +1,33 @@
-package httputil
+package credentials
 
 import "sync"
 
-// TokenHolder holds the current auth token in memory for the duration of a
+// CurrentCredentials holds the current auth token in memory for the duration of a
 // command invocation. It is populated by PersistentPreRunE after credentials
 // are resolved from the secure store, and read by API client request editors
 // on every outbound request.
 //
 // It is constructed once in NewRootCmd and passed by pointer to both the API
 // clients and CreateRootPersistentPreRunE. There is no global state.
-type TokenHolder struct {
+type CurrentCredentials struct {
 	mu    sync.RWMutex
 	token string
 }
 
-// NewTokenHolder creates a TokenHolder with an initial token value.
-func NewTokenHolder(token string) *TokenHolder {
-	return &TokenHolder{token: token}
+// New creates a CurrentCredentials with an initial token value.
+func New(token string) *CurrentCredentials {
+	return &CurrentCredentials{token: token}
 }
 
 // Set stores the token.
-func (h *TokenHolder) Set(token string) {
+func (h *CurrentCredentials) Set(token string) {
 	h.mu.Lock()
 	h.token = token
 	h.mu.Unlock()
 }
 
 // Get returns the current token.
-func (h *TokenHolder) Get() string {
+func (h *CurrentCredentials) Get() string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.token

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -1,15 +1,15 @@
-package httputil_test
+package credentials_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 )
 
-func TestTokenHolder(t *testing.T) {
-	h := &httputil.TokenHolder{}
+func TestCurrentCredentials(t *testing.T) {
+	h := &credentials.CurrentCredentials{}
 	assert.Equal(t, "", h.Get())
 
 	h.Set("Bearer abc")

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -1,0 +1,20 @@
+package credentials_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/astro-cli/pkg/credentials"
+)
+
+func TestCurrentCredentials(t *testing.T) {
+	h := &credentials.CurrentCredentials{}
+	assert.Equal(t, "", h.Get())
+
+	h.Set("Bearer abc")
+	assert.Equal(t, "Bearer abc", h.Get())
+
+	h.Set("")
+	assert.Equal(t, "", h.Get())
+}

--- a/pkg/httputil/token_holder.go
+++ b/pkg/httputil/token_holder.go
@@ -1,0 +1,34 @@
+package httputil
+
+import "sync"
+
+// TokenHolder holds the current auth token in memory for the duration of a
+// command invocation. It is populated by PersistentPreRunE after credentials
+// are resolved from the secure store, and read by API client request editors
+// on every outbound request.
+//
+// It is constructed once in NewRootCmd and passed by pointer to both the API
+// clients and CreateRootPersistentPreRunE. There is no global state.
+type TokenHolder struct {
+	mu    sync.RWMutex
+	token string
+}
+
+// NewTokenHolder creates a TokenHolder with an initial token value.
+func NewTokenHolder(token string) *TokenHolder {
+	return &TokenHolder{token: token}
+}
+
+// Set stores the token.
+func (h *TokenHolder) Set(token string) {
+	h.mu.Lock()
+	h.token = token
+	h.mu.Unlock()
+}
+
+// Get returns the current token.
+func (h *TokenHolder) Get() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.token
+}

--- a/pkg/httputil/token_holder_test.go
+++ b/pkg/httputil/token_holder_test.go
@@ -1,0 +1,20 @@
+package httputil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/astro-cli/pkg/httputil"
+)
+
+func TestTokenHolder(t *testing.T) {
+	h := &httputil.TokenHolder{}
+	assert.Equal(t, "", h.Get())
+
+	h.Set("Bearer abc")
+	assert.Equal(t, "Bearer abc", h.Get())
+
+	h.Set("")
+	assert.Equal(t, "", h.Get())
+}

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -1,0 +1,79 @@
+package keychain
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/99designs/keyring"
+)
+
+const serviceName = "astro-cli"
+
+// ErrNotFound is returned when no credentials exist for the given domain.
+var ErrNotFound = errors.New("credentials not found")
+
+// SecureStore persists and retrieves authentication credentials
+// using the OS-native secure store.
+type SecureStore interface {
+	GetCredentials(domain string) (Credentials, error)
+	SetCredentials(domain string, creds Credentials) error
+	DeleteCredentials(domain string) error
+}
+
+// Credentials holds all authentication credentials for a single context.
+type Credentials struct {
+	Token        string    `json:"token"`
+	RefreshToken string    `json:"refreshtoken"`
+	UserEmail    string    `json:"user_email"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+// keyringStore is the shared SecureStore implementation for macOS and Linux
+// Secret Service, backed by a 99designs/keyring.Keyring.
+//
+// On Windows, see keychain_windows.go for the per-field implementation.
+type keyringStore struct {
+	ring keyring.Keyring
+}
+
+func (s *keyringStore) GetCredentials(domain string) (Credentials, error) {
+	item, err := s.ring.Get(domain)
+	if errors.Is(err, keyring.ErrKeyNotFound) {
+		return Credentials{}, ErrNotFound
+	}
+	if err != nil {
+		return Credentials{}, fmt.Errorf("reading credentials: %w", err)
+	}
+	var creds Credentials
+	if err := json.Unmarshal(item.Data, &creds); err != nil {
+		return Credentials{}, fmt.Errorf("decoding credentials: %w", err)
+	}
+	return creds, nil
+}
+
+func (s *keyringStore) SetCredentials(domain string, creds Credentials) error {
+	data, err := json.Marshal(creds)
+	if err != nil {
+		return fmt.Errorf("encoding credentials: %w", err)
+	}
+	if err := s.ring.Set(keyring.Item{Key: domain, Label: "Astro CLI (" + domain + ")", Data: data}); err != nil {
+		return fmt.Errorf("writing credentials: %w", err)
+	}
+	return nil
+}
+
+func (s *keyringStore) DeleteCredentials(domain string) error {
+	err := s.ring.Remove(domain)
+	if err == nil || errors.Is(err, keyring.ErrKeyNotFound) {
+		return nil
+	}
+	return fmt.Errorf("deleting credentials: %w", err)
+}
+
+// NewTestStore returns an in-memory SecureStore for use in unit tests.
+// It is backed by keyring.NewArrayKeyring which ships with 99designs/keyring.
+func NewTestStore() SecureStore {
+	return &keyringStore{ring: keyring.NewArrayKeyring(nil)}
+}

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/99designs/keyring"
@@ -18,6 +19,33 @@ var ErrNotFound = errors.New("credentials not found")
 // is available and the user has set no_insecure_fallback, meaning they would
 // rather fail than have credentials written to disk in the clear.
 var ErrInsecureFallbackRefused = errors.New("no secure credential store available and the plaintext fallback is disabled")
+
+var (
+	credentialsDir   string
+	credentialsDirMu sync.RWMutex
+)
+
+// SetCredentialsDir sets the directory the plaintext fallback store writes to.
+// Must be called before New on any platform that can fall back to a file.
+//
+// Injected rather than resolved here because the astro home directory honors
+// ASTRO_HOME and the repo's own home-dir lookup, both of which live in package
+// config — which imports this package, so this one cannot import it back.
+// Resolving it independently would drift: credentials would land in ~/.astro
+// while config.yaml went to $ASTRO_HOME/.astro, splitting one login across two
+// directories. Same injection pattern as pkg/proxy.SetRoutesDir.
+func SetCredentialsDir(dir string) {
+	credentialsDirMu.Lock()
+	defer credentialsDirMu.Unlock()
+	credentialsDir = dir
+}
+
+// CredentialsDir returns the configured credentials directory.
+func CredentialsDir() string {
+	credentialsDirMu.RLock()
+	defer credentialsDirMu.RUnlock()
+	return credentialsDir
+}
 
 // SecureStore persists and retrieves authentication credentials
 // using the OS-native secure store.
@@ -35,8 +63,9 @@ type Credentials struct {
 	ExpiresAt    time.Time `json:"expires_at"`
 }
 
-// keyringStore is the shared SecureStore implementation for macOS and Linux
-// Secret Service, backed by a 99designs/keyring.Keyring.
+// keyringStore is the SecureStore implementation backed by a
+// 99designs/keyring.Keyring — macOS Keychain, or Secret Service / KWallet on
+// Linux.
 type keyringStore struct {
 	ring keyring.Keyring
 }

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -14,6 +14,11 @@ const serviceName = "astro-cli"
 // ErrNotFound is returned when no credentials exist for the given domain.
 var ErrNotFound = errors.New("credentials not found")
 
+// ErrInsecureFallbackRefused is returned by New when no OS-native secure store
+// is available and the user has set no_insecure_fallback, meaning they would
+// rather fail than have credentials written to disk in the clear.
+var ErrInsecureFallbackRefused = errors.New("no secure credential store available and the plaintext fallback is disabled")
+
 // SecureStore persists and retrieves authentication credentials
 // using the OS-native secure store.
 type SecureStore interface {

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -37,8 +37,6 @@ type Credentials struct {
 
 // keyringStore is the shared SecureStore implementation for macOS and Linux
 // Secret Service, backed by a 99designs/keyring.Keyring.
-//
-// On Windows, see keychain_windows.go for the per-field implementation.
 type keyringStore struct {
 	ring keyring.Keyring
 }

--- a/pkg/keychain/keychain_cached.go
+++ b/pkg/keychain/keychain_cached.go
@@ -1,0 +1,55 @@
+package keychain
+
+import "sync"
+
+// cachedStore wraps a SecureStore and caches credentials in memory so that
+// repeated reads of the same domain within a single process only hit the
+// underlying store (and trigger an OS keychain prompt) once.
+type cachedStore struct {
+	inner SecureStore
+	mu    sync.RWMutex
+	cache map[string]Credentials
+}
+
+func newCachedStore(inner SecureStore) SecureStore {
+	return &cachedStore{inner: inner, cache: make(map[string]Credentials)}
+}
+
+func (c *cachedStore) GetCredentials(domain string) (Credentials, error) {
+	c.mu.RLock()
+	creds, ok := c.cache[domain]
+	c.mu.RUnlock()
+	if ok {
+		return creds, nil
+	}
+
+	creds, err := c.inner.GetCredentials(domain)
+	if err != nil {
+		return Credentials{}, err
+	}
+
+	c.mu.Lock()
+	c.cache[domain] = creds
+	c.mu.Unlock()
+	return creds, nil
+}
+
+func (c *cachedStore) SetCredentials(domain string, creds Credentials) error {
+	if err := c.inner.SetCredentials(domain, creds); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.cache[domain] = creds
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *cachedStore) DeleteCredentials(domain string) error {
+	if err := c.inner.DeleteCredentials(domain); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	delete(c.cache, domain)
+	c.mu.Unlock()
+	return nil
+}

--- a/pkg/keychain/keychain_cached_test.go
+++ b/pkg/keychain/keychain_cached_test.go
@@ -1,0 +1,167 @@
+package keychain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockStore struct {
+	mock.Mock
+}
+
+func (m *mockStore) GetCredentials(domain string) (Credentials, error) {
+	args := m.Called(domain)
+	return args.Get(0).(Credentials), args.Error(1)
+}
+
+func (m *mockStore) SetCredentials(domain string, creds Credentials) error {
+	return m.Called(domain, creds).Error(0)
+}
+
+func (m *mockStore) DeleteCredentials(domain string) error {
+	return m.Called(domain).Error(0)
+}
+
+func TestCachedStore_Get(t *testing.T) {
+	t.Run("cache populated on first get, second get uses cache", func(t *testing.T) {
+		inner := new(mockStore)
+		inner.On("GetCredentials", "example.com").Return(Credentials{Token: "tok"}, nil)
+		store := newCachedStore(inner)
+
+		got, err := store.GetCredentials("example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "tok", got.Token)
+
+		got, err = store.GetCredentials("example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "tok", got.Token)
+
+		inner.AssertNumberOfCalls(t, "GetCredentials", 1)
+	})
+
+	t.Run("different domains cached independently", func(t *testing.T) {
+		inner := new(mockStore)
+		inner.On("GetCredentials", "a.io").Return(Credentials{Token: "a"}, nil)
+		inner.On("GetCredentials", "b.io").Return(Credentials{Token: "b"}, nil)
+		store := newCachedStore(inner)
+
+		_, err := store.GetCredentials("a.io")
+		require.NoError(t, err)
+
+		b, err := store.GetCredentials("b.io")
+		require.NoError(t, err)
+		assert.Equal(t, "b", b.Token)
+
+		inner.AssertNumberOfCalls(t, "GetCredentials", 2)
+	})
+
+	t.Run("inner error propagated and not cached", func(t *testing.T) {
+		inner := new(mockStore)
+		inner.On("GetCredentials", "example.com").Return(Credentials{}, errors.New("keyring locked")).Once()
+		inner.On("GetCredentials", "example.com").Return(Credentials{Token: "recovered"}, nil).Once()
+		store := newCachedStore(inner)
+
+		_, err := store.GetCredentials("example.com")
+		require.ErrorContains(t, err, "keyring locked")
+
+		got, err := store.GetCredentials("example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "recovered", got.Token)
+
+		inner.AssertNumberOfCalls(t, "GetCredentials", 2)
+	})
+}
+
+func TestCachedStore_Set(t *testing.T) {
+	t.Run("write-through then served from cache", func(t *testing.T) {
+		inner := new(mockStore)
+		creds := Credentials{Token: "new-tok"}
+		inner.On("SetCredentials", "example.com", creds).Return(nil)
+		store := newCachedStore(inner)
+
+		require.NoError(t, store.SetCredentials("example.com", creds))
+
+		got, err := store.GetCredentials("example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "new-tok", got.Token)
+
+		inner.AssertNotCalled(t, "GetCredentials")
+	})
+
+	t.Run("inner set error propagated and cache not updated", func(t *testing.T) {
+		inner := new(mockStore)
+		inner.On("SetCredentials", "example.com", mock.Anything).Return(errors.New("disk full"))
+		inner.On("GetCredentials", "example.com").Return(Credentials{}, ErrNotFound)
+		store := newCachedStore(inner)
+
+		err := store.SetCredentials("example.com", Credentials{Token: "tok"})
+		require.ErrorContains(t, err, "disk full")
+
+		_, err = store.GetCredentials("example.com")
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+}
+
+func TestCachedStore_Delete(t *testing.T) {
+	t.Run("invalidates cache so next get hits inner", func(t *testing.T) {
+		inner := new(mockStore)
+		inner.On("GetCredentials", "example.com").Return(Credentials{Token: "tok"}, nil).Once()
+		inner.On("GetCredentials", "example.com").Return(Credentials{}, ErrNotFound).Once()
+		inner.On("DeleteCredentials", "example.com").Return(nil)
+		store := newCachedStore(inner)
+
+		_, err := store.GetCredentials("example.com")
+		require.NoError(t, err)
+
+		require.NoError(t, store.DeleteCredentials("example.com"))
+
+		_, err = store.GetCredentials("example.com")
+		assert.ErrorIs(t, err, ErrNotFound)
+
+		inner.AssertNumberOfCalls(t, "GetCredentials", 2)
+	})
+
+	t.Run("does not affect other domains", func(t *testing.T) {
+		inner := new(mockStore)
+		inner.On("GetCredentials", "a.io").Return(Credentials{Token: "a"}, nil)
+		inner.On("GetCredentials", "b.io").Return(Credentials{Token: "b"}, nil)
+		inner.On("DeleteCredentials", "a.io").Return(nil)
+		store := newCachedStore(inner)
+
+		_, err := store.GetCredentials("a.io")
+		require.NoError(t, err)
+		_, err = store.GetCredentials("b.io")
+		require.NoError(t, err)
+
+		require.NoError(t, store.DeleteCredentials("a.io"))
+
+		got, err := store.GetCredentials("b.io")
+		require.NoError(t, err)
+		assert.Equal(t, "b", got.Token)
+
+		inner.AssertNumberOfCalls(t, "GetCredentials", 2)
+	})
+
+	t.Run("inner delete error propagated and cache preserved", func(t *testing.T) {
+		inner := new(mockStore)
+		inner.On("GetCredentials", "example.com").Return(Credentials{Token: "tok"}, nil)
+		inner.On("DeleteCredentials", "example.com").Return(errors.New("permission denied"))
+		store := newCachedStore(inner)
+
+		_, err := store.GetCredentials("example.com")
+		require.NoError(t, err)
+
+		err = store.DeleteCredentials("example.com")
+		require.ErrorContains(t, err, "permission denied")
+
+		got, err := store.GetCredentials("example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "tok", got.Token)
+
+		inner.AssertNumberOfCalls(t, "GetCredentials", 1)
+	})
+}

--- a/pkg/keychain/keychain_darwin.go
+++ b/pkg/keychain/keychain_darwin.go
@@ -1,0 +1,31 @@
+//go:build darwin
+
+package keychain
+
+import (
+	"fmt"
+
+	"github.com/99designs/keyring"
+)
+
+// New returns a macOS Keychain-backed SecureStore.
+//
+// Items are stored with per-app ACL (KeychainTrustApplication) so that other
+// processes — including the `security` CLI tool — must show a user prompt before
+// reading them. After each CLI binary update (binary hash changes), macOS
+// re-prompts once on first access. This is expected behavior.
+//
+// The cachedStore wrapper (see keychain_cached.go) ensures only one keychain
+// access per domain per process, so the user sees at most one prompt per
+// command invocation.
+func New() (SecureStore, error) {
+	ring, err := keyring.Open(keyring.Config{
+		ServiceName:                    serviceName,
+		KeychainTrustApplication:       true,
+		KeychainAccessibleWhenUnlocked: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("system keychain unavailable: %w", err)
+	}
+	return newCachedStore(&keyringStore{ring: ring}), nil
+}

--- a/pkg/keychain/keychain_darwin.go
+++ b/pkg/keychain/keychain_darwin.go
@@ -18,7 +18,10 @@ import (
 // The cachedStore wrapper (see keychain_cached.go) ensures only one keychain
 // access per domain per process, so the user sees at most one prompt per
 // command invocation.
-func New() (SecureStore, error) {
+//
+// macOS always has a Keychain, so there is nothing to fall back to and
+// allowInsecureFallback is not consulted — an unavailable Keychain is an error.
+func New(_ bool) (SecureStore, error) {
 	ring, err := keyring.Open(keyring.Config{
 		ServiceName:                    serviceName,
 		KeychainTrustApplication:       true,
@@ -27,5 +30,5 @@ func New() (SecureStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("system keychain unavailable: %w", err)
 	}
-	return newCachedStore(&keyringStore{ring: ring}), nil
+	return newCachedStore(withTimeout(&keyringStore{ring: ring}, keyringTimeout)), nil
 }

--- a/pkg/keychain/keychain_file.go
+++ b/pkg/keychain/keychain_file.go
@@ -1,0 +1,108 @@
+//go:build !darwin
+
+package keychain
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// fileStore is a plaintext JSON credential store for environments where no
+// OS-native secure store is available (Linux without Secret Service, Windows
+// before the Credential Manager backend lands). Credentials are written to
+// ~/.astro/credentials.json with mode 0600.
+//
+// Writes go via a temp-file + rename so a crash mid-write cannot corrupt an
+// existing credentials file.
+type fileStore struct {
+	path string
+}
+
+func newFileStore() (*fileStore, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".astro")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("cannot create credentials directory: %w", err)
+	}
+	return &fileStore{path: filepath.Join(dir, "credentials.json")}, nil
+}
+
+func writeAtomic(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".credentials-*.json")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func (s *fileStore) read() (map[string]Credentials, error) {
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return map[string]Credentials{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading credentials file: %w", err)
+	}
+	var store map[string]Credentials
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, fmt.Errorf("decoding credentials file: %w", err)
+	}
+	return store, nil
+}
+
+func (s *fileStore) write(store map[string]Credentials) error {
+	data, err := json.Marshal(store)
+	if err != nil {
+		return fmt.Errorf("encoding credentials: %w", err)
+	}
+	return writeAtomic(s.path, data)
+}
+
+func (s *fileStore) GetCredentials(domain string) (Credentials, error) {
+	store, err := s.read()
+	if err != nil {
+		return Credentials{}, err
+	}
+	creds, ok := store[domain]
+	if !ok {
+		return Credentials{}, ErrNotFound
+	}
+	return creds, nil
+}
+
+func (s *fileStore) SetCredentials(domain string, creds Credentials) error {
+	store, err := s.read()
+	if err != nil {
+		return err
+	}
+	store[domain] = creds
+	return s.write(store)
+}
+
+func (s *fileStore) DeleteCredentials(domain string) error {
+	store, err := s.read()
+	if err != nil {
+		return err
+	}
+	delete(store, domain)
+	return s.write(store)
+}

--- a/pkg/keychain/keychain_file.go
+++ b/pkg/keychain/keychain_file.go
@@ -5,8 +5,10 @@ package keychain
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 const (
@@ -14,6 +16,30 @@ const (
 	dirPerm  = 0o700
 	filePerm = 0o600
 )
+
+// insecureWarning fires the first time a plaintext write happens in a process.
+// It hangs off credential writes — login and each token refresh — rather than
+// store construction, because that is when secrets actually hit the disk. Once
+// per process keeps it from drowning out command output while still telling the
+// user on the invocation that did it.
+//
+// A pointer, not a value: resetting it in tests would otherwise copy a mutex.
+var (
+	insecureWarning              = &sync.Once{}
+	insecureWarningOut io.Writer = os.Stderr
+)
+
+// warnInsecureWrite tells the user their credentials went to disk in the clear.
+// A silent downgrade is the specific failure the GitHub CLI regrets shipping:
+// the user asks for keychain storage, does not get it, and never finds out.
+func warnInsecureWrite(path string) {
+	insecureWarning.Do(func() {
+		fmt.Fprintf(insecureWarningOut,
+			"! No OS credential store available — authentication credentials saved in plain text at %s\n"+
+				"  To require a secure store instead, run: astro config set -g no_insecure_fallback true\n",
+			path)
+	})
+}
 
 // fileStore is a plaintext JSON credential store for environments where no
 // OS-native secure store is available (Linux without Secret Service, Windows
@@ -101,7 +127,11 @@ func (s *fileStore) SetCredentials(domain string, creds Credentials) error {
 		return err
 	}
 	store[domain] = creds
-	return s.write(store)
+	if err := s.write(store); err != nil {
+		return err
+	}
+	warnInsecureWrite(s.path)
+	return nil
 }
 
 func (s *fileStore) DeleteCredentials(domain string) error {

--- a/pkg/keychain/keychain_file.go
+++ b/pkg/keychain/keychain_file.go
@@ -4,6 +4,7 @@ package keychain
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -29,9 +30,8 @@ var (
 	insecureWarningOut io.Writer = os.Stderr
 )
 
-// warnInsecureWrite tells the user their credentials went to disk in the clear.
-// A silent downgrade is the specific failure the GitHub CLI regrets shipping:
-// the user asks for keychain storage, does not get it, and never finds out.
+// warnInsecureWrite tells the user their credentials went to disk in the clear,
+// so a downgrade from the OS keychain is never silent.
 func warnInsecureWrite(path string) {
 	insecureWarning.Do(func() {
 		fmt.Fprintf(insecureWarningOut,
@@ -41,10 +41,12 @@ func warnInsecureWrite(path string) {
 	})
 }
 
-// fileStore is a plaintext JSON credential store for environments where no
-// OS-native secure store is available (Linux without Secret Service, Windows
-// before the Credential Manager backend lands). Credentials are written to
-// ~/.astro/credentials.json with mode 0600.
+var errNoCredentialsDir = errors.New("credentials directory not configured: SetCredentialsDir must be called first")
+
+// fileStore is a plaintext JSON credential store for environments with no
+// OS-native secure store: Linux without Secret Service, and Windows, which has
+// no Credential Manager backend. Credentials are written to credentials.json
+// with mode 0600.
 //
 // Writes go via a temp-file + rename so a crash mid-write cannot corrupt an
 // existing credentials file.
@@ -53,11 +55,10 @@ type fileStore struct {
 }
 
 func newFileStore() (*fileStore, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("cannot determine home directory: %w", err)
+	dir := CredentialsDir()
+	if dir == "" {
+		return nil, errNoCredentialsDir
 	}
-	dir := filepath.Join(home, ".astro")
 	if err := os.MkdirAll(dir, dirPerm); err != nil {
 		return nil, fmt.Errorf("cannot create credentials directory: %w", err)
 	}

--- a/pkg/keychain/keychain_file.go
+++ b/pkg/keychain/keychain_file.go
@@ -1,0 +1,114 @@
+//go:build !darwin
+
+package keychain
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// Secrets: the directory and file are owned by the user alone.
+	dirPerm  = 0o700
+	filePerm = 0o600
+)
+
+// fileStore is a plaintext JSON credential store for environments where no
+// OS-native secure store is available (Linux without Secret Service, Windows
+// before the Credential Manager backend lands). Credentials are written to
+// ~/.astro/credentials.json with mode 0600.
+//
+// Writes go via a temp-file + rename so a crash mid-write cannot corrupt an
+// existing credentials file.
+type fileStore struct {
+	path string
+}
+
+func newFileStore() (*fileStore, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".astro")
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return nil, fmt.Errorf("cannot create credentials directory: %w", err)
+	}
+	return &fileStore{path: filepath.Join(dir, "credentials.json")}, nil
+}
+
+func writeAtomic(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".credentials-*.json")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, filePerm); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func (s *fileStore) read() (map[string]Credentials, error) {
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return map[string]Credentials{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading credentials file: %w", err)
+	}
+	var store map[string]Credentials
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, fmt.Errorf("decoding credentials file: %w", err)
+	}
+	return store, nil
+}
+
+func (s *fileStore) write(store map[string]Credentials) error {
+	data, err := json.Marshal(store)
+	if err != nil {
+		return fmt.Errorf("encoding credentials: %w", err)
+	}
+	return writeAtomic(s.path, data)
+}
+
+func (s *fileStore) GetCredentials(domain string) (Credentials, error) {
+	store, err := s.read()
+	if err != nil {
+		return Credentials{}, err
+	}
+	creds, ok := store[domain]
+	if !ok {
+		return Credentials{}, ErrNotFound
+	}
+	return creds, nil
+}
+
+func (s *fileStore) SetCredentials(domain string, creds Credentials) error {
+	store, err := s.read()
+	if err != nil {
+		return err
+	}
+	store[domain] = creds
+	return s.write(store)
+}
+
+func (s *fileStore) DeleteCredentials(domain string) error {
+	store, err := s.read()
+	if err != nil {
+		return err
+	}
+	delete(store, domain)
+	return s.write(store)
+}

--- a/pkg/keychain/keychain_file_test.go
+++ b/pkg/keychain/keychain_file_test.go
@@ -1,0 +1,126 @@
+//go:build !darwin
+
+package keychain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileStore_CRUD(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T, s *fileStore)
+	}{
+		{
+			name: "get from missing file returns ErrNotFound",
+			run: func(t *testing.T, s *fileStore) {
+				_, err := s.GetCredentials("example.com")
+				assert.ErrorIs(t, err, ErrNotFound)
+			},
+		},
+		{
+			name: "set and get round-trip",
+			run: func(t *testing.T, s *fileStore) {
+				creds := Credentials{Token: "tok", UserEmail: "a@b.com"}
+				require.NoError(t, s.SetCredentials("example.com", creds))
+
+				got, err := s.GetCredentials("example.com")
+				require.NoError(t, err)
+				assert.Equal(t, creds, got)
+			},
+		},
+		{
+			name: "get missing domain returns ErrNotFound",
+			run: func(t *testing.T, s *fileStore) {
+				require.NoError(t, s.SetCredentials("a.io", Credentials{Token: "a"}))
+
+				_, err := s.GetCredentials("b.io")
+				assert.ErrorIs(t, err, ErrNotFound)
+			},
+		},
+		{
+			name: "set overwrites existing",
+			run: func(t *testing.T, s *fileStore) {
+				require.NoError(t, s.SetCredentials("x.io", Credentials{Token: "old"}))
+				require.NoError(t, s.SetCredentials("x.io", Credentials{Token: "new"}))
+
+				got, err := s.GetCredentials("x.io")
+				require.NoError(t, err)
+				assert.Equal(t, "new", got.Token)
+			},
+		},
+		{
+			name: "delete then get returns ErrNotFound",
+			run: func(t *testing.T, s *fileStore) {
+				require.NoError(t, s.SetCredentials("x.io", Credentials{Token: "tok"}))
+				require.NoError(t, s.DeleteCredentials("x.io"))
+
+				_, err := s.GetCredentials("x.io")
+				assert.ErrorIs(t, err, ErrNotFound)
+			},
+		},
+		{
+			name: "delete preserves other domains",
+			run: func(t *testing.T, s *fileStore) {
+				require.NoError(t, s.SetCredentials("a.io", Credentials{Token: "a"}))
+				require.NoError(t, s.SetCredentials("b.io", Credentials{Token: "b"}))
+				require.NoError(t, s.DeleteCredentials("a.io"))
+
+				got, err := s.GetCredentials("b.io")
+				require.NoError(t, err)
+				assert.Equal(t, "b", got.Token)
+			},
+		},
+		{
+			name: "file has 0600 permissions after set",
+			run: func(t *testing.T, s *fileStore) {
+				require.NoError(t, s.SetCredentials("x.io", Credentials{Token: "tok"}))
+
+				info, err := os.Stat(s.path)
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &fileStore{path: filepath.Join(t.TempDir(), "credentials.json")}
+			tt.run(t, s)
+		})
+	}
+}
+
+func TestFileStore_CorruptJSON(t *testing.T) {
+	s := &fileStore{path: filepath.Join(t.TempDir(), "credentials.json")}
+	require.NoError(t, os.WriteFile(s.path, []byte("not json{{{"), 0o600))
+
+	_, err := s.GetCredentials("example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding credentials file")
+}
+
+func TestWriteAtomic(t *testing.T) {
+	t.Run("writes file with expected content and permissions", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.json")
+		require.NoError(t, writeAtomic(path, []byte(`{"key":"value"}`)))
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, `{"key":"value"}`, string(data))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	})
+
+	t.Run("error when target dir does not exist", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "nodir", "file.json")
+		err := writeAtomic(path, []byte("data"))
+		require.Error(t, err)
+	})
+}

--- a/pkg/keychain/keychain_file_test.go
+++ b/pkg/keychain/keychain_file_test.go
@@ -127,10 +127,8 @@ func TestWriteAtomic(t *testing.T) {
 	})
 }
 
-// A plaintext downgrade has to announce itself. The GitHub CLI's equivalent
-// fallback shipped silently and is still, two years on, their most-complained-
-// about auth behaviour (cli/cli#10108) — the user asks for a secure store,
-// doesn't get one, and never finds out.
+// A plaintext downgrade has to announce itself: the user asked for a secure
+// store and didn't get one.
 func TestFileStore_WarnsOnPlaintextWrite(t *testing.T) {
 	var buf bytes.Buffer
 	origOut := insecureWarningOut
@@ -151,4 +149,24 @@ func TestFileStore_WarnsOnPlaintextWrite(t *testing.T) {
 	buf.Reset()
 	require.NoError(t, s.SetCredentials("astronomer.io", Credentials{Token: "tok2"}))
 	assert.Empty(t, buf.String())
+}
+
+// The fallback file must live wherever config.yaml lives. The astro home dir
+// honours ASTRO_HOME and package config owns resolving it; resolving it
+// independently here would split one login across two directories.
+func TestNewFileStore_UsesInjectedCredentialsDir(t *testing.T) {
+	dir := t.TempDir()
+	SetCredentialsDir(dir)
+	t.Cleanup(func() { SetCredentialsDir("") })
+
+	s, err := newFileStore()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "credentials.json"), s.path)
+}
+
+func TestNewFileStore_ErrorsWhenCredentialsDirUnset(t *testing.T) {
+	SetCredentialsDir("")
+
+	_, err := newFileStore()
+	assert.ErrorIs(t, err, errNoCredentialsDir)
 }

--- a/pkg/keychain/keychain_file_test.go
+++ b/pkg/keychain/keychain_file_test.go
@@ -3,8 +3,10 @@
 package keychain
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -123,4 +125,30 @@ func TestWriteAtomic(t *testing.T) {
 		err := writeAtomic(path, []byte("data"))
 		require.Error(t, err)
 	})
+}
+
+// A plaintext downgrade has to announce itself. The GitHub CLI's equivalent
+// fallback shipped silently and is still, two years on, their most-complained-
+// about auth behaviour (cli/cli#10108) — the user asks for a secure store,
+// doesn't get one, and never finds out.
+func TestFileStore_WarnsOnPlaintextWrite(t *testing.T) {
+	var buf bytes.Buffer
+	origOut := insecureWarningOut
+	insecureWarningOut = &buf
+	insecureWarning = &sync.Once{}
+	t.Cleanup(func() {
+		insecureWarningOut = origOut
+		insecureWarning = &sync.Once{}
+	})
+
+	s := &fileStore{path: filepath.Join(t.TempDir(), "credentials.json")}
+	require.NoError(t, s.SetCredentials("astronomer.io", Credentials{Token: "tok"}))
+
+	assert.Contains(t, buf.String(), "plain text")
+	assert.Contains(t, buf.String(), "no_insecure_fallback", "the warning should say how to refuse the fallback")
+
+	// Once per process: a token refresh mid-command shouldn't repeat it.
+	buf.Reset()
+	require.NoError(t, s.SetCredentials("astronomer.io", Credentials{Token: "tok2"}))
+	assert.Empty(t, buf.String())
 }

--- a/pkg/keychain/keychain_linux.go
+++ b/pkg/keychain/keychain_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package keychain
+
+import (
+	"fmt"
+
+	"github.com/99designs/keyring"
+)
+
+// New returns a Secret Service-backed SecureStore on Linux.
+//
+// If no Secret Service daemon is available (e.g. headless CI environments),
+// falls back to a plaintext JSON file at ~/.astro/credentials.json with
+// 0600 permissions. This matches the current plaintext config.yaml behaviour
+// and is intentional — encrypted file fallback is not worth the complexity
+// given that CI environments use ASTRO_API_TOKEN anyway.
+//
+// NOTE: if 99designs/keyring fails to connect to Secret Service in environments
+// that DO have it running, replace with godbus/dbus directly:
+// https://github.com/godbus/dbus — the SecureStore interface is the only
+// change boundary.
+func New() (SecureStore, error) {
+	ring, err := keyring.Open(keyring.Config{
+		ServiceName:             serviceName,
+		LibSecretCollectionName: "astro-cli",
+		KWalletAppID:            "astro-cli",
+		KWalletFolder:           "astro-cli",
+	})
+	if err == nil {
+		return newCachedStore(&keyringStore{ring: ring}), nil
+	}
+	// Secret Service unavailable — fall back to plaintext file.
+	fs, err := newFileStore()
+	if err != nil {
+		return nil, fmt.Errorf("credential store unavailable: %w", err)
+	}
+	return fs, nil
+}

--- a/pkg/keychain/keychain_linux.go
+++ b/pkg/keychain/keychain_linux.go
@@ -15,17 +15,21 @@ import (
 // 0600 permissions. This matches the current plaintext config.yaml behavior
 // and is intentional — encrypted file fallback is not worth the complexity
 // given that CI environments use ASTRO_API_TOKEN anyway.
-//
-// NOTE: if 99designs/keyring fails to connect to Secret Service in environments
-// that DO have it running, replace with godbus/dbus directly:
-// https://github.com/godbus/dbus — the SecureStore interface is the only
-// change boundary.
 func New() (SecureStore, error) {
 	ring, err := keyring.Open(keyring.Config{
 		ServiceName:             serviceName,
 		LibSecretCollectionName: "astro-cli",
 		KWalletAppID:            "astro-cli",
 		KWalletFolder:           "astro-cli",
+		// Only allow persistent, non-interactive backends. KeyCtl stores
+		// credentials in kernel memory that doesn't survive reboot. Pass
+		// and File prompt for passphrases, which breaks non-interactive
+		// CLI usage. When neither desktop backend is available we fall
+		// through to our own fileStore below.
+		AllowedBackends: []keyring.BackendType{
+			keyring.SecretServiceBackend,
+			keyring.KWalletBackend,
+		},
 	})
 	if err == nil {
 		return newCachedStore(&keyringStore{ring: ring}), nil

--- a/pkg/keychain/keychain_linux.go
+++ b/pkg/keychain/keychain_linux.go
@@ -12,7 +12,7 @@ import (
 //
 // If no Secret Service daemon is available (e.g. headless CI environments),
 // falls back to a plaintext JSON file at ~/.astro/credentials.json with
-// 0600 permissions. This matches the current plaintext config.yaml behaviour
+// 0600 permissions. This matches the current plaintext config.yaml behavior
 // and is intentional — encrypted file fallback is not worth the complexity
 // given that CI environments use ASTRO_API_TOKEN anyway.
 //

--- a/pkg/keychain/keychain_linux.go
+++ b/pkg/keychain/keychain_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package keychain
+
+import (
+	"fmt"
+
+	"github.com/99designs/keyring"
+)
+
+// New returns a Secret Service-backed SecureStore on Linux.
+//
+// If no Secret Service daemon is available (e.g. headless CI environments),
+// falls back to a plaintext JSON file at ~/.astro/credentials.json with
+// 0600 permissions. This matches the current plaintext config.yaml behavior
+// and is intentional — encrypted file fallback is not worth the complexity
+// given that CI environments use ASTRO_API_TOKEN anyway.
+func New() (SecureStore, error) {
+	ring, err := keyring.Open(keyring.Config{
+		ServiceName:             serviceName,
+		LibSecretCollectionName: "astro-cli",
+		KWalletAppID:            "astro-cli",
+		KWalletFolder:           "astro-cli",
+		// Only allow persistent, non-interactive backends. KeyCtl stores
+		// credentials in kernel memory that doesn't survive reboot. Pass
+		// and File prompt for passphrases, which breaks non-interactive
+		// CLI usage. When neither desktop backend is available we fall
+		// through to our own fileStore below.
+		AllowedBackends: []keyring.BackendType{
+			keyring.SecretServiceBackend,
+			keyring.KWalletBackend,
+		},
+	})
+	if err == nil {
+		return newCachedStore(&keyringStore{ring: ring}), nil
+	}
+	// Secret Service unavailable — fall back to plaintext file.
+	fs, err := newFileStore()
+	if err != nil {
+		return nil, fmt.Errorf("credential store unavailable: %w", err)
+	}
+	return fs, nil
+}

--- a/pkg/keychain/keychain_linux.go
+++ b/pkg/keychain/keychain_linux.go
@@ -23,9 +23,9 @@ import (
 func New(allowInsecureFallback bool) (SecureStore, error) {
 	ring, err := keyring.Open(keyring.Config{
 		ServiceName:             serviceName,
-		LibSecretCollectionName: "astro-cli",
-		KWalletAppID:            "astro-cli",
-		KWalletFolder:           "astro-cli",
+		LibSecretCollectionName: serviceName,
+		KWalletAppID:            serviceName,
+		KWalletFolder:           serviceName,
 		// Only allow persistent, non-interactive backends. KeyCtl stores
 		// credentials in kernel memory that doesn't survive reboot. Pass
 		// and File prompt for passphrases, which breaks non-interactive

--- a/pkg/keychain/keychain_linux.go
+++ b/pkg/keychain/keychain_linux.go
@@ -10,12 +10,17 @@ import (
 
 // New returns a Secret Service-backed SecureStore on Linux.
 //
-// If no Secret Service daemon is available (e.g. headless CI environments),
-// falls back to a plaintext JSON file at ~/.astro/credentials.json with
-// 0600 permissions. This matches the current plaintext config.yaml behavior
-// and is intentional — encrypted file fallback is not worth the complexity
-// given that CI environments use ASTRO_API_TOKEN anyway.
-func New() (SecureStore, error) {
+// If no Secret Service daemon is available (e.g. headless CI environments) and
+// allowInsecureFallback is true, falls back to a plaintext JSON file at
+// ~/.astro/credentials.json with 0600 permissions. This matches the previous
+// plaintext config.yaml posture and is acceptable because CI environments
+// typically use ASTRO_API_TOKEN rather than interactive login credentials.
+//
+// The fallback announces itself on every write (see warnInsecureWrite) and can
+// be refused outright with `astro config set -g no_insecure_fallback true`, in
+// which case an unavailable Secret Service is an error. A silent, unrefusable
+// downgrade is the part of this design the GitHub CLI regrets: see cli/cli#10108.
+func New(allowInsecureFallback bool) (SecureStore, error) {
 	ring, err := keyring.Open(keyring.Config{
 		ServiceName:             serviceName,
 		LibSecretCollectionName: "astro-cli",
@@ -32,12 +37,16 @@ func New() (SecureStore, error) {
 		},
 	})
 	if err == nil {
-		return newCachedStore(&keyringStore{ring: ring}), nil
+		return newCachedStore(withTimeout(&keyringStore{ring: ring}, keyringTimeout)), nil
 	}
-	// Secret Service unavailable — fall back to plaintext file.
+	// Secret Service unavailable — fall back to a plaintext file, unless the
+	// user has told us not to.
+	if !allowInsecureFallback {
+		return nil, fmt.Errorf("%w: no Secret Service available (%v)", ErrInsecureFallbackRefused, err)
+	}
 	fs, err := newFileStore()
 	if err != nil {
 		return nil, fmt.Errorf("credential store unavailable: %w", err)
 	}
-	return fs, nil
+	return newCachedStore(fs), nil
 }

--- a/pkg/keychain/keychain_linux_test.go
+++ b/pkg/keychain/keychain_linux_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // CI runs in a Docker container with no D-Bus / Secret Service, so New()
-// always takes the fileStore fallback path. We can't test the keyring
-// success path without a running Secret Service daemon.
+// falls back to a fileStore. We can't test the keyring success path
+// without a running Secret Service or KWallet daemon.
 func TestNew_FallsBackToFileStore(t *testing.T) {
 	store, err := New()
 	require.NoError(t, err)

--- a/pkg/keychain/keychain_linux_test.go
+++ b/pkg/keychain/keychain_linux_test.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package keychain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CI runs in a Docker container with no D-Bus / Secret Service, so New()
+// always takes the fileStore fallback path. We can't test the keyring
+// success path without a running Secret Service daemon.
+func TestNew_FallsBackToFileStore(t *testing.T) {
+	store, err := New()
+	require.NoError(t, err)
+	assert.IsType(t, &fileStore{}, store)
+}

--- a/pkg/keychain/keychain_linux_test.go
+++ b/pkg/keychain/keychain_linux_test.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package keychain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CI runs in a Docker container with no D-Bus / Secret Service, so New()
+// falls back to a fileStore. We can't test the keyring success path
+// without a running Secret Service or KWallet daemon.
+func TestNew_FallsBackToFileStore(t *testing.T) {
+	store, err := New()
+	require.NoError(t, err)
+	assert.IsType(t, &fileStore{}, store)
+}

--- a/pkg/keychain/keychain_linux_test.go
+++ b/pkg/keychain/keychain_linux_test.go
@@ -9,11 +9,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CI runs in a Docker container with no D-Bus / Secret Service, so New()
-// falls back to a fileStore. We can't test the keyring success path
-// without a running Secret Service or KWallet daemon.
-func TestNew_FallsBackToFileStore(t *testing.T) {
-	store, err := New()
+// CI runs in a Docker container with no D-Bus / Secret Service, so New() takes
+// the fallback path. We can't test the keyring success path without a running
+// Secret Service or KWallet daemon. HOME is redirected so these never touch a
+// real ~/.astro/credentials.json.
+
+func TestNew_FallsBackToFileStoreWhenAllowed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store, err := New(true)
 	require.NoError(t, err)
-	assert.IsType(t, &fileStore{}, store)
+
+	cached, ok := store.(*cachedStore)
+	require.True(t, ok, "fallback store should be cached like the keyring path")
+	assert.IsType(t, &fileStore{}, cached.inner)
+}
+
+// Refusing the fallback has to fail rather than quietly writing secrets to
+// disk — a silent, unrefusable downgrade is the part of this design the GitHub
+// CLI regrets shipping (cli/cli#10108).
+func TestNew_RefusesFallbackWhenDisallowed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := New(false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInsecureFallbackRefused)
 }

--- a/pkg/keychain/keychain_linux_test.go
+++ b/pkg/keychain/keychain_linux_test.go
@@ -11,11 +11,18 @@ import (
 
 // CI runs in a Docker container with no D-Bus / Secret Service, so New() takes
 // the fallback path. We can't test the keyring success path without a running
-// Secret Service or KWallet daemon. HOME is redirected so these never touch a
-// real ~/.astro/credentials.json.
+// Secret Service or KWallet daemon. The credentials dir is redirected so these
+// never touch a real ~/.astro/credentials.json.
+
+func setTestCredentialsDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	SetCredentialsDir(dir)
+	t.Cleanup(func() { SetCredentialsDir("") })
+}
 
 func TestNew_FallsBackToFileStoreWhenAllowed(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestCredentialsDir(t)
 
 	store, err := New(true)
 	require.NoError(t, err)
@@ -25,11 +32,9 @@ func TestNew_FallsBackToFileStoreWhenAllowed(t *testing.T) {
 	assert.IsType(t, &fileStore{}, cached.inner)
 }
 
-// Refusing the fallback has to fail rather than quietly writing secrets to
-// disk — a silent, unrefusable downgrade is the part of this design the GitHub
-// CLI regrets shipping (cli/cli#10108).
+// Refusing the fallback has to fail rather than quietly writing secrets to disk.
 func TestNew_RefusesFallbackWhenDisallowed(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestCredentialsDir(t)
 
 	_, err := New(false)
 	require.Error(t, err)

--- a/pkg/keychain/keychain_test.go
+++ b/pkg/keychain/keychain_test.go
@@ -1,0 +1,68 @@
+package keychain_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/astronomer/astro-cli/pkg/keychain"
+)
+
+func TestSetAndGetCredentials(t *testing.T) {
+	store := keychain.NewTestStore()
+	creds := keychain.Credentials{
+		Token:        "Bearer access-token",
+		RefreshToken: "refresh-token",
+		UserEmail:    "user@example.com",
+		ExpiresAt:    time.Now().Add(time.Hour).Truncate(time.Second),
+	}
+
+	err := store.SetCredentials("astronomer.io", creds)
+	require.NoError(t, err)
+
+	got, err := store.GetCredentials("astronomer.io")
+	require.NoError(t, err)
+	// Round-trip strips monotonic clock; normalise before comparing.
+	creds.ExpiresAt = creds.ExpiresAt.UTC()
+	got.ExpiresAt = got.ExpiresAt.UTC()
+	assert.Equal(t, creds, got)
+}
+
+func TestGetCredentials_NotFound(t *testing.T) {
+	store := keychain.NewTestStore()
+	_, err := store.GetCredentials("notexist.io")
+	assert.ErrorIs(t, err, keychain.ErrNotFound)
+}
+
+func TestDeleteCredentials(t *testing.T) {
+	store := keychain.NewTestStore()
+	creds := keychain.Credentials{Token: "Bearer tok"}
+
+	require.NoError(t, store.SetCredentials("astronomer.io", creds))
+	require.NoError(t, store.DeleteCredentials("astronomer.io"))
+
+	_, err := store.GetCredentials("astronomer.io")
+	assert.ErrorIs(t, err, keychain.ErrNotFound)
+}
+
+func TestDeleteCredentials_NotFound_NoError(t *testing.T) {
+	store := keychain.NewTestStore()
+	err := store.DeleteCredentials("notexist.io")
+	assert.NoError(t, err)
+}
+
+func TestIsolation(t *testing.T) {
+	store := keychain.NewTestStore()
+	require.NoError(t, store.SetCredentials("a.io", keychain.Credentials{Token: "token-a"}))
+	require.NoError(t, store.SetCredentials("b.io", keychain.Credentials{Token: "token-b"}))
+
+	a, err := store.GetCredentials("a.io")
+	require.NoError(t, err)
+	assert.Equal(t, "token-a", a.Token)
+
+	b, err := store.GetCredentials("b.io")
+	require.NoError(t, err)
+	assert.Equal(t, "token-b", b.Token)
+}

--- a/pkg/keychain/keychain_timeout.go
+++ b/pkg/keychain/keychain_timeout.go
@@ -1,0 +1,75 @@
+package keychain
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// keyringTimeout bounds a single OS keyring operation.
+//
+// Secret Service can block indefinitely when the D-Bus prompter cannot spawn —
+// headless sessions, SSH without a desktop, containers with a socket but no
+// agent — and 99designs/keyring offers no cancellation of its own. Without a
+// bound, `astro` hangs with no output instead of failing.
+const keyringTimeout = 3 * time.Second
+
+// ErrTimeout is returned when the OS keyring does not answer within
+// keyringTimeout.
+var ErrTimeout = errors.New("timed out talking to the system keyring")
+
+// timeoutStore bounds every call to the underlying store.
+//
+// A timed-out call leaks its goroutine until the process exits: the underlying
+// library gives us no way to cancel an in-flight request, so the alternative is
+// blocking forever. The CLI is short-lived, so the leak is bounded by the
+// command.
+//
+// A timed-out SetCredentials is genuinely ambiguous — the write may still land
+// afterwards. Callers must treat it as failed and not scrub any source copy of
+// the credentials on the strength of it.
+type timeoutStore struct {
+	inner SecureStore
+	d     time.Duration
+}
+
+func withTimeout(inner SecureStore, d time.Duration) SecureStore {
+	return &timeoutStore{inner: inner, d: d}
+}
+
+func (t *timeoutStore) GetCredentials(domain string) (Credentials, error) {
+	type result struct {
+		creds Credentials
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() { c, err := t.inner.GetCredentials(domain); ch <- result{c, err} }()
+	select {
+	case r := <-ch:
+		return r.creds, r.err
+	case <-time.After(t.d):
+		return Credentials{}, fmt.Errorf("%w after %s (reading credentials for %q)", ErrTimeout, t.d, domain)
+	}
+}
+
+func (t *timeoutStore) SetCredentials(domain string, creds Credentials) error {
+	ch := make(chan error, 1)
+	go func() { ch <- t.inner.SetCredentials(domain, creds) }()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(t.d):
+		return fmt.Errorf("%w after %s (saving credentials for %q)", ErrTimeout, t.d, domain)
+	}
+}
+
+func (t *timeoutStore) DeleteCredentials(domain string) error {
+	ch := make(chan error, 1)
+	go func() { ch <- t.inner.DeleteCredentials(domain) }()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(t.d):
+		return fmt.Errorf("%w after %s (deleting credentials for %q)", ErrTimeout, t.d, domain)
+	}
+}

--- a/pkg/keychain/keychain_timeout_test.go
+++ b/pkg/keychain/keychain_timeout_test.go
@@ -1,0 +1,83 @@
+package keychain
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hangingStore blocks until released, standing in for a Secret Service call
+// that never returns because the D-Bus prompter cannot spawn.
+type hangingStore struct{ release chan struct{} }
+
+func (h *hangingStore) GetCredentials(string) (Credentials, error) {
+	<-h.release
+	return Credentials{Token: "too-late"}, nil
+}
+
+func (h *hangingStore) SetCredentials(string, Credentials) error {
+	<-h.release
+	return nil
+}
+
+func (h *hangingStore) DeleteCredentials(string) error {
+	<-h.release
+	return nil
+}
+
+func TestWithTimeout_GetGivesUpRatherThanHanging(t *testing.T) {
+	h := &hangingStore{release: make(chan struct{})}
+	defer close(h.release)
+
+	store := withTimeout(h, 20*time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := store.GetCredentials("astronomer.io")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrTimeout)
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetCredentials hung instead of timing out")
+	}
+}
+
+func TestWithTimeout_SetGivesUpRatherThanHanging(t *testing.T) {
+	h := &hangingStore{release: make(chan struct{})}
+	defer close(h.release)
+
+	store := withTimeout(h, 20*time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() { done <- store.SetCredentials("astronomer.io", Credentials{Token: "t"}) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrTimeout)
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetCredentials hung instead of timing out")
+	}
+}
+
+func TestWithTimeout_PassesThroughWhenStoreAnswers(t *testing.T) {
+	inner := NewTestStore()
+	store := withTimeout(inner, time.Second)
+
+	require.NoError(t, store.SetCredentials("astronomer.io", Credentials{Token: "Bearer tok"}))
+
+	creds, err := store.GetCredentials("astronomer.io")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer tok", creds.Token)
+
+	require.NoError(t, store.DeleteCredentials("astronomer.io"))
+	_, err = store.GetCredentials("astronomer.io")
+	assert.True(t, errors.Is(err, ErrNotFound))
+}

--- a/pkg/keychain/keychain_windows.go
+++ b/pkg/keychain/keychain_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package keychain
+
+import "fmt"
+
+// New returns a file-backed SecureStore on Windows.
+//
+// This is a temporary fallback until the Windows Credential Manager backend
+// lands — credentials are stored in ~/.astro/credentials.json (mode 0600)
+// rather than in Credential Manager. See the follow-up PR for the upgrade.
+func New() (SecureStore, error) {
+	fs, err := newFileStore()
+	if err != nil {
+		return nil, fmt.Errorf("credential store unavailable: %w", err)
+	}
+	return newCachedStore(fs), nil
+}

--- a/pkg/keychain/keychain_windows.go
+++ b/pkg/keychain/keychain_windows.go
@@ -4,12 +4,17 @@ package keychain
 
 import "fmt"
 
-// New returns a file-backed SecureStore on Windows.
+// New returns a file-backed SecureStore on Windows: credentials go to
+// credentials.json (mode 0600), not to Credential Manager.
 //
-// This is a temporary fallback until the Windows Credential Manager backend
-// lands — credentials are stored in ~/.astro/credentials.json (mode 0600)
-// rather than in Credential Manager. See the follow-up PR for the upgrade.
-func New() (SecureStore, error) {
+// Plaintext is currently the only option here, so setting no_insecure_fallback
+// leaves nothing to fall back to and we fail rather than write secrets the user
+// has explicitly refused.
+func New(allowInsecureFallback bool) (SecureStore, error) {
+	if !allowInsecureFallback {
+		return nil, fmt.Errorf("%w: the Windows Credential Manager backend is not implemented yet, "+
+			"so credentials can only be stored in plain text on this platform", ErrInsecureFallbackRefused)
+	}
 	fs, err := newFileStore()
 	if err != nil {
 		return nil, fmt.Errorf("credential store unavailable: %w", err)

--- a/pkg/otto/config.go
+++ b/pkg/otto/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/astronomer/astro-cli/airflow/proxy"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 )
 
 // Config holds the environment configuration for spawning Otto.
@@ -20,12 +21,16 @@ type Config struct {
 }
 
 // NewConfigFromContext builds a Config from the current astro login context.
-func NewConfigFromContext() *Config {
+// The token comes from creds: the context carries no token, only the secure
+// store does, and PersistentPreRunE resolves it into creds.
+func NewConfigFromContext(creds *credentials.CurrentCredentials) *Config {
 	cfg := &Config{}
 
 	ctx, err := config.GetCurrentContext()
 	if err == nil {
-		cfg.Token = strings.TrimPrefix(ctx.Token, "Bearer ")
+		if creds != nil {
+			cfg.Token = strings.TrimPrefix(creds.Get(), "Bearer ")
+		}
 		cfg.Domain = ctx.Domain
 		cfg.Organization = ctx.Organization
 	}

--- a/pkg/otto/config_test.go
+++ b/pkg/otto/config_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/astronomer/astro-cli/airflow/proxy"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -45,7 +46,7 @@ func TestConfigSuite(t *testing.T) {
 
 func (s *ConfigSuite) TestNewConfigFromContext() {
 	// With test config initialized, should get auth fields
-	cfg := NewConfigFromContext()
+	cfg := NewConfigFromContext(credentials.New("test-token"))
 	// Test config has a domain and token set
 	s.NotEmpty(cfg.Domain)
 }

--- a/pkg/otto/start.go
+++ b/pkg/otto/start.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/logger"
 )
 
@@ -30,8 +31,8 @@ func isHelpOrVersion(args []string) bool {
 
 // Start spawns Otto with the given arguments and environment from the current context.
 // It blocks until Otto exits, forwarding signals for clean shutdown.
-func Start(args []string) error {
-	cfg := NewConfigFromContext()
+func Start(args []string, creds *credentials.CurrentCredentials) error {
+	cfg := NewConfigFromContext(creds)
 	if cfg.Token == "" && !isHelpOrVersion(args) {
 		fmt.Fprintln(os.Stderr, "You're not logged in to Astro. Otto is an AI assistant for Airflow — sign in or start a trial to use it.")
 		fmt.Fprintln(os.Stderr)

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -64,7 +64,6 @@ context: %s
 contexts:
   %s:
     domain: %s
-    token: token
     last_used_workspace: ck05r3bor07h40d02y2hw4n4v
     workspace: ck05r3bor07h40d02y2hw4n4v
     organization: test-org-id

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/input"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/software/workspace"
 )
@@ -84,7 +85,7 @@ func oAuth(oAuthURL string) string {
 }
 
 // RegistryAuth authenticates with the private registry
-func RegistryAuth(client houston.ClientInterface, out io.Writer, registryDomain string) error {
+func RegistryAuth(client houston.ClientInterface, out io.Writer, registryDomain, token string) error {
 	c, err := context.GetCurrentContext()
 	if err != nil {
 		return err
@@ -126,7 +127,7 @@ func RegistryAuth(client houston.ClientInterface, out io.Writer, registryDomain 
 	}
 
 	if !appConfig.Flags.BYORegistryEnabled {
-		err = registryHandler.Login("user", c.Token)
+		err = registryHandler.Login("user", token)
 	} else {
 		err = registryHandler.Login("", "")
 	}
@@ -161,7 +162,7 @@ func getWorkspaces(client houston.ClientInterface, interactive bool) ([]houston.
 }
 
 // Login handles authentication to houston and registry
-func Login(domain string, oAuthOnly bool, username, password, houstonVersion string, client houston.ClientInterface, out io.Writer) error {
+func Login(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, client houston.ClientInterface, out io.Writer) error {
 	var token string
 	var err error
 	var pageSize int
@@ -206,9 +207,12 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 		return err
 	}
 
-	err = c.SetContextKey("token", token)
-	if err != nil {
-		return err
+	if store == nil {
+		return fmt.Errorf("credential store not available; cannot save login credentials")
+	}
+	// Houston tokens do not have refresh tokens or expiry — only Token is stored.
+	if err := store.SetCredentials(c.Domain, keychain.Credentials{Token: token}); err != nil {
+		return fmt.Errorf("storing credentials: %w", err)
 	}
 
 	workspaces, err := getWorkspaces(client, interactive)
@@ -248,7 +252,7 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 		}
 	}
 
-	err = RegistryAuth(client, out, "")
+	err = RegistryAuth(client, out, "", token)
 	if err != nil {
 		logger.Debugf("There was an error logging into registry: %s", err.Error())
 	}
@@ -257,20 +261,13 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 }
 
 // Logout removes the locally stored token and reset current context
-func Logout(domain string) {
-	c, err := context.GetContext(domain)
-	if err != nil {
-		return
-	}
-
-	err = c.SetContextKey("token", "")
-	if err != nil {
-		return
+func Logout(domain string, store keychain.SecureStore) {
+	if err := store.DeleteCredentials(domain); err != nil {
+		fmt.Printf("Failed to remove credentials: %s\n", err.Error())
 	}
 
 	// remove the current context
-	err = config.ResetCurrentContext()
-	if err != nil {
+	if err := config.ResetCurrentContext(); err != nil {
 		fmt.Println("Failed to reset current context: ", err.Error())
 		return
 	}

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
@@ -162,7 +163,7 @@ func getWorkspaces(client houston.ClientInterface, interactive bool) ([]houston.
 }
 
 // Login handles authentication to houston and registry
-func Login(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, client houston.ClientInterface, out io.Writer) error {
+func Login(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, creds *credentials.CurrentCredentials, client houston.ClientInterface, out io.Writer) error {
 	var token string
 	var err error
 	var pageSize int
@@ -213,6 +214,9 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 	// Houston tokens do not have refresh tokens or expiry — only Token is stored.
 	if err := store.SetCredentials(c.Domain, keychain.Credentials{Token: token}); err != nil {
 		return fmt.Errorf("storing credentials: %w", err)
+	}
+	if creds != nil {
+		creds.Set(token)
 	}
 
 	workspaces, err := getWorkspaces(client, interactive)

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -262,7 +262,9 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 
 // Logout removes the locally stored token and reset current context
 func Logout(domain string, store keychain.SecureStore) {
-	if err := store.DeleteCredentials(domain); err != nil {
+	if store == nil {
+		fmt.Println("Warning: credential store not available; local credentials may not be cleared")
+	} else if err := store.DeleteCredentials(domain); err != nil {
 		fmt.Printf("Failed to remove credentials: %s\n", err.Error())
 	}
 

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/pkg/credentials"
 	"github.com/astronomer/astro-cli/pkg/input"
 	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
@@ -163,7 +164,7 @@ func getWorkspaces(client houston.ClientInterface, interactive bool) ([]houston.
 }
 
 // Login handles authentication to houston and registry
-func Login(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, client houston.ClientInterface, out io.Writer) error {
+func Login(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, creds *credentials.CurrentCredentials, client houston.ClientInterface, out io.Writer) error {
 	var token string
 	var err error
 	var pageSize int
@@ -214,6 +215,9 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 	// Houston tokens do not have refresh tokens or expiry — only Token is stored.
 	if err := store.SetCredentials(c.Domain, keychain.Credentials{Token: token}); err != nil {
 		return fmt.Errorf("storing credentials: %w", err)
+	}
+	if creds != nil {
+		creds.Set(token)
 	}
 
 	workspaces, err := getWorkspaces(client, interactive)

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/input"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/software/workspace"
 )
@@ -85,7 +86,7 @@ func oAuth(oAuthURL string) string {
 
 // RegistryAuth authenticates with the private registry.
 // appConfigReq supplies optional workspace/deployment context for Houston 2.0+ appConfig; use zero value when unknown (e.g. login).
-func RegistryAuth(client houston.ClientInterface, out io.Writer, registryDomain string, appConfigReq houston.GetAppConfigRequest) error {
+func RegistryAuth(client houston.ClientInterface, out io.Writer, registryDomain, token string, appConfigReq houston.GetAppConfigRequest) error {
 	c, err := context.GetCurrentContext()
 	if err != nil {
 		return err
@@ -127,7 +128,7 @@ func RegistryAuth(client houston.ClientInterface, out io.Writer, registryDomain 
 	}
 
 	if !appConfig.Flags.BYORegistryEnabled {
-		err = registryHandler.Login("user", c.Token)
+		err = registryHandler.Login("user", token)
 	} else {
 		err = registryHandler.Login("", "")
 	}
@@ -162,7 +163,7 @@ func getWorkspaces(client houston.ClientInterface, interactive bool) ([]houston.
 }
 
 // Login handles authentication to houston and registry
-func Login(domain string, oAuthOnly bool, username, password, houstonVersion string, client houston.ClientInterface, out io.Writer) error {
+func Login(domain string, oAuthOnly bool, username, password, houstonVersion string, store keychain.SecureStore, client houston.ClientInterface, out io.Writer) error {
 	var token string
 	var err error
 	var pageSize int
@@ -207,9 +208,12 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 		return err
 	}
 
-	err = c.SetContextKey("token", token)
-	if err != nil {
-		return err
+	if store == nil {
+		return fmt.Errorf("credential store not available; cannot save login credentials")
+	}
+	// Houston tokens do not have refresh tokens or expiry — only Token is stored.
+	if err := store.SetCredentials(c.Domain, keychain.Credentials{Token: token}); err != nil {
+		return fmt.Errorf("storing credentials: %w", err)
 	}
 
 	workspaces, err := getWorkspaces(client, interactive)
@@ -249,7 +253,7 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 		}
 	}
 
-	err = RegistryAuth(client, out, "", houston.GetAppConfigRequest{})
+	err = RegistryAuth(client, out, "", token, houston.GetAppConfigRequest{})
 	if err != nil {
 		logger.Debugf("There was an error logging into registry: %s", err.Error())
 	}
@@ -258,20 +262,15 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 }
 
 // Logout removes the locally stored token and reset current context
-func Logout(domain string) {
-	c, err := context.GetContext(domain)
-	if err != nil {
-		return
-	}
-
-	err = c.SetContextKey("token", "")
-	if err != nil {
-		return
+func Logout(domain string, store keychain.SecureStore) {
+	if store == nil {
+		fmt.Println("Warning: credential store not available; local credentials may not be cleared")
+	} else if err := store.DeleteCredentials(domain); err != nil {
+		fmt.Printf("Failed to remove credentials: %s\n", err.Error())
 	}
 
 	// remove the current context
-	err = config.ResetCurrentContext()
-	if err != nil {
+	if err := config.ResetCurrentContext(); err != nil {
 		fmt.Println("Failed to reset current context: ", err.Error())
 		return
 	}

--- a/software/auth/auth_test.go
+++ b/software/auth/auth_test.go
@@ -339,7 +339,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "test-workspace-id").Return(&houston.Workspace{ID: "test-workspace-id"}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if !s.NoError(Login("localhost", false, "test", "test", "0.29.0", keychain.NewTestStore(), houstonMock, out)) {
+		if !s.NoError(Login("localhost", false, "test", "test", "0.29.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -348,7 +348,7 @@ func (s *Suite) TestLoginSuccess() {
 
 		houstonMock.On("ListWorkspaces", nil).Return([]houston.Workspace{{ID: "ck05r3bor07h40d02y2hw4n4v"}, {ID: "test-workspace-id"}}, nil).Once()
 		out = &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-id"}, gotOut) {
@@ -378,7 +378,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "ck05r3bor07h40d02y2hw4n4v").Return(&houston.Workspace{}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-id"}, gotOut) {
@@ -407,7 +407,7 @@ func (s *Suite) TestLoginSuccess() {
 		}
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "ck05r3bor07h40d02y2hw4n4v"}, gotOut) {
@@ -439,7 +439,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "test-workspace-1").Return(&houston.Workspace{}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-1"}, gotOut) {
@@ -461,7 +461,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("GetAuthConfig", mock.Anything).Return(nil, errMockRegistry)
 
 		out := &bytes.Buffer{}
-		if !s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
+		if !s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -476,7 +476,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("AuthenticateWithBasicAuth", mock.Anything).Return("", errMockRegistry)
 
 		out := &bytes.Buffer{}
-		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
+		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -492,7 +492,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("ListWorkspaces", nil).Return([]houston.Workspace{}, errMockRegistry).Once()
 
 		out := &bytes.Buffer{}
-		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
+		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -509,7 +509,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("GetAppConfig", "").Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil)
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("dev.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("dev.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"dev.astro.io", "No default workspace detected"}, gotOut) {
@@ -532,7 +532,7 @@ func (s *Suite) TestLoginFailure() {
 		}
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("test.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("test.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"test.astro.io", "Failed to authenticate to the registry"}, gotOut) {

--- a/software/auth/auth_test.go
+++ b/software/auth/auth_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/houston"
 	houstonMocks "github.com/astronomer/astro-cli/houston/mocks"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -198,7 +199,7 @@ func (s *Suite) TestRegistryAuthSuccess() {
 			err = ctx.SwitchContext()
 			s.NoError(err)
 
-			tt.errAssertion(s.T(), RegistryAuth(houstonMock, out, ""))
+			tt.errAssertion(s.T(), RegistryAuth(houstonMock, out, "", ""))
 		})
 	}
 	mockRegistryHandler.AssertExpectations(s.T())
@@ -270,7 +271,7 @@ func (s *Suite) TestRegistryAuthRegistryDomain() {
 			}, nil)
 
 			out := new(bytes.Buffer)
-			RegistryAuth(houstonMock, out, tt.registryDomain)
+			RegistryAuth(houstonMock, out, tt.registryDomain, "")
 
 			mockRegistryHandler.AssertExpectations(s.T())
 		})
@@ -292,7 +293,7 @@ func (s *Suite) TestRegistryAuthFailure() {
 		houstonMock := new(houstonMocks.ClientInterface)
 		houstonMock.On("GetAppConfig", "").Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: true}}, nil).Twice()
 
-		err := RegistryAuth(houstonMock, out, "")
+		err := RegistryAuth(houstonMock, out, "", "")
 		s.ErrorIs(err, errMockRegistry)
 
 		mockRegistryHandler := new(mocks.RegistryHandler)
@@ -301,12 +302,12 @@ func (s *Suite) TestRegistryAuthFailure() {
 			return mockRegistryHandler, nil
 		}
 
-		err = RegistryAuth(houstonMock, out, "")
+		err = RegistryAuth(houstonMock, out, "", "")
 		s.NoError(err)
 
 		houstonMock.On("GetAppConfig", "").Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil).Once()
 
-		err = RegistryAuth(houstonMock, out, "")
+		err = RegistryAuth(houstonMock, out, "", "")
 		s.ErrorIs(err, errMockRegistry)
 
 		mockRegistryHandler.AssertExpectations(s.T())
@@ -318,7 +319,7 @@ func (s *Suite) TestRegistryAuthFailure() {
 		houstonMock := new(houstonMocks.ClientInterface)
 		houstonMock.On("GetAppConfig", "").Return(nil, errMockHouston).Once()
 
-		err := RegistryAuth(houstonMock, out, "")
+		err := RegistryAuth(houstonMock, out, "", "")
 		s.ErrorIs(err, errMockHouston)
 		houstonMock.AssertExpectations(s.T())
 	})
@@ -338,7 +339,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "test-workspace-id").Return(&houston.Workspace{ID: "test-workspace-id"}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if !s.NoError(Login("localhost", false, "test", "test", "0.29.0", houstonMock, out)) {
+		if !s.NoError(Login("localhost", false, "test", "test", "0.29.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -347,7 +348,7 @@ func (s *Suite) TestLoginSuccess() {
 
 		houstonMock.On("ListWorkspaces", nil).Return([]houston.Workspace{{ID: "ck05r3bor07h40d02y2hw4n4v"}, {ID: "test-workspace-id"}}, nil).Once()
 		out = &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-id"}, gotOut) {
@@ -377,7 +378,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "ck05r3bor07h40d02y2hw4n4v").Return(&houston.Workspace{}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-id"}, gotOut) {
@@ -406,7 +407,7 @@ func (s *Suite) TestLoginSuccess() {
 		}
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "ck05r3bor07h40d02y2hw4n4v"}, gotOut) {
@@ -438,7 +439,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "test-workspace-1").Return(&houston.Workspace{}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-1"}, gotOut) {
@@ -460,7 +461,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("GetAuthConfig", mock.Anything).Return(nil, errMockRegistry)
 
 		out := &bytes.Buffer{}
-		if !s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out), errMockRegistry) {
+		if !s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -475,7 +476,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("AuthenticateWithBasicAuth", mock.Anything).Return("", errMockRegistry)
 
 		out := &bytes.Buffer{}
-		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out), errMockRegistry) {
+		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -491,7 +492,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("ListWorkspaces", nil).Return([]houston.Workspace{}, errMockRegistry).Once()
 
 		out := &bytes.Buffer{}
-		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out), errMockRegistry) {
+		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -508,7 +509,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("GetAppConfig", "").Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil)
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("dev.astro.io", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("dev.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"dev.astro.io", "No default workspace detected"}, gotOut) {
@@ -531,7 +532,7 @@ func (s *Suite) TestLoginFailure() {
 		}
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("test.astro.io", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("test.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"test.astro.io", "Failed to authenticate to the registry"}, gotOut) {
@@ -565,7 +566,7 @@ func (s *Suite) TestLogout() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			Logout(tt.args.domain)
+			Logout(tt.args.domain, keychain.NewTestStore())
 		})
 	}
 }

--- a/software/auth/auth_test.go
+++ b/software/auth/auth_test.go
@@ -339,7 +339,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "test-workspace-id").Return(&houston.Workspace{ID: "test-workspace-id"}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if !s.NoError(Login("localhost", false, "test", "test", "0.29.0", keychain.NewTestStore(), houstonMock, out)) {
+		if !s.NoError(Login("localhost", false, "test", "test", "0.29.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -348,7 +348,7 @@ func (s *Suite) TestLoginSuccess() {
 
 		houstonMock.On("ListWorkspaces", nil).Return([]houston.Workspace{{ID: "ck05r3bor07h40d02y2hw4n4v"}, {ID: "test-workspace-id"}}, nil).Once()
 		out = &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-id"}, gotOut) {
@@ -378,7 +378,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "ck05r3bor07h40d02y2hw4n4v").Return(&houston.Workspace{}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-id"}, gotOut) {
@@ -407,7 +407,7 @@ func (s *Suite) TestLoginSuccess() {
 		}
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "ck05r3bor07h40d02y2hw4n4v"}, gotOut) {
@@ -439,7 +439,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "test-workspace-1").Return(&houston.Workspace{}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-1"}, gotOut) {
@@ -461,7 +461,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("GetAuthConfig", mock.Anything).Return(nil, errMockRegistry)
 
 		out := &bytes.Buffer{}
-		if !s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
+		if !s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -476,7 +476,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("AuthenticateWithBasicAuth", mock.Anything).Return("", errMockRegistry)
 
 		out := &bytes.Buffer{}
-		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
+		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -492,7 +492,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("ListWorkspaces", nil).Return([]houston.Workspace{}, errMockRegistry).Once()
 
 		out := &bytes.Buffer{}
-		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
+		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -509,7 +509,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil)
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("dev.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("dev.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"dev.astro.io", "No default workspace detected"}, gotOut) {
@@ -532,7 +532,7 @@ func (s *Suite) TestLoginFailure() {
 		}
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("test.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
+		if s.NoError(Login("test.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), nil, houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"test.astro.io", "Failed to authenticate to the registry"}, gotOut) {

--- a/software/auth/auth_test.go
+++ b/software/auth/auth_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/houston"
 	houstonMocks "github.com/astronomer/astro-cli/houston/mocks"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -198,7 +199,7 @@ func (s *Suite) TestRegistryAuthSuccess() {
 			err = ctx.SwitchContext()
 			s.NoError(err)
 
-			tt.errAssertion(s.T(), RegistryAuth(houstonMock, out, "", houston.GetAppConfigRequest{}))
+			tt.errAssertion(s.T(), RegistryAuth(houstonMock, out, "", "", houston.GetAppConfigRequest{}))
 		})
 	}
 	mockRegistryHandler.AssertExpectations(s.T())
@@ -270,7 +271,7 @@ func (s *Suite) TestRegistryAuthRegistryDomain() {
 			}, nil)
 
 			out := new(bytes.Buffer)
-			RegistryAuth(houstonMock, out, tt.registryDomain, houston.GetAppConfigRequest{})
+			RegistryAuth(houstonMock, out, tt.registryDomain, "", houston.GetAppConfigRequest{})
 
 			mockRegistryHandler.AssertExpectations(s.T())
 		})
@@ -292,7 +293,7 @@ func (s *Suite) TestRegistryAuthFailure() {
 		houstonMock := new(houstonMocks.ClientInterface)
 		houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: true}}, nil).Twice()
 
-		err := RegistryAuth(houstonMock, out, "", houston.GetAppConfigRequest{})
+		err := RegistryAuth(houstonMock, out, "", "", houston.GetAppConfigRequest{})
 		s.ErrorIs(err, errMockRegistry)
 
 		mockRegistryHandler := new(mocks.RegistryHandler)
@@ -301,12 +302,12 @@ func (s *Suite) TestRegistryAuthFailure() {
 			return mockRegistryHandler, nil
 		}
 
-		err = RegistryAuth(houstonMock, out, "", houston.GetAppConfigRequest{})
+		err = RegistryAuth(houstonMock, out, "", "", houston.GetAppConfigRequest{})
 		s.NoError(err)
 
 		houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil).Once()
 
-		err = RegistryAuth(houstonMock, out, "", houston.GetAppConfigRequest{})
+		err = RegistryAuth(houstonMock, out, "", "", houston.GetAppConfigRequest{})
 		s.ErrorIs(err, errMockRegistry)
 
 		mockRegistryHandler.AssertExpectations(s.T())
@@ -318,7 +319,7 @@ func (s *Suite) TestRegistryAuthFailure() {
 		houstonMock := new(houstonMocks.ClientInterface)
 		houstonMock.On("GetAppConfig", mock.Anything).Return(nil, errMockHouston).Once()
 
-		err := RegistryAuth(houstonMock, out, "", houston.GetAppConfigRequest{})
+		err := RegistryAuth(houstonMock, out, "", "", houston.GetAppConfigRequest{})
 		s.ErrorIs(err, errMockHouston)
 		houstonMock.AssertExpectations(s.T())
 	})
@@ -338,7 +339,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "test-workspace-id").Return(&houston.Workspace{ID: "test-workspace-id"}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if !s.NoError(Login("localhost", false, "test", "test", "0.29.0", houstonMock, out)) {
+		if !s.NoError(Login("localhost", false, "test", "test", "0.29.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -347,7 +348,7 @@ func (s *Suite) TestLoginSuccess() {
 
 		houstonMock.On("ListWorkspaces", nil).Return([]houston.Workspace{{ID: "ck05r3bor07h40d02y2hw4n4v"}, {ID: "test-workspace-id"}}, nil).Once()
 		out = &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-id"}, gotOut) {
@@ -377,7 +378,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "ck05r3bor07h40d02y2hw4n4v").Return(&houston.Workspace{}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-id"}, gotOut) {
@@ -406,7 +407,7 @@ func (s *Suite) TestLoginSuccess() {
 		}
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "ck05r3bor07h40d02y2hw4n4v"}, gotOut) {
@@ -438,7 +439,7 @@ func (s *Suite) TestLoginSuccess() {
 		houstonMock.On("ValidateWorkspaceID", "test-workspace-1").Return(&houston.Workspace{}, nil).Once()
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost", "test-workspace-1"}, gotOut) {
@@ -460,7 +461,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("GetAuthConfig", mock.Anything).Return(nil, errMockRegistry)
 
 		out := &bytes.Buffer{}
-		if !s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out), errMockRegistry) {
+		if !s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -475,7 +476,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("AuthenticateWithBasicAuth", mock.Anything).Return("", errMockRegistry)
 
 		out := &bytes.Buffer{}
-		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out), errMockRegistry) {
+		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -491,7 +492,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("ListWorkspaces", nil).Return([]houston.Workspace{}, errMockRegistry).Once()
 
 		out := &bytes.Buffer{}
-		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out), errMockRegistry) {
+		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out), errMockRegistry) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
@@ -508,7 +509,7 @@ func (s *Suite) TestLoginFailure() {
 		houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Flags: houston.FeatureFlags{BYORegistryEnabled: false}}, nil)
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("dev.astro.io", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("dev.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"dev.astro.io", "No default workspace detected"}, gotOut) {
@@ -531,7 +532,7 @@ func (s *Suite) TestLoginFailure() {
 		}
 
 		out := &bytes.Buffer{}
-		if s.NoError(Login("test.astro.io", false, "test", "test", "0.30.0", houstonMock, out)) {
+		if s.NoError(Login("test.astro.io", false, "test", "test", "0.30.0", keychain.NewTestStore(), houstonMock, out)) {
 			return
 		}
 		if gotOut := out.String(); !testUtil.StringContains([]string{"test.astro.io", "Failed to authenticate to the registry"}, gotOut) {
@@ -565,7 +566,7 @@ func (s *Suite) TestLogout() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			Logout(tt.args.domain)
+			Logout(tt.args.domain, keychain.NewTestStore())
 		})
 	}
 }

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -15,10 +15,12 @@ import (
 	"github.com/astronomer/astro-cli/airflow"
 	"github.com/astronomer/astro-cli/airflow/types"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/docker"
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/input"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/printutil"
 	"github.com/astronomer/astro-cli/software/auth"
@@ -76,7 +78,7 @@ var tab = printutil.Table{
 	Header:         []string{"#", "LABEL", "DEPLOYMENT NAME", "WORKSPACE", "DEPLOYMENT ID"},
 }
 
-func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+func Airflow(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 	deploymentID, deployments, err := getDeploymentIDForCurrentCommand(houstonClient, wsID, deploymentID, prompt)
 	if err != nil {
 		return deploymentID, err
@@ -126,7 +128,7 @@ func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID str
 	fmt.Printf(houstonDeploymentPrompt, releaseName)
 
 	// Build the image to deploy
-	err = buildPushDockerImage(houstonClient, &c, deploymentInfo, releaseName, path, nextTag, cloudDomain, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, description, imageName)
+	err = buildPushDockerImage(houstonClient, store, deploymentInfo, releaseName, path, nextTag, cloudDomain, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, description, imageName)
 	if err != nil {
 		return deploymentID, err
 	}
@@ -204,13 +206,17 @@ func UpdateDeploymentImage(houstonClient houston.ClientInterface, deploymentID, 
 	return deploymentID, err
 }
 
-func pushDockerImage(byoRegistryEnabled bool, deploymentInfo *houston.Deployment, byoRegistryDomain, name, nextTag, cloudDomain string, imageHandler airflow.ImageHandler, houstonClient houston.ClientInterface, c *config.Context, customImageName string) error {
+func pushDockerImage(byoRegistryEnabled bool, deploymentInfo *houston.Deployment, byoRegistryDomain, name, nextTag, cloudDomain string, imageHandler airflow.ImageHandler, houstonClient houston.ClientInterface, store keychain.SecureStore, customImageName string) error {
 	var registry, remoteImage, token string
 	if byoRegistryEnabled {
 		registry = byoRegistryDomain
 		remoteImage = fmt.Sprintf("%s:%s", registry, fmt.Sprintf("%s-%s", name, nextTag))
 	} else {
-		token = c.Token
+		if ctx, err := context.GetCurrentContext(); err == nil {
+			if creds, err := store.GetCredentials(ctx.Domain); err == nil {
+				token = creds.Token
+			}
+		}
 		platformVersion, _ := houstonClient.GetPlatformVersion(nil)
 		if versions.GreaterThanOrEqualTo(platformVersion, "1.0.0") {
 			var err error
@@ -219,7 +225,7 @@ func pushDockerImage(byoRegistryEnabled bool, deploymentInfo *houston.Deployment
 				return err
 			}
 			// Switch to per deployment registry login
-			err = auth.RegistryAuth(houstonClient, os.Stdout, registry)
+			err = auth.RegistryAuth(houstonClient, os.Stdout, registry, token)
 			if err != nil {
 				logger.Debugf("There was an error logging into registry: %s", err.Error())
 				return err
@@ -228,7 +234,6 @@ func pushDockerImage(byoRegistryEnabled bool, deploymentInfo *houston.Deployment
 		} else {
 			registry = registryDomainPrefix + cloudDomain
 			remoteImage = fmt.Sprintf("%s/%s", registry, airflow.ImageName(name, nextTag))
-			token = c.Token
 		}
 	}
 	if customImageName != "" {
@@ -320,14 +325,14 @@ func getGetTagFromImageName(imageName string) string {
 	return ""
 }
 
-func buildPushDockerImage(houstonClient houston.ClientInterface, c *config.Context, deploymentInfo *houston.Deployment, name, path, nextTag, cloudDomain, byoRegistryDomain string, ignoreCacheDeploy, byoRegistryEnabled bool, description, customImageName string) error {
+func buildPushDockerImage(houstonClient houston.ClientInterface, store keychain.SecureStore, deploymentInfo *houston.Deployment, name, path, nextTag, cloudDomain, byoRegistryDomain string, ignoreCacheDeploy, byoRegistryEnabled bool, description, customImageName string) error {
 	imageName := airflow.ImageName(name, "latest")
 	imageHandler := imageHandlerInit(imageName)
 	err := buildDockerImage(ignoreCacheDeploy, deploymentInfo, customImageName, path, imageHandler, houstonClient, description)
 	if err != nil {
 		return err
 	}
-	return pushDockerImage(byoRegistryEnabled, deploymentInfo, byoRegistryDomain, name, nextTag, cloudDomain, imageHandler, houstonClient, c, customImageName)
+	return pushDockerImage(byoRegistryEnabled, deploymentInfo, byoRegistryDomain, name, nextTag, cloudDomain, imageHandler, houstonClient, store, customImageName)
 }
 
 func getAirflowUILink(deploymentID string, deploymentURLs []houston.DeploymentURL) string {
@@ -468,7 +473,7 @@ func getDagDeployURL(deploymentInfo *houston.Deployment) string {
 	return ""
 }
 
-func DagsOnlyDeploy(houstonClient houston.ClientInterface, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
+func DagsOnlyDeploy(houstonClient houston.ClientInterface, store keychain.SecureStore, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 	deploymentID, _, err := getDeploymentIDForCurrentCommandVar(houstonClient, wsID, deploymentID, deploymentID == "")
 	if err != nil {
 		return err
@@ -540,8 +545,13 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, wsID, deploymentID, d
 
 	c, _ := config.GetCurrentContext()
 
+	var token string
+	if creds, err := store.GetCredentials(c.Domain); err == nil {
+		token = creds.Token
+	}
+
 	headers := map[string]string{
-		"authorization": c.Token,
+		"authorization": token,
 	}
 
 	uploadFileArgs := fileutil.UploadFileArguments{

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -16,10 +16,12 @@ import (
 	"github.com/astronomer/astro-cli/airflow"
 	"github.com/astronomer/astro-cli/airflow/types"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/docker"
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/input"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	"github.com/astronomer/astro-cli/pkg/logger"
 	"github.com/astronomer/astro-cli/pkg/printutil"
 	"github.com/astronomer/astro-cli/software/auth"
@@ -80,7 +82,7 @@ var tab = printutil.Table{
 	Header:         []string{"#", "LABEL", "DEPLOYMENT NAME", "WORKSPACE", "DEPLOYMENT ID"},
 }
 
-func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
+func Airflow(houstonClient houston.ClientInterface, store keychain.SecureStore, path, deploymentID, wsID string, ignoreCacheDeploy, prompt bool, description string, isImageOnlyDeploy bool, imageName string) (string, error) {
 	deploymentID, deployments, err := getDeploymentIDForCurrentCommand(houstonClient, wsID, deploymentID, prompt)
 	if err != nil {
 		return deploymentID, err
@@ -131,7 +133,7 @@ func Airflow(houstonClient houston.ClientInterface, path, deploymentID, wsID str
 	fmt.Printf(houstonDeploymentPrompt, releaseName)
 
 	// Build the image to deploy
-	err = buildPushDockerImage(houstonClient, &c, deploymentInfo, releaseName, path, nextTag, cloudDomain, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, description, imageName)
+	err = buildPushDockerImage(houstonClient, store, deploymentInfo, releaseName, path, nextTag, cloudDomain, byoRegistryDomain, ignoreCacheDeploy, byoRegistryEnabled, description, imageName)
 	if err != nil {
 		return deploymentID, err
 	}
@@ -224,13 +226,17 @@ func UpdateDeploymentImage(houstonClient houston.ClientInterface, deploymentID, 
 	return deploymentID, err
 }
 
-func pushDockerImage(byoRegistryEnabled bool, deploymentInfo *houston.Deployment, byoRegistryDomain, name, nextTag, cloudDomain string, imageHandler airflow.ImageHandler, houstonClient houston.ClientInterface, c *config.Context, customImageName string) error {
+func pushDockerImage(byoRegistryEnabled bool, deploymentInfo *houston.Deployment, byoRegistryDomain, name, nextTag, cloudDomain string, imageHandler airflow.ImageHandler, houstonClient houston.ClientInterface, store keychain.SecureStore, customImageName string) error {
 	var registry, remoteImage, token string
 	if byoRegistryEnabled {
 		registry = byoRegistryDomain
 		remoteImage = fmt.Sprintf("%s:%s", registry, fmt.Sprintf("%s-%s", name, nextTag))
 	} else {
-		token = c.Token
+		if ctx, err := context.GetCurrentContext(); err == nil {
+			if creds, err := store.GetCredentials(ctx.Domain); err == nil {
+				token = creds.Token
+			}
+		}
 		platformVersion, _ := houstonClient.GetPlatformVersion(nil)
 		if versions.GreaterThanOrEqualTo(platformVersion, "1.0.0") {
 			var err error
@@ -239,7 +245,7 @@ func pushDockerImage(byoRegistryEnabled bool, deploymentInfo *houston.Deployment
 				return err
 			}
 			// Switch to per deployment registry login
-			err = auth.RegistryAuth(houstonClient, os.Stdout, registry, houston.GetAppConfigRequest{
+			err = auth.RegistryAuth(houstonClient, os.Stdout, registry, token, houston.GetAppConfigRequest{
 				ClusterID:      deploymentInfo.ClusterID,
 				WorkspaceUUID:  deploymentInfo.Workspace.ID,
 				DeploymentUUID: deploymentInfo.ID,
@@ -252,7 +258,6 @@ func pushDockerImage(byoRegistryEnabled bool, deploymentInfo *houston.Deployment
 		} else {
 			registry = registryDomainPrefix + cloudDomain
 			remoteImage = fmt.Sprintf("%s/%s", registry, airflow.ImageName(name, nextTag))
-			token = c.Token
 		}
 	}
 	if customImageName != "" {
@@ -344,14 +349,14 @@ func getGetTagFromImageName(imageName string) string {
 	return ""
 }
 
-func buildPushDockerImage(houstonClient houston.ClientInterface, c *config.Context, deploymentInfo *houston.Deployment, name, path, nextTag, cloudDomain, byoRegistryDomain string, ignoreCacheDeploy, byoRegistryEnabled bool, description, customImageName string) error {
+func buildPushDockerImage(houstonClient houston.ClientInterface, store keychain.SecureStore, deploymentInfo *houston.Deployment, name, path, nextTag, cloudDomain, byoRegistryDomain string, ignoreCacheDeploy, byoRegistryEnabled bool, description, customImageName string) error {
 	imageName := airflow.ImageName(name, "latest")
 	imageHandler := imageHandlerInit(imageName)
 	err := buildDockerImage(ignoreCacheDeploy, deploymentInfo, customImageName, path, imageHandler, houstonClient, description)
 	if err != nil {
 		return err
 	}
-	return pushDockerImage(byoRegistryEnabled, deploymentInfo, byoRegistryDomain, name, nextTag, cloudDomain, imageHandler, houstonClient, c, customImageName)
+	return pushDockerImage(byoRegistryEnabled, deploymentInfo, byoRegistryDomain, name, nextTag, cloudDomain, imageHandler, houstonClient, store, customImageName)
 }
 
 func getAirflowUILink(deploymentID string, deploymentURLs []houston.DeploymentURL) string {
@@ -522,7 +527,7 @@ func getDagDeployURL(deploymentInfo *houston.Deployment) string {
 	return ""
 }
 
-func DagsOnlyDeploy(houstonClient houston.ClientInterface, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
+func DagsOnlyDeploy(houstonClient houston.ClientInterface, store keychain.SecureStore, wsID, deploymentID, dagsParentPath string, dagDeployURL *string, cleanUpFiles bool, description string) error {
 	deploymentID, deployments, err := getDeploymentIDForCurrentCommandVar(houstonClient, wsID, deploymentID, deploymentID == "")
 	if err != nil {
 		return err
@@ -595,8 +600,13 @@ func DagsOnlyDeploy(houstonClient houston.ClientInterface, wsID, deploymentID, d
 
 	c, _ := config.GetCurrentContext()
 
+	var token string
+	if creds, err := store.GetCredentials(c.Domain); err == nil {
+		token = creds.Token
+	}
+
 	headers := map[string]string{
-		"authorization": c.Token,
+		"authorization": token,
 	}
 
 	uploadFileArgs := fileutil.UploadFileArguments{

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	houston_mocks "github.com/astronomer/astro-cli/houston/mocks"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -162,7 +163,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithTagWarning() {
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(mockedDeploymentConfig, nil)
 	s.houstonMock.On("GetPlatformVersion", mock.Anything).Return("1.0.0", nil).Once()
 
-	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err := buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.NoError(err)
 }
 
@@ -189,7 +190,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithImageRepoWarning() {
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	s.houstonMock.On("GetPlatformVersion", mock.Anything).Return("1.0.0", nil).Once()
 
-	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err := buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.NoError(err)
 }
 
@@ -230,7 +231,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithBYORegistry() {
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	s.houstonMock.On("UpdateDeploymentImage", houston.UpdateDeploymentImageRequest{ReleaseName: "test", Image: "test.registry.io:test-test", AirflowVersion: "1.10.12", RuntimeVersion: ""}).Return(nil, nil)
 
-	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, "")
+	err := buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, "")
 	s.NoError(err)
 
 	expectedLabel := deployRevisionDescriptionLabel + "=" + description
@@ -262,7 +263,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithBYORegistry() {
 	}
 	config.CFG.ShaAsTag.SetHomeString("true")
 	defer config.CFG.ShaAsTag.SetHomeString("false")
-	err = buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, "")
+	err = buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, "")
 	s.NoError(err)
 	expectedLabel = deployRevisionDescriptionLabel + "=" + description
 	assert.Contains(s.T(), capturedBuildConfig.Labels, expectedLabel)
@@ -292,14 +293,14 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithBYORegistryAndCustomImageName
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	s.houstonMock.On("UpdateDeploymentImage", houston.UpdateDeploymentImageRequest{ReleaseName: "test", Image: "test.registry.io:latest", AirflowVersion: "1.10.12", RuntimeVersion: "12.2.0"}).Return(nil, nil)
 
-	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, customImageName)
+	err := buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, customImageName)
 	s.NoError(err)
 }
 
 func (s *Suite) TestBuildPushDockerImageFailure() {
 	// invalid dockerfile test
 	dockerfile = "Dockerfile.invalid"
-	err := buildPushDockerImage(nil, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err := buildPushDockerImage(nil, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.EqualError(err, "failed to parse dockerfile: testfiles/Dockerfile.invalid: when using JSON array syntax, arrays must be comprised of strings only")
 	dockerfile = "Dockerfile"
 
@@ -313,7 +314,7 @@ func (s *Suite) TestBuildPushDockerImageFailure() {
 	vars["clusterId"] = ""
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	// houston GetDeploymentConfig call failure
-	err = buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err = buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.Error(err, errMockHouston)
 
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(mockedDeploymentConfig, nil).Twice()
@@ -324,7 +325,7 @@ func (s *Suite) TestBuildPushDockerImageFailure() {
 	}
 
 	// build error test case
-	err = buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err = buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.Error(err, errSomeContainerIssue.Error())
 	s.mockImageHandler.AssertExpectations(s.T())
 
@@ -337,7 +338,7 @@ func (s *Suite) TestBuildPushDockerImageFailure() {
 	s.houstonMock.On("GetPlatformVersion", mock.Anything).Return("1.0.0", nil).Once()
 
 	// push error test case
-	err = buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err = buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.Error(err, errSomeContainerIssue.Error())
 }
 
@@ -430,13 +431,13 @@ func (s *Suite) TestGetDagDeployURL() {
 
 func (s *Suite) TestAirflowFailure() {
 	// No workspace ID test case
-	_, err := Airflow(nil, "", "", "", false, false, description, false, "")
+	_, err := Airflow(nil, keychain.NewTestStore(), "", "", "", false, false, description, false, "")
 	s.ErrorIs(err, ErrNoWorkspaceID)
 
 	// houston GetWorkspace failure case
 	s.houstonMock.On("GetWorkspace", mock.Anything).Return(nil, errMockHouston).Once()
 
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errMockHouston)
 	s.houstonMock.AssertExpectations(s.T())
 
@@ -444,7 +445,7 @@ func (s *Suite) TestAirflowFailure() {
 	s.houstonMock.On("GetWorkspace", mock.Anything).Return(&houston.Workspace{}, nil)
 	s.houstonMock.On("ListDeployments", mock.Anything).Return(nil, errMockHouston).Once()
 
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errMockHouston)
 	s.houstonMock.AssertExpectations(s.T())
 
@@ -455,36 +456,36 @@ func (s *Suite) TestAirflowFailure() {
 	// config GetCurrentContext failure case
 	config.ResetCurrentContext()
 
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.EqualError(err, "no context set, have you authenticated to Astro or Astro Private Cloud? Run astro login and try again")
 
 	context.Switch("localhost")
 
 	// Invalid deployment name case
-	_, err = Airflow(s.houstonMock, "", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errInvalidDeploymentID)
 
 	// No deployment in the current workspace case
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errDeploymentNotFound)
 	s.houstonMock.AssertExpectations(s.T())
 
 	// Invalid deployment selection case
 	s.houstonMock.On("ListDeployments", mock.Anything).Return([]houston.Deployment{{ID: "test-deployment-id"}}, nil)
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errInvalidDeploymentSelected)
 
 	// return error When houston get deployment throws an error
 	s.houstonMock.On("ListDeployments", mock.Anything).Return([]houston.Deployment{{ID: "test-deployment-id"}}, nil)
 	s.houstonMock.On("GetDeployment", mock.Anything).Return(nil, errMockHouston).Once()
-	_, err = Airflow(s.houstonMock, "", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 	s.Equal(err.Error(), "failed to get deployment info: "+errMockHouston.Error())
 
 	// buildPushDockerImage failure case
 	s.houstonMock.On("GetDeployment", "test-deployment-id").Return(&houston.Deployment{ClusterID: "test-cluster-id"}, nil)
 	s.houstonMock.On("GetAppConfig", "test-cluster-id").Return(&houston.AppConfig{}, nil)
 	dockerfile = "Dockerfile.invalid"
-	_, err = Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 	dockerfile = "Dockerfile"
 	s.Error(err)
 	s.Contains(err.Error(), "failed to parse dockerfile")
@@ -523,7 +524,7 @@ func (s *Suite) TestAirflowSuccess() {
 	vars["clusterId"] = "test-cluster-id"
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 	s.NoError(err)
 }
 
@@ -567,7 +568,7 @@ func (s *Suite) TestAirflowSuccessForBYORegistry() {
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 	s.houstonMock.On("UpdateDeploymentImage", mock.Anything).Return(&houston.UpdateDeploymentImageResp{}, nil).Once()
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 
 	s.NoError(err)
 }
@@ -591,7 +592,7 @@ func (s *Suite) TestAirflowFailureForNoBYORegistryDomain() {
 		},
 	}, nil).Once()
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 
 	s.ErrorIs(err, ErrBYORegistryDomainNotSet)
 }
@@ -636,7 +637,7 @@ func (s *Suite) TestAirflowSuccessForImageOnly() {
 	vars["clusterId"] = "test-cluster-id"
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, "")
 	s.NoError(err)
 }
 
@@ -681,7 +682,7 @@ func (s *Suite) TestAirflowSuccessForImageName() {
 	vars["clusterId"] = "test-cluster-id"
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, customImageName)
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, customImageName)
 	s.NoError(err)
 }
 
@@ -707,7 +708,7 @@ func (s *Suite) TestAirflowFailForImageNameWhenImageHasNoRuntimeLabel() {
 	s.houstonMock.On("GetDeployment", "test-deployment-id").Return(deployment, nil).Once()
 	s.houstonMock.On("GetAppConfig", "test-cluster-id").Return(&houston.AppConfig{}, nil).Once()
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, customImageName)
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, customImageName)
 	s.Error(err, ErrNoRuntimeLabelOnCustomImage)
 }
 
@@ -732,7 +733,7 @@ func (s *Suite) TestAirflowFailureForImageOnly() {
 	s.houstonMock.On("GetDeployment", "test-deployment-id").Return(deployment, nil).Once()
 	s.houstonMock.On("GetAppConfig", "test-cluster-id").Return(&houston.AppConfig{}, nil).Once()
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, "")
 	s.Error(err, ErrDeploymentTypeIncorrectForImageOnly)
 }
 
@@ -758,7 +759,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 		s.houstonMock.On("GetDeployment", deploymentID).Return(deployment, nil).Once()
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, ErrDagOnlyDeployDisabledInConfig)
 	})
 
@@ -766,7 +767,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, errDeploymentNotFound
 		}
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, errDeploymentNotFound)
 	})
 
@@ -775,7 +776,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 			return deploymentID, nil, nil
 		}
 		s.houstonMock.On("GetDeployment", deploymentID).Return(nil, errMockHouston).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorContains(err, "failed to get deployment info: some houston error")
 	})
 
@@ -799,7 +800,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 		s.houstonMock.On("GetDeployment", deploymentID).Return(deployment, nil).Once()
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, ErrDagOnlyDeployNotEnabledForDeployment)
 	})
 
@@ -824,7 +825,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		config.ResetCurrentContext()
 
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.EqualError(err, "could not get current context! Error: no context set, have you authenticated to Astro or Astro Private Cloud? Run astro login and try again")
 		context.Switch("localhost")
 	})
@@ -849,7 +850,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 		s.houstonMock.On("GetDeployment", deploymentID).Return(deployment, nil).Once()
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, errInvalidDeploymentID)
 	})
 
@@ -892,7 +893,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer os.RemoveAll("dags")
 
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", nil, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", nil, false, description)
 		s.EqualError(err, ErrEmptyDagFolderUserCancelledOperation.Error())
 
 		// assert that no tar or gz file exists
@@ -954,7 +955,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer server.Close()
 
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", &server.URL, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", &server.URL, false, description)
 		s.NoError(err)
 
 		// Validate that dags.tar file was created
@@ -1004,7 +1005,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, "./dags", nil, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, "./dags", nil, false, description)
 		s.EqualError(err, "open dags/dags.tar: no such file or directory")
 
 		// assert that no tar or gz file exists
@@ -1049,7 +1050,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", nil, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", nil, false, description)
 		s.ErrorIs(err, gzipMockError)
 
 		// Validate that dags.tar file was created
@@ -1110,7 +1111,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer server.Close()
 
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", &server.URL, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", &server.URL, false, description)
 		s.NoError(err)
 
 		// Validate that dags.tar file was created
@@ -1170,7 +1171,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer server.Close()
 
 		s.houstonMock.On("GetAppConfig", deployment.ClusterID).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", &server.URL, true, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", &server.URL, true, description)
 		s.NoError(err)
 
 		// assert that no tar or gz file exists

--- a/software/deploy/deploy_test.go
+++ b/software/deploy/deploy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/astronomer/astro-cli/houston"
 	houston_mocks "github.com/astronomer/astro-cli/houston/mocks"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
+	"github.com/astronomer/astro-cli/pkg/keychain"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -162,7 +163,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithTagWarning() {
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(mockedDeploymentConfig, nil)
 	s.houstonMock.On("GetPlatformVersion", mock.Anything).Return("1.0.0", nil).Once()
 
-	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err := buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.NoError(err)
 }
 
@@ -189,7 +190,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithImageRepoWarning() {
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	s.houstonMock.On("GetPlatformVersion", mock.Anything).Return("1.0.0", nil).Once()
 
-	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err := buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.NoError(err)
 }
 
@@ -230,7 +231,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithBYORegistry() {
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	s.houstonMock.On("UpdateDeploymentImage", houston.UpdateDeploymentImageRequest{ReleaseName: "test", Image: "test.registry.io:test-test", AirflowVersion: "1.10.12", RuntimeVersion: ""}).Return(nil, nil)
 
-	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, "")
+	err := buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, "")
 	s.NoError(err)
 
 	expectedLabel := deployRevisionDescriptionLabel + "=" + description
@@ -262,7 +263,7 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithBYORegistry() {
 	}
 	config.CFG.ShaAsTag.SetHomeString("true")
 	defer config.CFG.ShaAsTag.SetHomeString("false")
-	err = buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, "")
+	err = buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, "")
 	s.NoError(err)
 	expectedLabel = deployRevisionDescriptionLabel + "=" + description
 	assert.Contains(s.T(), capturedBuildConfig.Labels, expectedLabel)
@@ -292,14 +293,14 @@ func (s *Suite) TestBuildPushDockerImageSuccessWithBYORegistryAndCustomImageName
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	s.houstonMock.On("UpdateDeploymentImage", houston.UpdateDeploymentImageRequest{ReleaseName: "test", Image: "test.registry.io:latest", AirflowVersion: "1.10.12", RuntimeVersion: "12.2.0"}).Return(nil, nil)
 
-	err := buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, customImageName)
+	err := buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "test.registry.io", false, true, description, customImageName)
 	s.NoError(err)
 }
 
 func (s *Suite) TestBuildPushDockerImageFailure() {
 	// invalid dockerfile test
 	dockerfile = "Dockerfile.invalid"
-	err := buildPushDockerImage(nil, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err := buildPushDockerImage(nil, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.EqualError(err, "failed to parse dockerfile: testfiles/Dockerfile.invalid: when using JSON array syntax, arrays must be comprised of strings only")
 	dockerfile = "Dockerfile"
 
@@ -313,7 +314,7 @@ func (s *Suite) TestBuildPushDockerImageFailure() {
 	vars["clusterId"] = ""
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(houston.RuntimeReleases{}, nil)
 	// houston GetDeploymentConfig call failure
-	err = buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err = buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.Error(err, errMockHouston)
 
 	s.houstonMock.On("GetDeploymentConfig", nil).Return(mockedDeploymentConfig, nil).Twice()
@@ -324,7 +325,7 @@ func (s *Suite) TestBuildPushDockerImageFailure() {
 	}
 
 	// build error test case
-	err = buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err = buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.Error(err, errSomeContainerIssue.Error())
 	s.mockImageHandler.AssertExpectations(s.T())
 
@@ -337,7 +338,7 @@ func (s *Suite) TestBuildPushDockerImageFailure() {
 	s.houstonMock.On("GetPlatformVersion", mock.Anything).Return("1.0.0", nil).Once()
 
 	// push error test case
-	err = buildPushDockerImage(s.houstonMock, &config.Context{}, mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
+	err = buildPushDockerImage(s.houstonMock, keychain.NewTestStore(), mockDeployment, "test", "./testfiles/", "test", "test", "", false, false, description, "")
 	s.Error(err, errSomeContainerIssue.Error())
 }
 
@@ -430,13 +431,13 @@ func (s *Suite) TestGetDagDeployURL() {
 
 func (s *Suite) TestAirflowFailure() {
 	// No workspace ID test case
-	_, err := Airflow(nil, "", "", "", false, false, description, false, "")
+	_, err := Airflow(nil, keychain.NewTestStore(), "", "", "", false, false, description, false, "")
 	s.ErrorIs(err, ErrNoWorkspaceID)
 
 	// houston GetWorkspace failure case
 	s.houstonMock.On("GetWorkspace", mock.Anything).Return(nil, errMockHouston).Once()
 
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errMockHouston)
 	s.houstonMock.AssertExpectations(s.T())
 
@@ -444,7 +445,7 @@ func (s *Suite) TestAirflowFailure() {
 	s.houstonMock.On("GetWorkspace", mock.Anything).Return(&houston.Workspace{}, nil)
 	s.houstonMock.On("ListDeployments", mock.Anything).Return(nil, errMockHouston).Once()
 
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errMockHouston)
 	s.houstonMock.AssertExpectations(s.T())
 
@@ -455,36 +456,36 @@ func (s *Suite) TestAirflowFailure() {
 	// config GetCurrentContext failure case
 	config.ResetCurrentContext()
 
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.EqualError(err, "no context set, have you authenticated to Astro or Astro Private Cloud? Run astro login and try again")
 
 	context.Switch("localhost")
 
 	// Invalid deployment name case
-	_, err = Airflow(s.houstonMock, "", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errInvalidDeploymentID)
 
 	// No deployment in the current workspace case
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errDeploymentNotFound)
 	s.houstonMock.AssertExpectations(s.T())
 
 	// Invalid deployment selection case
 	s.houstonMock.On("ListDeployments", mock.Anything).Return([]houston.Deployment{{ID: "test-deployment-id"}}, nil)
-	_, err = Airflow(s.houstonMock, "", "", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "", "test-workspace-id", false, false, description, false, "")
 	s.ErrorIs(err, errInvalidDeploymentSelected)
 
 	// return error When houston get deployment throws an error
 	s.houstonMock.On("ListDeployments", mock.Anything).Return([]houston.Deployment{{ID: "test-deployment-id"}}, nil)
 	s.houstonMock.On("GetDeployment", mock.Anything).Return(nil, errMockHouston).Once()
-	_, err = Airflow(s.houstonMock, "", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 	s.Equal(err.Error(), "failed to get deployment info: "+errMockHouston.Error())
 
 	// buildPushDockerImage failure case
 	s.houstonMock.On("GetDeployment", "test-deployment-id").Return(&houston.Deployment{ClusterID: "test-cluster-id"}, nil)
 	s.houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{}, nil)
 	dockerfile = "Dockerfile.invalid"
-	_, err = Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err = Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 	dockerfile = "Dockerfile"
 	s.Error(err)
 	s.Contains(err.Error(), "failed to parse dockerfile")
@@ -523,7 +524,7 @@ func (s *Suite) TestAirflowSuccess() {
 	vars["clusterId"] = "test-cluster-id"
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 	s.NoError(err)
 }
 
@@ -567,7 +568,7 @@ func (s *Suite) TestAirflowSuccessForBYORegistry() {
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 	s.houstonMock.On("UpdateDeploymentImage", mock.Anything).Return(&houston.UpdateDeploymentImageResp{}, nil).Once()
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 
 	s.NoError(err)
 }
@@ -591,7 +592,7 @@ func (s *Suite) TestAirflowFailureForNoBYORegistryDomain() {
 		},
 	}, nil).Once()
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, false, "")
 
 	s.ErrorIs(err, ErrBYORegistryDomainNotSet)
 }
@@ -636,7 +637,7 @@ func (s *Suite) TestAirflowSuccessForImageOnly() {
 	vars["clusterId"] = "test-cluster-id"
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, "")
 	s.NoError(err)
 }
 
@@ -681,7 +682,7 @@ func (s *Suite) TestAirflowSuccessForImageName() {
 	vars["clusterId"] = "test-cluster-id"
 	s.houstonMock.On("GetRuntimeReleases", vars).Return(mockRuntimeReleases, nil)
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, customImageName)
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, customImageName)
 	s.NoError(err)
 }
 
@@ -707,7 +708,7 @@ func (s *Suite) TestAirflowFailForImageNameWhenImageHasNoRuntimeLabel() {
 	s.houstonMock.On("GetDeployment", "test-deployment-id").Return(deployment, nil).Once()
 	s.houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{}, nil).Once()
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, customImageName)
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, customImageName)
 	s.Error(err, ErrNoRuntimeLabelOnCustomImage)
 }
 
@@ -732,7 +733,7 @@ func (s *Suite) TestAirflowFailureForImageOnly() {
 	s.houstonMock.On("GetDeployment", "test-deployment-id").Return(deployment, nil).Once()
 	s.houstonMock.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{}, nil).Once()
 
-	_, err := Airflow(s.houstonMock, "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, "")
+	_, err := Airflow(s.houstonMock, keychain.NewTestStore(), "./testfiles/", "test-deployment-id", "test-workspace-id", false, false, description, true, "")
 	s.Error(err, ErrDeploymentTypeIncorrectForImageOnly)
 }
 
@@ -759,7 +760,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 		s.houstonMock.On("GetDeployment", deploymentID).Return(deployment, nil).Once()
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, ErrDagOnlyDeployDisabledInConfigLegacy)
 	})
 
@@ -781,7 +782,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 		s.houstonMock.On("GetDeployment", deploymentID).Return(deployment, nil).Once()
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, ErrDagOnlyDeployDisabledInConfig)
 	})
 
@@ -789,7 +790,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		getDeploymentIDForCurrentCommandVar = func(houstonClient houston.ClientInterface, wsID, deploymentID string, prompt bool) (string, []houston.Deployment, error) {
 			return deploymentID, nil, errDeploymentNotFound
 		}
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, errDeploymentNotFound)
 	})
 
@@ -798,7 +799,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 			return deploymentID, nil, nil
 		}
 		s.houstonMock.On("GetDeployment", deploymentID).Return(nil, errMockHouston).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorContains(err, "failed to get deployment info: some houston error")
 	})
 
@@ -822,7 +823,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 		s.houstonMock.On("GetDeployment", deploymentID).Return(deployment, nil).Once()
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, ErrDagOnlyDeployNotEnabledForDeployment)
 	})
 
@@ -847,7 +848,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		config.ResetCurrentContext()
 
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.EqualError(err, "could not get current context! Error: no context set, have you authenticated to Astro or Astro Private Cloud? Run astro login and try again")
 		context.Switch("localhost")
 	})
@@ -872,7 +873,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 		s.houstonMock.On("GetDeployment", deploymentID).Return(deployment, nil).Once()
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err := DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, config.WorkingPath, nil, false, description)
+		err := DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, config.WorkingPath, nil, false, description)
 		s.ErrorIs(err, errInvalidDeploymentID)
 	})
 
@@ -915,7 +916,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer os.RemoveAll("dags")
 
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", nil, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", nil, false, description)
 		s.EqualError(err, ErrEmptyDagFolderUserCancelledOperation.Error())
 
 		// assert that no tar or gz file exists
@@ -977,7 +978,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer server.Close()
 
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", &server.URL, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", &server.URL, false, description)
 		s.NoError(err)
 
 		// Validate that dags.tar file was created
@@ -1027,7 +1028,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer testUtil.MockUserInput(s.T(), "y")()
 
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, "./dags", nil, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, "./dags", nil, false, description)
 		s.EqualError(err, "open dags/dags.tar: no such file or directory")
 
 		// assert that no tar or gz file exists
@@ -1072,7 +1073,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		}
 
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", nil, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", nil, false, description)
 		s.ErrorIs(err, gzipMockError)
 
 		// Validate that dags.tar file was created
@@ -1133,7 +1134,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer server.Close()
 
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", &server.URL, false, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", &server.URL, false, description)
 		s.NoError(err)
 
 		// Validate that dags.tar file was created
@@ -1193,7 +1194,7 @@ func (s *Suite) TestDeployDagsOnlyFailure() {
 		defer server.Close()
 
 		s.houstonMock.On("GetAppConfig", mock.Anything).Return(appConfig, nil).Once()
-		err = DagsOnlyDeploy(s.houstonMock, wsID, deploymentID, ".", &server.URL, true, description)
+		err = DagsOnlyDeploy(s.houstonMock, keychain.NewTestStore(), wsID, deploymentID, ".", &server.URL, true, description)
 		s.NoError(err)
 
 		// assert that no tar or gz file exists

--- a/software/deployment/logs.go
+++ b/software/deployment/logs.go
@@ -33,7 +33,7 @@ func Log(deploymentID, component, search string, since time.Duration, client hou
 	return nil
 }
 
-func SubscribeDeploymentLog(deploymentID, component, search string, since time.Duration) error {
+func SubscribeDeploymentLog(deploymentID, component, search, token string, since time.Duration) error {
 	// Calculate timestamp as now - since e.g:
 	// (2019-04-02 17:51:03.780819 +0000 UTC - 2 mins) = 2019-04-02 17:49:03.780819 +0000 UTC
 	timestamp := time.Now().UTC().Add(-since)
@@ -43,7 +43,7 @@ func SubscribeDeploymentLog(deploymentID, component, search string, since time.D
 		return err
 	}
 
-	err = subscribe(cl.Token, cl.GetSoftwareWebsocketURL(), request)
+	err = subscribe(token, cl.GetSoftwareWebsocketURL(), request)
 	if err != nil {
 		return err
 	}

--- a/software/deployment/logs_test.go
+++ b/software/deployment/logs_test.go
@@ -41,7 +41,7 @@ func (s *Suite) TestSubscribeDeploymentLog() {
 			return nil
 		}
 
-		err := SubscribeDeploymentLog("test-id", "test-component", "test", 0)
+		err := SubscribeDeploymentLog("test-id", "test-component", "test", "test-token", 0)
 		s.NoError(err)
 	})
 
@@ -50,7 +50,7 @@ func (s *Suite) TestSubscribeDeploymentLog() {
 			return errMock
 		}
 
-		err := SubscribeDeploymentLog("test-id", "test-component", "test", 0)
+		err := SubscribeDeploymentLog("test-id", "test-component", "test", "test-token", 0)
 		s.ErrorIs(err, errMock)
 	})
 }


### PR DESCRIPTION
Move auth tokens and refresh tokens out of the plaintext config.yaml
into the OS-native credential store via 99designs/keyring:

- macOS: Keychain Services with per-app ACL (re-prompts after binary
  updates when another process tries to read the item)
- Linux: Secret Service (GNOME Keyring / KWallet) when a D-Bus
  session is available
- Windows support to follow

Credentials are managed through a SecureStore interface (pkg/keychain)
with Get/Set/DeleteCredentials methods. A TokenHolder (pkg/httputil) is
populated once during PersistentPreRunE and read by API client request
editors on every outbound request — replacing the previous per-request
context lookup for the token.

On first run, MigrateLegacyCredentials copies token/refreshtoken fields
from existing config.yaml contexts into the secure store and clears
them from the config file.

On Linux, when no Secret Service daemon is reachable (headless CI,
containers without D-Bus), the store falls back to a plaintext JSON
file at ~/.astro/credentials.json (mode 0600). This matches the
previous config.yaml security posture and is acceptable because CI
environments typically use ASTRO_API_TOKEN rather than interactive
login credentials.

Windows uses the same plaintext file fallback for now; the Credential
Manager backend is added in the follow-up commit.

After building and running this, the config file looks like:

<img width="595" height="395" alt="Screenshot 2026-04-09 at 13 11 54" src="https://github.com/user-attachments/assets/82807216-2bec-4c51-8bea-17ea441c0449" />

And we can see the item in keychain access.

<img width="1176" height="821" alt="Screenshot 2026-04-09 at 13 09 10" src="https://github.com/user-attachments/assets/665a8452-20e5-4e01-8b93-511a055fa776" />

As of this Pr. `astro auth token` still works without further prompting (but I have a separate PR to put that, at least on macOS behind a TouchID et al prompt).

A similar approach is possible on Windows (and the code is written, but not yet tested)