### PR TITLE
fix(otto): translate 404 into actionable platform error

### DIFF
--- a/pkg/otto/binary.go
+++ b/pkg/otto/binary.go
@@ -25,6 +25,7 @@ const (
 	MinVersion = "0.0.2"
 
 	cdnBaseURL    = "https://install.astronomer.io/otto"
+	versionURL    = cdnBaseURL + "/latest/version"
 	binaryName    = "otto"
 	pkgJSON       = "package.json"
 	windowsGOOS   = "windows"
@@ -73,7 +74,7 @@ func InstalledVersion() (string, error) {
 // LatestVersion fetches the latest version string from the CDN.
 func LatestVersion() (string, error) {
 	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(cdnBaseURL + "/latest/version")
+	resp, err := client.Get(versionURL)
 	if err != nil {
 		return "", fmt.Errorf("checking latest otto version: %w", err)
 	}
@@ -138,10 +139,6 @@ func Update() error {
 }
 
 // downloadURL constructs the CDN URL for the latest Otto on this platform.
-// The URL is generated unconditionally — astro-cli has no static knowledge of
-// which platforms Otto publishes binaries for. If the platform is unsupported,
-// the CDN returns 404 and downloadAndInstall translates that into a friendly
-// error via classifyDownloadFailure.
 func downloadURL() string {
 	goos := runtime.GOOS
 	arch := runtime.GOARCH
@@ -154,19 +151,16 @@ func downloadURL() string {
 	return fmt.Sprintf("%s/latest/%s-%s-%s.tar.gz", cdnBaseURL, binaryName, goos, arch)
 }
 
-// classifyDownloadFailure turns a 404 from the asset URL into a clear
-// "your platform isn't supported" error, but only after confirming the CDN
-// itself is reachable — otherwise we'd blame the user for an outage. The probe
-// URL is /latest/version: a tiny static file that's published for every
-// release, so a 200 there is a reliable proxy for "the CDN has releases."
-// Any other status code is reported verbatim.
+// classifyDownloadFailure rewrites a 404 from the asset URL into an
+// unsupported-platform error if the CDN is reachable, otherwise reports the
+// failure verbatim. Non-404 statuses pass through unchanged.
 func classifyDownloadFailure(status int, assetURL, probeURL string) error {
 	verbatim := fmt.Errorf("downloading otto: HTTP %d from %s", status, assetURL)
 	if status != http.StatusNotFound {
 		return verbatim
 	}
 	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(probeURL)
+	resp, err := client.Head(probeURL)
 	if err != nil {
 		return verbatim
 	}
@@ -174,11 +168,11 @@ func classifyDownloadFailure(status int, assetURL, probeURL string) error {
 	if resp.StatusCode != http.StatusOK {
 		return verbatim
 	}
-	return fmt.Errorf(
-		"otto is not available for %s/%s. See https://github.com/astronomer/astro-cli/releases for supported platforms. "+
-			"If you are on 64-bit Windows but installed the 32-bit astro CLI, reinstall the x86_64 build",
-		runtime.GOOS, runtime.GOARCH,
-	)
+	format := "otto is not available for %s/%s. See https://github.com/astronomer/astro-cli/releases for supported platforms"
+	if runtime.GOOS == windowsGOOS {
+		format += ". If you are on 64-bit Windows but installed the 32-bit astro CLI, reinstall the x86_64 build"
+	}
+	return fmt.Errorf(format, runtime.GOOS, runtime.GOARCH)
 }
 
 // downloadAndInstall fetches the Otto archive and extracts it to BinDir().
@@ -191,7 +185,7 @@ func downloadAndInstall() error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return classifyDownloadFailure(resp.StatusCode, url, cdnBaseURL+"/latest/version")
+		return classifyDownloadFailure(resp.StatusCode, url, versionURL)
 	}
 
 	binDir := BinDir()

--- a/pkg/otto/binary.go
+++ b/pkg/otto/binary.go
@@ -138,9 +138,13 @@ func Update() error {
 }
 
 // downloadURL constructs the CDN URL for the latest Otto on this platform.
+// The URL is generated unconditionally — astro-cli has no static knowledge of
+// which platforms Otto publishes binaries for. If the platform is unsupported,
+// the CDN returns 404 and downloadAndInstall translates that into a friendly
+// error via classifyDownloadFailure.
 func downloadURL() string {
-	goos := runtime.GOOS   // "darwin", "linux", "windows"
-	arch := runtime.GOARCH // "arm64", "amd64"
+	goos := runtime.GOOS
+	arch := runtime.GOARCH
 	if arch == "amd64" {
 		arch = "x64"
 	}
@@ -148,6 +152,33 @@ func downloadURL() string {
 		return fmt.Sprintf("%s/latest/%s-%s-%s.exe.zip", cdnBaseURL, binaryName, goos, arch)
 	}
 	return fmt.Sprintf("%s/latest/%s-%s-%s.tar.gz", cdnBaseURL, binaryName, goos, arch)
+}
+
+// classifyDownloadFailure turns a 404 from the asset URL into a clear
+// "your platform isn't supported" error, but only after confirming the CDN
+// itself is reachable — otherwise we'd blame the user for an outage. The probe
+// URL is /latest/version: a tiny static file that's published for every
+// release, so a 200 there is a reliable proxy for "the CDN has releases."
+// Any other status code is reported verbatim.
+func classifyDownloadFailure(status int, assetURL, probeURL string) error {
+	verbatim := fmt.Errorf("downloading otto: HTTP %d from %s", status, assetURL)
+	if status != http.StatusNotFound {
+		return verbatim
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(probeURL)
+	if err != nil {
+		return verbatim
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return verbatim
+	}
+	return fmt.Errorf(
+		"otto is not available for %s/%s. See https://github.com/astronomer/astro-cli/releases for supported platforms. "+
+			"If you are on 64-bit Windows but installed the 32-bit astro CLI, reinstall the x86_64 build",
+		runtime.GOOS, runtime.GOARCH,
+	)
 }
 
 // downloadAndInstall fetches the Otto archive and extracts it to BinDir().
@@ -160,7 +191,7 @@ func downloadAndInstall() error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("downloading otto: HTTP %d from %s", resp.StatusCode, url)
+		return classifyDownloadFailure(resp.StatusCode, url, cdnBaseURL+"/latest/version")
 	}
 
 	binDir := BinDir()

--- a/pkg/otto/binary_test.go
+++ b/pkg/otto/binary_test.go
@@ -101,13 +101,9 @@ func (s *BinarySuite) TestDownloadURL() {
 	s.Contains(url, ".tar.gz")
 }
 
-// 404 + CDN reachable = unsupported platform. This is the customer-facing
-// case the regression on 32-bit Windows landed in: the asset URL 404s but
-// the CDN is up, so the only explanation is that we don't ship that platform.
 func (s *BinarySuite) TestClassifyDownloadFailure_UnsupportedPlatform() {
 	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("v0.1.4"))
 	}))
 	defer probe.Close()
 
@@ -115,11 +111,9 @@ func (s *BinarySuite) TestClassifyDownloadFailure_UnsupportedPlatform() {
 	s.Error(err)
 	s.Contains(err.Error(), "otto is not available for")
 	s.Contains(err.Error(), runtime.GOOS+"/"+runtime.GOARCH)
-	s.NotContains(err.Error(), "HTTP 404", "should rewrite the raw HTTP error into something actionable")
+	s.NotContains(err.Error(), "HTTP 404")
 }
 
-// 404 + CDN unreachable = report verbatim. We deliberately don't blame the
-// user for what might be a CDN outage or DNS hiccup.
 func (s *BinarySuite) TestClassifyDownloadFailure_CDNDown() {
 	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -129,11 +123,9 @@ func (s *BinarySuite) TestClassifyDownloadFailure_CDNDown() {
 	err := classifyDownloadFailure(http.StatusNotFound, "https://example/otto-linux-x64.tar.gz", probe.URL)
 	s.Error(err)
 	s.Contains(err.Error(), "HTTP 404")
-	s.NotContains(err.Error(), "not available for", "should not assert unsupported platform when the CDN itself is down")
+	s.NotContains(err.Error(), "not available for")
 }
 
-// Anything other than 404 passes through unchanged — 5xx is an outage, not a
-// platform decision.
 func (s *BinarySuite) TestClassifyDownloadFailure_NonNotFound() {
 	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/otto/binary_test.go
+++ b/pkg/otto/binary_test.go
@@ -101,6 +101,51 @@ func (s *BinarySuite) TestDownloadURL() {
 	s.Contains(url, ".tar.gz")
 }
 
+// 404 + CDN reachable = unsupported platform. This is the customer-facing
+// case the regression on 32-bit Windows landed in: the asset URL 404s but
+// the CDN is up, so the only explanation is that we don't ship that platform.
+func (s *BinarySuite) TestClassifyDownloadFailure_UnsupportedPlatform() {
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("v0.1.4"))
+	}))
+	defer probe.Close()
+
+	err := classifyDownloadFailure(http.StatusNotFound, "https://example/otto-windows-386.exe.zip", probe.URL)
+	s.Error(err)
+	s.Contains(err.Error(), "otto is not available for")
+	s.Contains(err.Error(), runtime.GOOS+"/"+runtime.GOARCH)
+	s.NotContains(err.Error(), "HTTP 404", "should rewrite the raw HTTP error into something actionable")
+}
+
+// 404 + CDN unreachable = report verbatim. We deliberately don't blame the
+// user for what might be a CDN outage or DNS hiccup.
+func (s *BinarySuite) TestClassifyDownloadFailure_CDNDown() {
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer probe.Close()
+
+	err := classifyDownloadFailure(http.StatusNotFound, "https://example/otto-linux-x64.tar.gz", probe.URL)
+	s.Error(err)
+	s.Contains(err.Error(), "HTTP 404")
+	s.NotContains(err.Error(), "not available for", "should not assert unsupported platform when the CDN itself is down")
+}
+
+// Anything other than 404 passes through unchanged — 5xx is an outage, not a
+// platform decision.
+func (s *BinarySuite) TestClassifyDownloadFailure_NonNotFound() {
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer probe.Close()
+
+	err := classifyDownloadFailure(http.StatusServiceUnavailable, "https://example/otto-linux-x64.tar.gz", probe.URL)
+	s.Error(err)
+	s.Contains(err.Error(), "HTTP 503")
+	s.NotContains(err.Error(), "not available for")
+}
+
 func (s *BinarySuite) TestIsUpdateAvailable_NotInstalled() {
 	// With no package.json, IsUpdateAvailable returns (false, "", nil) without
 	// contacting the CDN.


### PR DESCRIPTION
## Summary

Customer on 32-bit Windows hit `astro otto` and got a bare `HTTP 404 from https://install.astronomer.io/otto/latest/otto-windows-386.exe.zip` with no actionable guidance ([Zendesk #91793](https://astronomer.zendesk.com/agent/tickets/91793)).

Otto doesn't ship 32-bit binaries because [Bun has no 32-bit `--compile` target](https://bun.com/docs/bundler/executables) — and won't anytime soon, since JavaScriptCore (Bun's underlying engine) dropped 32-bit Windows years ago. So this is a permanent platform gap, not a missing build.

This PR makes the failure mode useful instead of cryptic:

- On a 404 from the asset URL, probe `/latest/version` (a tiny static file published with every release) to confirm the CDN itself is reachable. If yes, the 404 is structurally an unsupported-platform error — rewrite it into a message that names the platform and points at the [astro-cli releases page](https://github.com/astronomer/astro-cli/releases) for supported builds, plus a hint about the common 64-bit-Windows-with-32-bit-CLI case.
- If the probe also fails, report the original `HTTP 404` verbatim — we don't blame the user for a CDN outage.
- Other status codes (5xx etc.) pass through unchanged.

Deliberately did not hardcode the supported-platform list in astro-cli — that would create a second source of truth that drifts the moment Otto adds or drops a build target. The CDN itself is the source of truth: if a binary isn't there, it's not supported.

Sample output for the customer's case:
```
Error: setting up otto: otto is not available for windows/386. See https://github.com/astronomer/astro-cli/releases for supported platforms. If you are on 64-bit Windows but installed the 32-bit astro CLI, reinstall the x86_64 build
```

## Test plan
- [x] `go test ./pkg/otto/...` — all green, including 3 new cases for the 404 classifier (unsupported platform, CDN down, non-404 status)
- [x] `go vet ./pkg/otto/...` clean
- [x] `golangci-lint run pkg/otto/...` 0 issues