### PR TITLE
otto: forward astro telemetry-disabled state to Otto

### DIFF
--- a/pkg/otto/af_test.go
+++ b/pkg/otto/af_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/astronomer/astro-cli/config"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
 type AfSuite struct {
@@ -22,6 +23,10 @@ type AfSuite struct {
 func (s *AfSuite) SetupTest() {
 	s.origHomeConfigPath = config.HomeConfigPath
 	s.tmpDir = s.T().TempDir()
+	// Initialize viper before overriding HomeConfigPath — BuildEnv now calls
+	// telemetry.IsEnabled(), which reads config.CFG.TelemetryEnabled and panics
+	// if viper hasn't been initialized.
+	testUtil.InitTestConfig(config.CloudPlatform)
 	config.HomeConfigPath = s.tmpDir
 }
 

--- a/pkg/otto/config.go
+++ b/pkg/otto/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/astronomer/astro-cli/airflow/proxy"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/internal/telemetry"
 )
 
 // Config holds the environment configuration for spawning Otto.
@@ -115,6 +116,14 @@ func (c *Config) BuildEnv() []string {
 	set("ASTRO_TOKEN", c.Token)
 	set("ASTRO_DOMAIN", c.Domain)
 	set("ASTRO_ORGANIZATION", c.Organization)
+
+	// Forward the astro CLI's telemetry-disabled state. Users who ran
+	// `astro telemetry disable` (or set ASTRO_TELEMETRY_DISABLED=1) expect that
+	// to cover anything launched via `astro otto` too. Otto has its own
+	// OTTO_TELEMETRY_DISABLE env var as the kill switch; we just flip it on.
+	if !telemetry.IsEnabled() {
+		set("OTTO_TELEMETRY_DISABLE", "1")
+	}
 
 	// Stop `astro dev start` from popping a browser when Otto runs it.
 	// The user is already having a conversation in the TUI — surprise browser

--- a/pkg/otto/config_test.go
+++ b/pkg/otto/config_test.go
@@ -113,6 +113,36 @@ func (s *ConfigSuite) TestBuildEnv_SkipsEmptyValues() {
 	s.Equal(os.DevNull, afConfig)
 }
 
+func (s *ConfigSuite) TestBuildEnv_ForwardsTelemetryDisabledFromEnv() {
+	// User exported ASTRO_TELEMETRY_DISABLED=1 — that should propagate to Otto
+	// via OTTO_TELEMETRY_DISABLE so the agent stops sending traces too.
+	os.Setenv("ASTRO_TELEMETRY_DISABLED", "1")
+	defer os.Unsetenv("ASTRO_TELEMETRY_DISABLED")
+
+	env := (&Config{Token: "t"}).BuildEnv()
+
+	for _, e := range env {
+		if strings.HasPrefix(e, "OTTO_TELEMETRY_DISABLE=") {
+			s.Equal("OTTO_TELEMETRY_DISABLE=1", e)
+			return
+		}
+	}
+	s.Fail("OTTO_TELEMETRY_DISABLE should be set when astro telemetry is disabled")
+}
+
+func (s *ConfigSuite) TestBuildEnv_DoesNotSetTelemetryDisableWhenEnabled() {
+	// Default test config has telemetry enabled and the env var unset, so Otto
+	// should NOT see OTTO_TELEMETRY_DISABLE — leaving its default (send) intact.
+	os.Unsetenv("ASTRO_TELEMETRY_DISABLED")
+
+	env := (&Config{Token: "t"}).BuildEnv()
+
+	for _, e := range env {
+		s.False(strings.HasPrefix(e, "OTTO_TELEMETRY_DISABLE="),
+			"OTTO_TELEMETRY_DISABLE must not be set when astro telemetry is enabled")
+	}
+}
+
 func (s *ConfigSuite) TestBuildEnv_DoesNotSetAFConfigWhenAirflowDetected() {
 	cfg := &Config{AirflowURL: "http://localhost:14955"}
 	env := cfg.BuildEnv()


### PR DESCRIPTION
## Summary
- when astro telemetry is off (`astro telemetry disable` or `ASTRO_TELEMETRY_DISABLED=1`), forward that to Otto by setting `OTTO_TELEMETRY_DISABLE=1` on the spawned process
- Otto already has its own kill switch on that env var; this just wires astro-cli's existing setting through to it
- direct `otto` / SDK invocations still need the env var explicitly, since they bypass astro-cli

## Test plan
- [x] `go test ./pkg/otto/...` passes
- [ ] manual: `astro telemetry disable && astro otto` and confirm `OTTO_TELEMETRY_DISABLE=1` reaches the child env
- [ ] manual: `astro telemetry enable && astro otto` and confirm the var is absent