### PR TITLE
fix: repair release workflow tag filter

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,9 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+(\.[0-9]+)*(-.*)?' 
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yaml` used regex syntax in its `on.push.tags` filter, but [GitHub Actions filter patterns are glob-style](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) — `()` and `\` are literal characters there, not grouping/escape.
- As a result the filter `'v[0-9]+(\.[0-9]+)*(-.*)?'` effectively required the tag to contain the literal string `(\.[0-9]+)*(-.*)?`, which no tag does.
- This workflow was added in #2072 on 2026-04-10. `v1.41.0` predates it, so no one noticed. `v1.42.0` was the first real test and the Release workflow silently didn't fire (`gh run list --workflow=release.yaml` shows zero runs, ever).
- Fix: replace the bad pattern with a valid glob (`v1.2.3`) and add `workflow_dispatch` so a release can be manually re-triggered if a tag-push ever misses this again.

## Test plan

- [ ] After merge, cherry-pick onto `release-1.42`, delete the orphaned `v1.42.0` tag, re-approve the CircleCI `approve-release` hold on the new `release-1.42` HEAD, and confirm that the `new-tag` job's tag push now fires the Release workflow and goreleaser publishes the pre-release.
- [ ] `gh api repos/astronomer/astro-cli/actions/workflows/release.yaml/runs` shows a run whose `head_branch` is `v1.42.0`.
- [ ] https://github.com/astronomer/astro-cli/releases/tag/v1.42.0 has binaries + `astro_1.42.0_checksums.txt`, marked pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)