### PR TITLE
fix(standalone): match docker template's auth + signing env vars

### DIFF
--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -771,6 +771,15 @@ func (s *Standalone) buildEnv() []string {
 	overrides["ASTRONOMER_ENVIRONMENT"] = "local"
 	overrides["AIRFLOW__CORE__LOAD_EXAMPLES"] = "False"
 	overrides["AIRFLOW__CORE__DAGS_FOLDER"] = filepath.Join(s.airflowHome, "dags")
+	// Stable Fernet key so encrypted connection extras survive restart.
+	// Same value the docker compose template ships.
+	overrides["AIRFLOW__CORE__FERNET_KEY"] = "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+	// Stable per-project signing secret so login sessions / JWTs survive
+	// restart. Falls back to a constant if the project hash isn't available.
+	signingSecret, err := ProjectNameUnique()
+	if err != nil {
+		signingSecret = "astro-standalone"
+	}
 	port := s.webserverPort()
 	if s.airflowMajorVersion == "3" {
 		overrides["AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS"] = "True"
@@ -778,6 +787,8 @@ func (s *Standalone) buildEnv() []string {
 			overrides["AIRFLOW__API__PORT"] = port
 		}
 		overrides["AIRFLOW__CORE__EXECUTION_API_SERVER_URL"] = "http://localhost:" + port + "/execution/"
+		overrides["AIRFLOW__API__SECRET_KEY"] = signingSecret
+		overrides["AIRFLOW__API_AUTH__JWT_SECRET"] = signingSecret
 	} else {
 		// AF2: point plugins at the project directory so the pickle-fix plugin
 		// written during Start() is visible to Airflow.  AF3 intentionally
@@ -800,14 +811,11 @@ func (s *Standalone) buildEnv() []string {
 		overrides["AIRFLOW__CORE__EXECUTOR"] = "LocalExecutor"
 		overrides["_AIRFLOW__SKIP_DATABASE_EXECUTOR_COMPATIBILITY_CHECK"] = "1"
 		overrides["AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER"] = "True"
-		// Enable basic auth on the API. AF2's upstream default is
-		// session-only auth, which 403s every basic-auth-using client
-		// (including `af` / astro-airflow-mcp). The docker-compose
-		// template has set this since PR #394 (2020); standalone has to
-		// match so workflows that drive the API from outside the UI
-		// (e.g. the airflow-upgrade skill calling `af config`) work
-		// regardless of dev mode.
+		// AF2's upstream default is session-only API auth, which 403s
+		// basic-auth clients like `af`. Match the docker template.
 		overrides["AIRFLOW__API__AUTH_BACKEND"] = "airflow.api.auth.backend.basic_auth"
+		overrides["AIRFLOW__WEBSERVER__SECRET_KEY"] = signingSecret
+		overrides["AIRFLOW__WEBSERVER__EXPOSE_CONFIG"] = "True"
 	}
 
 	// Layer 3: macOS fork-safety workarounds.

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -800,6 +800,14 @@ func (s *Standalone) buildEnv() []string {
 		overrides["AIRFLOW__CORE__EXECUTOR"] = "LocalExecutor"
 		overrides["_AIRFLOW__SKIP_DATABASE_EXECUTOR_COMPATIBILITY_CHECK"] = "1"
 		overrides["AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER"] = "True"
+		// Enable basic auth on the API. AF2's upstream default is
+		// session-only auth, which 403s every basic-auth-using client
+		// (including `af` / astro-airflow-mcp). The docker-compose
+		// template has set this since PR #394 (2020); standalone has to
+		// match so workflows that drive the API from outside the UI
+		// (e.g. the airflow-upgrade skill calling `af config`) work
+		// regardless of dev mode.
+		overrides["AIRFLOW__API__AUTH_BACKEND"] = "airflow.api.auth.backend.basic_auth"
 	}
 
 	// Layer 3: macOS fork-safety workarounds.

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -815,7 +815,7 @@ func (s *Standalone) buildEnv() []string {
 		// basic-auth clients like `af`. Match the docker template.
 		overrides["AIRFLOW__API__AUTH_BACKEND"] = "airflow.api.auth.backend.basic_auth"
 		overrides["AIRFLOW__WEBSERVER__SECRET_KEY"] = signingSecret
-		overrides["AIRFLOW__WEBSERVER__EXPOSE_CONFIG"] = "True"
+		overrides["AIRFLOW__WEBSERVER__EXPOSE_CONFIG"] = "True" //nolint:goconst // matches the docker template's literal value
 	}
 
 	// Layer 3: macOS fork-safety workarounds.

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -1415,6 +1415,11 @@ func (s *Suite) TestStandaloneBuildEnv_AF2() {
 	s.Equal("LocalExecutor", envMap["AIRFLOW__CORE__EXECUTOR"])
 	s.Equal("1", envMap["_AIRFLOW__SKIP_DATABASE_EXECUTOR_COMPATIBILITY_CHECK"])
 	s.Equal("True", envMap["AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER"])
+	// AF2 should advertise basic auth on the API so `af` / astro-airflow-mcp
+	// and other basic-auth clients can hit /api/v1/* endpoints without 403.
+	// Without this, the upstream default of session-only auth makes the
+	// airflow-upgrade skill's `af config` calls fail in standalone mode.
+	s.Equal("airflow.api.auth.backend.basic_auth", envMap["AIRFLOW__API__AUTH_BACKEND"])
 }
 
 func (s *Suite) TestStandaloneBuildEnv_AF2_CustomPort() {

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -566,6 +566,9 @@ func (s *Suite) TestStandaloneBuildEnv() {
 	s.Equal("/tmp/test-project/dags", envMap["AIRFLOW__CORE__DAGS_FOLDER"])
 	s.Equal("True", envMap["AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS"])
 	s.Contains(envMap["PATH"], "/tmp/test-project/.venv/bin")
+	s.Equal("d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw=", envMap["AIRFLOW__CORE__FERNET_KEY"])
+	s.NotEmpty(envMap["AIRFLOW__API__SECRET_KEY"])
+	s.NotEmpty(envMap["AIRFLOW__API_AUTH__JWT_SECRET"])
 }
 
 func (s *Suite) TestStandaloneBuildEnv_NoDuplicateKeys() {
@@ -1415,11 +1418,12 @@ func (s *Suite) TestStandaloneBuildEnv_AF2() {
 	s.Equal("LocalExecutor", envMap["AIRFLOW__CORE__EXECUTOR"])
 	s.Equal("1", envMap["_AIRFLOW__SKIP_DATABASE_EXECUTOR_COMPATIBILITY_CHECK"])
 	s.Equal("True", envMap["AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER"])
-	// AF2 should advertise basic auth on the API so `af` / astro-airflow-mcp
-	// and other basic-auth clients can hit /api/v1/* endpoints without 403.
-	// Without this, the upstream default of session-only auth makes the
-	// airflow-upgrade skill's `af config` calls fail in standalone mode.
+	// AF2 should mirror the docker template's auth + signing settings so
+	// basic-auth clients work and login state survives restarts.
 	s.Equal("airflow.api.auth.backend.basic_auth", envMap["AIRFLOW__API__AUTH_BACKEND"])
+	s.Equal("d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw=", envMap["AIRFLOW__CORE__FERNET_KEY"])
+	s.NotEmpty(envMap["AIRFLOW__WEBSERVER__SECRET_KEY"])
+	s.Equal("True", envMap["AIRFLOW__WEBSERVER__EXPOSE_CONFIG"])
 }
 
 func (s *Suite) TestStandaloneBuildEnv_AF2_CustomPort() {


### PR DESCRIPTION
## Summary

PR #2081 added AF2 support to standalone mode but didn't carry over a handful of env vars the docker-compose template has shipped for years. This PR closes the gap so docker-mode and standalone-mode behave the same way for auth and persistence.

**AF2 standalone now sets:**
- `AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.basic_auth` — basic-auth clients (`af` / astro-airflow-mcp, the airflow-upgrade skill, anything hitting `/api/v1/*` with `-u admin:admin`) were getting 403 against AF2's session-only default. Docker-mode AF2 has had this since PR #394.
- `AIRFLOW__CORE__FERNET_KEY` — same hardcoded key the docker template uses, so encrypted connection extras (passwords, etc.) survive a restart instead of becoming unreadable when Airflow generates a fresh key.
- `AIRFLOW__WEBSERVER__SECRET_KEY` — Flask session signing, derived from `ProjectNameUnique()`, so login state survives restart.
- `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` — UI parity (view airflow.cfg).

**AF3 standalone now sets:**
- `AIRFLOW__CORE__FERNET_KEY` — same as AF2, same reason.
- `AIRFLOW__API__SECRET_KEY` and `AIRFLOW__API_AUTH__JWT_SECRET` — both derived from `ProjectNameUnique()` so Flask sessions and JWTs survive restart.

## Repro (basic_auth fix)

```
$ astro dev start              # dev.mode=standalone, AF2 runtime, v1.42.0
$ af config providers
{"error": "Client error '403 Forbidden' for url '.../api/v1/providers'"}
```

After: returns the provider list.

## Tests

`TestStandaloneBuildEnv` and `TestStandaloneBuildEnv_AF2` extended; `go test ./airflow/` green.