### PR TITLE
fix: skip Dockerfile parse when --image-name is provided

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -41,7 +41,8 @@ const (
 	composeSkipImageBuildingPromptMsg = "Skipping building image..."
 	deploymentHeaderMsg               = "Authenticated to %s \n\n"
 
-	warningInvalidImageNameMsg = "WARNING! The image in your Dockerfile '%s' is not based on Astro Runtime and is not supported. Change your Dockerfile with an image that pulls from 'quay.io/astronomer/astro-runtime' to proceed.\n"
+	warningInvalidImageNameMsg         = "WARNING! The image in your Dockerfile '%s' is not based on Astro Runtime and is not supported. Change your Dockerfile with an image that pulls from 'quay.io/astronomer/astro-runtime' to proceed.\n"
+	warningInvalidPrebuiltImageNameMsg = "WARNING! The image '%s' does not appear to be based on Astro Runtime (the '%s' label is missing). Ensure your image is built FROM quay.io/astronomer/astro-runtime to proceed.\n"
 
 	allTests                 = "all-tests"
 	parseAndPytest           = "parse-and-all-tests"
@@ -723,18 +724,19 @@ func buildImage(path, currentVersion, deployImage, imageName, organizationID, bu
 	}
 
 	if config.CFG.ShowWarnings.GetBool() && version == "" {
-		// When a pre-built image is supplied via --image-name, the Dockerfile is
-		// not needed to determine the base image — use the image name directly in
-		// the warning.  Only parse the Dockerfile when we built locally.
-		warningImage := imageName
-		if imageName == "" {
+		if imageName != "" {
+			// Registry image names are arbitrary and do not convey base image
+			// information; reference the missing label in the warning instead.
+			fmt.Printf(warningInvalidPrebuiltImageNameMsg, imageName, runtimeImageLabel)
+		} else {
+			// Parse the Dockerfile to include the FROM image in the warning,
+			// giving the user a concrete reference for what needs to change.
 			cmds, err := docker.ParseFile(filepath.Join(path, dockerfile))
 			if err != nil {
 				return "", errors.Wrapf(err, "failed to parse dockerfile: %s", filepath.Join(path, dockerfile))
 			}
-			warningImage = docker.GetImageFromParsedFile(cmds)
+			fmt.Printf(warningInvalidImageNameMsg, docker.GetImageFromParsedFile(cmds))
 		}
-		fmt.Printf(warningInvalidImageNameMsg, warningImage)
 		fmt.Println("Canceling deploy...")
 		os.Exit(1)
 	}

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -717,21 +717,24 @@ func buildImage(path, currentVersion, deployImage, imageName, organizationID, bu
 		}
 	}
 
-	// parse dockerfile
-	cmds, err := docker.ParseFile(filepath.Join(path, dockerfile))
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse dockerfile: %s", filepath.Join(path, dockerfile))
-	}
-
-	DockerfileImage := docker.GetImageFromParsedFile(cmds)
-
 	version, err = imageHandler.GetLabel("", runtimeImageLabel)
 	if err != nil {
 		fmt.Println("unable get runtime version from image")
 	}
 
 	if config.CFG.ShowWarnings.GetBool() && version == "" {
-		fmt.Printf(warningInvalidImageNameMsg, DockerfileImage)
+		// When a pre-built image is supplied via --image-name, the Dockerfile is
+		// not needed to determine the base image — use the image name directly in
+		// the warning.  Only parse the Dockerfile when we built locally.
+		warningImage := imageName
+		if imageName == "" {
+			cmds, err := docker.ParseFile(filepath.Join(path, dockerfile))
+			if err != nil {
+				return "", errors.Wrapf(err, "failed to parse dockerfile: %s", filepath.Join(path, dockerfile))
+			}
+			warningImage = docker.GetImageFromParsedFile(cmds)
+		}
+		fmt.Printf(warningInvalidImageNameMsg, warningImage)
 		fmt.Println("Canceling deploy...")
 		os.Exit(1)
 	}

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -1111,19 +1111,35 @@ func TestBuildImageFailure(t *testing.T) {
 	_, err := buildImage("./testfiles/", "4.2.5", "", "", "", "", false, false, mockPlatformCoreClient)
 	assert.ErrorIs(t, err, errMock)
 
+	// dockerfile parsing error: no imageName, version label empty → enters parse branch
 	airflowImageHandler = func(image string) airflow.ImageHandler {
-		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil)
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("", nil).Once()
 		return mockImageHandler
 	}
