### PR TITLE
Fix astro run command for Airflow 3 by using db migrate

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -1534,16 +1534,32 @@ func (d *DockerCompose) RunDAG(dagID, settingsFile, dagFile, executionDate strin
 	if err != nil {
 		fmt.Printf("Adding 'astro-run-dag' package to requirements.txt unsuccessful: %s\nManually add package to requirements.txt", err.Error())
 	}
-	// add airflow db init
-	err = fileutil.AddLineToFile("./Dockerfile", "RUN airflow db init", "")
+
+	// Detect Airflow version to use the correct db command
+	airflowVersion, err := d.checkAirflowVersion()
 	if err != nil {
-		fmt.Printf("Adding line 'RUN airflow db init' to Dockerfile unsuccessful: %s\nYou may need to manually add this line for 'astro run' to work", err.Error())
+		fmt.Printf("Warning: unable to detect Airflow version, defaulting to 'airflow db init': %s\n", err.Error())
+		airflowVersion = defaultAirflowVersion
+	}
+
+	// Use 'airflow db migrate' for Airflow 3+, 'airflow db init' for Airflow 2
+	var dbCommand string
+	if airflowVersion >= 3 {
+		dbCommand = "RUN airflow db migrate"
+	} else {
+		dbCommand = "RUN airflow db init"
+	}
+
+	// add airflow db command
+	err = fileutil.AddLineToFile("./Dockerfile", dbCommand, "")
+	if err != nil {
+		fmt.Printf("Adding line '%s' to Dockerfile unsuccessful: %s\nYou may need to manually add this line for 'astro run' to work", dbCommand, err.Error())
 	}
 	defer func() {
-		// remove airflow db init
-		fileErr := fileutil.RemoveLineFromFile("./Dockerfile", "RUN airflow db init", "")
+		// remove airflow db command
+		fileErr := fileutil.RemoveLineFromFile("./Dockerfile", dbCommand, "")
 		if fileErr != nil {
-			fmt.Printf("Removing line 'RUN airflow db init' from Dockerfile unsuccessful: %s\n", err.Error())
+			fmt.Printf("Removing line '%s' from Dockerfile unsuccessful: %s\n", dbCommand, err.Error())
 		}
 		// remove astro-run-dag from requirments.txt
 		err = fileutil.RemoveLineFromFile("./requirements.txt", "astro-run-dag", " # This package is needed for the astro run command. It will be removed before a deploy")

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1956,6 +1956,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 	s.Run("success without container", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: "2.0.0"}, nil).Once()
 		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("RunDAG", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
@@ -1975,6 +1976,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 	s.Run("error without container", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: "2.0.0"}, nil).Once()
 		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("RunDAG", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
 
@@ -1994,6 +1996,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 	s.Run("build error without container", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: "2.0.0"}, nil).Once()
 		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -2019,6 +2022,26 @@ func (s *Suite) TestDockerComposeRunDAG() {
 		err := mockDockerCompose.RunDAG("", "", "", "", noCache, true)
 		s.ErrorIs(err, errMockDocker)
 
+		composeMock.AssertExpectations(s.T())
+	})
+
+	s.Run("success without container - Airflow 3", func() {
+		noCache := false
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: "3.0.0"}, nil).Once()
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("RunDAG", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+		composeMock := new(mocks.DockerComposeAPI)
+		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Once()
+
+		mockDockerCompose.composeService = composeMock
+		mockDockerCompose.imageHandler = imageHandler
+
+		err := mockDockerCompose.RunDAG("", "", "", "", noCache, true)
+		s.NoError(err)
+
+		imageHandler.AssertExpectations(s.T())
 		composeMock.AssertExpectations(s.T())
 	})
 }


### PR DESCRIPTION
Fixes #2095

The `astro run <dag-id>` command fails on Airflow 3 runtime images because it was hardcoded to use `airflow db init`, which was removed in Airflow 3.0.

This commit adds version detection logic to the `RunDAG` function to conditionally use the appropriate database command:
- `airflow db migrate` for Airflow 3+
- `airflow db init` for Airflow 2

The fix follows the same pattern used in PR #1811 for the `astro dev start` command path.

Changes:
- Added call to `checkAirflowVersion()` in the `RunDAG` function
- Conditionally set `dbCommand` based on detected Airflow version
- Updated error messages to use the dynamic `dbCommand` variable
- Added test mocks for `ListLabels()` to support version detection
- Added new test case for Airflow 3 to verify the fix


## Description

> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
