### PR TITLE
chore(otto): bump astro-airflow-mcp pin to 0.6.4

### DIFF
--- a/pkg/otto/af.go
+++ b/pkg/otto/af.go
@@ -9,7 +9,7 @@ import (
 
 // afPinnedVersion is the astro-airflow-mcp release that Otto is developed
 // against. Bump in lockstep with Otto's prompt reference.
-const afPinnedVersion = "0.6.1"
+const afPinnedVersion = "0.6.4"
 
 // afPackageSpec is the pip-style spec passed to uvx --from.
 const afPackageSpec = "astro-airflow-mcp==" + afPinnedVersion


### PR DESCRIPTION
## Summary

- bumps `afPinnedVersion` in `pkg/otto/af.go` from 0.6.1 to 0.6.4
- the wrapper astro-cli installs at `~/.astro/bin/af` now points at the matching release

Otto recently added its own wrapper at `~/.astro/otto/bin/af` and prepends that dir to PATH on startup, so this pin is no longer load-bearing for Otto's own correctness. It still matters for the standalone `af` users invoke outside `astro otto`.

## Related

- skills now use bare `af` (so they flow through whichever wrapper is on PATH): https://github.com/astronomer/agents/pull/203

## Test plan

- [x] `go test ./pkg/otto/...` passes