### PR TITLE
fix(otto): Refresh update cache before auto-update, not after

### DIFF
--- a/pkg/otto/start.go
+++ b/pkg/otto/start.go
@@ -45,6 +45,14 @@ func Start(args []string) error {
 		return fmt.Errorf("setting up otto: %w", err)
 	}
 
+	// Refresh the cached latest version up-front so autoUpdate / hint paths
+	// see today's release, not yesterday's. Previously this ran post-autoUpdate
+	// in a goroutine, which meant the very first launch after a release missed
+	// the new version (cache only caught up by the *next* invocation). Bounded
+	// by LatestVersion's 5s timeout; offline launches soft-fall-through to the
+	// previously cached value.
+	refreshUpdateCacheIfStale()
+
 	// Apply auto-update or fall back to the hint. Both must run before
 	// redirectCLILogs — post-redirect, writes would land in a log file the
 	// user never opens. autoUpdate downloads synchronously when the cache
@@ -72,11 +80,6 @@ func Start(args []string) error {
 	if err := EnsureAfWrapper(); err != nil {
 		logger.Warnf("otto: failed to install af wrapper: %v (will fall back to uvx)", err)
 	}
-
-	// Refresh the cached latest-version in the background so the next launch
-	// prints an up-to-date hint. Fire-and-forget; the goroutine lives for the
-	// duration of the Otto session via cmd.Wait() below.
-	go refreshUpdateCacheAsync()
 
 	env := cfg.BuildEnv()
 

--- a/pkg/otto/start.go
+++ b/pkg/otto/start.go
@@ -45,12 +45,9 @@ func Start(args []string) error {
 		return fmt.Errorf("setting up otto: %w", err)
 	}
 
-	// Refresh the cached latest version up-front so autoUpdate / hint paths
-	// see today's release, not yesterday's. Previously this ran post-autoUpdate
-	// in a goroutine, which meant the very first launch after a release missed
-	// the new version (cache only caught up by the *next* invocation). Bounded
-	// by LatestVersion's 5s timeout; offline launches soft-fall-through to the
-	// previously cached value.
+	// Refresh the cached latest version before autoUpdate and hintUpdateAvailable
+	// read it, so a launch on release day sees today's version. Bounded by
+	// LatestVersion's 5s timeout; offline launches keep the previous cache.
 	refreshUpdateCacheIfStale()
 
 	// Apply auto-update or fall back to the hint. Both must run before

--- a/pkg/otto/update.go
+++ b/pkg/otto/update.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	updateCheckInterval = 24 * time.Hour
+	updateCheckInterval = 1 * time.Hour
 	updateStateFile     = ".update-check"
 )
 
@@ -77,22 +77,32 @@ func autoUpdateEnabled() bool {
 	return config.CFG.OttoAutoUpdate.GetBool()
 }
 
