### PR TITLE
Accept context.Context in airflowrt.CheckHealth

### DIFF
--- a/pkg/airflowrt/health.go
+++ b/pkg/airflowrt/health.go
@@ -8,10 +8,11 @@ import (
 )
 
 // CheckHealth polls the Airflow health endpoint until it responds with 200 or the timeout is reached.
-var CheckHealth = func(port string, timeout time.Duration) error {
+// The provided context can be used to cancel the health check before the timeout expires.
+var CheckHealth = func(ctx context.Context, port string, timeout time.Duration) error {
 	url := fmt.Sprintf("http://localhost:%s/api/v2/monitor/health", port)
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	client := &http.Client{Timeout: 5 * time.Second}


### PR DESCRIPTION
## Summary
- Add `context.Context` as the first parameter to `airflowrt.CheckHealth` so callers can cancel long-running health checks
- The timeout is now derived from the caller-provided context instead of an internal `context.Background()`
- This enables astro-desktop to cancel health checks when a project is stopped/killed mid-startup, preventing stale "health check failed" notifications minutes after teardown

## Test plan
- [x] `go test ./pkg/airflowrt/...` passes
- [x] `go build ./...` passes
- [ ] Update astro-desktop caller to pass context directly instead of goroutine wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)