### PR TITLE
otto: stop setting AF_CONFIG=/dev/null in the no-Airflow fallback

### DIFF
--- a/pkg/otto/config.go
+++ b/pkg/otto/config.go
@@ -123,20 +123,23 @@ func (c *Config) BuildEnv() []string {
 	// airflow subcommands already honor it alongside their `--no-browser` flag.
 	set("ASTRONOMER_NO_BROWSER", "1")
 
-	// Airflow connection
+	// Airflow connection. When we matched the cwd to a running astro-dev
+	// project, hand Otto its URL + the standard local-dev creds. When we
+	// didn't, leave Otto's environment alone so af 0.8.0's layered config
+	// (project-local > project-shared > global ~/.astro/config.yaml) can
+	// resolve whatever the user has saved. The previous behavior here was
+	// `AF_CONFIG=/dev/null` to keep an unrelated global current-instance
+	// from leaking in; af 0.8.0's project-aware resolution makes that
+	// guard counterproductive — it hides the team's committed deployment
+	// inventory in `<project>/.astro/config.yaml` from the model. Surfacing
+	// the resolved instance in Otto's UI is a better safety net than
+	// blanking the config.
 	set("AIRFLOW_API_URL", c.AirflowURL)
 
 	if c.AirflowURL != "" {
 		// Default local Airflow credentials for af CLI token exchange
 		set("AIRFLOW_USERNAME", "admin")
 		set("AIRFLOW_PASSWORD", "admin")
-	} else {
-		// We couldn't match the current project to a running Airflow.
-		// Point the af CLI at an empty config so it doesn't silently fall
-		// back to ~/.af/config.yaml's `current-instance`, which is a
-		// globally-scoped pointer that usually references whatever project
-		// last ran `astro dev start` — not this one.
-		set("AF_CONFIG", os.DevNull)
 	}
 
 	return env

--- a/pkg/otto/config.go
+++ b/pkg/otto/config.go
@@ -123,17 +123,9 @@ func (c *Config) BuildEnv() []string {
 	// airflow subcommands already honor it alongside their `--no-browser` flag.
 	set("ASTRONOMER_NO_BROWSER", "1")
 
-	// Airflow connection. When we matched the cwd to a running astro-dev
-	// project, hand Otto its URL + the standard local-dev creds. When we
-	// didn't, leave Otto's environment alone so af 0.8.0's layered config
-	// (project-local > project-shared > global ~/.astro/config.yaml) can
-	// resolve whatever the user has saved. The previous behavior here was
-	// `AF_CONFIG=/dev/null` to keep an unrelated global current-instance
-	// from leaking in; af 0.8.0's project-aware resolution makes that
-	// guard counterproductive — it hides the team's committed deployment
-	// inventory in `<project>/.astro/config.yaml` from the model. Surfacing
-	// the resolved instance in Otto's UI is a better safety net than
-	// blanking the config.
+	// Airflow connection. Set when we matched the cwd to a project;
+	// otherwise leave the env alone so af's layered config (project-local
+	// > project-shared > global) resolves the user's saved instance.
 	set("AIRFLOW_API_URL", c.AirflowURL)
 
 	if c.AirflowURL != "" {

--- a/pkg/otto/config_test.go
+++ b/pkg/otto/config_test.go
@@ -104,18 +104,6 @@ func (s *ConfigSuite) TestBuildEnv_SkipsEmptyValues() {
 	s.False(hasKey("AIRFLOW_API_URL"))
 	s.False(hasKey("AIRFLOW_USERNAME"))
 	s.False(hasKey("AIRFLOW_PASSWORD"))
-
-	// AF_CONFIG must stay unset so af's layered config resolves the instance.
-	s.False(hasKey("AF_CONFIG"), "AF_CONFIG must not be set")
-}
-
-func (s *ConfigSuite) TestBuildEnv_DoesNotSetAFConfigWhenAirflowDetected() {
-	cfg := &Config{AirflowURL: "http://localhost:14955"}
-	env := cfg.BuildEnv()
-
-	for _, e := range env {
-		s.False(strings.HasPrefix(e, "AF_CONFIG="), "AF_CONFIG must not be overridden when Airflow is detected")
-	}
 }
 
 func (s *ConfigSuite) TestBuildEnv_OverridesExisting() {

--- a/pkg/otto/config_test.go
+++ b/pkg/otto/config_test.go
@@ -105,12 +105,13 @@ func (s *ConfigSuite) TestBuildEnv_SkipsEmptyValues() {
 	s.False(hasKey("AIRFLOW_USERNAME"))
 	s.False(hasKey("AIRFLOW_PASSWORD"))
 
-	// When we couldn't associate an Airflow with the current project, we point
-	// the af CLI at an empty config so it doesn't fall through to
-	// ~/.af/config.yaml and silently query a different project's Airflow.
-	afConfig, ok := findEnv("AF_CONFIG")
-	s.True(ok, "AF_CONFIG should be set when AirflowURL is empty")
-	s.Equal(os.DevNull, afConfig)
+	// When we couldn't associate an Airflow with the current project, we let
+	// af's own layered config (project-local > project-shared > global) drive
+	// instance resolution. The previous behavior set AF_CONFIG=/dev/null to
+	// blank the user's saved instances, but af 0.8.0's project-aware
+	// resolution makes that counterproductive — it hides the team's committed
+	// deployment inventory from the model.
+	s.False(hasKey("AF_CONFIG"), "AF_CONFIG must not be set; let af resolve via layered config")
 }
 
 func (s *ConfigSuite) TestBuildEnv_DoesNotSetAFConfigWhenAirflowDetected() {

--- a/pkg/otto/config_test.go
+++ b/pkg/otto/config_test.go
@@ -105,13 +105,8 @@ func (s *ConfigSuite) TestBuildEnv_SkipsEmptyValues() {
 	s.False(hasKey("AIRFLOW_USERNAME"))
 	s.False(hasKey("AIRFLOW_PASSWORD"))
 
-	// When we couldn't associate an Airflow with the current project, we let
-	// af's own layered config (project-local > project-shared > global) drive
-	// instance resolution. The previous behavior set AF_CONFIG=/dev/null to
-	// blank the user's saved instances, but af 0.8.0's project-aware
-	// resolution makes that counterproductive — it hides the team's committed
-	// deployment inventory from the model.
-	s.False(hasKey("AF_CONFIG"), "AF_CONFIG must not be set; let af resolve via layered config")
+	// AF_CONFIG must stay unset so af's layered config resolves the instance.
+	s.False(hasKey("AF_CONFIG"), "AF_CONFIG must not be set")
 }
 
 func (s *ConfigSuite) TestBuildEnv_DoesNotSetAFConfigWhenAirflowDetected() {


### PR DESCRIPTION
## Summary

The `else` branch in `pkg/otto/config.go:BuildEnv` set `AF_CONFIG=/dev/null` when otto couldn't match the cwd to a running astro-dev project. That blanked af's config view to prevent silent fallthrough to a globally-scoped `current-instance` that often pointed at whatever project the user last ran `astro dev start` in.

af 0.8.0 (shipped in `astro-airflow-mcp` 0.8.0, picked up by Otto 0.1.3) introduced a layered config: project-local > project-shared > global, with project root discovered by walking up from cwd looking for `.astro/`. That makes the sentinel counterproductive in two cases:

1. **Inside a project, no astro-dev running.** `<project>/.astro/config.yaml` may have the team's committed deployment inventory (the headline use case for the layered config). Today the model sees "no instances configured" and dead-ends; without the sentinel it sees the team's staging/prod/etc. and can answer questions like "what DAGs are failing on staging?".
2. **Outside any project.** The resolved global `current-instance` is typically a sensible default ("the Airflow I was last working with"), and surfacing the resolved instance to the user is a better safety net than blanking the config.

## Changes

- `pkg/otto/config.go`: drop the `else { set("AF_CONFIG", os.DevNull) }` block. Comment block explains the new contract: af owns instance resolution; otto's env-var injection still wins for the "active" Airflow when one was detected.
- `pkg/otto/config_test.go`: flip `TestBuildEnv_SkipsEmptyValues` to assert `AF_CONFIG` is NOT set in the no-Airflow case.

## Why this is safe

- `AIRFLOW_API_URL` injection is unchanged. When otto detects a project Airflow, env vars beat per-instance config in af 0.8.0, so otto's deployment selection still wins for actual API calls.
- The "stale global pointer surprise" risk is real but small: af 0.8.0's project-aware resolution already does the right thing inside a project (project-local current-instance shadows global). It only matters when running `astro otto` from a non-project dir with a stale global pointer — a case better solved by the otto-side change to surface the resolved instance in the UI.

## Test plan
- [x] `go test ./pkg/otto/...` passes (9 tests in `ConfigSuite`)
- [x] Updated `TestBuildEnv_SkipsEmptyValues` to assert the new behavior
- [ ] Manual verification: `astro otto` from a non-project dir, ask "list my Airflow instances" → returns the layered-config view instead of "no instances"

## Follow-ups (separate PRs)
1. **Otto:** surface the resolved af instance in the startup banner so silent picks become explicit
2. **Agents (skill):** nudge the model to disclose which instance it's hitting on the first af call of a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)