### PR TITLE
fix(deploy): do not treat --image-name as image-only

### DIFF
--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -61,7 +61,9 @@ func NewDeployCmd() *cobra.Command {
 		Long:  "Deploy your project to a Deployment on Astro. This command bundles your project files into a Docker image and pushes that Docker image to Astronomer. In Deployments with Remote Execution enabled, this only updates the Orchestration Plane components (the API Server and Scheduler). For all other components, use `astro remote deploy` instead. It does not include any metadata associated with your local Airflow environment.",
 		Args:  cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Flags().Changed(imageNameFlag) {
+			// --image with --image-name pushes a prebuilt image only; no local
+			// project files (DAGs, Dockerfile) are needed, so skip the check.
+			if image && cmd.Flags().Changed(imageNameFlag) {
 				return nil
 			}
 			return EnsureProjectDir(cmd, args)
@@ -131,15 +133,6 @@ func deploy(cmd *cobra.Command, args []string) error {
 
 	if dags && image {
 		return errors.New("cannot use both --dags and --image together. Run 'astro deploy' to update both your image and dags")
-	}
-
-	if cmd.Flags().Changed(imageNameFlag) {
-		for _, f := range []string{"dags", "dags-path", "no-dags-base-dir", "pytest", "parse", "build-secrets"} {
-			if cmd.Flags().Changed(f) {
-				return fmt.Errorf("cannot use --%s with --image-name; --image-name implies an image-only deploy", f)
-			}
-		}
-		image = true
 	}
 
 	// Save deploymentId in config if specified

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -68,7 +68,7 @@ func TestDeployImage(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDeploySkipsEnsureProjectDirWhenImageNameSet(t *testing.T) {
+func TestDeployProjectDirCheckWithImageName(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	EnsureProjectDir = func(cmd *cobra.Command, args []string) error {
@@ -82,16 +82,22 @@ func TestDeploySkipsEnsureProjectDirWhenImageNameSet(t *testing.T) {
 		return nil
 	}
 
-	// With --image-name, the project-dir check should be skipped.
-	err := execDeployCmd("-f", "test-deployment-id", "--image-name", "custom-image:latest")
+	// --image --image-name is an explicit image-only push of a prebuilt image;
+	// no local project files are needed, so the check is skipped.
+	err := execDeployCmd("-f", "test-deployment-id", "--image", "--image-name", "custom-image:latest")
 	assert.NoError(t, err)
 
-	// Without --image-name, the project-dir check should still run and propagate.
+	// --image-name alone keeps the default image-and-dags behavior, which
+	// reads DAGs from the working directory and so still requires a project.
+	err = execDeployCmd("-f", "test-deployment-id", "--image-name", "custom-image:latest")
+	assert.ErrorIs(t, err, assert.AnError)
+
+	// No --image-name: check still runs and propagates.
 	err = execDeployCmd("-f", "test-deployment-id")
 	assert.ErrorIs(t, err, assert.AnError)
 }
 
-func TestDeployImageNameForcesImageOnly(t *testing.T) {
+func TestDeployImageNameDoesNotForceImageOnly(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
@@ -104,34 +110,6 @@ func TestDeployImageNameForcesImageOnly(t *testing.T) {
 
 	err := execDeployCmd("-f", "test-deployment-id", "--image-name", "custom-image:latest")
 	assert.NoError(t, err)
-	assert.True(t, captured.Image, "--image-name should force image-only deploy")
+	assert.False(t, captured.Image, "--image-name alone must not force image-only; default deploy type is image-and-dags")
 	assert.Equal(t, "custom-image:latest", captured.ImageName)
-}
-
-func TestDeployImageNameRejectsIncompatibleFlags(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
-
-	EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
-	DeployImage = func(deployInput cloud.InputDeploy, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
-		return nil
-	}
-
-	cases := []struct {
-		name string
-		args []string
-	}{
-		{"dags", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--dags"}},
-		{"dags-path", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--dags-path", "./dags"}},
-		{"no-dags-base-dir", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--no-dags-base-dir"}},
-		{"pytest", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--pytest"}},
-		{"parse", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--parse"}},
-		{"build-secrets", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--build-secrets", "id=mysecret,src=secrets.txt"}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := execDeployCmd(tc.args...)
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "--image-name")
-		})
-	}
 }


### PR DESCRIPTION
## Summary

- **Regression in v1.42.0**: `astro deploy <id> --image-name <tag>` is auto-promoted to an image-only deploy. On any Deployment that has not enabled DAG deploys, that fails with `DAG-only deploys are not enabled for this Deployment`.
- The same flag combination performed an image-and-dags deploy through v1.41.0, and the GitHub Action `astronomer/deploy-action` relies on that — its `deploy-type: image-and-dags` step runs `astro deploy <id> --wait --image-name <tag>` and uses the explicit `--image --image-name` form for `image-only`. Auto-flipping `--image-name` to image-only therefore breaks the image-and-dags + prebuilt-image flow with no replacement.

This restores the historical semantics: `--image-name` specifies the image source, `--image` specifies the deploy type. They compose:

| Invocation | Deploy type | Project dir required |
| --- | --- | --- |
| `astro deploy --image-name X` | image-and-dags (default) | yes (DAGs come from `./dags`) |
| `astro deploy --image` | image-only | yes |
| `astro deploy --image --image-name X` | image-only | **no** (skipped — no local files needed) |

## Changes

- `cmd/cloud/deploy.go`: drop `image = true` auto-set and the forbidden-flag list (`--dags`, `--dags-path`, `--no-dags-base-dir`, `--pytest`, `--parse`, `--build-secrets`) introduced for `--image-name`. Scope the `EnsureProjectDir` skip to `--image && --image-name`.
- `cmd/cloud/deploy_test.go`: replace the now-inverted assertions; add a regression test that `--image-name` alone does not flip `Image` to true.

The previous user-facing scenario (`astro deploy --image-name X` from a non-project dir) is now served by the explicit `astro deploy --image --image-name X`, which is the form `deploy-action` already uses for image-only deploys.

## Test plan

- [x] `go test ./cmd/cloud/ ./cloud/deploy/` passes
- [x] `go vet ./cmd/cloud/ ./cloud/deploy/` clean
- [ ] Manual: `astro deploy <id> --image-name <tag>` against a Deployment without DAG deploys enabled completes (no `enableDagDeployMsg`)
- [ ] Manual: `astro deploy --image --image-name <tag>` from a non-project directory still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)