### PR TITLE
fix(proxy): use project.name for proxy hostname when set

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -219,7 +219,7 @@ func DockerComposeInit(airflowHome, envFile, dockerfile, imageName string) (*Doc
 // removeProxyRoute deregisters the proxy route for this project and
 // stops the proxy daemon if no routes remain.
 func (d *DockerCompose) removeProxyRoute() {
-	hostname, err := proxy.DeriveHostname(d.airflowHome)
+	hostname, err := proxy.DeriveHostname(config.CFG.ProjectName.GetString(), d.airflowHome)
 	if err != nil {
 		logger.Debugf("could not derive proxy hostname: %s", err)
 		return
@@ -290,7 +290,7 @@ func (d *DockerCompose) Start(opts *airflowTypes.StartOptions) error {
 			proxyPort = proxy.DefaultPort
 		}
 
-		hostname, hErr := proxy.DeriveHostname(d.airflowHome)
+		hostname, hErr := proxy.DeriveHostname(config.CFG.ProjectName.GetString(), d.airflowHome)
 		if hErr != nil {
 			// Fall back to non-proxy mode if hostname derivation fails
 			useProxy = false

--- a/airflow/proxy/hostname.go
+++ b/airflow/proxy/hostname.go
@@ -6,7 +6,9 @@ import (
 
 const localhostSuffix = pkgproxy.LocalhostSuffix
 
-// DeriveHostname converts a project directory path into a valid DNS hostname.
-func DeriveHostname(projectDir string) (string, error) {
-	return pkgproxy.DeriveHostname(projectDir)
+// DeriveHostname converts a project name and directory into a valid DNS hostname.
+// projectName (from .astro/config.yaml's project.name) is preferred over the
+// directory name when set. See pkg/proxy.DeriveHostname for full semantics.
+func DeriveHostname(projectName, projectDir string) (string, error) {
+	return pkgproxy.DeriveHostname(projectName, projectDir)
 }

--- a/airflow/proxy/hostname_test.go
+++ b/airflow/proxy/hostname_test.go
@@ -14,10 +14,10 @@ import (
 
 func TestDeriveHostname_Delegates(t *testing.T) {
 	// Verify the wrapper produces the same result as the pkg function.
-	hostname, err := DeriveHostname("/home/user/my-project")
+	hostname, err := DeriveHostname("circus", "/home/user/my-project")
 	require.NoError(t, err)
 
-	expected, err := pkgproxy.DeriveHostname("/home/user/my-project")
+	expected, err := pkgproxy.DeriveHostname("circus", "/home/user/my-project")
 	require.NoError(t, err)
 
 	assert.Equal(t, expected, hostname)

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -372,7 +372,7 @@ func (s *Standalone) Start(opts *types.StartOptions) error {
 			proxyPort = proxy.DefaultPort
 		}
 
-		hostname, hErr := proxy.DeriveHostname(s.airflowHome)
+		hostname, hErr := proxy.DeriveHostname(config.CFG.ProjectName.GetString(), s.airflowHome)
 		if hErr != nil {
 			// Fall back to non-proxy mode if hostname derivation fails
 			useProxy = false
@@ -956,7 +956,7 @@ func (s *Standalone) Stop(_ bool) error {
 // removeProxyRoute deregisters the proxy route for this project and
 // stops the proxy daemon if no routes remain.
 func (s *Standalone) removeProxyRoute() {
-	hostname, err := proxy.DeriveHostname(s.airflowHome)
+	hostname, err := proxy.DeriveHostname(config.CFG.ProjectName.GetString(), s.airflowHome)
 	if err != nil {
 		logger.Debugf("could not derive proxy hostname: %s", err)
 		return

--- a/pkg/proxy/hostname.go
+++ b/pkg/proxy/hostname.go
@@ -30,23 +30,35 @@ func SanitizeLabel(name string) string {
 	return name
 }
 
-// DeriveHostname converts a project directory path into a valid DNS hostname.
+// DeriveHostname converts a project name and directory into a valid DNS hostname.
 //
-// If the project is inside a git worktree, the hostname includes both the
-// worktree name and the repo name: <worktree>.<repo>.localhost.
-// Otherwise, it uses just the directory name: <dir>.localhost.
-func DeriveHostname(projectDir string) (string, error) {
-	// Try worktree detection first
-	if hostname, err := deriveWorktreeHostname(projectDir); err == nil && hostname != "" {
+// projectName comes from .astro/config.yaml (project.name) and is preferred
+// over the directory name when set. This matches the help text for
+// `astro dev proxy`, which advertises `<project>.localhost` URLs.
+//
+// If projectName is empty (or sanitizes to empty), the directory name is used
+// as a fallback.
+//
+// When the project lives inside a git worktree, the worktree name is prepended
+// for disambiguation: <worktree>.<projectLabel>.localhost.
+func DeriveHostname(projectName, projectDir string) (string, error) {
+	projectLabel := SanitizeLabel(projectName)
+
+	// Try worktree detection first; projectLabel fills in the project segment
+	// when set, otherwise the main repo's directory name is used.
+	if hostname, err := deriveWorktreeHostname(projectDir, projectLabel); err == nil && hostname != "" {
 		return hostname, nil
 	}
 
-	// Fallback: use directory name
-	label := SanitizeLabel(filepath.Base(projectDir))
-	if label == "" {
+	// Non-worktree: prefer project name, fall back to directory name.
+	if projectLabel != "" {
+		return projectLabel + LocalhostSuffix, nil
+	}
+	dirLabel := SanitizeLabel(filepath.Base(projectDir))
+	if dirLabel == "" {
 		return "", fmt.Errorf("could not derive a valid hostname from project directory %q", projectDir)
 	}
-	return label + LocalhostSuffix, nil
+	return dirLabel + LocalhostSuffix, nil
 }
 
 // ReadDotGit reads the .git file/directory at the given path. It is a variable
@@ -69,9 +81,12 @@ var ReadDotGit = func(projectDir string) ([]byte, bool, error) {
 
 // deriveWorktreeHostname detects if projectDir is a git worktree by checking
 // whether .git is a file (worktrees have a .git file pointing to the main
-// repo's .git/worktrees/<name> directory). Returns <worktree>.<repo>.localhost
-// or ("", nil) if not a worktree.
-func deriveWorktreeHostname(projectDir string) (string, error) {
+// repo's .git/worktrees/<name> directory). Returns
+// <worktree>.<projectLabelOrRepo>.localhost or ("", nil) if not a worktree.
+//
+// If projectLabel is non-empty it is used as the project segment; otherwise
+// the main repo's directory name is used.
+func deriveWorktreeHostname(projectDir, projectLabel string) (string, error) {
 	data, isDir, err := ReadDotGit(projectDir)
 	if err != nil {
 		return "", err
@@ -99,7 +114,10 @@ func deriveWorktreeHostname(projectDir string) (string, error) {
 	repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(gitdir)))
 
 	worktreeLabel := SanitizeLabel(filepath.Base(projectDir))
-	repoLabel := SanitizeLabel(filepath.Base(repoRoot))
+	repoLabel := projectLabel
+	if repoLabel == "" {
+		repoLabel = SanitizeLabel(filepath.Base(repoRoot))
+	}
 
 	if worktreeLabel == "" || repoLabel == "" {
 		return "", nil

--- a/pkg/proxy/hostname_test.go
+++ b/pkg/proxy/hostname_test.go
@@ -62,7 +62,7 @@ func TestDeriveHostname(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hostname, err := DeriveHostname(tt.projectDir)
+			hostname, err := DeriveHostname("", tt.projectDir)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, hostname)
 		})
@@ -77,7 +77,7 @@ func TestDeriveHostname_Empty(t *testing.T) {
 	defer func() { ReadDotGit = origReadDotGit }()
 
 	// A directory that results in an empty label after cleanup
-	_, err := DeriveHostname("/home/user/---")
+	_, err := DeriveHostname("", "/home/user/---")
 	assert.Error(t, err)
 }
 
@@ -89,7 +89,7 @@ func TestDeriveHostname_LongName(t *testing.T) {
 	defer func() { ReadDotGit = origReadDotGit }()
 
 	longName := strings.Repeat("a", 100)
-	hostname, err := DeriveHostname("/home/user/" + longName)
+	hostname, err := DeriveHostname("", "/home/user/" + longName)
 	require.NoError(t, err)
 	// Should be truncated to 63 chars + ".localhost"
 	label := strings.TrimSuffix(hostname, ".localhost")
@@ -106,7 +106,7 @@ func TestDeriveHostname_Worktree(t *testing.T) {
 		return []byte("gitdir: /home/user/my-repo/.git/worktrees/feature-branch\n"), false, nil
 	}
 
-	hostname, err := DeriveHostname("/home/user/worktrees/feature-branch")
+	hostname, err := DeriveHostname("", "/home/user/worktrees/feature-branch")
 	require.NoError(t, err)
 	assert.Equal(t, "feature-branch.my-repo.localhost", hostname)
 }
@@ -119,7 +119,7 @@ func TestDeriveHostname_WorktreeRelativePath(t *testing.T) {
 		return []byte("gitdir: ../../../.git/worktrees/my-worktree\n"), false, nil
 	}
 
-	hostname, err := DeriveHostname("/home/user/repos/my-repo/.claude/worktrees/my-worktree")
+	hostname, err := DeriveHostname("", "/home/user/repos/my-repo/.claude/worktrees/my-worktree")
 	require.NoError(t, err)
 	assert.Equal(t, "my-worktree.my-repo.localhost", hostname)
 }
@@ -133,7 +133,7 @@ func TestDeriveHostname_NormalRepo(t *testing.T) {
 		return nil, true, nil // isDir=true
 	}
 
-	hostname, err := DeriveHostname("/home/user/my-project")
+	hostname, err := DeriveHostname("", "/home/user/my-project")
 	require.NoError(t, err)
 	assert.Equal(t, "my-project.localhost", hostname)
 }
@@ -154,7 +154,75 @@ func TestDeriveHostname_RealWorktree(t *testing.T) {
 	gitFileContent := "gitdir: " + worktreesGitDir + "\n"
 	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte(gitFileContent), FilePermRW))
 
-	hostname, err := DeriveHostname(worktreeDir)
+	hostname, err := DeriveHostname("", worktreeDir)
 	require.NoError(t, err)
 	assert.Equal(t, "my-worktree.main-repo.localhost", hostname)
+}
+
+func TestDeriveHostname_ProjectNameOverridesDirName(t *testing.T) {
+	origReadDotGit := ReadDotGit
+	ReadDotGit = func(_ string) ([]byte, bool, error) {
+		return nil, false, os.ErrNotExist
+	}
+	defer func() { ReadDotGit = origReadDotGit }()
+
+	// project.name is set, so it wins over the directory name.
+	hostname, err := DeriveHostname("circus", "/home/user/airflow")
+	require.NoError(t, err)
+	assert.Equal(t, "circus.localhost", hostname)
+}
+
+func TestDeriveHostname_ProjectNameSanitized(t *testing.T) {
+	origReadDotGit := ReadDotGit
+	ReadDotGit = func(_ string) ([]byte, bool, error) {
+		return nil, false, os.ErrNotExist
+	}
+	defer func() { ReadDotGit = origReadDotGit }()
+
+	// project.name with mixed case and special chars should be normalized.
+	hostname, err := DeriveHostname("Acme Corp / Pipelines!", "/home/user/airflow")
+	require.NoError(t, err)
+	assert.Equal(t, "acme-corp-pipelines.localhost", hostname)
+}
+
+func TestDeriveHostname_EmptyProjectNameFallsThroughToDir(t *testing.T) {
+	origReadDotGit := ReadDotGit
+	ReadDotGit = func(_ string) ([]byte, bool, error) {
+		return nil, false, os.ErrNotExist
+	}
+	defer func() { ReadDotGit = origReadDotGit }()
+
+	// Empty project.name should preserve previous (directory-name) behavior.
+	hostname, err := DeriveHostname("", "/home/user/my-project")
+	require.NoError(t, err)
+	assert.Equal(t, "my-project.localhost", hostname)
+}
+
+func TestDeriveHostname_ProjectNameSanitizesToEmptyFallsThroughToDir(t *testing.T) {
+	origReadDotGit := ReadDotGit
+	ReadDotGit = func(_ string) ([]byte, bool, error) {
+		return nil, false, os.ErrNotExist
+	}
+	defer func() { ReadDotGit = origReadDotGit }()
+
+	// project.name made up entirely of separators sanitizes to empty,
+	// so we fall back to the directory name.
+	hostname, err := DeriveHostname("---", "/home/user/my-project")
+	require.NoError(t, err)
+	assert.Equal(t, "my-project.localhost", hostname)
+}
+
+func TestDeriveHostname_ProjectNameInWorktreeReplacesRepoSegment(t *testing.T) {
+	origReadDotGit := ReadDotGit
+	defer func() { ReadDotGit = origReadDotGit }()
+
+	ReadDotGit = func(_ string) ([]byte, bool, error) {
+		return []byte("gitdir: /home/user/my-repo/.git/worktrees/feature-branch\n"), false, nil
+	}
+
+	// In a worktree, project.name replaces the repo segment but the
+	// worktree segment is preserved for disambiguation across worktrees.
+	hostname, err := DeriveHostname("circus", "/home/user/worktrees/feature-branch")
+	require.NoError(t, err)
+	assert.Equal(t, "feature-branch.circus.localhost", hostname)
 }


### PR DESCRIPTION
## Summary

- standalone and docker proxy modes derived the `<x>.localhost` hostname purely from the project directory name, which meant subdir layouts (e.g. `airflow/`) ended up at `airflow.localhost` regardless of project identity
- the `astro dev proxy` help text already advertises `<project>.localhost`, so this aligns behavior with documentation
- `DeriveHostname` now takes `projectName` (from `.astro/config.yaml`'s `project.name`) and prefers it over the directory name when set; in worktrees, projectName replaces the repo segment while the per-worktree segment is preserved so URLs stay distinct across multiple worktrees of the same project

## Behavior change

| project.name | layout | before | after |
| --- | --- | --- | --- |
| unset | `~/foo/` | `foo.localhost` | `foo.localhost` (unchanged) |
| `circus` | `~/circus/airflow/` | `airflow.localhost` | `circus.localhost` |
| `circus` | worktree at `wt/feat-x/` of repo `circus` | `feat-x.circus.localhost` (was repo-derived) | `feat-x.circus.localhost` (now project.name-derived; same shape) |

existing users with `project.name == dirname` see no change. existing users with `project.name != dirname` get the documented `<project>.localhost` behavior, which may differ from what they had cached. worth a release note

## API note

`pkg/proxy.DeriveHostname` and `airflow/proxy.DeriveHostname` gain a leading `projectName string` parameter. these are exported but used internally by the CLI; any external Go importers would need to update call sites

## Test plan

- [x] `go test ./pkg/proxy/...` passes (existing tests + 5 new cases for project name behavior)
- [x] `go test ./airflow/...` passes (delegate test updated)
- [x] `go build ./...` clean
- [x] end-to-end verified: built binary, ran `astro dev start` in `circus/airflow/` (project.name=circus), URL went from `http://airflow.localhost:6563` to `http://circus.localhost:6563`, served HTTP 200