### PR TITLE
Track dev mode (standalone/docker) in CLI telemetry

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -25,6 +25,7 @@ import (
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/houston"
+	"github.com/astronomer/astro-cli/internal/telemetry"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
@@ -163,6 +164,8 @@ func newDevRootCmd(platformCoreClient astroplatformcore.CoreClient, astroCoreCli
 		PersistentPreRunE: utils.ChainRunEs(
 			SetupLogging,
 			ConfigureContainerRuntime,
+			setDevModeAnnotation,
+			telemetry.CreateTrackingHook(),
 		),
 	}
 	cmd.PersistentFlags().BoolVar(&standaloneFlag, "standalone", false, "Run in standalone mode (without Docker)")
@@ -197,6 +200,16 @@ func resolveDevMode() string {
 		return "docker"
 	}
 	return config.CFG.DevMode.GetString()
+}
+
+// setDevModeAnnotation writes the resolved dev mode into a cobra annotation
+// so the telemetry layer can include it without importing cmd-level config.
+func setDevModeAnnotation(cmd *cobra.Command, _ []string) error {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[telemetry.DevModeAnnotation] = resolveDevMode()
+	return nil
 }
 
 // isStandaloneMode returns true if the current dev mode is standalone.

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1782,6 +1782,43 @@ func (s *AirflowSuite) TestResolveDevMode() {
 	})
 }
 
