### PR TITLE
Revert image-only changes to allow pushing custom images to remote deployment

### DIFF
--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -139,7 +139,6 @@ func deploy(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("cannot use --%s with --image-name; --image-name implies an image-only deploy", f)
 			}
 		}
-		image = true
 	}
 
 	// Save deploymentId in config if specified

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -91,23 +91,6 @@ func TestDeploySkipsEnsureProjectDirWhenImageNameSet(t *testing.T) {
 	assert.ErrorIs(t, err, assert.AnError)
 }
 
-func TestDeployImageNameForcesImageOnly(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
-
-	EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
-
-	var captured cloud.InputDeploy
-	DeployImage = func(deployInput cloud.InputDeploy, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
-		captured = deployInput
-		return nil
-	}
-
-	err := execDeployCmd("-f", "test-deployment-id", "--image-name", "custom-image:latest")
-	assert.NoError(t, err)
-	assert.True(t, captured.Image, "--image-name should force image-only deploy")
-	assert.Equal(t, "custom-image:latest", captured.ImageName)
-}
-
 func TestDeployImageNameRejectsIncompatibleFlags(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 


### PR DESCRIPTION
## Description

Changes:

- Revert the implicit setting deploy type as `image only` by setting `image=true` when custom image is being pushed. This is to fix the issue around remote deployment that have dag deploy disabled running into issue where Astro platform will reject deploy type as `image only`.


> Describe the purpose of this pull request.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

- Validated that custom image push to remote deployment is working fine
<img width="1169" height="577" alt="Screenshot 2026-05-08 at 7 47 58 PM" src="https://github.com/user-attachments/assets/6e73e424-a09f-4ad8-be4b-4be1c787f310" />
 
- Validated that custom image push from outside local airflow project dir is working fine for both remote and non-remote deployment 
<img width="1210" height="674" alt="Screenshot 2026-05-08 at 7 50 52 PM" src="https://github.com/user-attachments/assets/c37a1f0d-be37-4439-9dc1-608b57d42536" />


## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)