### PR TITLE
don't require astro project dir when using --image-name

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -23,6 +23,12 @@ func ChainRunEs(runEs ...RunE) RunE {
 }
 
 func EnsureProjectDir(cmd *cobra.Command, args []string) error {
+	// Skip the project directory check when --image-name is provided, since
+	// deploying a prebuilt image does not require local project files.
+	if flag := cmd.Flags().Lookup("image-name"); flag != nil && flag.Changed {
+		return nil
+	}
+
 	isProjectDir, err := config.IsProjectDir(config.WorkingPath)
 	if err != nil {
 		return errors.Wrap(err, ansi.Red("failed to verify that your working directory is an Astro project.\nTry running astro dev init to turn your working directory into an Astro project"))

--- a/cmd/utils/utils_test.go
+++ b/cmd/utils/utils_test.go
@@ -37,6 +37,25 @@ func TestEnsureProjectDir(t *testing.T) {
 	config.ConfigDir = ""
 	err = EnsureProjectDir(&cobra.Command{}, []string{})
 	assert.NoError(t, err)
+
+	// --image-name passed: project dir check is skipped even when the directory is invalid
+	config.WorkingPath = "./test"
+	config.ConfigFileNameWithExt = fileName
+	config.ConfigDir = dirName
+	cmdWithImageName := &cobra.Command{}
+	var imageName string
+	cmdWithImageName.Flags().StringVarP(&imageName, "image-name", "i", "", "")
+	err = cmdWithImageName.Flags().Set("image-name", "my-custom-image")
+	assert.NoError(t, err)
+	err = EnsureProjectDir(cmdWithImageName, []string{})
+	assert.NoError(t, err)
+
+	// --image-name registered but not passed: project dir check still runs
+	cmdImageNameUnset := &cobra.Command{}
+	cmdImageNameUnset.Flags().StringVarP(&imageName, "image-name", "i", "", "")
+	err = EnsureProjectDir(cmdImageNameUnset, []string{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "this is not an Astro project directory")
 }
 
 func TestGetDefaultDeployDescription(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes issue where deploying a specific image requires an astro project dir

## 🎟 Issue(s)

Closes: #2106 

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.
Not quite sure how to functionally test this 😅 

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