+func (s *AirflowSuite) TestSetDevModeAnnotation() {
+	s.Run("sets standalone annotation", func() {
+		standaloneFlag = true
+		defer func() { standaloneFlag = false }()
+
+		cmd := &cobra.Command{Use: "start"}
+		err := setDevModeAnnotation(cmd, nil)
+		s.NoError(err)
+		s.Equal("standalone", cmd.Annotations["dev_mode"])
+	})
+
+	s.Run("sets docker annotation", func() {
+		standaloneFlag = false
+		dockerFlag = true
+		defer func() { dockerFlag = false }()
+
+		cmd := &cobra.Command{Use: "start"}
+		err := setDevModeAnnotation(cmd, nil)
+		s.NoError(err)
+		s.Equal("docker", cmd.Annotations["dev_mode"])
+	})
+
+	s.Run("works with existing annotations", func() {
+		standaloneFlag = false
+		dockerFlag = false
+
+		cmd := &cobra.Command{
+			Use:         "start",
+			Annotations: map[string]string{"other": "value"},
+		}
+		err := setDevModeAnnotation(cmd, nil)
+		s.NoError(err)
+		s.Equal("docker", cmd.Annotations["dev_mode"])
+		s.Equal("value", cmd.Annotations["other"])
+	})
+}
+
 func (s *AirflowSuite) TestStandaloneModeStart() {
 	s.Run("standalone flag uses localHandlerInit", func() {
 		cmd := newAirflowStartCmd(nil)

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1804,7 +1804,7 @@ func (s *AirflowSuite) TestSetDevModeAnnotation() {
 		s.Equal("docker", cmd.Annotations["dev_mode"])
 	})
 
-	s.Run("works with existing annotations", func() {
+	s.Run("preserves existing annotations", func() {
 		standaloneFlag = false
 		dockerFlag = false
 
@@ -1814,7 +1814,8 @@ func (s *AirflowSuite) TestSetDevModeAnnotation() {
 		}
 		err := setDevModeAnnotation(cmd, nil)
 		s.NoError(err)
-		s.Equal("docker", cmd.Annotations["dev_mode"])
+		// Neither flag is set, so resolveDevMode falls back to the config value.
+		s.Equal(config.CFG.DevMode.GetString(), cmd.Annotations["dev_mode"])
 		s.Equal("value", cmd.Annotations["other"])
 	})
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -23,6 +23,10 @@ const (
 	// SkipPreRunAnnotation is the cobra annotation key used to skip PersistentPreRunE
 	SkipPreRunAnnotation = "skipPreRun"
 
+	// DevModeAnnotation is the cobra annotation key for the resolved dev mode
+	// ("standalone" or "docker"). Set by the dev command's pre-run hook.
+	DevModeAnnotation = "dev_mode"
+
 	// EventCommandExecution is the event type for CLI command tracking
 	EventCommandExecution = "CLI Command"
 )
@@ -108,6 +112,10 @@ func TrackCommand(cmd *cobra.Command) {
 	}
 	if ciSystem := sharedtel.DetectCISystem(); ciSystem != "" {
 		properties["ci_system"] = ciSystem
+	}
+
+	if mode := cmd.Annotations[DevModeAnnotation]; mode != "" {
+		properties["dev_mode"] = mode
 	}
 
 	payload := sharedtel.TelemetryPayload{

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -78,27 +78,16 @@ func showFirstRunNotice() {
 	_ = config.CFG.TelemetryNoticeShown.SetHomeString("true")
 }
 
-// TrackCommand sends telemetry data for a command execution.
-// It spawns a subprocess to send the data asynchronously.
-func TrackCommand(cmd *cobra.Command) {
-	if !IsEnabled() || isTestRun() {
-		return
-	}
-
-	showFirstRunNotice()
-
-	commandPath := GetCommandPath(cmd)
-	if commandPath == "" || cmd.Hidden || strings.HasPrefix(commandPath, "telemetry") || strings.HasPrefix(commandPath, "_telemetry") {
-		return
-	}
-
+// buildCommandProperties constructs the telemetry property map for a command.
+// Extracted so it can be tested independently of the send path.
+func buildCommandProperties(cmd *cobra.Command) map[string]interface{} {
 	context := "non-interactive"
 	if IsInteractive() {
 		context = "interactive"
 	}
 
 	properties := map[string]interface{}{
-		"command":      commandPath,
+		"command":      GetCommandPath(cmd),
 		"cli_version":  version.CurrVersion,
 		"os":           runtime.GOOS,
 		"os_version":   sharedtel.GetOSVersion(),
@@ -115,8 +104,27 @@ func TrackCommand(cmd *cobra.Command) {
 	}
 
 	if mode := cmd.Annotations[DevModeAnnotation]; mode != "" {
-		properties["dev_mode"] = mode
+		properties[DevModeAnnotation] = mode
 	}
+
+	return properties
+}
+
+// TrackCommand sends telemetry data for a command execution.
+// It spawns a subprocess to send the data asynchronously.
+func TrackCommand(cmd *cobra.Command) {
+	if !IsEnabled() || isTestRun() {
+		return
+	}
+
+	showFirstRunNotice()
+
+	commandPath := GetCommandPath(cmd)
+	if commandPath == "" || cmd.Hidden || strings.HasPrefix(commandPath, "telemetry") || strings.HasPrefix(commandPath, "_telemetry") {
+		return
+	}
+
+	properties := buildCommandProperties(cmd)
 
 	payload := sharedtel.TelemetryPayload{
 		Source:      SourceName,

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -143,3 +143,29 @@ func TestGetAnonymousID(t *testing.T) {
 	id2 := GetAnonymousID()
 	assert.Equal(t, id1, id2, "Should return the same ID on subsequent calls")
 }
+
+func TestDevModeAnnotationConstant(t *testing.T) {
+	assert.Equal(t, "dev_mode", DevModeAnnotation, "annotation key should be dev_mode")
+}
+
+func TestDevModeAnnotationIncludedInProperties(t *testing.T) {
+	// TrackCommand is guarded by IsEnabled() and isTestRun(), so we can't
+	// easily call it end-to-end in a test binary.  Instead, verify that the
+	// annotation plumbing works by checking the constant is the expected
+	// value and that the Annotations map on cobra.Command behaves as expected.
+	cmd := &cobra.Command{
+		Use:         "start",
+		Annotations: map[string]string{DevModeAnnotation: "standalone"},
+	}
+	assert.Equal(t, "standalone", cmd.Annotations[DevModeAnnotation])
+
+	cmdDocker := &cobra.Command{
+		Use:         "start",
+		Annotations: map[string]string{DevModeAnnotation: "docker"},
+	}
+	assert.Equal(t, "docker", cmdDocker.Annotations[DevModeAnnotation])
+
+	cmdNoAnnotation := &cobra.Command{Use: "deploy"}
+	assert.Empty(t, cmdNoAnnotation.Annotations[DevModeAnnotation],
+		"non-dev commands should have no dev_mode annotation")
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -144,28 +144,31 @@ func TestGetAnonymousID(t *testing.T) {
 	assert.Equal(t, id1, id2, "Should return the same ID on subsequent calls")
 }
 
-func TestDevModeAnnotationConstant(t *testing.T) {
-	assert.Equal(t, "dev_mode", DevModeAnnotation, "annotation key should be dev_mode")
-}
+func TestBuildCommandProperties_DevMode(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "astro"}
+	devCmd := &cobra.Command{Use: "dev"}
+	startCmd := &cobra.Command{Use: "start"}
+	rootCmd.AddCommand(devCmd)
+	devCmd.AddCommand(startCmd)
 
-func TestDevModeAnnotationIncludedInProperties(t *testing.T) {
-	// TrackCommand is guarded by IsEnabled() and isTestRun(), so we can't
-	// easily call it end-to-end in a test binary.  Instead, verify that the
-	// annotation plumbing works by checking the constant is the expected
-	// value and that the Annotations map on cobra.Command behaves as expected.
-	cmd := &cobra.Command{
-		Use:         "start",
-		Annotations: map[string]string{DevModeAnnotation: "standalone"},
-	}
-	assert.Equal(t, "standalone", cmd.Annotations[DevModeAnnotation])
+	t.Run("includes dev_mode when annotation is set", func(t *testing.T) {
+		startCmd.Annotations = map[string]string{DevModeAnnotation: "standalone"}
+		props := buildCommandProperties(startCmd)
+		assert.Equal(t, "standalone", props[DevModeAnnotation])
+		assert.Equal(t, "dev start", props["command"])
+	})
 
-	cmdDocker := &cobra.Command{
-		Use:         "start",
-		Annotations: map[string]string{DevModeAnnotation: "docker"},
-	}
-	assert.Equal(t, "docker", cmdDocker.Annotations[DevModeAnnotation])
+	t.Run("includes docker dev_mode annotation", func(t *testing.T) {
+		startCmd.Annotations = map[string]string{DevModeAnnotation: "docker"}
+		props := buildCommandProperties(startCmd)
+		assert.Equal(t, "docker", props[DevModeAnnotation])
+	})
 
-	cmdNoAnnotation := &cobra.Command{Use: "deploy"}
-	assert.Empty(t, cmdNoAnnotation.Annotations[DevModeAnnotation],
-		"non-dev commands should have no dev_mode annotation")
+	t.Run("omits dev_mode for non-dev commands", func(t *testing.T) {
+		deployCmd := &cobra.Command{Use: "deploy"}
+		rootCmd.AddCommand(deployCmd)
+		props := buildCommandProperties(deployCmd)
+		_, hasDevMode := props[DevModeAnnotation]
+		assert.False(t, hasDevMode, "non-dev commands should not have dev_mode property")
+	})
 }


### PR DESCRIPTION
## Description

- Fix `astro dev *` commands being invisible to telemetry due to Cobra's `PersistentPreRunE` not chaining (child hooks silently replace the parent's)
- Add a `dev_mode` property ("standalone" or "docker") to the telemetry payload so we can measure standalone adoption

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Tested these changes locally

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