-
-	// dockerfile parsing error
 	dockerfile = "Dockerfile.invalid"
 	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, false, mockPlatformCoreClient)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse dockerfile")
 
+	// --image-name provided: Dockerfile parse is skipped, so a missing/invalid
+	// Dockerfile must not cause an error
+	airflowImageHandler = func(image string) airflow.ImageHandler {
+		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil).Once()
+		return mockImageHandler
+	}
+	mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentOptionsResponse, nil).Once()
+	dockerfile = "Dockerfile.invalid" // would normally cause a parse error
+	_, err = buildImage("./testfiles/", "4.2.5", "", "my-registry/my-image:tag", "", "", false, false, mockPlatformCoreClient)
+	assert.NoError(t, err, "Dockerfile should not be parsed when --image-name is provided")
+
 	// failed to get runtime releases
+	airflowImageHandler = func(image string) airflow.ImageHandler {
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("12.0.0", nil).Once()
+		return mockImageHandler
+	}
 	dockerfile = "Dockerfile"
 	mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentOptionsResponse, errMock).Once()
 	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, false, mockPlatformCoreClient)


### PR DESCRIPTION
## Summary

When `astro deploy --image-name <img>` is used, the image is pre-built and supplied externally. The CLI was unconditionally parsing the `Dockerfile` to extract the base image string for a warning — even though:

1. The build is skipped (`Skipping building image...`)
2. The runtime version is always obtained from the **image label**, not the `FROM` instruction

This caused a hard failure for projects that don't maintain a `Dockerfile` locally (e.g. repos where the image is built in a separate pipeline and referenced by digest/tag):

```
Skipping building image...
Error: failed to parse dockerfile: /path/to/Dockerfile: open /path/to/Dockerfile: no such file or directory
```

## Change

Move `docker.ParseFile` inside the `if version == ""` warning guard, and only execute it when no `--image-name` was given (i.e. a local build). When a pre-built image is provided, the missing label is referenced in the warning instead of the Dockerfile's `FROM` image.

```go
// before: always parsed
cmds, err := docker.ParseFile(filepath.Join(path, dockerfile))  // ← fails if no Dockerfile

// after: only parsed when needed for the warning
if imageName == "" {
    cmds, err := docker.ParseFile(...)
    warningImage = docker.GetImageFromParsedFile(cmds)
}
```

## Test plan

- [x] `TestBuildImageFailure` updated: the "dockerfile parsing error" sub-case now sets `GetLabel` to return `""` so the warning branch is entered (exercising the parse path)
- [x] New sub-case added: passes `imageName` with `Dockerfile.invalid` set — asserts `NoError`, proving the parse is skipped
- [x] Full `cloud/deploy` package test suite passes (`go test ./cloud/deploy/...`)## Summary

When `astro deploy --image-name <img>` is used, the image is pre-built and supplied externally. The CLI was unconditionally parsing the `Dockerfile` to extract the base image string for a warning — even though:

1. The build is skipped (`Skipping building image...`)
2. The runtime version is always obtained from the **image label**, not the `FROM` instruction

This caused a hard failure for projects that don't maintain a `Dockerfile` locally (e.g. repos where the image is built in a separate pipeline and referenced by digest/tag):

```
Skipping building image...
Error: failed to parse dockerfile: /path/to/Dockerfile: open /path/to/Dockerfile: no such file or directory
```

## Change

Move `docker.ParseFile` inside the `if version == ""` warning guard, and only execute it when no `--image-name` was given (i.e. a local build). When a pre-built image is provided, the missing label is referenced in the warning instead of the Dockerfile's `FROM` image.

```go
// before: always parsed
cmds, err := docker.ParseFile(filepath.Join(path, dockerfile))  // ← fails if no Dockerfile

// after: only parsed when needed for the warning
if imageName == "" {
    cmds, err := docker.ParseFile(...)
    warningImage = docker.GetImageFromParsedFile(cmds)
}
```

## Test plan

- [x] `TestBuildImageFailure` updated: the "dockerfile parsing error" sub-case now sets `GetLabel` to return `""` so the warning branch is entered (exercising the parse path)
- [x] New sub-case added: passes `imageName` with `Dockerfile.invalid` set — asserts `NoError`, proving the parse is skipped
- [x] Full `cloud/deploy` package test suite passes (`go test ./cloud/deploy/...`)