-// refreshUpdateCacheAsync refreshes the cached latest version if the cache is
-// older than updateCheckInterval. Safe to run in a goroutine after the logger
-// is redirected — it never prints, only updates the state file.
-func refreshUpdateCacheAsync() {
+// refreshUpdateCacheIfStale refreshes the cached latest version when the
+// cache is older than updateCheckInterval. Synchronous — must run before
+// autoUpdate / hintUpdateAvailable read the cache so the very next launch
+// after a release picks up the new version. Bounded by LatestVersion's 5s
+// timeout; network failures still bump LastCheck so the same 5s wait does
+// not repeat on every launch when the CDN is unreachable (negative-cache).
+// LatestKnown is preserved on failure so downstream paths fall back to that
+// last-known answer.
+func refreshUpdateCacheIfStale() {
 	state, _ := readUpdateState()
 	if t, err := time.Parse(time.RFC3339, state.LastCheck); err == nil {
 		if time.Since(t) < updateCheckInterval {
 			return
 		}
 	}
+	now := time.Now().UTC().Format(time.RFC3339)
 	latest, err := LatestVersion()
 	if err != nil {
+		// Negative cache: bump LastCheck to avoid 5s waits on every launch
+		// when the CDN is blocked. Keep LatestKnown so the hint still works.
+		state.LastCheck = now
+		_ = writeUpdateState(state)
 		return
 	}
 	_ = writeUpdateState(updateState{
-		LastCheck:   time.Now().UTC().Format(time.RFC3339),
+		LastCheck:   now,
 		LatestKnown: latest,
 	})
 }

--- a/pkg/otto/update.go
+++ b/pkg/otto/update.go
@@ -78,13 +78,11 @@ func autoUpdateEnabled() bool {
 }
 
 // refreshUpdateCacheIfStale refreshes the cached latest version when the
-// cache is older than updateCheckInterval. Synchronous — must run before
-// autoUpdate / hintUpdateAvailable read the cache so the very next launch
-// after a release picks up the new version. Bounded by LatestVersion's 5s
-// timeout; network failures still bump LastCheck so the same 5s wait does
-// not repeat on every launch when the CDN is unreachable (negative-cache).
-// LatestKnown is preserved on failure so downstream paths fall back to that
-// last-known answer.
+// cache is older than updateCheckInterval. Must run before autoUpdate and
+// hintUpdateAvailable read the cache so a launch right after a release picks
+// up the new version. On network failure, LastCheck is still bumped so the
+// 5s LatestVersion timeout does not repeat on every launch when the CDN is
+// unreachable; LatestKnown is preserved so the hint still works.
 func refreshUpdateCacheIfStale() {
 	state, _ := readUpdateState()
 	if t, err := time.Parse(time.RFC3339, state.LastCheck); err == nil {
@@ -92,19 +90,11 @@ func refreshUpdateCacheIfStale() {
 			return
 		}
 	}
-	now := time.Now().UTC().Format(time.RFC3339)
-	latest, err := LatestVersion()
-	if err != nil {
-		// Negative cache: bump LastCheck to avoid 5s waits on every launch
-		// when the CDN is blocked. Keep LatestKnown so the hint still works.
-		state.LastCheck = now
-		_ = writeUpdateState(state)
-		return
+	state.LastCheck = time.Now().UTC().Format(time.RFC3339)
+	if latest, err := LatestVersion(); err == nil {
+		state.LatestKnown = latest
 	}
-	_ = writeUpdateState(updateState{
-		LastCheck:   now,
-		LatestKnown: latest,
-	})
+	_ = writeUpdateState(state)
 }
 
 func readUpdateState() (updateState, error) {

--- a/pkg/otto/update_test.go
+++ b/pkg/otto/update_test.go
@@ -119,14 +119,14 @@ func (s *UpdateSuite) TestHintUpdateAvailable_CacheUnparseable() {
 	s.Empty(buf.String())
 }
 
-// --- refreshUpdateCacheAsync ---
+// --- refreshUpdateCacheIfStale ---
 // `cdnBaseURL` is a const, so LatestVersion can't be pointed at a test server
 // without a refactor. The tests here cover the throttle-skip path and the
 // read/write helpers — the network-hit branch is exercised by the real-auth
 // smoke path.
 
 func (s *UpdateSuite) TestRefreshUpdateCache_SkipsWhenFresh() {
-	// Write a state with a recent LastCheck. refreshUpdateCacheAsync should
+	// Write a state with a recent LastCheck. refreshUpdateCacheIfStale should
 	// not touch the network and should leave the state alone.
 	fresh := updateState{
 		LastCheck:   time.Now().UTC().Format(time.RFC3339),
@@ -134,7 +134,7 @@ func (s *UpdateSuite) TestRefreshUpdateCache_SkipsWhenFresh() {
 	}
 	s.writeCache(fresh)
 
-	refreshUpdateCacheAsync()
+	refreshUpdateCacheIfStale()
 
 	got, err := readUpdateState()
 	s.NoError(err)

--- a/pkg/otto/update_test.go
+++ b/pkg/otto/update_test.go
@@ -241,7 +241,7 @@ func (s *UpdateSuite) TestAutoUpdate_NoCachedVersion_SkipsDownload() {
 	var buf bytes.Buffer
 	autoUpdate(&buf, download)
 
-	s.False(*called, "auto-update should wait for the async refresh to populate the cache")
+	s.False(*called, "auto-update should skip when no LatestKnown is cached")
 	s.Empty(buf.String())
 }
 


### PR DESCRIPTION
## Summary

`astro otto` did not auto-download v0.1.1 the morning it released. The 24h TTL was a contributor, but the underlying bug was ordering: the cache refresh ran in a fire-and-forget goroutine *after* `autoUpdate` had already read stale data. The cache only caught up during the session for the *next* invocation's benefit, so the first launch after every release missed the new version.

Fixes [AI-485](https://linear.app/astronomer/issue/AI-485/otto-does-not-auto-download-latest-version).

## What changed

- **Move the refresh to before the check, synchronously.** `refreshUpdateCacheIfStale` now runs in `Start()` *before* `autoUpdate` / `hintUpdateAvailable` read the cache, instead of as a post-launch goroutine. The CDN endpoint returns a tiny version string bounded by `LatestVersion`'s existing 5s timeout.
- **Lower TTL from 24h → 1h.** Even when the cache is "fresh," a 24h window could hide a recent release for a full day. 1h shrinks the worst-case miss window to a single hour.
- **Negative-cache failures.** On network failure, `LastCheck` still advances (preserving `LatestKnown` so the hint keeps working). Otherwise a blocked CDN would impose a 5s wait on every launch.

## Design rationale

- *Why synchronous and not just shorten the goroutine timer?* Because the bug isn't TTL length — it's that the goroutine runs *after* the decision it should inform. Any value of "refresh later for next time" still misses the current launch.
- *Why keep the cache at all instead of always fetching?* The cache lets us skip the network call on rapid relaunches and serves as a graceful fallback when offline. Dropping it entirely would mean a 5s timeout on every launch when the CDN is blocked.
- *Why 1h and not 5min?* 1h is what the issue thread suggested. It's short enough that releases are picked up promptly while still avoiding chatty CDN traffic from users who launch Otto many times per hour.
- *Why bump `LastCheck` on failure?* Without it, a stale-cache + blocked-CDN environment would re-pay the 5s timeout on every launch indefinitely. With it, that user sees one 5s wait per hour.

## Tradeoffs

- Worst-case startup penalty in a blocked-CDN environment is now visible (5s once per hour), where previously it was invisible because the network call lived in a goroutine. Acceptable: the alternative (the bug we're fixing) was that releases never arrived without manual `astro otto update`.
- Users who launched within the last hour of a release still won't get it on the very next invocation. That window is unavoidable without dropping the cache entirely.