### PR TITLE
otto: pitch trial signup in unauthenticated message

### DIFF
--- a/pkg/otto/start.go
+++ b/pkg/otto/start.go
@@ -33,9 +33,11 @@ func isHelpOrVersion(args []string) bool {
 func Start(args []string) error {
 	cfg := NewConfigFromContext()
 	if cfg.Token == "" && !isHelpOrVersion(args) {
-		fmt.Fprintln(os.Stderr, "You're not logged in to Astro.")
-		fmt.Fprintln(os.Stderr, "  • Already have an account? Run `astro login`")
-		fmt.Fprintln(os.Stderr, "  • New to Astro? Sign up for a free trial at https://www.astronomer.io/try-astro")
+		fmt.Fprintln(os.Stderr, "You're not logged in to Astro. Otto is an AI assistant for Airflow — sign in or start a trial to use it.")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "  • Sign in:        astro login")
+		fmt.Fprintln(os.Stderr, "  • Free trial:     https://www.astronomer.io/try-astro")
+		fmt.Fprintln(os.Stderr, "  • What Otto does: astro otto --help")
 		return ErrNotLoggedIn
 	}
 


### PR DESCRIPTION
## Summary
- Rewrites the `astro otto` not-logged-in output to surface a free-trial CTA and a pointer to `astro otto --help` for users curious about what Otto can do.
- Keeps the explicit "you're not logged in to Astro" framing so users understand they need to sign in or sign up to actually use Otto.

Before:
```
You're not logged in to Astro.
  • Already have an account? Run `astro login`
  • New to Astro? Sign up for a free trial at https://www.astronomer.io/try-astro
```

After:
```
You're not logged in to Astro. Otto is an AI assistant for Airflow — sign in or start a trial to use it.

  • Sign in:        astro login
  • Free trial:     https://www.astronomer.io/try-astro
  • What Otto does: astro otto --help
```

## Test plan
- [x] `go build ./...`
- [x] Manually ran `HOME=/tmp/empty-home astro otto` and confirmed the new message renders, exit code is 1
- [ ] Manually verify `astro otto --help` still works without auth (already supported via `isHelpOrVersion`)