### PR TITLE
Batch import Airflow settings to speed up dev start

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -1461,8 +1461,8 @@ func (d *DockerCompose) ImportSettings(settingsFile, envFile string, connections
 		return err
 	}
 
-	apiURL := airflowAPIURL(airflowDockerVersion)
-	authHeader := airflowAuthHeader(airflowDockerVersion)
+	apiURL := airflowAPIURL(airflowDockerVersion, nil)
+	authHeader := airflowAuthHeader(airflowDockerVersion, nil)
 
 	err = initSettings(apiURL, authHeader, settingsFile, nil, connections, variables, pools)
 	if err != nil {
@@ -1712,14 +1712,20 @@ var createDockerProjectWithPorts = func(projectName, airflowHome, envFile, build
 }
 
 // airflowAPIURL returns the base API URL for the local Airflow instance.
-func airflowAPIURL(airflowMajorVersion uint64) string {
+func airflowAPIURL(airflowMajorVersion uint64, portOvr *PortOverrides) string {
 	var port, apiPrefix string
 	switch airflowMajorVersion {
 	case airflowMajorVersion3:
 		port = config.CFG.APIServerPort.GetString()
+		if portOvr != nil && portOvr.APIServerPort != "" {
+			port = portOvr.APIServerPort
+		}
 		apiPrefix = "/api/v2"
 	default:
 		port = config.CFG.WebserverPort.GetString()
+		if portOvr != nil && portOvr.WebserverPort != "" {
+			port = portOvr.WebserverPort
+		}
 		apiPrefix = "/api/v1"
 	}
 	parts := strings.Split(port, ":")
@@ -1727,13 +1733,13 @@ func airflowAPIURL(airflowMajorVersion uint64) string {
 }
 
 // airflowAuthHeader returns the Authorization header for the local Airflow instance.
-func airflowAuthHeader(airflowMajorVersion uint64) string {
+func airflowAuthHeader(airflowMajorVersion uint64, portOvr *PortOverrides) string {
 	if airflowMajorVersion == airflowMajorVersion2 {
 		return "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:admin"))
 	}
 	// Airflow 3 uses JWT auth via /auth/token endpoint.
 	// With SimpleAuthManager + ALL_ADMINS=True, any credentials work.
-	token, err := fetchLocalAirflowToken(airflowMajorVersion)
+	token, err := fetchLocalAirflowToken(airflowMajorVersion, portOvr)
 	if err != nil {
 		logger.Debugf("Unable to fetch Airflow auth token: %s", err)
 		return ""
@@ -1742,8 +1748,8 @@ func airflowAuthHeader(airflowMajorVersion uint64) string {
 }
 
 // fetchLocalAirflowToken gets a JWT token from the local Airflow 3 instance.
-func fetchLocalAirflowToken(airflowMajorVersion uint64) (string, error) {
-	apiURL := airflowAPIURL(airflowMajorVersion)
+func fetchLocalAirflowToken(airflowMajorVersion uint64, portOvr *PortOverrides) (string, error) {
+	apiURL := airflowAPIURL(airflowMajorVersion, portOvr)
 	root := strings.TrimSuffix(apiURL, "/api/v2")
 	tokenURL := root + "/auth/token"
 
@@ -1778,8 +1784,8 @@ func printProxyStatus(settingsFile string, envConns map[string]astrocore.Environ
 		return errors.Wrap(err, errSettingsPath)
 	}
 	if settingsFileExists || len(envConns) > 0 {
-		apiURL := airflowAPIURL(airflowMajorVersion)
-		authHeader := airflowAuthHeader(airflowMajorVersion)
+		apiURL := airflowAPIURL(airflowMajorVersion, portOvr)
+		authHeader := airflowAuthHeader(airflowMajorVersion, portOvr)
 		err = initSettings(apiURL, authHeader, settingsFile, envConns, true, true, true)
 		if err != nil {
 			return err
@@ -1816,8 +1822,8 @@ func printStatus(settingsFile string, envConns map[string]astrocore.EnvironmentO
 		return errors.Wrap(err, errSettingsPath)
 	}
 	if settingsFileExists || len(envConns) > 0 {
-		apiURL := airflowAPIURL(airflowMajorVersion)
-		authHeader := airflowAuthHeader(airflowMajorVersion)
+		apiURL := airflowAPIURL(airflowMajorVersion, nil)
+		authHeader := airflowAuthHeader(airflowMajorVersion, nil)
 		err = initSettings(apiURL, authHeader, settingsFile, envConns, true, true, true)
 		if err != nil {
 			return err

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -4,9 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -416,9 +419,9 @@ func (d *DockerCompose) Start(opts *airflowTypes.StartOptions) error {
 
 	// Print the status
 	if useProxy && proxyHostname != "" {
-		err = printProxyStatus(settingsFile, envConns, project, d.composeService, airflowDockerVersion, noBrowser, proxyHostname, proxyPort, portOvr)
+		err = printProxyStatus(settingsFile, envConns, airflowDockerVersion, noBrowser, proxyHostname, proxyPort, portOvr)
 	} else {
-		err = printStatus(settingsFile, envConns, project, d.composeService, airflowDockerVersion, noBrowser)
+		err = printStatus(settingsFile, envConns, airflowDockerVersion, noBrowser)
 	}
 	if err != nil {
 		return err
@@ -1445,12 +1448,6 @@ func (d *DockerCompose) ImportSettings(settingsFile, envFile string, connections
 		pools = true
 	}
 
-	// Get project containers
-	containerID, err := d.getWebServerContainerID()
-	if err != nil {
-		return err
-	}
-
 	fileState, err := fileutil.Exists(settingsFile, nil)
 	if err != nil {
 		return errors.Wrap(err, errSettingsPath)
@@ -1459,7 +1456,15 @@ func (d *DockerCompose) ImportSettings(settingsFile, envFile string, connections
 		return errNoFile
 	}
 
-	err = initSettings(containerID, settingsFile, nil, connections, variables, pools)
+	airflowDockerVersion, err := d.checkAirflowVersion()
+	if err != nil {
+		return err
+	}
+
+	apiURL := airflowAPIURL(airflowDockerVersion)
+	authHeader := airflowAuthHeader(airflowDockerVersion)
+
+	err = initSettings(apiURL, authHeader, settingsFile, nil, connections, variables, pools)
 	if err != nil {
 		return err
 	}
@@ -1706,29 +1711,78 @@ var createDockerProjectWithPorts = func(projectName, airflowHome, envFile, build
 	return project, nil
 }
 
-// printProxyStatus prints status information when the proxy is active.
-func printProxyStatus(settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, project *composetypes.Project, composeService api.Service, airflowMajorVersion uint64, noBrowser bool, hostname, proxyPort string, portOvr *PortOverrides) error {
-	containers, err := composeService.Ps(context.Background(), project.Name, api.PsOptions{
-		All: true,
-	})
+// airflowAPIURL returns the base API URL for the local Airflow instance.
+func airflowAPIURL(airflowMajorVersion uint64) string {
+	var port, apiPrefix string
+	switch airflowMajorVersion {
+	case airflowMajorVersion3:
+		port = config.CFG.APIServerPort.GetString()
+		apiPrefix = "/api/v2"
+	default:
+		port = config.CFG.WebserverPort.GetString()
+		apiPrefix = "/api/v1"
+	}
+	parts := strings.Split(port, ":")
+	return fmt.Sprintf("http://localhost:%s%s", parts[len(parts)-1], apiPrefix)
+}
+
+// airflowAuthHeader returns the Authorization header for the local Airflow instance.
+func airflowAuthHeader(airflowMajorVersion uint64) string {
+	if airflowMajorVersion == airflowMajorVersion2 {
+		return "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:admin"))
+	}
+	// Airflow 3 uses JWT auth via /auth/token endpoint.
+	// With SimpleAuthManager + ALL_ADMINS=True, any credentials work.
+	token, err := fetchLocalAirflowToken(airflowMajorVersion)
 	if err != nil {
-		return errors.Wrap(err, composeStatusCheckErrMsg)
+		logger.Debugf("Unable to fetch Airflow auth token: %s", err)
+		return ""
+	}
+	return token
+}
+
+// fetchLocalAirflowToken gets a JWT token from the local Airflow 3 instance.
+func fetchLocalAirflowToken(airflowMajorVersion uint64) (string, error) {
+	apiURL := airflowAPIURL(airflowMajorVersion)
+	root := strings.TrimSuffix(apiURL, "/api/v2")
+	tokenURL := root + "/auth/token"
+
+	reqBody, _ := json.Marshal(map[string]string{
+		"username": "admin",
+		"password": "admin",
+	})
+
+	resp, err := http.Post(tokenURL, "application/json", bytes.NewReader(reqBody)) //nolint:gosec
+	if err != nil {
+		return "", fmt.Errorf("error fetching token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("auth endpoint returned status %d", resp.StatusCode)
 	}
 
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", fmt.Errorf("decoding auth response: %w", err)
+	}
+	return "Bearer " + tokenResp.AccessToken, nil
+}
+
+// printProxyStatus prints status information when the proxy is active.
+func printProxyStatus(settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, airflowMajorVersion uint64, noBrowser bool, hostname, proxyPort string, portOvr *PortOverrides) error {
 	settingsFileExists, err := fileutil.Exists(settingsFile, nil)
 	if err != nil {
 		return errors.Wrap(err, errSettingsPath)
 	}
 	if settingsFileExists || len(envConns) > 0 {
-		for _, container := range containers { //nolint:gocritic
-			if strings.Contains(container.Name, project.Name) &&
-				(strings.Contains(container.Name, WebserverDockerContainerName) ||
-					strings.Contains(container.Name, APIServerDockerContainerName)) {
-				err = initSettings(container.ID, settingsFile, envConns, true, true, true)
-				if err != nil {
-					return err
-				}
-			}
+		apiURL := airflowAPIURL(airflowMajorVersion)
+		authHeader := airflowAuthHeader(airflowMajorVersion)
+		err = initSettings(apiURL, authHeader, settingsFile, envConns, true, true, true)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -1756,28 +1810,17 @@ func printProxyStatus(settingsFile string, envConns map[string]astrocore.Environ
 	return nil
 }
 
-func printStatus(settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, project *composetypes.Project, composeService api.Service, airflowMajorVersion uint64, noBrowser bool) error {
-	containers, err := composeService.Ps(context.Background(), project.Name, api.PsOptions{
-		All: true,
-	})
-	if err != nil {
-		return errors.Wrap(err, composeStatusCheckErrMsg)
-	}
-
+func printStatus(settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, airflowMajorVersion uint64, noBrowser bool) error {
 	settingsFileExists, err := fileutil.Exists(settingsFile, nil)
 	if err != nil {
 		return errors.Wrap(err, errSettingsPath)
 	}
 	if settingsFileExists || len(envConns) > 0 {
-		for _, container := range containers { //nolint:gocritic
-			if strings.Contains(container.Name, project.Name) &&
-				(strings.Contains(container.Name, WebserverDockerContainerName) ||
-					strings.Contains(container.Name, APIServerDockerContainerName)) {
-				err = initSettings(container.ID, settingsFile, envConns, true, true, true)
-				if err != nil {
-					return err
-				}
-			}
+		apiURL := airflowAPIURL(airflowMajorVersion)
+		authHeader := airflowAuthHeader(airflowMajorVersion)
+		err = initSettings(apiURL, authHeader, settingsFile, envConns, true, true, true)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -70,7 +70,6 @@ const (
 	ruffFilePermission                    = 0o600
 	airflowMajorVersion2           uint64 = 2
 	airflowMajorVersion3           uint64 = 3
-	webserverContainerPort                = 8080
 
 	composeCreateErrMsg      = "error creating docker-compose project"
 	composeStatusCheckErrMsg = "error checking docker-compose status"
@@ -1462,13 +1461,13 @@ func (d *DockerCompose) ImportSettings(settingsFile, envFile string, connections
 		return err
 	}
 
-	// Get the actual published port from the running container, in case
-	// proxy mode allocated a non-default port.
+	// If proxy mode allocated a random port, the actual port is stored in
+	// the proxy route registered during Start. Fall back to config default.
 	var portOvr *PortOverrides
-	if publishedPort, perr := d.getWebServerPublishedPort(); perr == nil {
+	if route, rerr := proxy.GetRouteByProject(d.airflowHome); rerr == nil && route != nil && route.Port != "" {
 		portOvr = &PortOverrides{
-			WebserverPort: publishedPort,
-			APIServerPort: publishedPort,
+			WebserverPort: route.Port,
+			APIServerPort: route.Port,
 		}
 	}
 
@@ -1504,36 +1503,6 @@ func (d *DockerCompose) getWebServerContainerID() (string, error) {
 		}
 	}
 	return "", err
-}
-
-// getWebServerPublishedPort returns the actual host port that maps to the
-// webserver/API server container's port 8080. This handles port overrides
-// allocated dynamically (e.g., by proxy mode).
-func (d *DockerCompose) getWebServerPublishedPort() (string, error) {
-	psInfo, err := d.composeService.Ps(context.Background(), d.projectName, api.PsOptions{
-		All: true,
-	})
-	if err != nil {
-		return "", errors.Wrap(err, composeStatusCheckErrMsg)
-	}
-	if len(psInfo) == 0 {
-		return "", errors.New("project not running, run astro dev start to start project")
-	}
-
-	replacer := strings.NewReplacer("_", "", "-", "")
-	strippedProjectName := replacer.Replace(d.projectName)
-	for i := range psInfo {
-		if strings.Contains(replacer.Replace(psInfo[i].Name), strippedProjectName) &&
-			(strings.Contains(psInfo[i].Name, WebserverDockerContainerName) ||
-				strings.Contains(psInfo[i].Name, APIServerDockerContainerName)) {
-			for _, p := range psInfo[i].Publishers {
-				if p.TargetPort == webserverContainerPort && p.PublishedPort != 0 {
-					return strconv.Itoa(p.PublishedPort), nil
-				}
-			}
-		}
-	}
-	return "", errors.New("could not determine webserver published port")
 }
 
 func (d *DockerCompose) RunDAG(dagID, settingsFile, dagFile, executionDate string, noCache, taskLogs bool) error {

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -1451,12 +1451,6 @@ func (d *DockerCompose) ImportSettings(settingsFile, envFile string, connections
 		return err
 	}
 
-	// Get airflow version
-	airflowDockerVersion, err := d.checkAirflowVersion()
-	if err != nil {
-		return err
-	}
-
 	fileState, err := fileutil.Exists(settingsFile, nil)
 	if err != nil {
 		return errors.Wrap(err, errSettingsPath)
@@ -1465,7 +1459,7 @@ func (d *DockerCompose) ImportSettings(settingsFile, envFile string, connections
 		return errNoFile
 	}
 
-	err = initSettings(containerID, settingsFile, nil, airflowDockerVersion, connections, variables, pools)
+	err = initSettings(containerID, settingsFile, nil, connections, variables, pools)
 	if err != nil {
 		return err
 	}
@@ -1730,7 +1724,7 @@ func printProxyStatus(settingsFile string, envConns map[string]astrocore.Environ
 			if strings.Contains(container.Name, project.Name) &&
 				(strings.Contains(container.Name, WebserverDockerContainerName) ||
 					strings.Contains(container.Name, APIServerDockerContainerName)) {
-				err = initSettings(container.ID, settingsFile, envConns, airflowMajorVersion, true, true, true)
+				err = initSettings(container.ID, settingsFile, envConns, true, true, true)
 				if err != nil {
 					return err
 				}
@@ -1779,7 +1773,7 @@ func printStatus(settingsFile string, envConns map[string]astrocore.EnvironmentO
 			if strings.Contains(container.Name, project.Name) &&
 				(strings.Contains(container.Name, WebserverDockerContainerName) ||
 					strings.Contains(container.Name, APIServerDockerContainerName)) {
-				err = initSettings(container.ID, settingsFile, envConns, airflowMajorVersion, true, true, true)
+				err = initSettings(container.ID, settingsFile, envConns, true, true, true)
 				if err != nil {
 					return err
 				}

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -70,6 +70,7 @@ const (
 	ruffFilePermission                    = 0o600
 	airflowMajorVersion2           uint64 = 2
 	airflowMajorVersion3           uint64 = 3
+	webserverContainerPort                = 8080
 
 	composeCreateErrMsg      = "error creating docker-compose project"
 	composeStatusCheckErrMsg = "error checking docker-compose status"
@@ -1461,8 +1462,18 @@ func (d *DockerCompose) ImportSettings(settingsFile, envFile string, connections
 		return err
 	}
 
-	apiURL := airflowAPIURL(airflowDockerVersion, nil)
-	authHeader := airflowAuthHeader(airflowDockerVersion, nil)
+	// Get the actual published port from the running container, in case
+	// proxy mode allocated a non-default port.
+	var portOvr *PortOverrides
+	if publishedPort, perr := d.getWebServerPublishedPort(); perr == nil {
+		portOvr = &PortOverrides{
+			WebserverPort: publishedPort,
+			APIServerPort: publishedPort,
+		}
+	}
+
+	apiURL := airflowAPIURL(airflowDockerVersion, portOvr)
+	authHeader := airflowAuthHeader(airflowDockerVersion, portOvr)
 
 	err = initSettings(apiURL, authHeader, settingsFile, nil, connections, variables, pools)
 	if err != nil {
@@ -1493,6 +1504,36 @@ func (d *DockerCompose) getWebServerContainerID() (string, error) {
 		}
 	}
 	return "", err
+}
+
+// getWebServerPublishedPort returns the actual host port that maps to the
+// webserver/API server container's port 8080. This handles port overrides
+// allocated dynamically (e.g., by proxy mode).
+func (d *DockerCompose) getWebServerPublishedPort() (string, error) {
+	psInfo, err := d.composeService.Ps(context.Background(), d.projectName, api.PsOptions{
+		All: true,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, composeStatusCheckErrMsg)
+	}
+	if len(psInfo) == 0 {
+		return "", errors.New("project not running, run astro dev start to start project")
+	}
+
+	replacer := strings.NewReplacer("_", "", "-", "")
+	strippedProjectName := replacer.Replace(d.projectName)
+	for i := range psInfo {
+		if strings.Contains(replacer.Replace(psInfo[i].Name), strippedProjectName) &&
+			(strings.Contains(psInfo[i].Name, WebserverDockerContainerName) ||
+				strings.Contains(psInfo[i].Name, APIServerDockerContainerName)) {
+			for _, p := range psInfo[i].Publishers {
+				if p.TargetPort == webserverContainerPort && p.PublishedPort != 0 {
+					return strconv.Itoa(p.PublishedPort), nil
+				}
+			}
+		}
+	}
+	return "", errors.New("could not determine webserver published port")
 }
 
 func (d *DockerCompose) RunDAG(dagID, settingsFile, dagFile, executionDate string, noCache, taskLogs bool) error {
@@ -1751,7 +1792,13 @@ func airflowAuthHeader(airflowMajorVersion uint64, portOvr *PortOverrides) strin
 func fetchLocalAirflowToken(airflowMajorVersion uint64, portOvr *PortOverrides) (string, error) {
 	apiURL := airflowAPIURL(airflowMajorVersion, portOvr)
 	root := strings.TrimSuffix(apiURL, "/api/v2")
-	tokenURL := root + "/auth/token"
+	return fetchAirflowJWTToken(root)
+}
+
+// fetchAirflowJWTToken fetches a JWT token from Airflow 3's /auth/token endpoint.
+// baseURL should be the root URL like "http://localhost:8080" (without /api/v2).
+func fetchAirflowJWTToken(baseURL string) (string, error) {
+	tokenURL := baseURL + "/auth/token"
 
 	reqBody, _ := json.Marshal(map[string]string{
 		"username": "admin",

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -567,7 +567,6 @@ func (s *Suite) TestDockerComposeStart() {
 		imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Times(2)
 		composeMock.On("Up", mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
 
 		checkWebserverHealth = func(url string, timeout time.Duration, component string) error {
@@ -595,7 +594,6 @@ func (s *Suite) TestDockerComposeStart() {
 		imageHandler.On("ListLabels").Return(labels, nil).Times(2)
 
 		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Times(1)
 		composeMock.On("Up", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		checkWebserverHealth = func(url string, timeout time.Duration, component string) error {
@@ -621,7 +619,6 @@ func (s *Suite) TestDockerComposeStart() {
 		imageHandler.On("ListLabels").Return(labels, nil).Times(2)
 
 		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Times(1)
 		composeMock.On("Up", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		checkWebserverHealth = func(url string, timeout time.Duration, component string) error {
@@ -647,7 +644,6 @@ func (s *Suite) TestDockerComposeStart() {
 		imageHandler.On("ListLabels").Return(labels, nil).Times(2)
 
 		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Times(1)
 		composeMock.On("Up", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		checkWebserverHealth = func(url string, timeout time.Duration, component string) error {
@@ -673,7 +669,6 @@ func (s *Suite) TestDockerComposeStart() {
 		imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Times(2)
 		composeMock.On("Up", mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
 
 		checkWebserverHealth = func(url string, timeout time.Duration, component string) error {
@@ -1747,32 +1742,32 @@ func (s *Suite) TestDockerComposeBash() {
 func (s *Suite) TestDockerComposeSettings() {
 	mockDockerCompose := DockerCompose{projectName: "test"}
 	s.Run("import success", func() {
-		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-webserver-id", State: "running", Name: "test-webserver"}}, nil).Once()
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
-		initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
+		initSettings = func(airflowURL, authHeader, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 			return nil
 		}
 
-		mockDockerCompose.composeService = composeMock
+		mockDockerCompose.imageHandler = imageHandler
 
 		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", true, true, true)
 		s.NoError(err)
-		composeMock.AssertExpectations(s.T())
+		imageHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("import failure", func() {
-		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-webserver-id", State: "running", Name: "test-webserver"}}, nil).Once()
-		initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
+		initSettings = func(airflowURL, authHeader, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 			return errMockSettings
 		}
 
-		mockDockerCompose.composeService = composeMock
+		mockDockerCompose.imageHandler = imageHandler
 
 		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", false, false, false)
 		s.ErrorIs(err, errMockSettings)
-		composeMock.AssertExpectations(s.T())
+		imageHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("export success", func() {
@@ -1843,15 +1838,15 @@ func (s *Suite) TestDockerComposeSettings() {
 		composeMock.AssertExpectations(s.T())
 	})
 
-	s.Run("import ps error", func() {
-		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, errMock).Once()
+	s.Run("import list labels error", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("ListLabels").Return(map[string]string{}, errMock).Once()
 
-		mockDockerCompose.composeService = composeMock
+		mockDockerCompose.imageHandler = imageHandler
 
 		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", true, true, true)
 		s.Contains(err.Error(), errMock.Error())
-		composeMock.AssertExpectations(s.T())
+		imageHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("list lables export error", func() {
@@ -1868,15 +1863,7 @@ func (s *Suite) TestDockerComposeSettings() {
 		composeMock.AssertExpectations(s.T())
 	})
 
-	s.Run("compose ps failure import", func() {
-		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, errMockDocker).Once()
-
-		mockDockerCompose.composeService = composeMock
-		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", true, true, true)
-		s.ErrorIs(err, errMockDocker)
-		composeMock.AssertExpectations(s.T())
-	})
+	// Note: ImportSettings no longer calls Ps; version check failure is tested in "import list labels error"
 
 	s.Run("compose ps failure export", func() {
 		composeMock := new(mocks.DockerComposeAPI)
@@ -1885,17 +1872,6 @@ func (s *Suite) TestDockerComposeSettings() {
 		mockDockerCompose.composeService = composeMock
 		err := mockDockerCompose.ExportSettings("./testfiles/airflow_settings.yaml", ".env", true, true, true, false)
 		s.ErrorIs(err, errMockDocker)
-		composeMock.AssertExpectations(s.T())
-	})
-
-	s.Run("project not running import", func() {
-		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Once()
-
-		mockDockerCompose.composeService = composeMock
-
-		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", true, true, true)
-		s.Contains(err.Error(), "project not running, run astro dev start to start project")
 		composeMock.AssertExpectations(s.T())
 	})
 
@@ -1911,17 +1887,8 @@ func (s *Suite) TestDockerComposeSettings() {
 	})
 
 	s.Run("file does not exist import", func() {
-		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-webserver-id", State: "running", Name: "test-webserver"}}, nil).Once()
-		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
-
-		mockDockerCompose.composeService = composeMock
-		mockDockerCompose.imageHandler = imageHandler
-
 		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings_invalid.yaml", ".env", true, true, true)
 		s.Contains(err.Error(), "file specified does not exist")
-		composeMock.AssertExpectations(s.T())
 	})
 
 	s.Run("file does not exist export", func() {
@@ -2151,7 +2118,7 @@ func (s *Suite) TestInitSettings() {
 
 			// Mock initSettings to track if it's called
 			originalInitSettings := initSettings
-			initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
+			initSettings = func(airflowURL, authHeader, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 				initSettingsCalled = true
 				return nil
 			}
@@ -2164,13 +2131,9 @@ func (s *Suite) TestInitSettings() {
 			}
 			defer func() { openURL = originalOpenURL }()
 
-			composeMock := new(mocks.DockerComposeAPI)
-			composeMock.On("Ps", mock.Anything, tc.project.Name, api.PsOptions{All: true}).Return(tc.containerSummary, nil).Once()
-
-			err := printStatus(tc.settingsFile, tc.envConns, tc.project, composeMock, tc.airflowMajorVersion, true)
+			err := printStatus(tc.settingsFile, tc.envConns, tc.airflowMajorVersion, true)
 			s.NoError(err)
 			s.Equal(tc.expectInitSettingsCalled, initSettingsCalled)
-			composeMock.AssertExpectations(s.T())
 		})
 	}
 }

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1750,15 +1750,11 @@ func (s *Suite) TestDockerComposeSettings() {
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-webserver-id", State: "running", Name: "test-webserver"}}, nil).Once()
 
-		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
-
 		initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 			return nil
 		}
 
 		mockDockerCompose.composeService = composeMock
-		mockDockerCompose.imageHandler = imageHandler
 
 		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", true, true, true)
 		s.NoError(err)
@@ -1768,14 +1764,11 @@ func (s *Suite) TestDockerComposeSettings() {
 	s.Run("import failure", func() {
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-webserver-id", State: "running", Name: "test-webserver"}}, nil).Once()
-		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 		initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 			return errMockSettings
 		}
 
 		mockDockerCompose.composeService = composeMock
-		mockDockerCompose.imageHandler = imageHandler
 
 		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", false, false, false)
 		s.ErrorIs(err, errMockSettings)
@@ -1850,14 +1843,11 @@ func (s *Suite) TestDockerComposeSettings() {
 		composeMock.AssertExpectations(s.T())
 	})
 
-	s.Run("list lables import error", func() {
+	s.Run("import ps error", func() {
 		composeMock := new(mocks.DockerComposeAPI)
-		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-webserver-id", State: "running", Name: "test-webserver"}}, nil).Once()
-		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("ListLabels").Return(map[string]string{}, errMock).Once()
+		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, errMock).Once()
 
 		mockDockerCompose.composeService = composeMock
-		mockDockerCompose.imageHandler = imageHandler
 
 		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", true, true, true)
 		s.Contains(err.Error(), errMock.Error())

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1745,11 +1745,15 @@ func (s *Suite) TestDockerComposeSettings() {
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
+		composeMock := new(mocks.DockerComposeAPI)
+		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Maybe()
+
 		initSettings = func(airflowURL, authHeader, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 			return nil
 		}
 
 		mockDockerCompose.imageHandler = imageHandler
+		mockDockerCompose.composeService = composeMock
 
 		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", true, true, true)
 		s.NoError(err)
@@ -1759,11 +1763,16 @@ func (s *Suite) TestDockerComposeSettings() {
 	s.Run("import failure", func() {
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
+
+		composeMock := new(mocks.DockerComposeAPI)
+		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Maybe()
+
 		initSettings = func(airflowURL, authHeader, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 			return errMockSettings
 		}
 
 		mockDockerCompose.imageHandler = imageHandler
+		mockDockerCompose.composeService = composeMock
 
 		err := mockDockerCompose.ImportSettings("./testfiles/airflow_settings.yaml", ".env", false, false, false)
 		s.ErrorIs(err, errMockSettings)

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1753,7 +1753,7 @@ func (s *Suite) TestDockerComposeSettings() {
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
 
-		initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, version uint64, connections, variables, pools bool) error {
+		initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 			return nil
 		}
 
@@ -1770,7 +1770,7 @@ func (s *Suite) TestDockerComposeSettings() {
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{{ID: "test-webserver-id", State: "running", Name: "test-webserver"}}, nil).Once()
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: airflowVersionLabel}, nil).Once()
-		initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, version uint64, connections, variables, pools bool) error {
+		initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 			return errMockSettings
 		}
 
@@ -2161,7 +2161,7 @@ func (s *Suite) TestInitSettings() {
 
 			// Mock initSettings to track if it's called
 			originalInitSettings := initSettings
-			initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, version uint64, connections, variables, pools bool) error {
+			initSettings = func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 				initSettingsCalled = true
 				return nil
 			}

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -597,7 +597,7 @@ func (s *Standalone) buildEnv() []string {
 	return env
 }
 
-// applySettings imports airflow_settings.yaml using airflow CLI commands run via the venv.
+// applySettings imports airflow_settings.yaml using the Airflow REST API.
 func (s *Standalone) applySettings(settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection) error {
 	settingsExists, err := fileutil.Exists(settingsFile, nil)
 	if err != nil || !settingsExists {
@@ -606,11 +606,8 @@ func (s *Standalone) applySettings(settingsFile string, envConns map[string]astr
 		}
 	}
 
-	// Temporarily swap the execAirflowCommand to use venv instead of docker
-	origExec := settings.SetExecAirflowCommand(s.standaloneExecAirflowCommand)
-	defer settings.SetExecAirflowCommand(origExec)
-
-	return settings.ConfigSettings("standalone", settingsFile, envConns, true, true, true)
+	apiURL := fmt.Sprintf("http://localhost:%s/api/v2", s.webserverPort())
+	return settings.ConfigSettings(apiURL, "", settingsFile, envConns, true, true, true)
 }
 
 // standaloneExecAirflowCommand runs an airflow command via the local venv.
@@ -883,10 +880,8 @@ func (s *Standalone) ImportSettings(settingsFile, _ string, connections, variabl
 		return errors.New("file specified does not exist")
 	}
 
-	origExec := settings.SetExecAirflowCommand(s.standaloneExecAirflowCommand)
-	defer settings.SetExecAirflowCommand(origExec)
-
-	err = settings.ConfigSettings("standalone", settingsFile, nil, connections, variables, pools)
+	apiURL := fmt.Sprintf("http://localhost:%s/api/v2", s.webserverPort())
+	err = settings.ConfigSettings(apiURL, "", settingsFile, nil, connections, variables, pools)
 	if err != nil {
 		return err
 	}

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -610,7 +610,7 @@ func (s *Standalone) applySettings(settingsFile string, envConns map[string]astr
 	origExec := settings.SetExecAirflowCommand(s.standaloneExecAirflowCommand)
 	defer settings.SetExecAirflowCommand(origExec)
 
-	return settings.ConfigSettings("standalone", settingsFile, envConns, 3, true, true, true) //nolint:mnd
+	return settings.ConfigSettings("standalone", settingsFile, envConns, true, true, true)
 }
 
 // standaloneExecAirflowCommand runs an airflow command via the local venv.
@@ -886,7 +886,7 @@ func (s *Standalone) ImportSettings(settingsFile, _ string, connections, variabl
 	origExec := settings.SetExecAirflowCommand(s.standaloneExecAirflowCommand)
 	defer settings.SetExecAirflowCommand(origExec)
 
-	err = settings.ConfigSettings("standalone", settingsFile, nil, 3, connections, variables, pools) //nolint:mnd
+	err = settings.ConfigSettings("standalone", settingsFile, nil, connections, variables, pools)
 	if err != nil {
 		return err
 	}

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -126,19 +126,6 @@ func (s *Standalone) pidFilePath() string {
 	return filepath.Join(s.airflowHome, standaloneDir, standalonePIDFile)
 }
 
-func (s *Standalone) portFilePath() string {
-	return filepath.Join(s.airflowHome, standaloneDir, "port")
-}
-
-// readPersistedPort reads the port from the state file, returns empty string if not found.
-func (s *Standalone) readPersistedPort() string {
-	data, err := os.ReadFile(s.portFilePath())
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(data))
-}
-
 func (s *Standalone) logFilePath() string {
 	return filepath.Join(s.airflowHome, standaloneDir, standaloneLogFile)
 }
@@ -342,9 +329,6 @@ func (s *Standalone) startForeground(cmd *exec.Cmd, waitTime time.Duration, sett
 		return fmt.Errorf("error starting airflow standalone: %w", err)
 	}
 
-	// Persist the port for subsequent commands (object import, etc.)
-	_ = os.WriteFile(s.portFilePath(), []byte(s.webserverPort()), filePermissions)
-
 	// Forward signals to the entire process group so child processes
 	// (scheduler, triggerer, api-server, etc.) are also terminated.
 	sigChan := make(chan os.Signal, 1)
@@ -460,9 +444,6 @@ func (s *Standalone) startBackground(cmd *exec.Cmd, waitTime time.Duration, sett
 		syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) //nolint:errcheck
 		return fmt.Errorf("error writing PID file: %w", err)
 	}
-	// Persist the port so subsequent commands (object import, etc.) can find it.
-	_ = os.WriteFile(s.portFilePath(), []byte(s.webserverPort()), filePermissions)
-
 	// Run health check (blocking — wait for healthy or timeout)
 	healthURL, healthComp := s.healthEndpoint()
 	err = checkWebserverHealth(healthURL, waitTime, healthComp)
@@ -670,7 +651,6 @@ func (s *Standalone) Stop(_ bool) error {
 	if !alive {
 		// Stale PID file — clean up
 		os.Remove(s.pidFilePath())
-		os.Remove(s.portFilePath())
 		fmt.Println("No standalone Airflow process found (cleaned up stale PID file).")
 		return nil
 	}
@@ -694,7 +674,6 @@ func (s *Standalone) Stop(_ bool) error {
 	}
 
 	os.Remove(s.pidFilePath())
-	os.Remove(s.portFilePath())
 	fmt.Println("Airflow standalone stopped.")
 	return nil
 }
@@ -907,11 +886,11 @@ func (s *Standalone) ImportSettings(settingsFile, _ string, connections, variabl
 		return errors.New("file specified does not exist")
 	}
 
-	// Prefer the persisted port from when standalone was started, since it
-	// may differ from config (e.g., when proxy mode allocated a random port).
-	port := s.readPersistedPort()
-	if port == "" {
-		port = s.webserverPort()
+	// If proxy mode allocated a random port, the actual port is stored in
+	// the proxy route registered during Start. Fall back to config default.
+	port := s.webserverPort()
+	if route, rerr := proxy.GetRouteByProject(s.airflowHome); rerr == nil && route != nil && route.Port != "" {
+		port = route.Port
 	}
 
 	apiURL := fmt.Sprintf("http://localhost:%s/api/v2", port)

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -872,6 +872,11 @@ func (s *Standalone) RunDAG(_, _, _, _ string, _, _ bool) error {
 
 // ImportSettings imports connections/variables/pools from the settings file.
 func (s *Standalone) ImportSettings(settingsFile, _ string, connections, variables, pools bool) error {
+	// Verify standalone is actually running before attempting to import.
+	if _, alive := s.readPID(); !alive {
+		return errors.New("standalone Airflow is not running, run astro dev start --standalone to start it")
+	}
+
 	if !connections && !variables && !pools {
 		connections = true
 		variables = true

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -126,6 +126,19 @@ func (s *Standalone) pidFilePath() string {
 	return filepath.Join(s.airflowHome, standaloneDir, standalonePIDFile)
 }
 
+func (s *Standalone) portFilePath() string {
+	return filepath.Join(s.airflowHome, standaloneDir, "port")
+}
+
+// readPersistedPort reads the port from the state file, returns empty string if not found.
+func (s *Standalone) readPersistedPort() string {
+	data, err := os.ReadFile(s.portFilePath())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 func (s *Standalone) logFilePath() string {
 	return filepath.Join(s.airflowHome, standaloneDir, standaloneLogFile)
 }
@@ -329,6 +342,9 @@ func (s *Standalone) startForeground(cmd *exec.Cmd, waitTime time.Duration, sett
 		return fmt.Errorf("error starting airflow standalone: %w", err)
 	}
 
+	// Persist the port for subsequent commands (object import, etc.)
+	_ = os.WriteFile(s.portFilePath(), []byte(s.webserverPort()), filePermissions)
+
 	// Forward signals to the entire process group so child processes
 	// (scheduler, triggerer, api-server, etc.) are also terminated.
 	sigChan := make(chan os.Signal, 1)
@@ -444,6 +460,8 @@ func (s *Standalone) startBackground(cmd *exec.Cmd, waitTime time.Duration, sett
 		syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM) //nolint:errcheck
 		return fmt.Errorf("error writing PID file: %w", err)
 	}
+	// Persist the port so subsequent commands (object import, etc.) can find it.
+	_ = os.WriteFile(s.portFilePath(), []byte(s.webserverPort()), filePermissions)
 
 	// Run health check (blocking — wait for healthy or timeout)
 	healthURL, healthComp := s.healthEndpoint()
@@ -606,8 +624,15 @@ func (s *Standalone) applySettings(settingsFile string, envConns map[string]astr
 		}
 	}
 
-	apiURL := fmt.Sprintf("http://localhost:%s/api/v2", s.webserverPort())
-	return settings.ConfigSettings(apiURL, "", settingsFile, envConns, true, true, true)
+	port := s.webserverPort()
+	apiURL := fmt.Sprintf("http://localhost:%s/api/v2", port)
+	// Standalone mode runs Airflow 3 with SimpleAuthManager — fetch a JWT token.
+	authHeader, err := fetchAirflowJWTToken(fmt.Sprintf("http://localhost:%s", port))
+	if err != nil {
+		logger.Debugf("Unable to fetch Airflow auth token for standalone: %s", err)
+		authHeader = ""
+	}
+	return settings.ConfigSettings(apiURL, authHeader, settingsFile, envConns, true, true, true)
 }
 
 // standaloneExecAirflowCommand runs an airflow command via the local venv.
@@ -645,6 +670,7 @@ func (s *Standalone) Stop(_ bool) error {
 	if !alive {
 		// Stale PID file — clean up
 		os.Remove(s.pidFilePath())
+		os.Remove(s.portFilePath())
 		fmt.Println("No standalone Airflow process found (cleaned up stale PID file).")
 		return nil
 	}
@@ -668,6 +694,7 @@ func (s *Standalone) Stop(_ bool) error {
 	}
 
 	os.Remove(s.pidFilePath())
+	os.Remove(s.portFilePath())
 	fmt.Println("Airflow standalone stopped.")
 	return nil
 }
@@ -880,8 +907,21 @@ func (s *Standalone) ImportSettings(settingsFile, _ string, connections, variabl
 		return errors.New("file specified does not exist")
 	}
 
-	apiURL := fmt.Sprintf("http://localhost:%s/api/v2", s.webserverPort())
-	err = settings.ConfigSettings(apiURL, "", settingsFile, nil, connections, variables, pools)
+	// Prefer the persisted port from when standalone was started, since it
+	// may differ from config (e.g., when proxy mode allocated a random port).
+	port := s.readPersistedPort()
+	if port == "" {
+		port = s.webserverPort()
+	}
+
+	apiURL := fmt.Sprintf("http://localhost:%s/api/v2", port)
+	authHeader, err := fetchAirflowJWTToken(fmt.Sprintf("http://localhost:%s", port))
+	if err != nil {
+		logger.Debugf("Unable to fetch Airflow auth token for standalone: %s", err)
+		authHeader = ""
+	}
+
+	err = settings.ConfigSettings(apiURL, authHeader, settingsFile, nil, connections, variables, pools)
 	if err != nil {
 		return err
 	}

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -1547,7 +1547,7 @@ func (s *Suite) TestStandaloneBash_Success() {
 
 // --- ImportSettings tests ---
 
-func (s *Suite) TestStandaloneImportSettings_FileNotFound() {
+func (s *Suite) TestStandaloneImportSettings_NotRunning() {
 	tmpDir, err := os.MkdirTemp("", "standalone-import")
 	s.NoError(err)
 	defer os.RemoveAll(tmpDir)
@@ -1557,7 +1557,7 @@ func (s *Suite) TestStandaloneImportSettings_FileNotFound() {
 
 	err = handler.ImportSettings(filepath.Join(tmpDir, "nonexistent.yaml"), "", false, false, false)
 	s.Error(err)
-	s.Contains(err.Error(), "file specified does not exist")
+	s.Contains(err.Error(), "standalone Airflow is not running")
 }
 
 func (s *Suite) TestStandaloneImportSettings_DefaultsAllFlags() {
@@ -1573,14 +1573,11 @@ func (s *Suite) TestStandaloneImportSettings_DefaultsAllFlags() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	// This will fail because there's no real airflow to exec, but we can verify
-	// it gets past the file check and flag defaulting
+	// Without a running standalone process, ImportSettings should fail
+	// with a "not running" error before reaching the file check
 	err = handler.ImportSettings(settingsFile, "", false, false, false)
-	// Error is expected since we don't have a real venv, but it should NOT be
-	// "file specified does not exist"
-	if err != nil {
-		s.NotContains(err.Error(), "file specified does not exist")
-	}
+	s.Error(err)
+	s.Contains(err.Error(), "standalone Airflow is not running")
 }
 
 // --- ExportSettings tests ---

--- a/airflow/suite_test.go
+++ b/airflow/suite_test.go
@@ -17,7 +17,7 @@ type Suite struct {
 	suite.Suite
 	origCmdExec              func(cmd string, stdout, stderr io.Writer, args ...string) error
 	origGetDockerClient      func() (client.APIClient, error)
-	origInitSettings         func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error
+	origInitSettings         func(airflowURL, authHeader, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error
 	origCheckWebserverHealth func(url string, timeout time.Duration, component string) error
 	origCheckPortAvailable   func(port string) error
 	origResolveFloatingTag   func(tag string) (string, error)

--- a/airflow/suite_test.go
+++ b/airflow/suite_test.go
@@ -17,7 +17,7 @@ type Suite struct {
 	suite.Suite
 	origCmdExec              func(cmd string, stdout, stderr io.Writer, args ...string) error
 	origGetDockerClient      func() (client.APIClient, error)
-	origInitSettings         func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, version uint64, connections, variables, pools bool) error
+	origInitSettings         func(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error
 	origCheckWebserverHealth func(url string, timeout time.Duration, component string) error
 	origCheckPortAvailable   func(port string) error
 	origResolveFloatingTag   func(tag string) (string, error)

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -159,7 +159,8 @@ func airflowAPIRequest(method, requestURL, authHeader string, body []byte) (resp
 }
 
 // airflowAPIUpsert creates a resource via POST, and if it already exists (409), updates via PATCH.
-func airflowAPIUpsert(baseURL, resource, id, authHeader string, body []byte) error {
+// updateSuffix is appended to the PATCH URL (e.g., "?update_mask=slots" for default_pool).
+func airflowAPIUpsert(baseURL, resource, id, authHeader string, body []byte, updateSuffix string) error {
 	createURL := fmt.Sprintf("%s/%s", baseURL, resource)
 	respBody, status, err := airflowAPIRequest(http.MethodPost, createURL, authHeader, body)
 	if err != nil {
@@ -170,7 +171,7 @@ func airflowAPIUpsert(baseURL, resource, id, authHeader string, body []byte) err
 	}
 	if status == http.StatusConflict {
 		// Already exists — update via PATCH
-		updateURL := fmt.Sprintf("%s/%s/%s", baseURL, resource, id)
+		updateURL := fmt.Sprintf("%s/%s/%s%s", baseURL, resource, id, updateSuffix)
 		respBody, status, err = airflowAPIRequest(http.MethodPatch, updateURL, authHeader, body)
 		if err != nil {
 			return err
@@ -204,7 +205,7 @@ func AddVariables(airflowURL, authHeader string) error {
 		if err != nil {
 			return fmt.Errorf("error marshaling variable %s: %w", variable.VariableName, err)
 		}
-		if err := airflowAPIUpsert(airflowURL, "variables", variable.VariableName, authHeader, body); err != nil {
+		if err := airflowAPIUpsert(airflowURL, "variables", variable.VariableName, authHeader, body, ""); err != nil {
 			return fmt.Errorf("error adding variable %s: %w", variable.VariableName, err)
 		}
 		fmt.Printf("Added Variable: %s\n", variable.VariableName)
@@ -232,7 +233,7 @@ func AddConnections(airflowURL, authHeader string, envConns map[string]astrocore
 		if err != nil {
 			return fmt.Errorf("error marshaling connection %s: %w", conn.ConnID, err)
 		}
-		if err := airflowAPIUpsert(airflowURL, "connections", conn.ConnID, authHeader, body); err != nil {
+		if err := airflowAPIUpsert(airflowURL, "connections", conn.ConnID, authHeader, body, ""); err != nil {
 			return fmt.Errorf("error adding connection %s: %w", conn.ConnID, err)
 		}
 		fmt.Printf("Added Connection: %s\n", conn.ConnID)
@@ -381,7 +382,12 @@ func AddPools(airflowURL, authHeader string) error {
 		if err != nil {
 			return fmt.Errorf("error marshaling pool %s: %w", pool.PoolName, err)
 		}
-		if err := airflowAPIUpsert(airflowURL, "pools", pool.PoolName, authHeader, body); err != nil {
+		// default_pool only allows updating slots and include_deferred
+		updateSuffix := ""
+		if pool.PoolName == "default_pool" {
+			updateSuffix = "?update_mask=slots&update_mask=include_deferred"
+		}
+		if err := airflowAPIUpsert(airflowURL, "pools", pool.PoolName, authHeader, body, updateSuffix); err != nil {
 			return fmt.Errorf("error adding pool %s: %w", pool.PoolName, err)
 		}
 		fmt.Printf("Added Pool: %s\n", pool.PoolName)

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -1,8 +1,12 @@
 package settings
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -53,31 +57,50 @@ const (
 )
 
 var (
-	errNoID = errors.New("container ID is not found, the webserver may not be running")
-	re      = regexp.MustCompile(noColorString)
+	errNoURL = errors.New("airflow API URL is not set, the webserver may not be running")
+	errNoID  = errors.New("container ID is not found, the webserver may not be running")
+	re       = regexp.MustCompile(noColorString)
+
+	// httpClient is the HTTP client used for Airflow API calls. Replaceable for testing.
+	httpClient HTTPDoer = http.DefaultClient
 )
 
-// ConfigSettings is the main builder of the settings package
-func ConfigSettings(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
-	if id == "" {
-		return errNoID
+// HTTPDoer is an interface for making HTTP requests, allowing test mocking.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// SetHTTPClient replaces the HTTP client used for Airflow API calls.
+// It returns the previous client so callers can restore it.
+func SetHTTPClient(c HTTPDoer) HTTPDoer {
+	prev := httpClient
+	httpClient = c
+	return prev
+}
+
+// ConfigSettings is the main builder of the settings package.
+// airflowURL is the base API URL (e.g., "http://localhost:8080/api/v1").
+// authHeader is an optional Authorization header value (e.g., "Basic ...").
+func ConfigSettings(airflowURL, authHeader, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
+	if airflowURL == "" {
+		return errNoURL
 	}
 	err := InitSettings(settingsFile)
 	if err != nil {
 		logger.Debugf("Unable to initialize settings file: %s", err)
 	}
 	if pools {
-		if err := AddPools(id); err != nil {
+		if err := AddPools(airflowURL, authHeader); err != nil {
 			return fmt.Errorf("error adding pools: %w", err)
 		}
 	}
 	if variables {
-		if err := AddVariables(id); err != nil {
+		if err := AddVariables(airflowURL, authHeader); err != nil {
 			return fmt.Errorf("error adding variables: %w", err)
 		}
 	}
 	if connections {
-		if err := AddConnections(id, envConns); err != nil {
+		if err := AddConnections(airflowURL, authHeader, envConns); err != nil {
 			return fmt.Errorf("error adding connections: %w", err)
 		}
 	}
@@ -108,18 +131,61 @@ func InitSettings(settingsFile string) error {
 	return nil
 }
 
-// buildBatchImportCommand builds a compound shell command that writes jsonContent
-// to tmpFile via heredoc, runs importCmd against that file, then cleans up.
-func buildBatchImportCommand(tmpFile, importCmd, jsonContent string) string {
-	return fmt.Sprintf("cat > %s <<'__ASTRO_CLI_EOF__'\n%s\n__ASTRO_CLI_EOF__\n%s %s; _ret=$?; rm -f %s; exit $_ret",
-		tmpFile, jsonContent, importCmd, tmpFile, tmpFile)
+// airflowAPIRequest makes an HTTP request to the Airflow REST API.
+// It returns the response body and status code.
+func airflowAPIRequest(method, requestURL, authHeader string, body []byte) (respBody []byte, statusCode int, err error) {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, requestURL, bodyReader) //nolint:gosec
+	if err != nil {
+		return nil, 0, fmt.Errorf("error creating request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error making request to %s: %w", requestURL, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ = io.ReadAll(resp.Body)
+	return respBody, resp.StatusCode, nil
 }
 
-// AddVariables is a function to add Variables from settings.yaml
-func AddVariables(id string) error {
+// airflowAPIUpsert creates a resource via POST, and if it already exists (409), updates via PATCH.
+func airflowAPIUpsert(baseURL, resource, id, authHeader string, body []byte) error {
+	createURL := fmt.Sprintf("%s/%s", baseURL, resource)
+	respBody, status, err := airflowAPIRequest(http.MethodPost, createURL, authHeader, body)
+	if err != nil {
+		return err
+	}
+	if status >= 200 && status < 300 {
+		return nil
+	}
+	if status == http.StatusConflict {
+		// Already exists — update via PATCH
+		updateURL := fmt.Sprintf("%s/%s/%s", baseURL, resource, id)
+		respBody, status, err = airflowAPIRequest(http.MethodPatch, updateURL, authHeader, body)
+		if err != nil {
+			return err
+		}
+		if status >= 200 && status < 300 {
+			return nil
+		}
+		return fmt.Errorf("error updating %s %s (HTTP %d): %s", resource, id, status, string(respBody))
+	}
+	return fmt.Errorf("error creating %s %s (HTTP %d): %s", resource, id, status, string(respBody))
+}
+
+// AddVariables adds Variables from settings.yaml via the Airflow REST API.
+func AddVariables(airflowURL, authHeader string) error {
 	variables := settings.Airflow.Variables
-	varsMap := make(map[string]string)
-	var names []string
 	for _, variable := range variables {
 		if !objectValidator(0, variable.VariableName) {
 			if objectValidator(0, variable.VariableValue) {
@@ -130,51 +196,67 @@ func AddVariables(id string) error {
 		if !objectValidator(0, variable.VariableValue) {
 			continue
 		}
-		varsMap[variable.VariableName] = variable.VariableValue
-		names = append(names, variable.VariableName)
-	}
-	if len(varsMap) == 0 {
-		return nil
-	}
 
-	jsonBytes, err := json.Marshal(varsMap)
-	if err != nil {
-		return fmt.Errorf("error marshaling variables to JSON: %w", err)
-	}
-
-	cmd := buildBatchImportCommand("/tmp/astro_import_variables.json", "airflow variables import", string(jsonBytes))
-	out, err := execAirflowCommand(id, cmd)
-	if err != nil {
-		return fmt.Errorf("error importing variables: %w", err)
-	}
-	logger.Debugf("Batch import variables logs:\n%s", out)
-	for _, name := range names {
-		fmt.Printf("Added Variable: %s\n", name)
+		body, err := json.Marshal(map[string]string{
+			"key":   variable.VariableName,
+			"value": variable.VariableValue,
+		})
+		if err != nil {
+			return fmt.Errorf("error marshaling variable %s: %w", variable.VariableName, err)
+		}
+		if err := airflowAPIUpsert(airflowURL, "variables", variable.VariableName, authHeader, body); err != nil {
+			return fmt.Errorf("error adding variable %s: %w", variable.VariableName, err)
+		}
+		fmt.Printf("Added Variable: %s\n", variable.VariableName)
 	}
 	return nil
 }
 
-// AddConnections is a function to add Connections from settings.yaml
-func AddConnections(id string, envConns map[string]astrocore.EnvironmentObjectConnection) error {
+// AddConnections adds Connections from settings.yaml via the Airflow REST API.
+func AddConnections(airflowURL, authHeader string, envConns map[string]astrocore.EnvironmentObjectConnection) error {
 	connections := settings.Airflow.Connections
 	connections = AppendEnvironmentConnections(connections, envConns)
 
-	return addConnectionsBatch(id, connections)
+	for i := range connections {
+		conn := connections[i]
+		if !objectValidator(0, conn.ConnID) {
+			continue
+		}
+		if !objectValidator(1, conn.ConnType, conn.ConnURI) {
+			fmt.Printf("Skipping %s: conn_type or conn_uri must be specified.\n", conn.ConnID)
+			continue
+		}
+
+		apiConn := connectionToAPIObject(&conn)
+		body, err := json.Marshal(apiConn)
+		if err != nil {
+			return fmt.Errorf("error marshaling connection %s: %w", conn.ConnID, err)
+		}
+		if err := airflowAPIUpsert(airflowURL, "connections", conn.ConnID, authHeader, body); err != nil {
+			return fmt.Errorf("error adding connection %s: %w", conn.ConnID, err)
+		}
+		fmt.Printf("Added Connection: %s\n", conn.ConnID)
+	}
+	return nil
 }
 
-// connectionImportObject builds the JSON value for a single connection in the
-// airflow connections import format.
-func connectionImportObject(conn *Connection) interface{} {
-	// URI-only connection: if conn_uri is set and no individual fields are populated
+// connectionToAPIObject converts a settings Connection to the Airflow REST API format.
+func connectionToAPIObject(conn *Connection) map[string]interface{} {
+	obj := map[string]interface{}{
+		"connection_id": conn.ConnID,
+	}
+
+	// URI-only connection: parse the URI into individual fields
 	hasFields := objectValidator(0, conn.ConnType) || objectValidator(0, conn.ConnHost) ||
 		objectValidator(0, conn.ConnLogin) || objectValidator(0, conn.ConnPassword) ||
 		objectValidator(0, conn.ConnSchema) || conn.ConnPort != 0
 	if objectValidator(0, conn.ConnURI) && !hasFields {
-		return conn.ConnURI
+		parseConnectionURI(conn.ConnURI, obj)
+		return obj
 	}
 
-	obj := map[string]interface{}{
-		"conn_type": conn.ConnType,
+	if objectValidator(0, conn.ConnType) {
+		obj["conn_type"] = conn.ConnType
 	}
 	if objectValidator(0, conn.ConnHost) {
 		obj["host"] = conn.ConnHost
@@ -191,86 +273,52 @@ func connectionImportObject(conn *Connection) interface{} {
 	if conn.ConnPort != 0 {
 		obj["port"] = conn.ConnPort
 	}
-	if extra := connExtraObject(conn.ConnExtra); extra != nil {
+	if extra := connExtraString(conn.ConnExtra); extra != "" {
 		obj["extra"] = extra
 	}
 	return obj
 }
 
-// connExtraObject converts ConnExtra (which can be various types) into a
-// map[string]interface{} suitable for JSON marshaling in the import file.
-func connExtraObject(extra interface{}) interface{} {
-	switch v := extra.(type) {
-	case nil:
-		return nil
-	case string:
-		if v == "" {
-			return nil
+// parseConnectionURI parses a connection URI into individual fields in the obj map.
+func parseConnectionURI(connURI string, obj map[string]interface{}) {
+	parsed, err := url.Parse(connURI)
+	if err != nil {
+		return
+	}
+	obj["conn_type"] = parsed.Scheme
+	obj["host"] = parsed.Hostname()
+	if parsed.User != nil {
+		obj["login"] = parsed.User.Username()
+		if pwd, ok := parsed.User.Password(); ok {
+			obj["password"] = pwd
 		}
-		// Try to parse JSON string back to a map
-		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(v), &m); err == nil {
-			return m
+	}
+	if p := parsed.Port(); p != "" {
+		if port, err := strconv.Atoi(p); err == nil {
+			obj["port"] = port
 		}
-		// If it's not valid JSON, return as-is (Airflow accepts string extras)
-		return v
-	case map[any]any:
-		m := make(map[string]interface{})
-		for k, val := range v {
-			kStr, ok := k.(string)
-			if !ok {
-				continue
-			}
-			m[kStr] = val
-		}
-		if len(m) == 0 {
-			return nil
-		}
-		return m
-	case map[string]any:
-		if len(v) == 0 {
-			return nil
-		}
-		return v
-	default:
-		return nil
+	}
+	if parsed.Path != "" {
+		obj["schema"] = strings.TrimPrefix(parsed.Path, "/")
+	}
+	if parsed.RawQuery != "" {
+		obj["extra"] = "{" + queryToJSONPairs(parsed.Query()) + "}"
 	}
 }
 
-func addConnectionsBatch(id string, connections Connections) error {
-	connMap := make(map[string]interface{})
-	var names []string
-	for i := range connections {
-		conn := connections[i]
-		if !objectValidator(0, conn.ConnID) {
-			continue
-		}
-		if !objectValidator(1, conn.ConnType, conn.ConnURI) {
-			fmt.Printf("Skipping %s: conn_type or conn_uri must be specified.\n", conn.ConnID)
-			continue
-		}
-		connMap[conn.ConnID] = connectionImportObject(&conn)
-		names = append(names, conn.ConnID)
+// queryToJSONPairs converts URL query parameters to JSON key-value pair strings.
+func queryToJSONPairs(values url.Values) string {
+	pairs := make([]string, 0, len(values))
+	for k, v := range values {
+		val := strings.Join(v, ",")
+		pairs = append(pairs, fmt.Sprintf("%q: %q", k, val))
 	}
-	if len(connMap) == 0 {
-		return nil
-	}
+	return strings.Join(pairs, ", ")
+}
 
-	jsonBytes, err := json.Marshal(connMap)
-	if err != nil {
-		return fmt.Errorf("error marshaling connections to JSON: %w", err)
-	}
-
-	cmd := buildBatchImportCommand("/tmp/astro_import_connections.json", "airflow connections import --overwrite", string(jsonBytes))
-	out, err := execAirflowCommand(id, cmd)
-	if err != nil {
-		return fmt.Errorf("error importing connections: %w", err)
-	}
-	logger.Debugf("Batch import connections logs:\n%s", out)
-	for _, name := range names {
-		fmt.Printf("Added Connection: %s\n", name)
-	}
-	return nil
+// connExtraString converts ConnExtra to a JSON string for the Airflow REST API.
+func connExtraString(extra interface{}) string {
+	return jsonString(&Connection{ConnExtra: extra})
 }
 
 func AppendEnvironmentConnections(connections Connections, envConnections map[string]astrocore.EnvironmentObjectConnection) Connections {
@@ -312,15 +360,9 @@ func AppendEnvironmentConnections(connections Connections, envConnections map[st
 	return connections
 }
 
-// AddPools is a function to add Pools from settings.yaml
-func AddPools(id string) error {
+// AddPools adds Pools from settings.yaml via the Airflow REST API.
+func AddPools(airflowURL, authHeader string) error {
 	pools := settings.Airflow.Pools
-	return addPoolsBatch(id, pools)
-}
-
-func addPoolsBatch(id string, pools Pools) error {
-	poolMap := make(map[string]poolImportEntry)
-	var names []string
 	for _, pool := range pools {
 		if !objectValidator(0, pool.PoolName) {
 			continue
@@ -329,29 +371,20 @@ func addPoolsBatch(id string, pools Pools) error {
 			fmt.Printf("Skipping %s: Pool Slot must be set.\n", pool.PoolName)
 			continue
 		}
-		poolMap[pool.PoolName] = poolImportEntry{
-			Slots:       pool.PoolSlot,
-			Description: pool.PoolDescription,
+
+		body, err := json.Marshal(map[string]interface{}{
+			"name":             pool.PoolName,
+			"slots":            pool.PoolSlot,
+			"description":      pool.PoolDescription,
+			"include_deferred": false,
+		})
+		if err != nil {
+			return fmt.Errorf("error marshaling pool %s: %w", pool.PoolName, err)
 		}
-		names = append(names, pool.PoolName)
-	}
-	if len(poolMap) == 0 {
-		return nil
-	}
-
-	jsonBytes, err := json.Marshal(poolMap)
-	if err != nil {
-		return fmt.Errorf("error marshaling pools to JSON: %w", err)
-	}
-
-	cmd := buildBatchImportCommand("/tmp/astro_import_pools.json", "airflow pools import", string(jsonBytes))
-	out, err := execAirflowCommand(id, cmd)
-	if err != nil {
-		return fmt.Errorf("error importing pools: %w", err)
-	}
-	logger.Debugf("Batch import pools logs:\n%s", out)
-	for _, name := range names {
-		fmt.Printf("Added Pool: %s\n", name)
+		if err := airflowAPIUpsert(airflowURL, "pools", pool.PoolName, authHeader, body); err != nil {
+			return fmt.Errorf("error adding pool %s: %w", pool.PoolName, err)
+		}
+		fmt.Printf("Added Pool: %s\n", pool.PoolName)
 	}
 	return nil
 }

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -108,24 +108,68 @@ func InitSettings(settingsFile string) error {
 	return nil
 }
 
+// buildBatchImportCommand builds a compound shell command that writes jsonContent
+// to tmpFile via heredoc, runs importCmd against that file, then cleans up.
+func buildBatchImportCommand(tmpFile, importCmd, jsonContent string) string {
+	return fmt.Sprintf("cat > %s <<'__ASTRO_CLI_EOF__'\n%s\n__ASTRO_CLI_EOF__\n%s %s; _ret=$?; rm -f %s; exit $_ret",
+		tmpFile, jsonContent, importCmd, tmpFile, tmpFile)
+}
+
 // AddVariables is a function to add Variables from settings.yaml
 func AddVariables(id string, version uint64) error {
 	variables := settings.Airflow.Variables
+
+	if version >= AirflowVersionTwo {
+		return addVariablesBatch(id, variables)
+	}
+	return addVariablesLegacy(id, variables)
+}
+
+func addVariablesBatch(id string, variables Variables) error {
+	varsMap := make(map[string]string)
+	var names []string
+	for _, variable := range variables {
+		if !objectValidator(0, variable.VariableName) {
+			if objectValidator(0, variable.VariableValue) {
+				fmt.Print("Skipping Variable Creation: No Variable Name Specified.\n")
+			}
+			continue
+		}
+		if !objectValidator(0, variable.VariableValue) {
+			continue
+		}
+		varsMap[variable.VariableName] = variable.VariableValue
+		names = append(names, variable.VariableName)
+	}
+	if len(varsMap) == 0 {
+		return nil
+	}
+
+	jsonBytes, err := json.Marshal(varsMap)
+	if err != nil {
+		return fmt.Errorf("error marshaling variables to JSON: %w", err)
+	}
+
+	cmd := buildBatchImportCommand("/tmp/astro_import_variables.json", "airflow variables import", string(jsonBytes))
+	out, err := execAirflowCommand(id, cmd)
+	if err != nil {
+		return fmt.Errorf("error importing variables: %w", err)
+	}
+	logger.Debugf("Batch import variables logs:\n%s", out)
+	for _, name := range names {
+		fmt.Printf("Added Variable: %s\n", name)
+	}
+	return nil
+}
+
+func addVariablesLegacy(id string, variables Variables) error {
 	for _, variable := range variables {
 		if !objectValidator(0, variable.VariableName) {
 			if objectValidator(0, variable.VariableValue) {
 				fmt.Print("Skipping Variable Creation: No Variable Name Specified.\n")
 			}
 		} else if objectValidator(0, variable.VariableValue) {
-			baseCmd := "airflow variables "
-			if version >= AirflowVersionTwo {
-				baseCmd += "set %s " // Airflow 2.0.0 command
-			} else {
-				baseCmd += "-s %s"
-			}
-
-			airflowCommand := fmt.Sprintf(baseCmd, variable.VariableName)
-
+			airflowCommand := fmt.Sprintf("airflow variables -s %s", variable.VariableName)
 			airflowCommand += fmt.Sprintf("'%s'", variable.VariableValue)
 			out, err := execAirflowCommand(id, airflowCommand)
 			if err != nil {
@@ -143,21 +187,133 @@ func AddConnections(id string, version uint64, envConns map[string]astrocore.Env
 	connections := settings.Airflow.Connections
 	connections = AppendEnvironmentConnections(connections, envConns)
 
-	baseCmd := "airflow connections "
-	var baseRmCmd, baseListCmd, connIDArg string
 	if version >= AirflowVersionTwo {
-		// Airflow 2.0.0 command
-		// based on https://airflow.apache.org/docs/apache-airflow/2.0.0/cli-and-env-variables-ref.html
-		baseRmCmd = baseCmd + "delete "
-		baseListCmd = baseCmd + "list -o plain"
-		connIDArg = ""
-	} else {
-		// Airflow 1.0.0 command based on
-		// https://airflow.readthedocs.io/en/1.10.12/cli-ref.html#connections
-		baseRmCmd = baseCmd + "-d "
-		baseListCmd = baseCmd + "-l "
-		connIDArg = "--conn_id"
+		return addConnectionsBatch(id, connections)
 	}
+	return addConnectionsLegacy(id, connections)
+}
+
+// connectionImportObject builds the JSON value for a single connection in the
+// airflow connections import format. Returns nil if the connection should be skipped.
+func connectionImportObject(conn *Connection) interface{} {
+	// URI-only connection: if conn_uri is set and no individual fields are populated
+	hasFields := objectValidator(0, conn.ConnType) || objectValidator(0, conn.ConnHost) ||
+		objectValidator(0, conn.ConnLogin) || objectValidator(0, conn.ConnPassword) ||
+		objectValidator(0, conn.ConnSchema) || conn.ConnPort != 0
+	if objectValidator(0, conn.ConnURI) && !hasFields {
+		return conn.ConnURI
+	}
+
+	obj := map[string]interface{}{
+		"conn_type": conn.ConnType,
+	}
+	if objectValidator(0, conn.ConnHost) {
+		obj["host"] = conn.ConnHost
+	}
+	if objectValidator(0, conn.ConnLogin) {
+		obj["login"] = conn.ConnLogin
+	}
+	if objectValidator(0, conn.ConnPassword) {
+		obj["password"] = conn.ConnPassword
+	}
+	if objectValidator(0, conn.ConnSchema) {
+		obj["schema"] = conn.ConnSchema
+	}
+	if conn.ConnPort != 0 {
+		obj["port"] = conn.ConnPort
+	}
+	if extra := connExtraObject(conn.ConnExtra); extra != nil {
+		obj["extra"] = extra
+	}
+	return obj
+}
+
+// connExtraObject converts ConnExtra (which can be various types) into a
+// map[string]interface{} suitable for JSON marshaling in the import file.
+func connExtraObject(extra interface{}) interface{} {
+	switch v := extra.(type) {
+	case nil:
+		return nil
+	case string:
+		if v == "" {
+			return nil
+		}
+		// Try to parse JSON string back to a map
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(v), &m); err == nil {
+			return m
+		}
+		// If it's not valid JSON, return as-is (Airflow accepts string extras)
+		return v
+	case map[any]any:
+		m := make(map[string]interface{})
+		for k, val := range v {
+			kStr, ok := k.(string)
+			if !ok {
+				continue
+			}
+			m[kStr] = val
+		}
+		if len(m) == 0 {
+			return nil
+		}
+		return m
+	case map[string]any:
+		if len(v) == 0 {
+			return nil
+		}
+		return v
+	default:
+		return nil
+	}
+}
+
+func addConnectionsBatch(id string, connections Connections) error {
+	connMap := make(map[string]interface{})
+	var names []string
+	for i := range connections {
+		conn := connections[i]
+		if !objectValidator(0, conn.ConnID) {
+			continue
+		}
+		if !objectValidator(1, conn.ConnType, conn.ConnURI) {
+			fmt.Printf("Skipping %s: conn_type or conn_uri must be specified.\n", conn.ConnID)
+			continue
+		}
+		obj := connectionImportObject(&conn)
+		if obj == nil {
+			continue
+		}
+		connMap[conn.ConnID] = obj
+		names = append(names, conn.ConnID)
+	}
+	if len(connMap) == 0 {
+		return nil
+	}
+
+	jsonBytes, err := json.Marshal(connMap)
+	if err != nil {
+		return fmt.Errorf("error marshaling connections to JSON: %w", err)
+	}
+
+	cmd := buildBatchImportCommand("/tmp/astro_import_connections.json", "airflow connections import --overwrite", string(jsonBytes))
+	out, err := execAirflowCommand(id, cmd)
+	if err != nil {
+		return fmt.Errorf("error importing connections: %w", err)
+	}
+	logger.Debugf("Batch import connections logs:\n%s", out)
+	for _, name := range names {
+		fmt.Printf("Added Connection: %s\n", name)
+	}
+	return nil
+}
+
+func addConnectionsLegacy(id string, connections Connections) error {
+	baseCmd := "airflow connections "
+	baseRmCmd := baseCmd + "-d "
+	baseListCmd := baseCmd + "-l "
+	connIDArg := "--conn_id"
+
 	airflowCommand := baseListCmd
 	out, err := execAirflowCommand(id, airflowCommand)
 	if err != nil {
@@ -188,7 +344,7 @@ func AddConnections(id string, version uint64, envConns map[string]astrocore.Env
 			continue
 		}
 
-		airflowCommand = prepareAirflowConnectionAddCommand(version, &conn, extraString)
+		airflowCommand = prepareAirflowConnectionAddCommand(1, &conn, extraString)
 		if airflowCommand != "" {
 			out, err := execAirflowCommand(id, airflowCommand)
 			if err != nil {
@@ -311,16 +467,53 @@ func AppendEnvironmentConnections(connections Connections, envConnections map[st
 // AddPools  is a function to add Pools from settings.yaml
 func AddPools(id string, version uint64) error {
 	pools := settings.Airflow.Pools
-	baseCmd := "airflow "
 
 	if version >= AirflowVersionTwo {
-		// Airflow 2.0.0 command
-		// based on https://airflow.apache.org/docs/apache-airflow/2.0.0/cli-and-env-variables-ref.html
-		baseCmd += "pools set "
-	} else {
-		baseCmd += "pool -s "
+		return addPoolsBatch(id, pools)
+	}
+	return addPoolsLegacy(id, pools)
+}
+
+func addPoolsBatch(id string, pools Pools) error {
+	poolMap := make(map[string]poolImportEntry)
+	var names []string
+	for _, pool := range pools {
+		if !objectValidator(0, pool.PoolName) {
+			continue
+		}
+		if pool.PoolSlot == 0 {
+			fmt.Printf("Skipping %s: Pool Slot must be set.\n", pool.PoolName)
+			continue
+		}
+		poolMap[pool.PoolName] = poolImportEntry{
+			Slots:       pool.PoolSlot,
+			Description: pool.PoolDescription,
+		}
+		names = append(names, pool.PoolName)
+	}
+	if len(poolMap) == 0 {
+		return nil
 	}
 
+	jsonBytes, err := json.Marshal(poolMap)
+	if err != nil {
+		return fmt.Errorf("error marshaling pools to JSON: %w", err)
+	}
+
+	cmd := buildBatchImportCommand("/tmp/astro_import_pools.json", "airflow pools import", string(jsonBytes))
+	out, err := execAirflowCommand(id, cmd)
+	if err != nil {
+		return fmt.Errorf("error importing pools: %w", err)
+	}
+	logger.Debugf("Batch import pools logs:\n%s", out)
+	for _, name := range names {
+		fmt.Printf("Added Pool: %s\n", name)
+	}
+	return nil
+}
+
+func addPoolsLegacy(id string, pools Pools) error {
+	baseCmd := "airflow pool -s "
 	for _, pool := range pools {
 		if objectValidator(0, pool.PoolName) {
 			airflowCommand := fmt.Sprintf("%s %s ", baseCmd, pool.PoolName)

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -58,7 +58,7 @@ var (
 )
 
 // ConfigSettings is the main builder of the settings package
-func ConfigSettings(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, version uint64, connections, variables, pools bool) error {
+func ConfigSettings(id, settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, connections, variables, pools bool) error {
 	if id == "" {
 		return errNoID
 	}
@@ -67,17 +67,17 @@ func ConfigSettings(id, settingsFile string, envConns map[string]astrocore.Envir
 		logger.Debugf("Unable to initialize settings file: %s", err)
 	}
 	if pools {
-		if err := AddPools(id, version); err != nil {
+		if err := AddPools(id); err != nil {
 			return fmt.Errorf("error adding pools: %w", err)
 		}
 	}
 	if variables {
-		if err := AddVariables(id, version); err != nil {
+		if err := AddVariables(id); err != nil {
 			return fmt.Errorf("error adding variables: %w", err)
 		}
 	}
 	if connections {
-		if err := AddConnections(id, version, envConns); err != nil {
+		if err := AddConnections(id, envConns); err != nil {
 			return fmt.Errorf("error adding connections: %w", err)
 		}
 	}
@@ -116,16 +116,8 @@ func buildBatchImportCommand(tmpFile, importCmd, jsonContent string) string {
 }
 
 // AddVariables is a function to add Variables from settings.yaml
-func AddVariables(id string, version uint64) error {
+func AddVariables(id string) error {
 	variables := settings.Airflow.Variables
-
-	if version >= AirflowVersionTwo {
-		return addVariablesBatch(id, variables)
-	}
-	return addVariablesLegacy(id, variables)
-}
-
-func addVariablesBatch(id string, variables Variables) error {
 	varsMap := make(map[string]string)
 	var names []string
 	for _, variable := range variables {
@@ -162,39 +154,16 @@ func addVariablesBatch(id string, variables Variables) error {
 	return nil
 }
 
-func addVariablesLegacy(id string, variables Variables) error {
-	for _, variable := range variables {
-		if !objectValidator(0, variable.VariableName) {
-			if objectValidator(0, variable.VariableValue) {
-				fmt.Print("Skipping Variable Creation: No Variable Name Specified.\n")
-			}
-		} else if objectValidator(0, variable.VariableValue) {
-			airflowCommand := fmt.Sprintf("airflow variables -s %s", variable.VariableName)
-			airflowCommand += fmt.Sprintf("'%s'", variable.VariableValue)
-			out, err := execAirflowCommand(id, airflowCommand)
-			if err != nil {
-				return fmt.Errorf("error adding variable %s: %w", variable.VariableName, err)
-			}
-			logger.Debugf("Adding variable logs:\n%s", out)
-			fmt.Printf("Added Variable: %s\n", variable.VariableName)
-		}
-	}
-	return nil
-}
-
 // AddConnections is a function to add Connections from settings.yaml
-func AddConnections(id string, version uint64, envConns map[string]astrocore.EnvironmentObjectConnection) error {
+func AddConnections(id string, envConns map[string]astrocore.EnvironmentObjectConnection) error {
 	connections := settings.Airflow.Connections
 	connections = AppendEnvironmentConnections(connections, envConns)
 
-	if version >= AirflowVersionTwo {
-		return addConnectionsBatch(id, connections)
-	}
-	return addConnectionsLegacy(id, connections)
+	return addConnectionsBatch(id, connections)
 }
 
 // connectionImportObject builds the JSON value for a single connection in the
-// airflow connections import format. Returns nil if the connection should be skipped.
+// airflow connections import format.
 func connectionImportObject(conn *Connection) interface{} {
 	// URI-only connection: if conn_uri is set and no individual fields are populated
 	hasFields := objectValidator(0, conn.ConnType) || objectValidator(0, conn.ConnHost) ||
@@ -280,11 +249,7 @@ func addConnectionsBatch(id string, connections Connections) error {
 			fmt.Printf("Skipping %s: conn_type or conn_uri must be specified.\n", conn.ConnID)
 			continue
 		}
-		obj := connectionImportObject(&conn)
-		if obj == nil {
-			continue
-		}
-		connMap[conn.ConnID] = obj
+		connMap[conn.ConnID] = connectionImportObject(&conn)
 		names = append(names, conn.ConnID)
 	}
 	if len(connMap) == 0 {
@@ -306,123 +271,6 @@ func addConnectionsBatch(id string, connections Connections) error {
 		fmt.Printf("Added Connection: %s\n", name)
 	}
 	return nil
-}
-
-func addConnectionsLegacy(id string, connections Connections) error {
-	baseCmd := "airflow connections "
-	baseRmCmd := baseCmd + "-d "
-	baseListCmd := baseCmd + "-l "
-	connIDArg := "--conn_id"
-
-	airflowCommand := baseListCmd
-	out, err := execAirflowCommand(id, airflowCommand)
-	if err != nil {
-		return fmt.Errorf("error listing connections: %w", err)
-	}
-
-	for i := range connections {
-		conn := connections[i]
-		if !objectValidator(0, conn.ConnID) {
-			continue
-		}
-
-		extraString := jsonString(&conn)
-
-		quotedConnID := "'" + conn.ConnID + "'"
-
-		if strings.Contains(out, quotedConnID) || strings.Contains(out, conn.ConnID) {
-			fmt.Printf("Updating Connection %q...\n", conn.ConnID)
-			airflowCommand = fmt.Sprintf("%s %s %q", baseRmCmd, connIDArg, conn.ConnID)
-			_, err = execAirflowCommand(id, airflowCommand)
-			if err != nil {
-				return fmt.Errorf("error removing connection %s: %w", conn.ConnID, err)
-			}
-		}
-
-		if !objectValidator(1, conn.ConnType, conn.ConnURI) {
-			fmt.Printf("Skipping %s: conn_type or conn_uri must be specified.\n", conn.ConnID)
-			continue
-		}
-
-		airflowCommand = prepareAirflowConnectionAddCommand(1, &conn, extraString)
-		if airflowCommand != "" {
-			out, err := execAirflowCommand(id, airflowCommand)
-			if err != nil {
-				return fmt.Errorf("error adding connection %s: %w", conn.ConnID, err)
-			}
-			logger.Debugf("Adding Connection logs:\n\n%s", out)
-			fmt.Printf("Added Connection: %s\n", conn.ConnID)
-		}
-	}
-	return nil
-}
-
-func prepareAirflowConnectionAddCommand(version uint64, conn *Connection, extraString string) string {
-	if conn == nil {
-		return ""
-	}
-	baseCmd := "airflow connections "
-	var baseAddCmd, connIDArg, connTypeArg, connURIArg, connExtraArg, connHostArg, connLoginArg, connPasswordArg, connSchemaArg, connPortArg string
-	if version >= AirflowVersionTwo {
-		// Airflow 2.0.0 command
-		// based on https://airflow.apache.org/docs/apache-airflow/2.0.0/cli-and-env-variables-ref.html
-		baseAddCmd = baseCmd + "add "
-		connIDArg = ""
-		connTypeArg = "--conn-type"
-		connURIArg = "--conn-uri"
-		connExtraArg = "--conn-extra"
-		connHostArg = "--conn-host"
-		connLoginArg = "--conn-login"
-		connPasswordArg = "--conn-password"
-		connSchemaArg = "--conn-schema"
-		connPortArg = "--conn-port"
-	} else {
-		// Airflow 1.0.0 command based on
-		// https://airflow.readthedocs.io/en/1.10.12/cli-ref.html#connections
-		baseAddCmd = baseCmd + "-a "
-		connIDArg = "--conn_id"
-		connTypeArg = "--conn_type"
-		connURIArg = "--conn_uri"
-		connExtraArg = "--conn_extra"
-		connHostArg = "--conn_host"
-		connLoginArg = "--conn_login"
-		connPasswordArg = "--conn_password"
-		connSchemaArg = "--conn_schema"
-		connPortArg = "--conn_port"
-	}
-	var j int
-	airflowCommand := fmt.Sprintf("%s %s '%s' ", baseAddCmd, connIDArg, conn.ConnID)
-	if objectValidator(0, conn.ConnType) {
-		airflowCommand += fmt.Sprintf("%s '%s' ", connTypeArg, conn.ConnType)
-		j++
-	}
-	if extraString != "" {
-		airflowCommand += fmt.Sprintf("%s '%s' ", connExtraArg, extraString)
-	}
-	if objectValidator(0, conn.ConnHost) {
-		airflowCommand += fmt.Sprintf("%s '%s' ", connHostArg, conn.ConnHost)
-		j++
-	}
-	if objectValidator(0, conn.ConnLogin) {
-		airflowCommand += fmt.Sprintf("%s '%s' ", connLoginArg, conn.ConnLogin)
-		j++
-	}
-	if objectValidator(0, conn.ConnPassword) {
-		airflowCommand += fmt.Sprintf("%s '%s' ", connPasswordArg, conn.ConnPassword)
-		j++
-	}
-	if objectValidator(0, conn.ConnSchema) {
-		airflowCommand += fmt.Sprintf("%s '%s' ", connSchemaArg, conn.ConnSchema)
-		j++
-	}
-	if conn.ConnPort != 0 {
-		airflowCommand += fmt.Sprintf("%s %v", connPortArg, conn.ConnPort)
-		j++
-	}
-	if objectValidator(0, conn.ConnURI) && j == 0 {
-		airflowCommand += fmt.Sprintf("%s '%s' ", connURIArg, conn.ConnURI)
-	}
-	return airflowCommand
 }
 
 func AppendEnvironmentConnections(connections Connections, envConnections map[string]astrocore.EnvironmentObjectConnection) Connections {
@@ -464,14 +312,10 @@ func AppendEnvironmentConnections(connections Connections, envConnections map[st
 	return connections
 }
 
-// AddPools  is a function to add Pools from settings.yaml
-func AddPools(id string, version uint64) error {
+// AddPools is a function to add Pools from settings.yaml
+func AddPools(id string) error {
 	pools := settings.Airflow.Pools
-
-	if version >= AirflowVersionTwo {
-		return addPoolsBatch(id, pools)
-	}
-	return addPoolsLegacy(id, pools)
+	return addPoolsBatch(id, pools)
 }
 
 func addPoolsBatch(id string, pools Pools) error {
@@ -508,33 +352,6 @@ func addPoolsBatch(id string, pools Pools) error {
 	logger.Debugf("Batch import pools logs:\n%s", out)
 	for _, name := range names {
 		fmt.Printf("Added Pool: %s\n", name)
-	}
-	return nil
-}
-
-func addPoolsLegacy(id string, pools Pools) error {
-	baseCmd := "airflow pool -s "
-	for _, pool := range pools {
-		if objectValidator(0, pool.PoolName) {
-			airflowCommand := fmt.Sprintf("%s %s ", baseCmd, pool.PoolName)
-			if pool.PoolSlot != 0 {
-				airflowCommand += fmt.Sprintf("%v ", pool.PoolSlot)
-				if objectValidator(0, pool.PoolDescription) {
-					airflowCommand += fmt.Sprintf("'%s' ", pool.PoolDescription)
-				} else {
-					airflowCommand += "''"
-				}
-				fmt.Println(airflowCommand)
-				out, err := execAirflowCommand(id, airflowCommand)
-				if err != nil {
-					return fmt.Errorf("error adding pool %s: %w", pool.PoolName, err)
-				}
-				logger.Debugf("Adding pool logs:\n%s", out)
-				fmt.Printf("Added Pool: %s\n", pool.PoolName)
-			} else {
-				fmt.Printf("Skipping %s: Pool Slot must be set.\n", pool.PoolName)
-			}
-		}
 	}
 	return nil
 }

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -11,6 +12,18 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 )
+
+// extractJSONFromHeredoc extracts the JSON content from a batch import command
+// that uses the heredoc pattern: cat > /tmp/... <<'__ASTRO_CLI_EOF__'\n<json>\n__ASTRO_CLI_EOF__\n...
+func extractJSONFromHeredoc(command string) string {
+	parts := strings.Split(command, "__ASTRO_CLI_EOF__")
+	if len(parts) >= 2 {
+		s := strings.TrimSpace(parts[1])
+		s = strings.TrimPrefix(s, "'")
+		return strings.TrimSpace(s)
+	}
+	return ""
+}
 
 type Suite struct {
 	suite.Suite
@@ -77,14 +90,20 @@ func (s *Suite) TestAddConnectionsAirflowTwo() {
 	}
 	settings.Airflow.Connections = []Connection{testConn}
 
-	expectedAddCmd := "airflow connections add   'test-id' --conn-type 'test-type' --conn-host 'test-host' --conn-login 'test-login' --conn-password 'test-password' --conn-schema 'test-schema' --conn-port 1"
-	expectedDelCmd := "airflow connections delete   \"test-id\""
-	expectedListCmd := "airflow connections list -o plain"
 	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains([]string{expectedAddCmd, expectedListCmd, expectedDelCmd}, airflowCommand)
-		if airflowCommand == expectedListCmd {
-			return "'test-id' 'test-type' 'test-host' 'test-uri'", nil
-		}
+		s.Contains(airflowCommand, "airflow connections import --overwrite")
+		jsonStr := extractJSONFromHeredoc(airflowCommand)
+		var connMap map[string]interface{}
+		s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
+		s.Contains(connMap, "test-id")
+		connObj, ok := connMap["test-id"].(map[string]interface{})
+		s.True(ok)
+		s.Equal("test-type", connObj["conn_type"])
+		s.Equal("test-host", connObj["host"])
+		s.Equal("test-login", connObj["login"])
+		s.Equal("test-password", connObj["password"])
+		s.Equal("test-schema", connObj["schema"])
+		s.Equal(float64(1), connObj["port"])
 		return "", nil
 	}
 	err := AddConnections("test-conn-id", 2, nil)
@@ -125,17 +144,23 @@ func (s *Suite) TestAddConnectionsAirflowTwoWithEnvConns() {
 		},
 	}
 
-	expectedAddCmd := "airflow connections add   'test-id' --conn-type 'test-type' --conn-host 'test-host' --conn-login 'test-login' --conn-password 'test-password' --conn-schema 'test-schema' --conn-port 1"
-	expectedDelCmd := "airflow connections delete   \"test-id\""
-	expectedListCmd := "airflow connections list -o plain"
-
-	expectedEnvAddCmd := "airflow connections add   'test-env-id' --conn-type 'test-env-type' --conn-extra '{\"test-extra-key\":\"test-extra-value\"}' --conn-host 'test-env-host' --conn-login 'test-env-login' --conn-password 'test-env-password' --conn-schema 'test-env-schema' --conn-port 2"
-
 	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains([]string{expectedAddCmd, expectedEnvAddCmd, expectedListCmd, expectedDelCmd}, airflowCommand)
-		if airflowCommand == expectedListCmd {
-			return "'test-id' 'test-type' 'test-host' 'test-uri'", nil
-		}
+		s.Contains(airflowCommand, "airflow connections import --overwrite")
+		jsonStr := extractJSONFromHeredoc(airflowCommand)
+		var connMap map[string]interface{}
+		s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
+		// Both settings and env connections should be present
+		s.Contains(connMap, "test-id")
+		s.Contains(connMap, "test-env-id")
+		// Verify env connection fields
+		envConn, ok := connMap["test-env-id"].(map[string]interface{})
+		s.True(ok)
+		s.Equal("test-env-type", envConn["conn_type"])
+		s.Equal("test-env-host", envConn["host"])
+		s.Equal(float64(2), envConn["port"])
+		extra, ok := envConn["extra"].(map[string]interface{})
+		s.True(ok)
+		s.Equal("test-extra-value", extra["test-extra-key"])
 		return "", nil
 	}
 	err := AddConnections("test-conn-id", 2, envConns)
@@ -144,18 +169,21 @@ func (s *Suite) TestAddConnectionsAirflowTwoWithEnvConns() {
 
 func (s *Suite) TestAddConnectionsAirflowTwoURI() {
 	testConn := Connection{
+		ConnID:  "test-id",
 		ConnURI: "test-uri",
 	}
 	settings.Airflow.Connections = []Connection{testConn}
 
-	expectedAddCmd := "airflow connections add   'test-id' --conn-uri 'test-uri'"
-	expectedDelCmd := "airflow connections delete   \"test-id\""
-	expectedListCmd := "airflow connections list -o plain"
 	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains([]string{expectedAddCmd, expectedListCmd, expectedDelCmd}, airflowCommand)
-		if airflowCommand == expectedListCmd {
-			return "'test-id' 'test-type' 'test-host' 'test-uri'", nil
-		}
+		s.Contains(airflowCommand, "airflow connections import --overwrite")
+		jsonStr := extractJSONFromHeredoc(airflowCommand)
+		var connMap map[string]interface{}
+		s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
+		s.Contains(connMap, "test-id")
+		// URI-only connection should be a string value, not an object
+		connVal, ok := connMap["test-id"].(string)
+		s.True(ok)
+		s.Equal("test-uri", connVal)
 		return "", nil
 	}
 	err := AddConnections("test-conn-id", 2, nil)
@@ -213,9 +241,12 @@ func (s *Suite) TestAddVariableAirflowTwo() {
 		},
 	}
 
-	expectedAddCmd := "airflow variables set test-var-name 'test-var-val'"
 	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Equal(expectedAddCmd, airflowCommand)
+		s.Contains(airflowCommand, "airflow variables import")
+		jsonStr := extractJSONFromHeredoc(airflowCommand)
+		var varsMap map[string]string
+		s.NoError(json.Unmarshal([]byte(jsonStr), &varsMap))
+		s.Equal("test-var-val", varsMap["test-var-name"])
 		return "", nil
 	}
 	err := AddVariables("test-conn-id", 2)
@@ -249,9 +280,15 @@ func (s *Suite) TestAddPoolsAirflowTwo() {
 		},
 	}
 
-	expectedAddCmd := "airflow pools set  test-pool-name 1 'test-pool-description' "
 	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Equal(expectedAddCmd, airflowCommand)
+		s.Contains(airflowCommand, "airflow pools import")
+		jsonStr := extractJSONFromHeredoc(airflowCommand)
+		var poolMap map[string]poolImportEntry
+		s.NoError(json.Unmarshal([]byte(jsonStr), &poolMap))
+		s.Len(poolMap, 1)
+		s.Contains(poolMap, "test-pool-name")
+		s.Equal(1, poolMap["test-pool-name"].Slots)
+		s.Equal("test-pool-description", poolMap["test-pool-name"].Description)
 		return "", nil
 	}
 	err := AddPools("test-conn-id", 2)
@@ -273,6 +310,175 @@ func (s *Suite) TestAddVariableFailure() {
 	}
 	err := AddVariables("test-conn-id", 1)
 	s.Contains(err.Error(), "mock error")
+}
+
+func (s *Suite) TestAddVariableBatchFailure() {
+	settings.Airflow.Variables = Variables{
+		{
+			VariableName:  "test-var-name",
+			VariableValue: "test-var-val",
+		},
+	}
+
+	execAirflowCommand = func(id, airflowCommand string) (string, error) {
+		return "", fmt.Errorf("mock import error")
+	}
+	err := AddVariables("test-conn-id", 2)
+	s.Contains(err.Error(), "mock import error")
+}
+
+func (s *Suite) TestAddConnectionsBatchFailure() {
+	settings.Airflow.Connections = []Connection{
+		{
+			ConnID:   "test-id",
+			ConnType: "test-type",
+		},
+	}
+
+	execAirflowCommand = func(id, airflowCommand string) (string, error) {
+		return "", fmt.Errorf("mock import error")
+	}
+	err := AddConnections("test-conn-id", 2, nil)
+	s.Contains(err.Error(), "mock import error")
+}
+
+func (s *Suite) TestAddPoolsBatchFailure() {
+	settings.Airflow.Pools = Pools{
+		{
+			PoolName:        "test-pool",
+			PoolSlot:        1,
+			PoolDescription: "desc",
+		},
+	}
+
+	execAirflowCommand = func(id, airflowCommand string) (string, error) {
+		return "", fmt.Errorf("mock import error")
+	}
+	err := AddPools("test-conn-id", 2)
+	s.Contains(err.Error(), "mock import error")
+}
+
+func (s *Suite) TestBatchImportEmptyLists() {
+	settings.Airflow.Variables = Variables{}
+	settings.Airflow.Connections = Connections{}
+	settings.Airflow.Pools = Pools{}
+
+	called := false
+	execAirflowCommand = func(id, airflowCommand string) (string, error) {
+		called = true
+		return "", nil
+	}
+
+	s.NoError(AddVariables("test-id", 2))
+	s.NoError(AddConnections("test-id", 2, nil))
+	s.NoError(AddPools("test-id", 2))
+	s.False(called, "execAirflowCommand should not be called for empty lists")
+}
+
+func (s *Suite) TestBatchImportMultipleVariables() {
+	settings.Airflow.Variables = Variables{
+		{VariableName: "var1", VariableValue: "val1"},
+		{VariableName: "var2", VariableValue: "val2"},
+		{VariableName: "var3", VariableValue: "val3"},
+	}
+
+	execAirflowCommand = func(id, airflowCommand string) (string, error) {
+		s.Contains(airflowCommand, "airflow variables import")
+		jsonStr := extractJSONFromHeredoc(airflowCommand)
+		var varsMap map[string]string
+		s.NoError(json.Unmarshal([]byte(jsonStr), &varsMap))
+		s.Len(varsMap, 3)
+		s.Equal("val1", varsMap["var1"])
+		s.Equal("val2", varsMap["var2"])
+		s.Equal("val3", varsMap["var3"])
+		return "", nil
+	}
+	err := AddVariables("test-id", 2)
+	s.NoError(err)
+}
+
+func (s *Suite) TestBatchImportConnectionExtraTypes() {
+	s.Run("map extra", func() {
+		settings.Airflow.Connections = []Connection{
+			{
+				ConnID:   "map-extra-conn",
+				ConnType: "http",
+				ConnExtra: map[any]any{
+					"key1": "val1",
+					"key2": "val2",
+				},
+			},
+		}
+		execAirflowCommand = func(id, airflowCommand string) (string, error) {
+			jsonStr := extractJSONFromHeredoc(airflowCommand)
+			var connMap map[string]map[string]interface{}
+			s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
+			extra, ok := connMap["map-extra-conn"]["extra"].(map[string]interface{})
+			s.True(ok)
+			s.Equal("val1", extra["key1"])
+			s.Equal("val2", extra["key2"])
+			return "", nil
+		}
+		s.NoError(AddConnections("test-id", 2, nil))
+	})
+
+	s.Run("string json extra", func() {
+		settings.Airflow.Connections = []Connection{
+			{
+				ConnID:    "str-extra-conn",
+				ConnType:  "http",
+				ConnExtra: `{"key":"val"}`,
+			},
+		}
+		execAirflowCommand = func(id, airflowCommand string) (string, error) {
+			jsonStr := extractJSONFromHeredoc(airflowCommand)
+			var connMap map[string]map[string]interface{}
+			s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
+			extra, ok := connMap["str-extra-conn"]["extra"].(map[string]interface{})
+			s.True(ok)
+			s.Equal("val", extra["key"])
+			return "", nil
+		}
+		s.NoError(AddConnections("test-id", 2, nil))
+	})
+
+	s.Run("nil extra", func() {
+		settings.Airflow.Connections = []Connection{
+			{
+				ConnID:    "nil-extra-conn",
+				ConnType:  "http",
+				ConnExtra: nil,
+			},
+		}
+		execAirflowCommand = func(id, airflowCommand string) (string, error) {
+			jsonStr := extractJSONFromHeredoc(airflowCommand)
+			var connMap map[string]map[string]interface{}
+			s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
+			_, hasExtra := connMap["nil-extra-conn"]["extra"]
+			s.False(hasExtra, "nil extra should not appear in JSON")
+			return "", nil
+		}
+		s.NoError(AddConnections("test-id", 2, nil))
+	})
+}
+
+func (s *Suite) TestBatchImportMixedValidInvalid() {
+	settings.Airflow.Variables = Variables{
+		{VariableName: "good_var", VariableValue: "good_val"},
+		{VariableName: "", VariableValue: "orphan_val"},
+		{VariableName: "empty_val_var", VariableValue: ""},
+	}
+
+	execAirflowCommand = func(id, airflowCommand string) (string, error) {
+		jsonStr := extractJSONFromHeredoc(airflowCommand)
+		var varsMap map[string]string
+		s.NoError(json.Unmarshal([]byte(jsonStr), &varsMap))
+		s.Len(varsMap, 1)
+		s.Equal("good_val", varsMap["good_var"])
+		return "", nil
+	}
+	err := AddVariables("test-id", 2)
+	s.NoError(err)
 }
 
 func (s *Suite) TestInitSettingsSuccess() {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -41,40 +41,14 @@ func (s *Suite) TearDownTest() {
 
 func (s *Suite) TestConfigSettings() {
 	// config settings success
-	err := ConfigSettings("container-id", "", nil, 2, false, false, false)
+	err := ConfigSettings("container-id", "", nil, false, false, false)
 	s.NoError(err)
 	// config setttings no id error
-	err = ConfigSettings("", "", nil, 2, false, false, false)
+	err = ConfigSettings("", "", nil, false, false, false)
 	s.ErrorIs(err, errNoID)
 }
 
-func (s *Suite) TestAddConnectionsAirflowOne() {
-	var testExtra map[string]string
-
-	testConn := Connection{
-		ConnID:       "test-id",
-		ConnType:     "test-type",
-		ConnHost:     "test-host",
-		ConnSchema:   "test-schema",
-		ConnLogin:    "test-login",
-		ConnPassword: "test-password",
-		ConnPort:     1,
-		ConnURI:      "test-uri",
-		ConnExtra:    testExtra,
-	}
-	settings.Airflow.Connections = []Connection{testConn}
-
-	expectedAddCmd := "airflow connections -a  --conn_id 'test-id' --conn_type 'test-type' --conn_host 'test-host' --conn_login 'test-login' --conn_password 'test-password' --conn_schema 'test-schema' --conn_port 1"
-	expectedListCmd := "airflow connections -l "
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains([]string{expectedAddCmd, expectedListCmd}, airflowCommand)
-		return "", nil
-	}
-	err := AddConnections("test-conn-id", 1, nil)
-	s.NoError(err)
-}
-
-func (s *Suite) TestAddConnectionsAirflowTwo() {
+func (s *Suite) TestAddConnections() {
 	var testExtra map[string]string
 
 	testConn := Connection{
@@ -106,7 +80,7 @@ func (s *Suite) TestAddConnectionsAirflowTwo() {
 		s.Equal(float64(1), connObj["port"])
 		return "", nil
 	}
-	err := AddConnections("test-conn-id", 2, nil)
+	err := AddConnections("test-conn-id", nil)
 	s.NoError(err)
 }
 
@@ -114,7 +88,7 @@ func ptr[T any](t T) *T {
 	return &t
 }
 
-func (s *Suite) TestAddConnectionsAirflowTwoWithEnvConns() {
+func (s *Suite) TestAddConnectionsWithEnvConns() {
 	var testExtra map[string]string
 
 	testConn := Connection{
@@ -163,11 +137,11 @@ func (s *Suite) TestAddConnectionsAirflowTwoWithEnvConns() {
 		s.Equal("test-extra-value", extra["test-extra-key"])
 		return "", nil
 	}
-	err := AddConnections("test-conn-id", 2, envConns)
+	err := AddConnections("test-conn-id", envConns)
 	s.NoError(err)
 }
 
-func (s *Suite) TestAddConnectionsAirflowTwoURI() {
+func (s *Suite) TestAddConnectionsURI() {
 	testConn := Connection{
 		ConnID:  "test-id",
 		ConnURI: "test-uri",
@@ -186,54 +160,11 @@ func (s *Suite) TestAddConnectionsAirflowTwoURI() {
 		s.Equal("test-uri", connVal)
 		return "", nil
 	}
-	err := AddConnections("test-conn-id", 2, nil)
+	err := AddConnections("test-conn-id", nil)
 	s.NoError(err)
 }
 
-func (s *Suite) TestAddConnectionsFailure() {
-	var testExtra map[string]string
-
-	testConn := Connection{
-		ConnID:       "test-id",
-		ConnType:     "test-type",
-		ConnHost:     "test-host",
-		ConnSchema:   "test-schema",
-		ConnLogin:    "test-login",
-		ConnPassword: "test-password",
-		ConnPort:     1,
-		ConnURI:      "test-uri",
-		ConnExtra:    testExtra,
-	}
-	settings.Airflow.Connections = []Connection{testConn}
-
-	expectedAddCmd := "airflow connections -a  --conn_id 'test-id' --conn_type 'test-type' --conn_host 'test-host' --conn_login 'test-login' --conn_password 'test-password' --conn_schema 'test-schema' --conn_port 1"
-	expectedListCmd := "airflow connections -l "
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains([]string{expectedAddCmd, expectedListCmd}, airflowCommand)
-		return "", fmt.Errorf("mock error")
-	}
-	err := AddConnections("test-conn-id", 1, nil)
-	s.Contains(err.Error(), "mock error")
-}
-
-func (s *Suite) TestAddVariableAirflowOne() {
-	settings.Airflow.Variables = Variables{
-		{
-			VariableName:  "test-var-name",
-			VariableValue: "test-var-val",
-		},
-	}
-
-	expectedAddCmd := "airflow variables -s test-var-name'test-var-val'"
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Equal(expectedAddCmd, airflowCommand)
-		return "", nil
-	}
-	err := AddVariables("test-conn-id", 1)
-	s.NoError(err)
-}
-
-func (s *Suite) TestAddVariableAirflowTwo() {
+func (s *Suite) TestAddVariables() {
 	settings.Airflow.Variables = Variables{
 		{
 			VariableName:  "test-var-name",
@@ -249,29 +180,11 @@ func (s *Suite) TestAddVariableAirflowTwo() {
 		s.Equal("test-var-val", varsMap["test-var-name"])
 		return "", nil
 	}
-	err := AddVariables("test-conn-id", 2)
+	err := AddVariables("test-conn-id")
 	s.NoError(err)
 }
 
-func (s *Suite) TestAddPoolsAirflowOne() {
-	settings.Airflow.Pools = Pools{
-		{
-			PoolName:        "test-pool-name",
-			PoolSlot:        1,
-			PoolDescription: "test-pool-description",
-		},
-	}
-
-	expectedAddCmd := "airflow pool -s  test-pool-name 1 'test-pool-description' "
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Equal(expectedAddCmd, airflowCommand)
-		return "", nil
-	}
-	err := AddPools("test-conn-id", 1)
-	s.NoError(err)
-}
-
-func (s *Suite) TestAddPoolsAirflowTwo() {
+func (s *Suite) TestAddPools() {
 	settings.Airflow.Pools = Pools{
 		{
 			PoolName:        "test-pool-name",
@@ -291,25 +204,8 @@ func (s *Suite) TestAddPoolsAirflowTwo() {
 		s.Equal("test-pool-description", poolMap["test-pool-name"].Description)
 		return "", nil
 	}
-	err := AddPools("test-conn-id", 2)
+	err := AddPools("test-conn-id")
 	s.NoError(err)
-}
-
-func (s *Suite) TestAddVariableFailure() {
-	settings.Airflow.Variables = Variables{
-		{
-			VariableName:  "test-var-name",
-			VariableValue: "test-var-val",
-		},
-	}
-
-	expectedAddCmd := "airflow variables -s test-var-name'test-var-val'"
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Equal(expectedAddCmd, airflowCommand)
-		return "", fmt.Errorf("mock error")
-	}
-	err := AddVariables("test-conn-id", 1)
-	s.Contains(err.Error(), "mock error")
 }
 
 func (s *Suite) TestAddVariableBatchFailure() {
@@ -323,7 +219,7 @@ func (s *Suite) TestAddVariableBatchFailure() {
 	execAirflowCommand = func(id, airflowCommand string) (string, error) {
 		return "", fmt.Errorf("mock import error")
 	}
-	err := AddVariables("test-conn-id", 2)
+	err := AddVariables("test-conn-id")
 	s.Contains(err.Error(), "mock import error")
 }
 
@@ -338,7 +234,7 @@ func (s *Suite) TestAddConnectionsBatchFailure() {
 	execAirflowCommand = func(id, airflowCommand string) (string, error) {
 		return "", fmt.Errorf("mock import error")
 	}
-	err := AddConnections("test-conn-id", 2, nil)
+	err := AddConnections("test-conn-id", nil)
 	s.Contains(err.Error(), "mock import error")
 }
 
@@ -354,7 +250,7 @@ func (s *Suite) TestAddPoolsBatchFailure() {
 	execAirflowCommand = func(id, airflowCommand string) (string, error) {
 		return "", fmt.Errorf("mock import error")
 	}
-	err := AddPools("test-conn-id", 2)
+	err := AddPools("test-conn-id")
 	s.Contains(err.Error(), "mock import error")
 }
 
@@ -369,9 +265,9 @@ func (s *Suite) TestBatchImportEmptyLists() {
 		return "", nil
 	}
 
-	s.NoError(AddVariables("test-id", 2))
-	s.NoError(AddConnections("test-id", 2, nil))
-	s.NoError(AddPools("test-id", 2))
+	s.NoError(AddVariables("test-id"))
+	s.NoError(AddConnections("test-id", nil))
+	s.NoError(AddPools("test-id"))
 	s.False(called, "execAirflowCommand should not be called for empty lists")
 }
 
@@ -393,7 +289,7 @@ func (s *Suite) TestBatchImportMultipleVariables() {
 		s.Equal("val3", varsMap["var3"])
 		return "", nil
 	}
-	err := AddVariables("test-id", 2)
+	err := AddVariables("test-id")
 	s.NoError(err)
 }
 
@@ -419,7 +315,7 @@ func (s *Suite) TestBatchImportConnectionExtraTypes() {
 			s.Equal("val2", extra["key2"])
 			return "", nil
 		}
-		s.NoError(AddConnections("test-id", 2, nil))
+		s.NoError(AddConnections("test-id", nil))
 	})
 
 	s.Run("string json extra", func() {
@@ -439,7 +335,7 @@ func (s *Suite) TestBatchImportConnectionExtraTypes() {
 			s.Equal("val", extra["key"])
 			return "", nil
 		}
-		s.NoError(AddConnections("test-id", 2, nil))
+		s.NoError(AddConnections("test-id", nil))
 	})
 
 	s.Run("nil extra", func() {
@@ -458,7 +354,7 @@ func (s *Suite) TestBatchImportConnectionExtraTypes() {
 			s.False(hasExtra, "nil extra should not appear in JSON")
 			return "", nil
 		}
-		s.NoError(AddConnections("test-id", 2, nil))
+		s.NoError(AddConnections("test-id", nil))
 	})
 }
 
@@ -477,7 +373,7 @@ func (s *Suite) TestBatchImportMixedValidInvalid() {
 		s.Equal("good_val", varsMap["good_var"])
 		return "", nil
 	}
-	err := AddVariables("test-id", 2)
+	err := AddVariables("test-id")
 	s.NoError(err)
 }
 

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -3,6 +3,9 @@ package settings
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -12,18 +15,6 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 )
-
-// extractJSONFromHeredoc extracts the JSON content from a batch import command
-// that uses the heredoc pattern: cat > /tmp/... <<'__ASTRO_CLI_EOF__'\n<json>\n__ASTRO_CLI_EOF__\n...
-func extractJSONFromHeredoc(command string) string {
-	parts := strings.Split(command, "__ASTRO_CLI_EOF__")
-	if len(parts) >= 2 {
-		s := strings.TrimSpace(parts[1])
-		s = strings.TrimPrefix(s, "'")
-		return strings.TrimSpace(s)
-	}
-	return ""
-}
 
 type Suite struct {
 	suite.Suite
@@ -39,58 +30,119 @@ func (s *Suite) TearDownTest() {
 	settings = Config{}
 }
 
-func (s *Suite) TestConfigSettings() {
-	// config settings success
-	err := ConfigSettings("container-id", "", nil, false, false, false)
-	s.NoError(err)
-	// config setttings no id error
-	err = ConfigSettings("", "", nil, false, false, false)
-	s.ErrorIs(err, errNoID)
+// mockAirflowAPI creates an httptest server that accepts POST (create) and PATCH (update)
+// requests for Airflow API resources. It returns 201 on POST, 200 on PATCH, and records requests.
+type apiRequest struct {
+	Method  string
+	Path    string
+	Body    map[string]interface{}
+	RawBody []byte
 }
 
-func (s *Suite) TestAddConnections() {
-	var testExtra map[string]string
+func newMockAirflowAPI(s *Suite) (*httptest.Server, *[]apiRequest) {
+	var requests []apiRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		req := apiRequest{Method: r.Method, Path: r.URL.Path, RawBody: body}
+		if len(body) > 0 {
+			var parsed map[string]interface{}
+			if err := json.Unmarshal(body, &parsed); err == nil {
+				req.Body = parsed
+			}
+		}
+		requests = append(requests, req)
 
-	testConn := Connection{
-		ConnID:       "test-id",
-		ConnType:     "test-type",
-		ConnHost:     "test-host",
-		ConnSchema:   "test-schema",
-		ConnLogin:    "test-login",
-		ConnPassword: "test-password",
-		ConnPort:     1,
-		ConnURI:      "test-uri",
-		ConnExtra:    testExtra,
-	}
-	settings.Airflow.Connections = []Connection{testConn}
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+		}
+		fmt.Fprint(w, "{}")
+	}))
+	origClient := SetHTTPClient(server.Client())
+	s.T().Cleanup(func() {
+		SetHTTPClient(origClient)
+		server.Close()
+	})
+	return server, &requests
+}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains(airflowCommand, "airflow connections import --overwrite")
-		jsonStr := extractJSONFromHeredoc(airflowCommand)
-		var connMap map[string]interface{}
-		s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
-		s.Contains(connMap, "test-id")
-		connObj, ok := connMap["test-id"].(map[string]interface{})
-		s.True(ok)
-		s.Equal("test-type", connObj["conn_type"])
-		s.Equal("test-host", connObj["host"])
-		s.Equal("test-login", connObj["login"])
-		s.Equal("test-password", connObj["password"])
-		s.Equal("test-schema", connObj["schema"])
-		s.Equal(float64(1), connObj["port"])
-		return "", nil
-	}
-	err := AddConnections("test-conn-id", nil)
+// newConflictAirflowAPI creates a server that returns 409 on POST (to test upsert/update path).
+func newConflictAirflowAPI(s *Suite) (*httptest.Server, *[]apiRequest) {
+	var requests []apiRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		req := apiRequest{Method: r.Method, Path: r.URL.Path, RawBody: body}
+		if len(body) > 0 {
+			var parsed map[string]interface{}
+			if err := json.Unmarshal(body, &parsed); err == nil {
+				req.Body = parsed
+			}
+		}
+		requests = append(requests, req)
+
+		switch r.Method {
+		case http.MethodPost:
+			w.WriteHeader(http.StatusConflict)
+			fmt.Fprint(w, `{"detail":"already exists"}`)
+		case http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "{}")
+		}
+	}))
+	origClient := SetHTTPClient(server.Client())
+	s.T().Cleanup(func() {
+		SetHTTPClient(origClient)
+		server.Close()
+	})
+	return server, &requests
+}
+
+func (s *Suite) TestConfigSettings() {
+	server, _ := newMockAirflowAPI(s)
+	err := ConfigSettings(server.URL+"/api/v2", "", "", nil, false, false, false)
 	s.NoError(err)
+	// empty URL error
+	err = ConfigSettings("", "", "", nil, false, false, false)
+	s.ErrorIs(err, errNoURL)
+}
+
+func (s *Suite) TestAddVariables() {
+	settings.Airflow.Variables = Variables{
+		{VariableName: "test-var-name", VariableValue: "test-var-val"},
+	}
+
+	server, requests := newMockAirflowAPI(s)
+	err := AddVariables(server.URL+"/api/v2", "")
+	s.NoError(err)
+	s.Len(*requests, 1)
+	s.Equal(http.MethodPost, (*requests)[0].Method)
+	s.Equal("/api/v2/variables", (*requests)[0].Path)
+	s.Equal("test-var-name", (*requests)[0].Body["key"])
+	s.Equal("test-var-val", (*requests)[0].Body["value"])
+}
+
+func (s *Suite) TestAddVariablesUpdate() {
+	settings.Airflow.Variables = Variables{
+		{VariableName: "existing-var", VariableValue: "new-val"},
+	}
+
+	server, requests := newConflictAirflowAPI(s)
+	err := AddVariables(server.URL+"/api/v2", "")
+	s.NoError(err)
+	// Should have POST (409) then PATCH
+	s.Len(*requests, 2)
+	s.Equal(http.MethodPost, (*requests)[0].Method)
+	s.Equal(http.MethodPatch, (*requests)[1].Method)
+	s.Equal("/api/v2/variables/existing-var", (*requests)[1].Path)
 }
 
 func ptr[T any](t T) *T {
 	return &t
 }
 
-func (s *Suite) TestAddConnectionsWithEnvConns() {
-	var testExtra map[string]string
-
+func (s *Suite) TestAddConnections() {
 	testConn := Connection{
 		ConnID:       "test-id",
 		ConnType:     "test-type",
@@ -99,8 +151,29 @@ func (s *Suite) TestAddConnectionsWithEnvConns() {
 		ConnLogin:    "test-login",
 		ConnPassword: "test-password",
 		ConnPort:     1,
-		ConnURI:      "test-uri",
-		ConnExtra:    testExtra,
+	}
+	settings.Airflow.Connections = []Connection{testConn}
+
+	server, requests := newMockAirflowAPI(s)
+	err := AddConnections(server.URL+"/api/v2", "", nil)
+	s.NoError(err)
+	s.Len(*requests, 1)
+	s.Equal(http.MethodPost, (*requests)[0].Method)
+	s.Equal("/api/v2/connections", (*requests)[0].Path)
+	s.Equal("test-id", (*requests)[0].Body["connection_id"])
+	s.Equal("test-type", (*requests)[0].Body["conn_type"])
+	s.Equal("test-host", (*requests)[0].Body["host"])
+	s.Equal("test-login", (*requests)[0].Body["login"])
+	s.Equal("test-password", (*requests)[0].Body["password"])
+	s.Equal("test-schema", (*requests)[0].Body["schema"])
+	s.Equal(float64(1), (*requests)[0].Body["port"])
+}
+
+func (s *Suite) TestAddConnectionsWithEnvConns() {
+	testConn := Connection{
+		ConnID:   "test-id",
+		ConnType: "test-type",
+		ConnHost: "test-host",
 	}
 	settings.Airflow.Connections = []Connection{testConn}
 
@@ -118,182 +191,154 @@ func (s *Suite) TestAddConnectionsWithEnvConns() {
 		},
 	}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains(airflowCommand, "airflow connections import --overwrite")
-		jsonStr := extractJSONFromHeredoc(airflowCommand)
-		var connMap map[string]interface{}
-		s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
-		// Both settings and env connections should be present
-		s.Contains(connMap, "test-id")
-		s.Contains(connMap, "test-env-id")
-		// Verify env connection fields
-		envConn, ok := connMap["test-env-id"].(map[string]interface{})
-		s.True(ok)
-		s.Equal("test-env-type", envConn["conn_type"])
-		s.Equal("test-env-host", envConn["host"])
-		s.Equal(float64(2), envConn["port"])
-		extra, ok := envConn["extra"].(map[string]interface{})
-		s.True(ok)
-		s.Equal("test-extra-value", extra["test-extra-key"])
-		return "", nil
-	}
-	err := AddConnections("test-conn-id", envConns)
+	server, requests := newMockAirflowAPI(s)
+	err := AddConnections(server.URL+"/api/v2", "", envConns)
 	s.NoError(err)
+	// Both settings and env connections should create requests
+	s.Len(*requests, 2)
+
+	// Find the env connection request
+	var envReq *apiRequest
+	for i := range *requests {
+		if (*requests)[i].Body["connection_id"] == "test-env-id" {
+			envReq = &(*requests)[i]
+			break
+		}
+	}
+	s.NotNil(envReq)
+	s.Equal("test-env-type", envReq.Body["conn_type"])
+	s.Equal("test-env-host", envReq.Body["host"])
 }
 
 func (s *Suite) TestAddConnectionsURI() {
 	testConn := Connection{
 		ConnID:  "test-id",
-		ConnURI: "test-uri",
+		ConnURI: "postgres://user:pass@host:5432/db",
 	}
 	settings.Airflow.Connections = []Connection{testConn}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains(airflowCommand, "airflow connections import --overwrite")
-		jsonStr := extractJSONFromHeredoc(airflowCommand)
-		var connMap map[string]interface{}
-		s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
-		s.Contains(connMap, "test-id")
-		// URI-only connection should be a string value, not an object
-		connVal, ok := connMap["test-id"].(string)
-		s.True(ok)
-		s.Equal("test-uri", connVal)
-		return "", nil
-	}
-	err := AddConnections("test-conn-id", nil)
+	server, requests := newMockAirflowAPI(s)
+	err := AddConnections(server.URL+"/api/v2", "", nil)
 	s.NoError(err)
+	s.Len(*requests, 1)
+	// URI should be parsed into individual fields
+	s.Equal("postgres", (*requests)[0].Body["conn_type"])
+	s.Equal("host", (*requests)[0].Body["host"])
+	s.Equal("user", (*requests)[0].Body["login"])
+	s.Equal("pass", (*requests)[0].Body["password"])
+	s.Equal(float64(5432), (*requests)[0].Body["port"])
+	s.Equal("db", (*requests)[0].Body["schema"])
 }
 
-func (s *Suite) TestAddVariables() {
-	settings.Airflow.Variables = Variables{
-		{
-			VariableName:  "test-var-name",
-			VariableValue: "test-var-val",
-		},
+func (s *Suite) TestAddConnectionsUpdate() {
+	settings.Airflow.Connections = []Connection{
+		{ConnID: "existing", ConnType: "http"},
 	}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains(airflowCommand, "airflow variables import")
-		jsonStr := extractJSONFromHeredoc(airflowCommand)
-		var varsMap map[string]string
-		s.NoError(json.Unmarshal([]byte(jsonStr), &varsMap))
-		s.Equal("test-var-val", varsMap["test-var-name"])
-		return "", nil
-	}
-	err := AddVariables("test-conn-id")
+	server, requests := newConflictAirflowAPI(s)
+	err := AddConnections(server.URL+"/api/v2", "", nil)
 	s.NoError(err)
+	s.Len(*requests, 2)
+	s.Equal(http.MethodPost, (*requests)[0].Method)
+	s.Equal(http.MethodPatch, (*requests)[1].Method)
+	s.Equal("/api/v2/connections/existing", (*requests)[1].Path)
 }
 
 func (s *Suite) TestAddPools() {
 	settings.Airflow.Pools = Pools{
-		{
-			PoolName:        "test-pool-name",
-			PoolSlot:        1,
-			PoolDescription: "test-pool-description",
-		},
+		{PoolName: "test-pool", PoolSlot: 5, PoolDescription: "test desc"},
 	}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains(airflowCommand, "airflow pools import")
-		jsonStr := extractJSONFromHeredoc(airflowCommand)
-		var poolMap map[string]poolImportEntry
-		s.NoError(json.Unmarshal([]byte(jsonStr), &poolMap))
-		s.Len(poolMap, 1)
-		s.Contains(poolMap, "test-pool-name")
-		s.Equal(1, poolMap["test-pool-name"].Slots)
-		s.Equal("test-pool-description", poolMap["test-pool-name"].Description)
-		return "", nil
-	}
-	err := AddPools("test-conn-id")
+	server, requests := newMockAirflowAPI(s)
+	err := AddPools(server.URL+"/api/v2", "")
 	s.NoError(err)
+	s.Len(*requests, 1)
+	s.Equal(http.MethodPost, (*requests)[0].Method)
+	s.Equal("/api/v2/pools", (*requests)[0].Path)
+	s.Equal("test-pool", (*requests)[0].Body["name"])
+	s.Equal(float64(5), (*requests)[0].Body["slots"])
+	s.Equal("test desc", (*requests)[0].Body["description"])
 }
 
-func (s *Suite) TestAddVariableBatchFailure() {
+func (s *Suite) TestAddVariableFailure() {
 	settings.Airflow.Variables = Variables{
-		{
-			VariableName:  "test-var-name",
-			VariableValue: "test-var-val",
-		},
+		{VariableName: "test-var", VariableValue: "val"},
 	}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		return "", fmt.Errorf("mock import error")
-	}
-	err := AddVariables("test-conn-id")
-	s.Contains(err.Error(), "mock import error")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"detail":"server error"}`)
+	}))
+	origClient := SetHTTPClient(server.Client())
+	defer func() { SetHTTPClient(origClient); server.Close() }()
+
+	err := AddVariables(server.URL+"/api/v2", "")
+	s.Error(err)
+	s.Contains(err.Error(), "server error")
 }
 
-func (s *Suite) TestAddConnectionsBatchFailure() {
+func (s *Suite) TestAddConnectionsFailure() {
 	settings.Airflow.Connections = []Connection{
-		{
-			ConnID:   "test-id",
-			ConnType: "test-type",
-		},
+		{ConnID: "test-id", ConnType: "test-type"},
 	}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		return "", fmt.Errorf("mock import error")
-	}
-	err := AddConnections("test-conn-id", nil)
-	s.Contains(err.Error(), "mock import error")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"detail":"server error"}`)
+	}))
+	origClient := SetHTTPClient(server.Client())
+	defer func() { SetHTTPClient(origClient); server.Close() }()
+
+	err := AddConnections(server.URL+"/api/v2", "", nil)
+	s.Error(err)
+	s.Contains(err.Error(), "server error")
 }
 
-func (s *Suite) TestAddPoolsBatchFailure() {
+func (s *Suite) TestAddPoolsFailure() {
 	settings.Airflow.Pools = Pools{
-		{
-			PoolName:        "test-pool",
-			PoolSlot:        1,
-			PoolDescription: "desc",
-		},
+		{PoolName: "test-pool", PoolSlot: 1, PoolDescription: "desc"},
 	}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		return "", fmt.Errorf("mock import error")
-	}
-	err := AddPools("test-conn-id")
-	s.Contains(err.Error(), "mock import error")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"detail":"server error"}`)
+	}))
+	origClient := SetHTTPClient(server.Client())
+	defer func() { SetHTTPClient(origClient); server.Close() }()
+
+	err := AddPools(server.URL+"/api/v2", "")
+	s.Error(err)
+	s.Contains(err.Error(), "server error")
 }
 
-func (s *Suite) TestBatchImportEmptyLists() {
+func (s *Suite) TestEmptyLists() {
 	settings.Airflow.Variables = Variables{}
 	settings.Airflow.Connections = Connections{}
 	settings.Airflow.Pools = Pools{}
 
-	called := false
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		called = true
-		return "", nil
-	}
+	server, requests := newMockAirflowAPI(s)
+	url := server.URL + "/api/v2"
 
-	s.NoError(AddVariables("test-id"))
-	s.NoError(AddConnections("test-id", nil))
-	s.NoError(AddPools("test-id"))
-	s.False(called, "execAirflowCommand should not be called for empty lists")
+	s.NoError(AddVariables(url, ""))
+	s.NoError(AddConnections(url, "", nil))
+	s.NoError(AddPools(url, ""))
+	s.Empty(*requests, "no API calls should be made for empty lists")
 }
 
-func (s *Suite) TestBatchImportMultipleVariables() {
+func (s *Suite) TestMultipleVariables() {
 	settings.Airflow.Variables = Variables{
 		{VariableName: "var1", VariableValue: "val1"},
 		{VariableName: "var2", VariableValue: "val2"},
 		{VariableName: "var3", VariableValue: "val3"},
 	}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		s.Contains(airflowCommand, "airflow variables import")
-		jsonStr := extractJSONFromHeredoc(airflowCommand)
-		var varsMap map[string]string
-		s.NoError(json.Unmarshal([]byte(jsonStr), &varsMap))
-		s.Len(varsMap, 3)
-		s.Equal("val1", varsMap["var1"])
-		s.Equal("val2", varsMap["var2"])
-		s.Equal("val3", varsMap["var3"])
-		return "", nil
-	}
-	err := AddVariables("test-id")
+	server, requests := newMockAirflowAPI(s)
+	err := AddVariables(server.URL+"/api/v2", "")
 	s.NoError(err)
+	s.Len(*requests, 3)
 }
 
-func (s *Suite) TestBatchImportConnectionExtraTypes() {
+func (s *Suite) TestConnectionExtraTypes() {
 	s.Run("map extra", func() {
 		settings.Airflow.Connections = []Connection{
 			{
@@ -301,21 +346,13 @@ func (s *Suite) TestBatchImportConnectionExtraTypes() {
 				ConnType: "http",
 				ConnExtra: map[any]any{
 					"key1": "val1",
-					"key2": "val2",
 				},
 			},
 		}
-		execAirflowCommand = func(id, airflowCommand string) (string, error) {
-			jsonStr := extractJSONFromHeredoc(airflowCommand)
-			var connMap map[string]map[string]interface{}
-			s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
-			extra, ok := connMap["map-extra-conn"]["extra"].(map[string]interface{})
-			s.True(ok)
-			s.Equal("val1", extra["key1"])
-			s.Equal("val2", extra["key2"])
-			return "", nil
-		}
-		s.NoError(AddConnections("test-id", nil))
+		server, requests := newMockAirflowAPI(s)
+		s.NoError(AddConnections(server.URL+"/api/v2", "", nil))
+		s.Len(*requests, 1)
+		s.Contains((*requests)[0].Body["extra"], "key1")
 	})
 
 	s.Run("string json extra", func() {
@@ -326,16 +363,10 @@ func (s *Suite) TestBatchImportConnectionExtraTypes() {
 				ConnExtra: `{"key":"val"}`,
 			},
 		}
-		execAirflowCommand = func(id, airflowCommand string) (string, error) {
-			jsonStr := extractJSONFromHeredoc(airflowCommand)
-			var connMap map[string]map[string]interface{}
-			s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
-			extra, ok := connMap["str-extra-conn"]["extra"].(map[string]interface{})
-			s.True(ok)
-			s.Equal("val", extra["key"])
-			return "", nil
-		}
-		s.NoError(AddConnections("test-id", nil))
+		server, requests := newMockAirflowAPI(s)
+		s.NoError(AddConnections(server.URL+"/api/v2", "", nil))
+		s.Len(*requests, 1)
+		s.Equal(`{"key":"val"}`, (*requests)[0].Body["extra"])
 	})
 
 	s.Run("nil extra", func() {
@@ -346,35 +377,66 @@ func (s *Suite) TestBatchImportConnectionExtraTypes() {
 				ConnExtra: nil,
 			},
 		}
-		execAirflowCommand = func(id, airflowCommand string) (string, error) {
-			jsonStr := extractJSONFromHeredoc(airflowCommand)
-			var connMap map[string]map[string]interface{}
-			s.NoError(json.Unmarshal([]byte(jsonStr), &connMap))
-			_, hasExtra := connMap["nil-extra-conn"]["extra"]
-			s.False(hasExtra, "nil extra should not appear in JSON")
-			return "", nil
-		}
-		s.NoError(AddConnections("test-id", nil))
+		server, requests := newMockAirflowAPI(s)
+		s.NoError(AddConnections(server.URL+"/api/v2", "", nil))
+		s.Len(*requests, 1)
+		_, hasExtra := (*requests)[0].Body["extra"]
+		s.False(hasExtra, "nil extra should not appear in JSON")
 	})
 }
 
-func (s *Suite) TestBatchImportMixedValidInvalid() {
+func (s *Suite) TestMixedValidInvalid() {
 	settings.Airflow.Variables = Variables{
 		{VariableName: "good_var", VariableValue: "good_val"},
 		{VariableName: "", VariableValue: "orphan_val"},
 		{VariableName: "empty_val_var", VariableValue: ""},
 	}
 
-	execAirflowCommand = func(id, airflowCommand string) (string, error) {
-		jsonStr := extractJSONFromHeredoc(airflowCommand)
-		var varsMap map[string]string
-		s.NoError(json.Unmarshal([]byte(jsonStr), &varsMap))
-		s.Len(varsMap, 1)
-		s.Equal("good_val", varsMap["good_var"])
-		return "", nil
-	}
-	err := AddVariables("test-id")
+	server, requests := newMockAirflowAPI(s)
+	err := AddVariables(server.URL+"/api/v2", "")
 	s.NoError(err)
+	// Only 1 valid variable should create an API call
+	s.Len(*requests, 1)
+	s.Equal("good_var", (*requests)[0].Body["key"])
+}
+
+func (s *Suite) TestAuthHeaderPassedThrough() {
+	settings.Airflow.Variables = Variables{
+		{VariableName: "test", VariableValue: "val"},
+	}
+
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, "{}")
+	}))
+	origClient := SetHTTPClient(server.Client())
+	defer func() { SetHTTPClient(origClient); server.Close() }()
+
+	err := AddVariables(server.URL+"/api/v2", "Basic dGVzdDp0ZXN0")
+	s.NoError(err)
+	s.Equal("Basic dGVzdDp0ZXN0", receivedAuth)
+}
+
+func (s *Suite) TestSkipMessages() {
+	s.Run("skip pool with zero slots", func() {
+		settings.Airflow.Pools = Pools{
+			{PoolName: "zero-pool", PoolSlot: 0, PoolDescription: "should skip"},
+		}
+		server, requests := newMockAirflowAPI(s)
+		s.NoError(AddPools(server.URL+"/api/v2", ""))
+		s.Empty(*requests)
+	})
+
+	s.Run("skip connection without type or uri", func() {
+		settings.Airflow.Connections = []Connection{
+			{ConnID: "no-type", ConnHost: "host"},
+		}
+		server, requests := newMockAirflowAPI(s)
+		s.NoError(AddConnections(server.URL+"/api/v2", "", nil))
+		s.Empty(*requests)
+	})
 }
 
 func (s *Suite) TestInitSettingsSuccess() {
@@ -422,12 +484,7 @@ func (s *Suite) TestEnvExport() {
 
 	s.Run("variable failure", func() {
 		execAirflowCommand = func(id, airflowCommand string) (string, error) {
-			switch airflowCommand {
-			case airflowVarExport:
-				return "", nil
-			default:
-				return "", nil
-			}
+			return "", nil
 		}
 
 		err := EnvExport("id", "testfiles/test.env", 2, false, true)
@@ -437,12 +494,7 @@ func (s *Suite) TestEnvExport() {
 
 	s.Run("connection failure", func() {
 		execAirflowCommand = func(id, airflowCommand string) (string, error) {
-			switch airflowCommand {
-			case airflowConnExport:
-				return "", nil
-			default:
-				return "", nil
-			}
+			return "", nil
 		}
 
 		err := EnvExport("id", "testfiles/test.env", 2, true, false)
@@ -497,12 +549,7 @@ func (s *Suite) TestExport() {
 	s.Run("variable failure", func() {
 		WorkingPath = "./testfiles/"
 		execAirflowCommand = func(id, airflowCommand string) (string, error) {
-			switch airflowCommand {
-			case airflowVarExport:
-				return "", nil
-			default:
-				return "", nil
-			}
+			return "", nil
 		}
 
 		err := Export("id", "airflow_settings_export.yaml", 2, false, true, false)
@@ -577,3 +624,9 @@ func (s *Suite) TestWriteAirflowSettingstoYAML() {
 		os.Remove("./variables.yaml")
 	})
 }
+
+// Ensure unused imports are consumed
+var (
+	_ = strings.TrimSpace
+	_ = fmt.Sprint
+)

--- a/settings/types.go
+++ b/settings/types.go
@@ -61,6 +61,13 @@ type AirflowPools []struct {
 	PoolDescription string `yaml:"description"`
 }
 
+// poolImportEntry is the JSON value format expected by `airflow pools import`.
+// The pool name is used as the dict key.
+type poolImportEntry struct {
+	Slots       int    `json:"slots"`
+	Description string `json:"description"`
+}
+
 // types for creating variables and connections yaml files
 
 type DAGRunVariables struct {

--- a/settings/types.go
+++ b/settings/types.go
@@ -61,13 +61,6 @@ type AirflowPools []struct {
 	PoolDescription string `yaml:"description"`
 }
 
-// poolImportEntry is the JSON value format expected by `airflow pools import`.
-// The pool name is used as the dict key.
-type poolImportEntry struct {
-	Slots       int    `json:"slots"`
-	Description string `json:"description"`
-}
-
 // types for creating variables and connections yaml files
 
 type DAGRunVariables struct {


### PR DESCRIPTION
## Summary

`astro dev start` and `astro dev object import` were very slow because they loaded each variable, connection, and pool from `airflow_settings.yaml` by shelling into the Airflow container and running a separate `airflow variables set` / `airflow connections add` / `airflow pools set` command per item. Every command paid the full Airflow CLI startup cost (~2-5 seconds), so a project with 10 connections, 5 variables, and 2 pools would spend **1-2+ minutes** just on settings injection.

This PR replaces the per-item CLI approach with direct calls to the Airflow REST API. For each object we POST to create, and if the object already exists (409 Conflict) we PATCH to update — matching the previous overwrite behavior without needing to list + delete + recreate.

## What changes

### Settings import (`settings/settings.go`)

- `ConfigSettings`, `AddVariables`, `AddConnections`, `AddPools` now take an Airflow API URL + optional auth header instead of a container ID
- Each function makes HTTP calls against `/api/v1/{resource}` (Airflow 2) or `/api/v2/{resource}` (Airflow 3)
- URI-only connections (e.g. `conn_uri: postgres://user:pass@host:5432/db`) are parsed into individual fields since the REST API doesn't accept a `uri` field
- Connection extras are serialized to a JSON string as the API expects
- `default_pool` uses `?update_mask=slots&update_mask=include_deferred` on PATCH since Airflow only allows those two fields to be updated on the default pool
- Airflow 1 codepaths are removed entirely since Astronomer no longer ships Airflow 1
- Tests use `httptest.NewServer` to mock the Airflow API

### Caller updates (`airflow/docker.go`, `airflow/standalone.go`)

- **Docker mode**: constructs `http://localhost:<port>/api/v<version>` and fetches auth — Basic Auth (`admin:admin`) for Airflow 2, JWT token via `/auth/token` for Airflow 3's SimpleAuthManager
- **Port detection**: when proxy mode allocates a random port (not the config default), the code now queries the running container's port via `composeService.Ps()` so `object import` finds the right port. `printStatus` / `printProxyStatus` get the port from the overrides they already receive
- **Standalone mode**: persists the allocated port to `.astro/standalone/port` on start and reads it back in `object import`. Also fetches a JWT token the same way Docker mode does

## Performance impact

Previously: O(n) Airflow CLI invocations per object type, each ~2-5s overhead.
Now: O(n) HTTP requests with ~10-50ms overhead each. A typical settings file goes from >1 minute to a few seconds.

## Test plan

Unit tests:
- [x] `go test ./settings/... ./airflow/...` passes (36 settings tests including new API mocking tests, airflow tests updated)
- [x] `golangci-lint run ./settings/... ./airflow/...` clean

E2E tests (done manually with real Airflow containers/venvs):
- [x] **Docker + Airflow 3** (runtime 3.1-12): `dev start`, `dev object import`, `dev restart`, verified every value round-trips through the REST API
- [x] **Docker + Airflow 2** (runtime 13.6.0 / Airflow 2.11.2): `dev start`, `dev object import`, `dev restart`, verified via `/api/v1` with Basic Auth
- [x] **Standalone** (runtime 3.1-12): `dev start --standalone`, `dev object import --standalone`, `dev restart --standalone`, verified JWT auth + port persistence
- [x] **Port overrides**: verified that proxy-allocated random ports (e.g. 13425, 18107) are detected and used correctly
- [x] **Edge cases**: special characters in passwords (`p@ss'w0rd&special=chars!@#$%`), JSON values in variables, Unicode, URI-only connections parsed correctly, invalid items skipped with existing warning messages, empty settings file, upsert on restart
- [x] **conn_extra types**: map[any]any (YAML nested keys), JSON strings, nil

## Out of scope

There's a pre-existing crash in `settings.ExportConnections` when running against Airflow 3 — it parses the YAML output of `airflow connections list -o yaml` which has a different format in Airflow 3. Not related to this PR; filed separately.