### PR TITLE
Move monorepo-dependent exports out of platform-core sub-module

### DIFF
--- a/astro-client-platform-core/client.go
+++ b/astro-client-platform-core/client.go
@@ -1,26 +1,4 @@
 package astroplatformcore
 
-import (
-	"github.com/astronomer/astro-cli/context"
-	"github.com/astronomer/astro-cli/pkg/httputil"
-)
-
-// NormalizeAPIError is a deliberate re-export of httputil.NormalizeAPIError, allowing
-// callers to override error normalization per-client without importing pkg/httputil.
-var NormalizeAPIError = httputil.NormalizeAPIError
-
-// a shorter alias
+// CoreClient is a shorter alias for the platform core client interface.
 type CoreClient = ClientWithResponsesInterface
-
-// create api client for astro platform core services
-func NewPlatformCoreClient(c *httputil.HTTPClient) *ClientWithResponses {
-	// we append base url in request editor, so set to an empty string here
-	cl, _ := NewClientWithResponses("", WithHTTPClient(c.HTTPClient), WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
-		ctx, err := context.GetCurrentContext()
-		if err != nil {
-			return "", "", err
-		}
-		return ctx.Token, ctx.GetPublicRESTAPIURL("platform/v1beta1"), nil
-	})))
-	return cl
-}

--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -17,6 +17,7 @@ import (
 
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	"github.com/astronomer/astro-cli/cloud/platformclient"
 	"github.com/astronomer/astro-cli/cloud/workspace"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
@@ -276,7 +277,7 @@ func CheckUserSession(c *config.Context, coreClient astrocore.CoreClient, platfo
 	if err != nil {
 		return err
 	}
-	err = astroplatformcore.NormalizeAPIError(orgsResp.HTTPResponse, orgsResp.Body)
+	err = platformclient.NormalizeAPIError(orgsResp.HTTPResponse, orgsResp.Body)
 	if err != nil {
 		return err
 	}

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -13,6 +13,7 @@ import (
 	astrocore "github.com/astronomer/astro-cli/astro-client-core"
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
 	"github.com/astronomer/astro-cli/cloud/auth"
+	"github.com/astronomer/astro-cli/cloud/platformclient"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -52,7 +53,7 @@ func ListOrganizations(platformCoreClient astroplatformcore.CoreClient) ([]astro
 	if err != nil {
 		return nil, err
 	}
-	err = astroplatformcore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+	err = platformclient.NormalizeAPIError(resp.HTTPResponse, resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +67,7 @@ func GetOrganization(orgID string, platformCoreClient astroplatformcore.CoreClie
 	if err != nil {
 		return nil, err
 	}
-	err = astroplatformcore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+	err = platformclient.NormalizeAPIError(resp.HTTPResponse, resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +96,7 @@ func findOrganizationByName(name string, platformCoreClient astroplatformcore.Co
 		if err != nil {
 			return nil, err
 		}
-		err = astroplatformcore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+		err = platformclient.NormalizeAPIError(resp.HTTPResponse, resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -301,7 +302,7 @@ func ExportAuditLogs(coreClient astrocore.CoreClient, platformCoreClient astropl
 	if err != nil {
 		return err
 	}
-	err = astroplatformcore.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+	err = platformclient.NormalizeAPIError(resp.HTTPResponse, resp.Body)
 	if err != nil {
 		return err
 	}

--- a/cloud/platformclient/client.go
+++ b/cloud/platformclient/client.go
@@ -2,10 +2,23 @@ package platformclient
 
 import (
 	astroplatformcore "github.com/astronomer/astro-cli/astro-client-platform-core"
+	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 )
 
+// NormalizeAPIError is a deliberate re-export of httputil.NormalizeAPIError, allowing
+// callers to normalize platform API errors without importing pkg/httputil directly.
+var NormalizeAPIError = httputil.NormalizeAPIError
+
 // NewPlatformCoreClient creates an API client for Astro platform core services.
 func NewPlatformCoreClient(c *httputil.HTTPClient) *astroplatformcore.ClientWithResponses {
-	return astroplatformcore.NewPlatformCoreClient(c)
+	// we append base url in request editor, so set to an empty string here
+	cl, _ := astroplatformcore.NewClientWithResponses("", astroplatformcore.WithHTTPClient(c.HTTPClient), astroplatformcore.WithRequestEditorFn(httputil.NewRequestEditorFn(func() (string, string, error) {
+		ctx, err := context.GetCurrentContext()
+		if err != nil {
+			return "", "", err
+		}
+		return ctx.Token, ctx.GetPublicRESTAPIURL("platform/v1beta1"), nil
+	})))
+	return cl
 }


### PR DESCRIPTION
## Summary
- Move `NormalizeAPIError` and `NewPlatformCoreClient` out of the `astro-client-platform-core` sub-module into `cloud/platformclient/`
- The sub-module's `client.go` imported `context` and `pkg/httputil` from the monorepo root, making it impossible to `go get` the sub-module without pulling in the entire monorepo (ambiguous import error)
- `CoreClient` type alias stays in the sub-module (no monorepo imports)

## Test plan
- [x] `go build ./...` passes (monorepo)
- [x] `go build ./...` passes in `astro-client-platform-core/` sub-module with `GOWORK=off`
- [x] Existing tests pass for `cloud/platformclient`, `cloud/auth`, `cloud/organization`

🤖 Generated with [Claude Code](https://claude.com/claude-code)