### PR TITLE
Paginate deployment log fetches to return all requested logs

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -292,17 +292,34 @@ func Logs(deploymentID, ws, deploymentName, keyword string, logServer, logSchedu
 		getDeploymentLogsParams.SearchText = &logLevel
 	}
 
-	deploymentLogs, err := GetDeploymentLogs("", deploymentID, getDeploymentLogsParams, coreClient)
-	if err != nil {
-		return err
+	var allResults []astrocore.DeploymentLogEntry
+	for {
+		deploymentLogs, err := GetDeploymentLogs("", deploymentID, getDeploymentLogsParams, coreClient)
+		if err != nil {
+			return err
+		}
+
+		allResults = append(allResults, deploymentLogs.Results...)
+
+		// Stop paginating if we got fewer results than the per-page limit
+		// (meaning there are no more pages) or we've reached the requested count.
+		if deploymentLogs.ResultCount < deploymentLogs.Limit || len(allResults) >= logCount {
+			break
+		}
+
+		// Set up the next page request using the search cursor and updated offset.
+		searchID := deploymentLogs.SearchId
+		getDeploymentLogsParams.SearchId = &searchID
+		nextOffset := deploymentLogs.Offset + deploymentLogs.ResultCount
+		getDeploymentLogsParams.Offset = &nextOffset
 	}
 
-	if len(deploymentLogs.Results) == 0 {
+	if len(allResults) == 0 {
 		fmt.Println("No matching logs have been recorded in the past 24 hours for Deployment " + deployment.Name)
 		return nil
 	}
-	for i := range deploymentLogs.Results {
-		fmt.Printf("%f %s %s\n", deploymentLogs.Results[i].Timestamp, deploymentLogs.Results[i].Raw, deploymentLogs.Results[i].Source)
+	for i := range allResults {
+		fmt.Printf("%f %s %s\n", allResults[i].Timestamp, allResults[i].Raw, allResults[i].Source)
 	}
 	return nil
 }

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -282,8 +282,11 @@ func Logs(deploymentID, ws, deploymentName, keyword string, logServer, logSchedu
 		componentSources = append(componentSources, serverComponent, "scheduler", "triggerer", "worker")
 	}
 
+	maxPerPage := 5000
+	perPage := min(logCount, maxPerPage)
 	getDeploymentLogsParams := astrocore.GetDeploymentLogsParams{
 		Sources:       componentSources,
+		Limit:         &perPage,
 		MaxNumResults: &logCount,
 		Range:         &timeRange,
 		Offset:        &offset,

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -311,14 +311,24 @@ func Logs(deploymentID, ws, deploymentName, keyword string, logServer, logSchedu
 		}
 
 		// Set up the next page request using the search cursor and updated offset.
+		// Shrink the next page to only what's still needed so the API doesn't ship
+		// results we'll throw away.
 		searchID := deploymentLogs.SearchId
 		getDeploymentLogsParams.SearchId = &searchID
 		nextOffset := deploymentLogs.Offset + deploymentLogs.ResultCount
 		getDeploymentLogsParams.Offset = &nextOffset
+		nextPerPage := min(logCount-len(allResults), maxPerPage)
+		getDeploymentLogsParams.Limit = &nextPerPage
+	}
+
+	// Belt-and-suspenders for the case where the API still over-returns.
+	if len(allResults) > logCount {
+		allResults = allResults[:logCount]
 	}
 
 	if len(allResults) == 0 {
-		fmt.Println("No matching logs have been recorded in the past 24 hours for Deployment " + deployment.Name)
+		hours := timeRange / 3600
+		fmt.Printf("No matching logs have been recorded in the past %d hours for Deployment %s\n", hours, deployment.Name)
 		return nil
 	}
 	for i := range allResults {

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -1023,6 +1023,75 @@ func (s *Suite) TestLogs() {
 		mockPlatformCoreClient.AssertExpectations(s.T())
 		mockCoreClient.AssertExpectations(s.T())
 	})
+	s.Run("subsequent pages shrink to remaining count", func() {
+		// logCount=3, page 1 returns 2 (API capping at Limit=2) → page 2 should be
+		// requested with Limit=1, not the original Limit=3, so the API doesn't
+		// ship results we'd discard.
+		page1Response := astrocore.GetDeploymentLogsResponse{
+			JSON200: &astrocore.DeploymentLog{
+				Limit: 2, MaxNumResults: 3, Offset: 0, ResultCount: 2,
+				Results: []astrocore.DeploymentLogEntry{
+					{Raw: "log 1", Timestamp: 1, Source: astrocore.DeploymentLogEntrySourceScheduler},
+					{Raw: "log 2", Timestamp: 2, Source: astrocore.DeploymentLogEntrySourceScheduler},
+				},
+				SearchId: "search-id-shrink",
+			},
+			HTTPResponse: &http.Response{StatusCode: 200},
+		}
+		page2Response := astrocore.GetDeploymentLogsResponse{
+			JSON200: &astrocore.DeploymentLog{
+				Limit: 1, MaxNumResults: 3, Offset: 2, ResultCount: 1,
+				Results: []astrocore.DeploymentLogEntry{
+					{Raw: "log 3", Timestamp: 3, Source: astrocore.DeploymentLogEntrySourceScheduler},
+				},
+				SearchId: "search-id-shrink",
+			},
+			HTTPResponse: &http.Response{StatusCode: 200},
+		}
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+
+		// First call: Limit pointer points to 3.
+		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything,
+			mock.MatchedBy(func(p *astrocore.GetDeploymentLogsParams) bool { return p.Limit != nil && *p.Limit == 3 }),
+		).Return(&page1Response, nil).Once()
+		// Second call: Limit pointer should have been shrunk to 1 (logCount - already-fetched).
+		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything,
+			mock.MatchedBy(func(p *astrocore.GetDeploymentLogsParams) bool { return p.Limit != nil && *p.Limit == 1 }),
+		).Return(&page2Response, nil).Once()
+
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, false, false, 3, mockPlatformCoreClient, mockCoreClient)
+		s.NoError(err)
+		mockPlatformCoreClient.AssertExpectations(s.T())
+		mockCoreClient.AssertExpectations(s.T())
+	})
+	s.Run("over-returned page is trimmed to requested count", func() {
+		// API returns more results on a single page than logCount asked for. The
+		// trim guard at the end of Logs should keep us from printing the extra.
+		// We verify by mocking a single call (trim happens, no second call needed)
+		// and asserting only one mock call landed.
+		oversizedResponse := astrocore.GetDeploymentLogsResponse{
+			JSON200: &astrocore.DeploymentLog{
+				Limit: 2, MaxNumResults: 2, Offset: 0, ResultCount: 5,
+				Results: []astrocore.DeploymentLogEntry{
+					{Raw: "log 1", Timestamp: 1, Source: astrocore.DeploymentLogEntrySourceScheduler},
+					{Raw: "log 2", Timestamp: 2, Source: astrocore.DeploymentLogEntrySourceScheduler},
+					{Raw: "log 3", Timestamp: 3, Source: astrocore.DeploymentLogEntrySourceScheduler},
+					{Raw: "log 4", Timestamp: 4, Source: astrocore.DeploymentLogEntrySourceScheduler},
+					{Raw: "log 5", Timestamp: 5, Source: astrocore.DeploymentLogEntrySourceScheduler},
+				},
+			},
+			HTTPResponse: &http.Response{StatusCode: 200},
+		}
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&oversizedResponse, nil).Once()
+
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, false, false, 2, mockPlatformCoreClient, mockCoreClient)
+		s.NoError(err)
+		mockPlatformCoreClient.AssertExpectations(s.T())
+		mockCoreClient.AssertExpectations(s.T())
+	})
 	// Add after the "multiple components" subtest
 	s.Run("airflow 3 deployment fetches apiserver logs", func() {
 		// Mock Airflow 3 deployment

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -850,7 +850,7 @@ func (s *Suite) TestLogs() {
 			Limit:         logCount,
 			MaxNumResults: 10,
 			Offset:        0,
-			ResultCount:   1,
+			ResultCount:   2,
 			Results: []astrocore.DeploymentLogEntry{
 				{
 					Raw:       "test log line",
@@ -871,10 +871,10 @@ func (s *Suite) TestLogs() {
 	}
 	mockGetDeploymentLogsMultipleComponentsResponse := astrocore.GetDeploymentLogsResponse{
 		JSON200: &astrocore.DeploymentLog{
-			Limit:         4,
+			Limit:         10,
 			MaxNumResults: 10,
 			Offset:        0,
-			ResultCount:   1,
+			ResultCount:   5,
 			Results: []astrocore.DeploymentLogEntry{
 				{
 					Raw:       "test log line",
@@ -979,6 +979,45 @@ func (s *Suite) TestLogs() {
 		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockGetDeploymentLogsMultipleComponentsResponse, nil).Once()
 
 		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
+		s.NoError(err)
+
+		mockPlatformCoreClient.AssertExpectations(s.T())
+		mockCoreClient.AssertExpectations(s.T())
+	})
+	s.Run("pagination fetches multiple pages", func() {
+		page1Response := astrocore.GetDeploymentLogsResponse{
+			JSON200: &astrocore.DeploymentLog{
+				Limit:         2,
+				MaxNumResults: 10,
+				Offset:        0,
+				ResultCount:   2,
+				Results: []astrocore.DeploymentLogEntry{
+					{Raw: "log line 1", Timestamp: 1, Source: astrocore.DeploymentLogEntrySourceScheduler},
+					{Raw: "log line 2", Timestamp: 2, Source: astrocore.DeploymentLogEntrySourceScheduler},
+				},
+				SearchId: "search-id-1",
+			},
+			HTTPResponse: &http.Response{StatusCode: 200},
+		}
+		page2Response := astrocore.GetDeploymentLogsResponse{
+			JSON200: &astrocore.DeploymentLog{
+				Limit:         2,
+				MaxNumResults: 10,
+				Offset:        2,
+				ResultCount:   1,
+				Results: []astrocore.DeploymentLogEntry{
+					{Raw: "log line 3", Timestamp: 3, Source: astrocore.DeploymentLogEntrySourceScheduler},
+				},
+				SearchId: "search-id-1",
+			},
+			HTTPResponse: &http.Response{StatusCode: 200},
+		}
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&page1Response, nil).Once()
+		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&page2Response, nil).Once()
+
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, false, false, 10, mockPlatformCoreClient, mockCoreClient)
 		s.NoError(err)
 
 		mockPlatformCoreClient.AssertExpectations(s.T())


### PR DESCRIPTION
## Description

The `logs --log-count` command was only making a single API call, so results were capped at the API's per-page limit (~500-750 lines) regardless of the requested count. This adds a pagination loop that uses the API's `offset` and `searchId` fields to fetch subsequent pages until the requested log count is reached or no more results are available.

## 🎟 Issue(s)

Related #1736

## 🧪 Functional Testing

1. Run `astro deployment logs <id> --scheduler --log-count 5000`
2. Verify that more than ~750 lines are returned when sufficient logs exist
3. Verify that `--log-count 10` still correctly limits output to 10 lines

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
