### PR TITLE
Fix local astro project setup using podman container engine on windows os

### DIFF
--- a/airflow/runtimes/podman_runtime.go
+++ b/airflow/runtimes/podman_runtime.go
@@ -268,10 +268,14 @@ func (rt PodmanRuntime) configureMachineForUsage(machine *types.InspectedMachine
 	}
 
 	// Set CONTAINER_HOST for native Podman commands (e.g., podman build)
-	// This ensures podman commands also use the machine socket
-	err = os.Setenv("CONTAINER_HOST", dockerHost)
-	if err != nil {
-		return fmt.Errorf("error setting CONTAINER_HOST: %s", err)
+	// on non-Windows platforms. On Windows, the npipe:// scheme is not
+	// supported by native Podman commands, and SetMachineAsDefault
+	// below is sufficient for routing Podman commands correctly.
+	if !rt.OSChecker.IsWindows() {
+		err = os.Setenv("CONTAINER_HOST", dockerHost)
+		if err != nil {
+			return fmt.Errorf("error setting CONTAINER_HOST: %s", err)
+		}
 	}
 
 	// Set the podman default connection to our machine.

--- a/airflow/runtimes/podman_runtime_test.go
+++ b/airflow/runtimes/podman_runtime_test.go
@@ -49,6 +49,7 @@ func (s *PodmanRuntimeSuite) Unsetenv(key string) {
 func (s *PodmanRuntimeSuite) SetupTest() {
 	// Reset some variables to defaults.
 	s.Unsetenv("DOCKER_HOST")
+	s.Unsetenv("CONTAINER_HOST")
 	mockPodmanEngine = new(mocks.PodmanEngine)
 	mockPodmanOSChecker = new(mocks.OSChecker)
 	mockListedMachines = []types.ListedMachine{}
@@ -101,6 +102,8 @@ func (s *PodmanRuntimeSuite) TestPodmanRuntimeInitialize() {
 		// Run our test and assert expectations.
 		err := rt.Initialize()
 		assert.Nil(s.T(), err)
+		assert.Equal(s.T(), "unix:///path/to/astro-machine.sock", os.Getenv("DOCKER_HOST"))
+		assert.Equal(s.T(), "unix:///path/to/astro-machine.sock", os.Getenv("CONTAINER_HOST"))
 		mockPodmanEngine.AssertExpectations(s.T())
 		mockPodmanOSChecker.AssertExpectations(s.T())
 	})
@@ -122,6 +125,8 @@ func (s *PodmanRuntimeSuite) TestPodmanRuntimeInitializeWindows() {
 		// Run our test and assert expectations.
 		err := rt.Initialize()
 		assert.Nil(s.T(), err)
+		assert.Equal(s.T(), "npipe:////./pipe/podman-astro-machine", os.Getenv("DOCKER_HOST"))
+		assert.Empty(s.T(), os.Getenv("CONTAINER_HOST"))
 		mockPodmanEngine.AssertExpectations(s.T())
 		mockPodmanOSChecker.AssertExpectations(s.T())
 	})


### PR DESCRIPTION
## Description

- Skip setting `CONTAINER_HOST` on Windows, where the `npipe://` scheme
  is not supported by native Podman commands
- `DOCKER_HOST=npipe://` remains set for Docker Compose compatibility
- Native Podman commands (e.g., `podman build`) use the default
  connection configured by `SetMachineAsDefault`

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Tested locally on windows os:

```
PS D:\airflow-test> ..\astro.exe dev start
✔ Project image has been updated
✔ Project started
Warning: could not start proxy: proxy daemon is not supported on Windows
➤ Airflow UI: http://localhost:19741
➤ Postgres Database: postgresql://localhost:19409/postgres
➤ The default Postgres DB credentials are: postgres:postgres
```

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
