### PR TITLE
fix(otto): Alias `upgrade` to `update` and surface subcommands in --help

### DIFF
--- a/cmd/otto.go
+++ b/cmd/otto.go
@@ -22,7 +22,7 @@ func hasHelpFlag(args []string) bool {
 }
 
 func printAstroSubcommands(w io.Writer) {
-	fmt.Fprintln(w, "Subcommands handled by astro CLI (everything else is forwarded to Otto):")
+	fmt.Fprintln(w, "Subcommands:")
 	fmt.Fprintln(w, "  astro otto update    Download and install the latest Otto binary")
 	fmt.Fprintln(w, "  astro otto version   Print the installed Otto version")
 	fmt.Fprintln(w)

--- a/cmd/otto.go
+++ b/cmd/otto.go
@@ -22,9 +22,10 @@ func hasHelpFlag(args []string) bool {
 }
 
 func printAstroSubcommands(w io.Writer) {
+	// Match Otto's help format: 2-space indent, description column at col 24.
 	fmt.Fprintln(w, "Subcommands:")
-	fmt.Fprintln(w, "  astro otto update    Download and install the latest Otto binary")
-	fmt.Fprintln(w, "  astro otto version   Print the installed Otto version")
+	fmt.Fprintln(w, "  astro otto update     Download and install the latest Otto binary")
+	fmt.Fprintln(w, "  astro otto version    Print the installed Otto version")
 	fmt.Fprintln(w)
 }
 

--- a/cmd/otto.go
+++ b/cmd/otto.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 
@@ -10,6 +11,22 @@ import (
 
 	"github.com/astronomer/astro-cli/pkg/otto"
 )
+
+func hasHelpFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--help" || a == "-h" {
+			return true
+		}
+	}
+	return false
+}
+
+func printAstroSubcommands(w io.Writer) {
+	fmt.Fprintln(w, "Subcommands handled by astro CLI (everything else is forwarded to Otto):")
+	fmt.Fprintln(w, "  astro otto update    Download and install the latest Otto binary")
+	fmt.Fprintln(w, "  astro otto version   Print the installed Otto version")
+	fmt.Fprintln(w)
+}
 
 func newOttoCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -26,10 +43,12 @@ func newOttoCmd() *cobra.Command {
 
 func ottoRun(cmd *cobra.Command, args []string) error {
 	// With DisableFlagParsing, cobra won't route to subcommands,
-	// so we dispatch "update" and "version" ourselves.
+	// so we dispatch "update" and "version" ourselves. "upgrade" is
+	// aliased to "update" — otherwise it falls through to Otto and gets
+	// interpreted as a prompt asking it to upgrade the Astro project.
 	if len(args) > 0 {
 		switch args[0] {
-		case "update":
+		case "update", "upgrade":
 			return otto.Update()
 		case "version":
 			installed, err := otto.InstalledVersion()
@@ -48,6 +67,13 @@ func ottoRun(cmd *cobra.Command, args []string) error {
 			}
 			return nil
 		}
+	}
+
+	// `astro otto --help` forwards to Otto's own help, which doesn't know
+	// about the astro CLI's `update` / `version` subcommands. Prepend a short
+	// banner so they're discoverable.
+	if hasHelpFlag(args) {
+		printAstroSubcommands(os.Stdout)
 	}
 
 	// Everything else (flags, prompt, etc.) is forwarded directly to Otto.


### PR DESCRIPTION
## Summary

Two small fixes for `astro otto` subcommand discoverability, both surfaced by users in:

1. **`astro otto upgrade` is now an alias for `astro otto update`.** Previously, `upgrade` fell through to the Otto binary and was interpreted as a user prompt — Otto would happily start upgrading the user's Astro project. (`update` was the only dispatched form; users naturally typed `upgrade`.)

2. **`astro otto --help` now lists the astro-CLI-side subcommands (`update`, `version`).** They were invisible because `DisableFlagParsing: true` makes cobra forward `--help` straight to the Otto binary, which doesn't know about them.

## Design rationale

- **Why a banner instead of registering `update`/`version` as proper cobra subcommands?** The parent `otto` command sets `DisableFlagParsing: true` so it can forward arbitrary flags (`--mode`, `--rpc`, `-c`, etc.) to the Otto binary unchanged. Under that flag, cobra's normal `--help` behavior is bypassed entirely — Otto's binary handles `--help` itself. Registering subcommands wouldn't make them appear in Otto's help. A short banner printed before forwarding is the lowest-risk way to make them discoverable.

- **Why alias `upgrade` rather than reject it with a "did you mean" hint?** Users typing `upgrade` clearly want to update the binary. Aliasing matches intent in one keystroke; a hint would just bounce them back. Both spellings are common in the wild (`apt upgrade` vs `brew update`).

## Usage

```
$ astro otto --help
Subcommands handled by astro CLI (everything else is forwarded to Otto):
  astro otto update    Download and install the latest Otto binary
  astro otto version   Print the installed Otto version

Otto 0.1.1 — Astronomer AI coding agent for Airflow development and operations.
... (Otto's own help follows)
```

```
$ astro otto upgrade   # same as `astro otto update`
Updating Otto...
Otto 0.1.1 installed
```

## Gotchas

- The banner only fires when `--help` or `-h` is in the arg list. It does not fire on bare `astro otto`, which launches the TUI as before.
- The banner prints to stdout (matching where Otto writes its own help), so piping `astro otto --help | less` keeps everything together.