### PR TITLE
fix: copy include/ artifacts back to host after astro dev pytest

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -254,6 +254,21 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 		}
 	}
 
+	// Copy the contents of include/ back from the container to the host so
+	// artifacts written to include/ during the test run (e.g.
+	// --junit-xml=include/pytest_report.junit.xml) are accessible after
+	// pytest finishes, as documented at
+	// https://www.astronomer.io/docs/astro/cli/astro-dev-pytest.
+	includeDest := airflowHome + "/include"
+	if exists, _ := util.Exists(includeDest); exists {
+		// The trailing /. copies the contents of include/ into the existing
+		// host include/ directory instead of nesting it.
+		cpErr := cmdExec(containerRuntime, nil, stderr, "cp", "astro-pytest:/usr/local/airflow/include/.", includeDest)
+		if cpErr != nil {
+			logger.Debugf("Error copying include/ from the pytest container: %s", cpErr.Error())
+		}
+	}
+
 	// delete container
 	rmErr := cmdExec(containerRuntime, nil, stderr, "rm", "astro-pytest")
 	if rmErr != nil {

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -204,6 +204,59 @@ func (s *Suite) TestDockerImagePytest() {
 		s.Error(err)
 	})
 
+	s.Run("copies include/ back to host after test run", func() {
+		// Docs contract: artifacts written to include/ must be accessible on
+		// the host after pytest finishes.
+		// https://www.astronomer.io/docs/astro/cli/astro-dev-pytest
+		airflowHome := s.T().TempDir()
+		includeDir := airflowHome + "/include"
+		s.NoError(os.MkdirAll(includeDir, os.ModePerm))
+
+		var cpArgs [][]string
+		started := false
+		reverseIncludeAfterStart := false
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			if args[0] == "start" {
+				started = true
+			}
+			if args[0] == "cp" {
+				snapshot := make([]string, len(args))
+				copy(snapshot, args)
+				cpArgs = append(cpArgs, snapshot)
+				if started && args[1] == "astro-pytest:/usr/local/airflow/include/." && args[2] == includeDir {
+					reverseIncludeAfterStart = true
+				}
+			}
+			return nil
+		}
+		_, err = handler.Pytest("", airflowHome, "", "", []string{}, false, options)
+		s.NoError(err)
+
+		// The reverse copy must happen after the container has been started,
+		// otherwise artifacts written during the run would not be captured.
+		s.True(reverseIncludeAfterStart, "expected include/ to be copied from the pytest container back to the host after start, got: %v", cpArgs)
+	})
+
+	s.Run("skips reverse include/ copy when host include/ does not exist", func() {
+		airflowHome := s.T().TempDir()
+
+		cpArgs := [][]string{}
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			if args[0] == "cp" {
+				snapshot := make([]string, len(args))
+				copy(snapshot, args)
+				cpArgs = append(cpArgs, snapshot)
+			}
+			return nil
+		}
+		_, err = handler.Pytest("", airflowHome, "", "", []string{}, false, options)
+		s.NoError(err)
+
+		for _, a := range cpArgs {
+			s.NotEqual("astro-pytest:/usr/local/airflow/include/.", a[1], "reverse cp should be skipped when host include/ is absent")
+		}
+	})
+
 	s.Run("pytest error", func() {
 		options = airflowTypes.ImageBuildConfig{
 			Path:            cwd,


### PR DESCRIPTION
## Summary

- Fixes #2066: after `astro dev pytest` finishes, files written to `include/` (e.g. `--junit-xml=include/pytest_report.junit.xml`) are once again accessible on the host.
- #2036 replaced the pytest bind mounts with a forward `docker cp` loop but never added a reverse copy, so artifacts stayed stranded inside the container.
- Scope is intentionally limited to the documented contract at https://www.astronomer.io/docs/astro/cli/astro-dev-pytest — only `include/` is copied back, not `dags/`, `tests/`, or `plugins/`.

## Implementation notes

- After the pytest container runs, `docker cp astro-pytest:/usr/local/airflow/include/. <airflowHome>/include` restores artifact visibility on the host.
- The reverse copy is skipped when the host has no `include/` directory, so `docker cp` never errors on projects without one.
- Errors are logged at debug level (same pattern used for the HTML report copy and the final `rm`) so an unexpected `cp` failure does not mask the real pytest exit code.

## Test plan

- [x] `go test ./airflow/ -run 'TestAirflow/TestDockerImagePytest' -v -count=1` — all existing pytest subtests pass, plus two new ones:
  - `copies include/ back to host after test run` — asserts the reverse `cp` targets `astro-pytest:/usr/local/airflow/include/.` → `<airflowHome>/include` and runs after `start`.
  - `skips reverse include/ copy when host include/ does not exist` — asserts no reverse `cp` is attempted when the host directory is absent.
- [x] `go test ./airflow/ -count=1` — full airflow package passes.
- [ ] Manual verification on a real project: `astro dev pytest --args '--junit-xml=include/pytest_report.junit.xml'` followed by `file include/pytest_report.junit.xml` to confirm the artifact is present.