### PR TITLE
fix(deploy): skip project-dir check when --image-name is provided

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -246,10 +246,12 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 		return err
 	}
 
-	// Check if git metadata is enabled (default: true)
+	// Check if git metadata is enabled (default: true).
+	// Skip when --image-name is provided: the local working directory does not necessarily
+	// reflect the contents of a prebuilt image, so attaching its git metadata would be misleading.
 	var deployGit *astrocore.DeployGit
 	var commitMessage string
-	if config.CFG.DeployGitMetadata.GetBool() {
+	if config.CFG.DeployGitMetadata.GetBool() && deployInput.ImageName == "" {
 		deployGit, commitMessage = retrieveLocalGitMetadata(deployInput.Path)
 	}
 

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -131,6 +131,17 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return errors.New("cannot use both --dags and --image together. Run 'astro deploy' to update both your image and dags")
 	}
 
+	// --image-name supplies a prebuilt image, so this is an image-only deploy by definition.
+	// Reject flags that only apply when building from a local project, and force image-only semantics.
+	if cmd.Flags().Changed("image-name") {
+		for _, f := range []string{"dags", "dags-path", "no-dags-base-dir", "pytest", "parse", "build-secrets"} {
+			if cmd.Flags().Changed(f) {
+				return fmt.Errorf("cannot use --%s with --image-name; --image-name implies an image-only deploy", f)
+			}
+		}
+		image = true
+	}
+
 	// Save deploymentId in config if specified
 	if deploymentID != "" && saveDeployConfig {
 		err := config.CFG.ProjectDeployment.SetProjectString(deploymentID)

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -50,6 +50,8 @@ const (
 	registryUncommitedChangesMsg = "Project directory has uncommitted changes, use `astro deploy [deployment-id] -f` to force deploy."
 
 	deployWaitTime = 300 * time.Second
+
+	imageNameFlag = "image-name"
 )
 
 func NewDeployCmd() *cobra.Command {
@@ -59,7 +61,7 @@ func NewDeployCmd() *cobra.Command {
 		Long:    "Deploy your project to a Deployment on Astro. This command bundles your project files into a Docker image and pushes that Docker image to Astronomer. In Deployments with Remote Execution enabled, this only updates the Orchestration Plane components (the API Server and Scheduler). For all other components, use `astro remote deploy` instead. It does not include any metadata associated with your local Airflow environment.",
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Flags().Changed("image-name") {
+			if cmd.Flags().Changed(imageNameFlag) {
 				return nil
 			}
 			return EnsureProjectDir(cmd, args)
@@ -74,7 +76,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&pytest, "pytest", false, "Deploy code to Astro only if the specified Pytests are passed")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables for Pytests")
 	cmd.Flags().StringVarP(&pytestFile, "test", "t", "", "Location of Pytests or specific Pytest file. All Pytest files must be located in the tests directory")
-	cmd.Flags().StringVarP(&imageName, "image-name", "i", "", "Name of a custom image to deploy, or image name with custom tag when used with --client")
+	cmd.Flags().StringVarP(&imageName, imageNameFlag, "i", "", "Name of a custom image to deploy, or image name with custom tag when used with --client")
 	cmd.Flags().BoolVarP(&dags, "dags", "d", false, "Push only DAGs to your Astro Deployment")
 	cmd.Flags().BoolVar(&noDagsBaseDir, "no-dags-base-dir", false, "Exclude the dags directory prefix from the bundle. Use for Airflow 3.x deployments where sys.path includes the bundle root")
 	cmd.Flags().BoolVarP(&image, "image", "", false, "Push only an image to your Astro Deployment. If you have DAG Deploy enabled your DAGs will not be affected.")
@@ -131,9 +133,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return errors.New("cannot use both --dags and --image together. Run 'astro deploy' to update both your image and dags")
 	}
 
-	// --image-name supplies a prebuilt image, so this is an image-only deploy by definition.
-	// Reject flags that only apply when building from a local project, and force image-only semantics.
-	if cmd.Flags().Changed("image-name") {
+	if cmd.Flags().Changed(imageNameFlag) {
 		for _, f := range []string{"dags", "dags-path", "no-dags-base-dir", "pytest", "parse", "build-secrets"} {
 			if cmd.Flags().Changed(f) {
 				return fmt.Errorf("cannot use --%s with --image-name; --image-name implies an image-only deploy", f)

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -57,8 +57,13 @@ func NewDeployCmd() *cobra.Command {
 		Use:     "deploy DEPLOYMENT-ID",
 		Short:   "Deploy your project to a Deployment on Astro",
 		Long:    "Deploy your project to a Deployment on Astro. This command bundles your project files into a Docker image and pushes that Docker image to Astronomer. In Deployments with Remote Execution enabled, this only updates the Orchestration Plane components (the API Server and Scheduler). For all other components, use `astro remote deploy` instead. It does not include any metadata associated with your local Airflow environment.",
-		Args:    cobra.MaximumNArgs(1),
-		PreRunE: EnsureProjectDir,
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("image-name") {
+				return nil
+			}
+			return EnsureProjectDir(cmd, args)
+		},
 		RunE:    deploy,
 		Example: deployExample,
 	}

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -56,10 +56,10 @@ const (
 
 func NewDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "deploy DEPLOYMENT-ID",
-		Short:   "Deploy your project to a Deployment on Astro",
-		Long:    "Deploy your project to a Deployment on Astro. This command bundles your project files into a Docker image and pushes that Docker image to Astronomer. In Deployments with Remote Execution enabled, this only updates the Orchestration Plane components (the API Server and Scheduler). For all other components, use `astro remote deploy` instead. It does not include any metadata associated with your local Airflow environment.",
-		Args: cobra.MaximumNArgs(1),
+		Use:   "deploy DEPLOYMENT-ID",
+		Short: "Deploy your project to a Deployment on Astro",
+		Long:  "Deploy your project to a Deployment on Astro. This command bundles your project files into a Docker image and pushes that Docker image to Astronomer. In Deployments with Remote Execution enabled, this only updates the Orchestration Plane components (the API Server and Scheduler). For all other components, use `astro remote deploy` instead. It does not include any metadata associated with your local Airflow environment.",
+		Args:  cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed(imageNameFlag) {
 				return nil

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -90,3 +90,48 @@ func TestDeploySkipsEnsureProjectDirWhenImageNameSet(t *testing.T) {
 	err = execDeployCmd("-f", "test-deployment-id")
 	assert.ErrorIs(t, err, assert.AnError)
 }
+
+func TestDeployImageNameForcesImageOnly(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
+
+	var captured cloud.InputDeploy
+	DeployImage = func(deployInput cloud.InputDeploy, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+		captured = deployInput
+		return nil
+	}
+
+	err := execDeployCmd("-f", "test-deployment-id", "--image-name", "custom-image:latest")
+	assert.NoError(t, err)
+	assert.True(t, captured.Image, "--image-name should force image-only deploy")
+	assert.Equal(t, "custom-image:latest", captured.ImageName)
+}
+
+func TestDeployImageNameRejectsIncompatibleFlags(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
+	DeployImage = func(deployInput cloud.InputDeploy, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+		return nil
+	}
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"dags", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--dags"}},
+		{"dags-path", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--dags-path", "./dags"}},
+		{"no-dags-base-dir", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--no-dags-base-dir"}},
+		{"pytest", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--pytest"}},
+		{"parse", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--parse"}},
+		{"build-secrets", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--build-secrets", "id=mysecret,src=secrets.txt"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := execDeployCmd(tc.args...)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "--image-name")
+		})
+	}
+}

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -67,3 +67,26 @@ func TestDeployImage(t *testing.T) {
 	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--parse", "--pytest")
 	assert.NoError(t, err)
 }
+
+func TestDeploySkipsEnsureProjectDirWhenImageNameSet(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	EnsureProjectDir = func(cmd *cobra.Command, args []string) error {
+		return assert.AnError
+	}
+	defer func() {
+		EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
+	}()
+
+	DeployImage = func(deployInput cloud.InputDeploy, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+		return nil
+	}
+
+	// With --image-name, the project-dir check should be skipped.
+	err := execDeployCmd("-f", "test-deployment-id", "--image-name", "custom-image:latest")
+	assert.NoError(t, err)
+
+	// Without --image-name, the project-dir check should still run and propagate.
+	err = execDeployCmd("-f", "test-deployment-id")
+	assert.ErrorIs(t, err, assert.AnError)
+}

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -54,8 +54,13 @@ func NewDeployCmd() *cobra.Command {
 		Use:     "deploy [DEPLOYMENT ID]",
 		Short:   "Deploy an Airflow project",
 		Long:    "Deploy an Airflow project to an Astronomer Cluster",
-		Args:    cobra.MaximumNArgs(1),
-		PreRunE: EnsureProjectDir,
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("image-name") {
+				return nil
+			}
+			return EnsureProjectDir(cmd, args)
+		},
 		RunE:    deployAirflow,
 		Example: deployExample,
 	}

--- a/cmd/software/deploy.go
+++ b/cmd/software/deploy.go
@@ -51,10 +51,10 @@ const (
 
 func NewDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "deploy [DEPLOYMENT ID]",
-		Short:   "Deploy an Airflow project",
-		Long:    "Deploy an Airflow project to an Astronomer Cluster",
-		Args: cobra.MaximumNArgs(1),
+		Use:   "deploy [DEPLOYMENT ID]",
+		Short: "Deploy an Airflow project",
+		Long:  "Deploy an Airflow project to an Astronomer Cluster",
+		Args:  cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("image-name") {
 				return nil


### PR DESCRIPTION
## Description

`astro deploy --image-name <image>` is implicitly an image-only deploy: the user is supplying a prebuilt image, so the local working directory may not represent it and project-build flags do not apply. This PR aligns the command's behavior with that intent.

- Skip the project-dir check, so the command works outside an Astro project.
- Force image-only semantics when `--image-name` is set (no dag deploy, no dag-deletion warning prompt).
- Reject flags that only make sense when building from a local project: `--dags`, `--dags-path`, `--no-dags-base-dir`, `--pytest`, `--parse`, `--build-secrets`.
- Skip local git metadata collection, since the working dir may not correspond to the prebuilt image.

Same project-dir fix applied to `software` deploy for consistency; the broader Option C scope is Astro-only.

Fixes #2106

## 🧪 Functional Testing

- From a directory that is not an Astro project, run `astro deploy --image-name <image>` and confirm it no longer errors at the project-dir check.
- From an Astro project directory, run `astro deploy` (without `--image-name`) and confirm the existing project-dir validation still applies.
- Run `astro deploy --image-name <image> --dags` (or `--pytest`, `--parse`, `--dags-path`, `--no-dags-base-dir`, `--build-secrets`) and confirm a clear error is returned.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
