### PR TITLE
fix(deploy): skip dag-deploy check on Remote Execution deployments

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -235,7 +235,7 @@ func Deploy(deployInput InputDeploy, platformCoreClient astroplatformcore.CoreCl
 		return nil
 	}
 
-	if deployInput.Image {
+	if deployInput.Image && !deployInfo.isRemoteExecutionEnabled {
 		if !deployInfo.dagDeployEnabled {
 			return fmt.Errorf(enableDagDeployMsg, deployInfo.deploymentID) //nolint
 		}

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -790,6 +790,56 @@ func TestNoDagsImageDeployForceSkipsPrompt(t *testing.T) {
 	mockPlatformCoreClient.AssertExpectations(t)
 }
 
+// Regression test for v1.42.0: --image-name on a Remote Execution
+// deployment auto-set Image=true and tripped the dagDeployEnabled guard,
+// returning a bogus "DAG-only deploys are not enabled" error even though
+// RE deployments don't deploy DAGs to the orchestration plane.
+func TestImageDeployOnRemoteExecutionDeploymentSucceedsWithoutDagDeploy(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	config.CFG.ShowWarnings.SetHomeString("false")
+
+	mockCoreClient := new(astrocore_mocks.ClientWithResponsesInterface)
+	mockPlatformCoreClient := new(astroplatformcore_mocks.ClientWithResponsesInterface)
+
+	mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponseRemoteExecution, nil)
+	mockPlatformCoreClient.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentOptionsResponse, nil)
+	mockPlatformCoreClient.On("CreateDeployWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&createDeployResponse, nil)
+	mockPlatformCoreClient.On("FinalizeDeployWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&finalizeDeployResponse, nil)
+
+	mockImageHandler := new(mocks.ImageHandler)
+	airflowImageHandler = func(image string) airflow.ImageHandler {
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockImageHandler.On("Push", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", nil)
+		mockImageHandler.On("GetLabel", mock.Anything, runtimeImageLabel).Return("3.0-1", nil)
+		mockImageHandler.On("TagLocalImage", mock.Anything).Return(nil)
+		return mockImageHandler
+	}
+
+	ctx, err := config.GetCurrentContext()
+	assert.NoError(t, err)
+	ctx.Token = "test testing"
+	err = ctx.SetContext()
+	assert.NoError(t, err)
+
+	deployInput := InputDeploy{
+		Path:      "./testfiles/",
+		RuntimeID: deploymentID,
+		WsID:      ws,
+		EnvFile:   "./testfiles/.env",
+		ImageName: "custom-image",
+		Image:     true,
+		Force:     true,
+	}
+
+	err = Deploy(deployInput, mockPlatformCoreClient, mockCoreClient)
+	assert.NoError(t, err)
+	if err != nil {
+		assert.NotContains(t, err.Error(), "DAG-only deploys are not enabled")
+	}
+
+	mockPlatformCoreClient.AssertExpectations(t)
+}
+
 func TestDagsDeployFailed(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	config.CFG.ShowWarnings.SetHomeString("false")


### PR DESCRIPTION
## Summary
- Fixes a regression introduced in v1.42.0 (PR #2107) where Remote Execution customers running ``astro deploy --image-name ...`` hit ``Error: DAG-only deploys are not enabled for this Deployment. Run 'astro deployment update <id> --dag-deploy enable' to enable DAG-only deploys``.
- PR #2107 began auto-setting ``image = true`` whenever ``--image-name`` is provided. That flows into the long-standing guard at ``cloud/deploy/deploy.go:238`` which requires ``dagDeployEnabled``. RE deployments don't deploy DAGs to the orchestration plane and typically have ``IsDagDeployEnabled=false``, so the check fires incorrectly.
- The guard now skips when ``isRemoteExecutionEnabled`` is true (consistent with the existing RE-aware branches elsewhere in this function, e.g. line 223).

## Test plan
- [ ] ``astro deploy <re-deployment-id> --image-name my/image:tag`` against an RE deployment with dag-deploy disabled completes without the bogus error
- [ ] ``astro deploy <deployment-id> --image`` against a non-RE deployment with dag-deploy disabled still returns the existing error (unchanged behavior)
- [ ] ``go test ./cloud/deploy/...``

🤖 Generated with [Claude Code](https://claude.com/claude-code)