### PR TITLE
 fix: align WORKSPACE column in astro login output

### DIFF
--- a/config/software.go
+++ b/config/software.go
@@ -27,7 +27,7 @@ func (c *Context) PrintSoftwareContext(out io.Writer) error {
 		workspace = noApply
 	}
 	tab := printutil.Table{
-		Padding: []int{36, 36},
+		Padding: []int{60, 20},
 		Header:  []string{"CLUSTER", "WORKSPACE"},
 	}
 


### PR DESCRIPTION
## What does this PR do?
Fixes column misalignment in `astro login` output.

The CLUSTER column padding was set to 36 chars but real cluster URLs can be 48+ chars, causing the WORKSPACE value to appear concatenated with the CLUSTER string.

Increased padding to 60 chars to accommodate long domain names.

## How to test
1. Run `astro login astro.cp-dr.test.us-east-2.astro-foo.example.com`
2. Confirm N/A appears aligned under WORKSPACE header with proper spacing

## Screenshots
**Before:** 
<img width="959" height="115" alt="github before screenshot" src="https://github.com/user-attachments/assets/d793da68-9c0a-49e1-b84c-85c5d5ffa028" />


**After:** 
<img width="953" height="73" alt="after pic github" src="https://github.com/user-attachments/assets/072b468b-ed9c-4b5e-b31e-f1778a802a7a" />



Closes #2088