### PR TITLE
fix(dev): print localhost URL when proxy daemon fails to start

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -394,10 +394,14 @@ func (d *DockerCompose) Start(opts *airflowTypes.StartOptions) error {
 
 	spinner.StopWithCheckmark(s, "Project started")
 
-	// Register route with the proxy and start the daemon
-	if useProxy && proxyHostname != "" {
+	// Register route with the proxy and start the daemon. If either step fails
+	// (e.g. proxy daemon unsupported on Windows), fall back to printing the
+	// localhost URL using the actual webserver port that compose bound.
+	proxyActive := useProxy && proxyHostname != ""
+	if proxyActive {
 		if _, ensureErr := proxy.EnsureRunning(proxyPort); ensureErr != nil {
 			fmt.Printf("Warning: could not start proxy: %s\n", ensureErr.Error())
+			proxyActive = false
 		} else {
 			services := map[string]string{}
 			if portOvr != nil && portOvr.PostgresPort != "" {
@@ -413,15 +417,16 @@ func (d *DockerCompose) Start(opts *airflowTypes.StartOptions) error {
 			}
 			if addErr := proxy.AddRoute(&route); addErr != nil {
 				fmt.Printf("Warning: could not register proxy route: %s\n", addErr.Error())
+				proxyActive = false
 			}
 		}
 	}
 
 	// Print the status
-	if useProxy && proxyHostname != "" {
+	if proxyActive {
 		err = printProxyStatus(settingsFile, envConns, airflowDockerVersion, noBrowser, proxyHostname, proxyPort, portOvr)
 	} else {
-		err = printStatus(settingsFile, envConns, airflowDockerVersion, noBrowser)
+		err = printStatus(settingsFile, envConns, airflowDockerVersion, noBrowser, portOvr)
 	}
 	if err != nil {
 		return err
@@ -1832,14 +1837,14 @@ func printProxyStatus(settingsFile string, envConns map[string]astrocore.Environ
 	return nil
 }
 
-func printStatus(settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, airflowMajorVersion uint64, noBrowser bool) error {
+func printStatus(settingsFile string, envConns map[string]astrocore.EnvironmentObjectConnection, airflowMajorVersion uint64, noBrowser bool, portOvr *PortOverrides) error {
 	settingsFileExists, err := fileutil.Exists(settingsFile, nil)
 	if err != nil {
 		return errors.Wrap(err, errSettingsPath)
 	}
 	if settingsFileExists || len(envConns) > 0 {
-		apiURL := airflowAPIURL(airflowMajorVersion, nil)
-		authHeader := airflowAuthHeader(airflowMajorVersion, nil)
+		apiURL := airflowAPIURL(airflowMajorVersion, portOvr)
+		authHeader := airflowAuthHeader(airflowMajorVersion, portOvr)
 		err = initSettings(apiURL, authHeader, settingsFile, envConns, true, true, true)
 		if err != nil {
 			return err
@@ -1850,14 +1855,24 @@ func printStatus(settingsFile string, envConns map[string]astrocore.EnvironmentO
 	switch airflowMajorVersion {
 	case airflowMajorVersion2:
 		port = config.CFG.WebserverPort.GetString()
+		if portOvr != nil && portOvr.WebserverPort != "" {
+			port = portOvr.WebserverPort
+		}
 	case airflowMajorVersion3:
 		port = config.CFG.APIServerPort.GetString()
+		if portOvr != nil && portOvr.APIServerPort != "" {
+			port = portOvr.APIServerPort
+		}
 	}
 	parts := strings.Split(port, ":")
 	uiURL := "http://localhost:" + parts[len(parts)-1]
+	pgPort := config.CFG.PostgresPort.GetString()
+	if portOvr != nil && portOvr.PostgresPort != "" {
+		pgPort = portOvr.PostgresPort
+	}
 	bullet := ansi.Cyan("\u27A4") + " "
 	fmt.Printf(bullet+composeLinkUIMsg+"\n", ansi.Bold(uiURL))
-	fmt.Printf(bullet+composeLinkPostgresMsg+"\n", ansi.Bold("postgresql://localhost:"+config.CFG.PostgresPort.GetString()+"/postgres"))
+	fmt.Printf(bullet+composeLinkPostgresMsg+"\n", ansi.Bold("postgresql://localhost:"+pgPort+"/postgres"))
 	// The CLI configures Airflow 3 to run without UI credentials, so we don't want to print them out
 	if airflowMajorVersion == airflowMajorVersion2 {
 		fmt.Printf(bullet+composeUserPasswordMsg+"\n", ansi.Bold("admin:admin"))

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -2025,6 +2025,67 @@ func (s *Suite) TestDockerComposeRunDAG() {
 
 var errExecMock = errors.New("docker is not running")
 
+func (s *Suite) TestPrintStatusURL() {
+	fs := afero.NewMemMapFs()
+	configYaml := testUtil.NewTestConfig(testUtil.LocalPlatform)
+	err := afero.WriteFile(fs, config.HomeConfigFile, configYaml, 0o777)
+	s.NoError(err)
+	config.InitConfig(fs)
+
+	originalOpenURL := openURL
+	openURL = func(url string) error { return nil }
+	defer func() { openURL = originalOpenURL }()
+
+	capture := func(fn func()) string {
+		origStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		fn()
+		w.Close()
+		os.Stdout = origStdout
+		out, _ := io.ReadAll(r)
+		return string(out)
+	}
+
+	s.Run("uses config port when no overrides (Airflow 2)", func() {
+		out := capture(func() {
+			err := printStatus("./testfiles/non_existent_settings.yaml", nil, airflowMajorVersion2, true, nil)
+			s.NoError(err)
+		})
+		s.Contains(out, "http://localhost:"+config.CFG.WebserverPort.GetString())
+	})
+
+	s.Run("uses webserver port override (Airflow 2)", func() {
+		ovr := &PortOverrides{
+			PostgresPort:  "55432",
+			WebserverPort: "58080",
+			APIServerPort: "58080",
+		}
+		out := capture(func() {
+			err := printStatus("./testfiles/non_existent_settings.yaml", nil, airflowMajorVersion2, true, ovr)
+			s.NoError(err)
+		})
+		s.Contains(out, "http://localhost:58080")
+		s.Contains(out, "postgresql://localhost:55432/postgres")
+		// Make sure the proxy hostname did NOT leak into the printed URL.
+		s.NotContains(out, ".localhost:")
+	})
+
+	s.Run("uses api-server port override (Airflow 3)", func() {
+		ovr := &PortOverrides{
+			PostgresPort:  "55432",
+			WebserverPort: "58080",
+			APIServerPort: "58080",
+		}
+		out := capture(func() {
+			err := printStatus("./testfiles/non_existent_settings.yaml", nil, airflowMajorVersion3, true, ovr)
+			s.NoError(err)
+		})
+		s.Contains(out, "http://localhost:58080")
+		s.NotContains(out, ".localhost:")
+	})
+}
+
 func (s *Suite) TestInitSettings() {
 	testCases := []struct {
 		name                     string

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -2140,7 +2140,7 @@ func (s *Suite) TestInitSettings() {
 			}
 			defer func() { openURL = originalOpenURL }()
 
-			err := printStatus(tc.settingsFile, tc.envConns, tc.airflowMajorVersion, true)
+			err := printStatus(tc.settingsFile, tc.envConns, tc.airflowMajorVersion, true, nil)
 			s.NoError(err)
 			s.Equal(tc.expectInitSettingsCalled, initSettingsCalled)
 		})


### PR DESCRIPTION
## Description

On Windows the proxy daemon is unsupported, so `proxy.EnsureRunning` returns an error. The Docker `astro dev start` path printed the warning but still printed the proxy URL (e.g. `http://astro-data-transformation.localhost:6563`), which doesn't resolve and won't open in a browser.

This makes the Docker path fall back to the localhost URL — using the actual (possibly randomly allocated) webserver port that compose bound — whenever `EnsureRunning` or `AddRoute` fails. Standalone already handled this correctly.

## 🧪 Functional Testing

- On Windows, run `astro dev start`. The proxy warning still prints, but the Airflow UI URL is now `http://localhost:<port>` and opens successfully.
- On macOS/Linux with the proxy working, the proxy URL is unchanged.

## 📋 Checklist

- [ ] Rebased from the main branch
- [ ] Ran `make test`
- [ ] Ran `make lint`
- [x] Added/updated applicable tests
