### PR TITLE
Skip yanked runtime versions when picking default image tags

### DIFF
--- a/airflow_versions/airflow_versions.go
+++ b/airflow_versions/airflow_versions.go
@@ -115,6 +115,9 @@ func getAstroRuntimeTag(runtimeVersions, runtimeVersionsV3 map[string]RuntimeVer
 		if r.Metadata.Channel != VersionChannelStable {
 			continue
 		}
+		if r.Metadata.Yanked {
+			continue
+		}
 		if airflowVersion != "" && r.Metadata.AirflowVersion != airflowVersion {
 			continue
 		}
@@ -122,6 +125,9 @@ func getAstroRuntimeTag(runtimeVersions, runtimeVersionsV3 map[string]RuntimeVer
 	}
 	for runtimeVersion, r := range runtimeVersionsV3 {
 		if r.Metadata.Channel != VersionChannelStable {
+			continue
+		}
+		if r.Metadata.Yanked {
 			continue
 		}
 		if airflowVersion != "" && r.Metadata.AirflowVersion != airflowVersion {
@@ -267,20 +273,29 @@ func ResolveFloatingTag(floatingTag string) (string, error) {
 		return "", fmt.Errorf("failed to fetch runtime versions: %w", err)
 	}
 
-	var latest string
-	for version := range resp.RuntimeVersionsV3 {
-		if strings.HasPrefix(version, floatingTag+"-") || strings.HasPrefix(version, floatingTag+".") {
-			if latest == "" || CompareRuntimeVersions(version, latest) > 0 {
-				latest = version
-			}
-		}
-	}
-
+	latest := pickLatestMatchingRuntimeVersion(floatingTag, resp.RuntimeVersionsV3)
 	if latest == "" {
 		return "", fmt.Errorf("no runtime version found matching '%s'", floatingTag)
 	}
-
 	return latest, nil
+}
+
+// pickLatestMatchingRuntimeVersion returns the highest non-yanked version whose
+// name starts with the floating tag. Returns "" if nothing matches.
+func pickLatestMatchingRuntimeVersion(floatingTag string, runtimeVersionsV3 map[string]RuntimeVersion) string {
+	var latest string
+	for version, rv := range runtimeVersionsV3 {
+		if rv.Metadata.Yanked {
+			continue
+		}
+		if !strings.HasPrefix(version, floatingTag+"-") && !strings.HasPrefix(version, floatingTag+".") {
+			continue
+		}
+		if latest == "" || CompareRuntimeVersions(version, latest) > 0 {
+			latest = version
+		}
+	}
+	return latest
 }
 
 // GetDefaultPythonVersion fetches the runtime versions JSON and returns the

--- a/airflow_versions/airflow_versions_test.go
+++ b/airflow_versions/airflow_versions_test.go
@@ -192,6 +192,18 @@ func (s *Suite) TestGetAstroRuntimeTag() {
 				AirflowDatabase: false,
 			},
 		},
+		"3.0-9": {
+			Metadata: RuntimeVersionMetadata{
+				AirflowVersion: "3.0.5",
+				Channel:        VersionChannelStable,
+				ReleaseDate:    "2025-08-20",
+				Yanked:         true,
+				YankedReason:   "broken connection extras deserialization",
+			},
+			Migrations: RuntimeVersionMigrations{
+				AirflowDatabase: false,
+			},
+		},
 	}
 
 	tests := []struct {
@@ -203,6 +215,7 @@ func (s *Suite) TestGetAstroRuntimeTag() {
 		{airflowVersion: "2.1.1", output: "3.0.1", err: nil},
 		{airflowVersion: "2.2.2", output: "", err: ErrNoTagAvailable{airflowVersion: "2.2.2"}},
 		{airflowVersion: "3.0.0", output: "3.0-1", err: nil},
+		{airflowVersion: "3.0.5", output: "", err: ErrNoTagAvailable{airflowVersion: "3.0.5"}},
 	}
 
 	for _, tt := range tests {
@@ -214,6 +227,42 @@ func (s *Suite) TestGetAstroRuntimeTag() {
 		}
 		s.Equal(tt.output, defaultImageTag)
 	}
+}
+
+func (s *Suite) TestPickLatestMatchingRuntimeVersion() {
+	runtimeVersionsV3 := map[string]RuntimeVersion{
+		"3.0-1": {Metadata: RuntimeVersionMetadata{Channel: VersionChannelStable}},
+		"3.0-3": {Metadata: RuntimeVersionMetadata{Channel: VersionChannelStable}},
+		"3.0-9": {
+			Metadata: RuntimeVersionMetadata{
+				Channel:      VersionChannelStable,
+				Yanked:       true,
+				YankedReason: "broken connection extras deserialization",
+			},
+		},
+		"3.1-1": {Metadata: RuntimeVersionMetadata{Channel: VersionChannelStable}},
+		"3.1-2": {Metadata: RuntimeVersionMetadata{Channel: VersionChannelStable}},
+	}
+
+	tests := []struct {
+		floatingTag string
+		output      string
+	}{
+		{floatingTag: "3.0", output: "3.0-3"},
+		{floatingTag: "3.1", output: "3.1-2"},
+		{floatingTag: "4.0", output: ""},
+	}
+
+	for _, tt := range tests {
+		s.Equal(tt.output, pickLatestMatchingRuntimeVersion(tt.floatingTag, runtimeVersionsV3), "floatingTag=%q", tt.floatingTag)
+	}
+
+	s.Run("all matching yanked returns empty", func() {
+		allYanked := map[string]RuntimeVersion{
+			"3.2-1": {Metadata: RuntimeVersionMetadata{Channel: VersionChannelStable, Yanked: true}},
+		}
+		s.Equal("", pickLatestMatchingRuntimeVersion("3.2", allYanked))
+	})
 }
 
 func (s *Suite) TestGetDefaultImageTag() {
@@ -333,6 +382,18 @@ func (s *Suite) TestGetDefaultImageTag() {
 						AirflowVersion: "2.2.0",
 						Channel:        VersionChannelStable,
 						ReleaseDate:    "2021-10-12",
+					},
+					Migrations: RuntimeVersionMigrations{
+						AirflowDatabase: false,
+					},
+				},
+				"5.0.0": {
+					Metadata: RuntimeVersionMetadata{
+						AirflowVersion: "2.3.0",
+						Channel:        VersionChannelStable,
+						ReleaseDate:    "2022-01-01",
+						Yanked:         true,
+						YankedReason:   "critical regression",
 					},
 					Migrations: RuntimeVersionMigrations{
 						AirflowDatabase: false,

--- a/airflow_versions/types.go
+++ b/airflow_versions/types.go
@@ -33,6 +33,8 @@ type RuntimeVersionMetadata struct {
 	ReleaseDate          string   `json:"releaseDate"`
 	PythonVersions       []string `json:"pythonVersions,omitempty"`
 	DefaultPythonVersion string   `json:"defaultPythonVersion,omitempty"`
+	Yanked               bool     `json:"yanked,omitempty"`
+	YankedReason         string   `json:"yankedReason,omitempty"`
 }
 
 type RuntimeVersionMigrations struct {


### PR DESCRIPTION
## Description

`astro dev init` and `astro dev start --standalone` were selecting yanked Astro Runtime versions (e.g. `3.0-9`, yanked 2025-08-20 for broken connection-extras deserialization) because the version-selection logic only filtered on `Channel`, not on the `yanked` field now present in the `updates.astronomer.io/astronomer-runtime` JSON feed.

This PR:
- Adds `Yanked` / `YankedReason` to `RuntimeVersionMetadata`.
- Skips yanked entries in `getAstroRuntimeTag` (used by `dev init`, `dev upgrade-runtime`, client image resolution, and cloud default-runtime lookups).
- Skips yanked entries in `ResolveFloatingTag` (used by `dev start --standalone` to map a floating tag in the user's Dockerfile to a concrete pinned runtime version). The selection logic is extracted into a pure helper so it's testable without the HTTP layer.

Note: existing projects that pin a floating tag in their Dockerfile (e.g. `FROM astrocrpublic.azurecr.io/runtime:3.0`) aren't helped by this PR — Docker pulls whatever the registry says that tag points to. A separate RUNTIME-team issue will track repointing floating tags at yank time.

## 🎟 Issue(s)

Fixes #1923

## 🧪 Functional Testing

The live `updates.astronomer.io/astronomer-runtime` feed has no "latest of a line is yanked" scenario — yanks so far haven't hit the top of a line. To exercise the fix end-to-end, I served a locally-doctored copy of the feed (marking the current top of each `3.x` line as yanked) via `python3 -m http.server`, temporarily pointed `RuntimeReleaseURL` at it, and ran the CLI.

- [x] `go test ./airflow_versions/...` passes.
- [x] In a scratch dir against the doctored feed, `astro dev init` generated a Dockerfile with `FROM astrocrpublic.azurecr.io/runtime:3.1-13` — the highest non-yanked version — skipping the yanked `3.1-14`, `3.2-1`, and `3.2-2`.
- [x] In a scratch dir with `FROM astrocrpublic.azurecr.io/runtime:3.1` (floating), `astro dev start --standalone` installed `apache-airflow==3.1.7` (from `3.1-13`, non-yanked), not `3.1.8` (which is the yanked `3.1-14`).

## 📸 Screenshots

N/A

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)

