### PR TITLE
Add stale issues and PRs workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Handle stale issues and PRs
+on:
+  schedule:
+    - cron: "0 11 * * *"
+jobs:
+  handle-stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 120
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 120 days since being marked as stale."
+          days-before-pr-stale: 60
+          days-before-pr-close: 30
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR is stale because it has been open for 60 days with no activity."
+          close-pr-message: "This PR was closed because it has been inactive for 30 days since being marked as stale."
+          exempt-issue-labels: "do-not-stale"
+          exempt-pr-labels: "do-not-stale"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a daily GitHub Action (via `actions/stale@v10`) to manage stale issues and PRs
- Issues are marked stale after **60 days** of inactivity and auto-closed after **180 days** (120 days after the stale label)
- PRs are marked stale after **60 days** and auto-closed after **90 days** (30 days after the stale label)
- Issues/PRs labeled `do-not-stale` are exempt

## Note on pre-existing issues
The `days-before-close` countdown starts from when the action *applies* the stale label, not from the issue's last activity. On the first run, long-inactive issues will be freshly labeled and get a full 120-day grace period before being eligible for closing. If any issues already carry a `stale` label from manual labeling, consider removing those labels before merging to avoid unintended early closure.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm the action runs on schedule and labels inactive issues/PRs
- [ ] Confirm exempt labels are respected