### PR TITLE
feat(logs): add --dag-processor and generic --component flags to deployment logs

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -223,7 +223,7 @@ func ListWithFormat(ws string, fromAllWorkspaces bool, platformCoreClient astrop
 }
 
 // TODO (https://github.com/astronomer/astro-cli/issues/1709): move these input arguments to a struct, and drop the nolint
-func Logs(deploymentID, ws, deploymentName, keyword string, logServer, logScheduler, logTriggerer, logWorkers, warnLogs, errorLogs, infoLogs bool, logCount int, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
+func Logs(deploymentID, ws, deploymentName, keyword string, logServer, logScheduler, logTriggerer, logWorkers, logDagProcessor bool, extraComponents []string, warnLogs, errorLogs, infoLogs bool, logCount int, platformCoreClient astroplatformcore.CoreClient, coreClient astrocore.CoreClient) error {
 	var logLevel string
 	var i int
 	// log level
@@ -278,8 +278,18 @@ func Logs(deploymentID, ws, deploymentName, keyword string, logServer, logSchedu
 	if logWorkers {
 		componentSources = append(componentSources, "worker")
 	}
+	if logDagProcessor {
+		componentSources = append(componentSources, astrocore.GetDeploymentLogsParamsSourcesDagProcessor)
+	}
+	for _, c := range extraComponents {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		componentSources = append(componentSources, astrocore.GetDeploymentLogsParamsSources(c))
+	}
 	if len(componentSources) == 0 {
-		componentSources = append(componentSources, serverComponent, "scheduler", "triggerer", "worker")
+		componentSources = append(componentSources, serverComponent, "scheduler", "triggerer", "worker", astrocore.GetDeploymentLogsParamsSourcesDagProcessor)
 	}
 
 	maxPerPage := 5000

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -915,7 +915,7 @@ func (s *Suite) TestLogs() {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
 		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockGetDeploymentLogsResponse, nil).Once()
 
-		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, false, nil, true, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
 		s.NoError(err)
 
 		mockPlatformCoreClient.AssertExpectations(s.T())
@@ -943,7 +943,7 @@ func (s *Suite) TestLogs() {
 		defer func() { os.Stdin = stdin }()
 		os.Stdin = r
 
-		err = Logs("", ws, "", "keyword", true, true, true, true, false, false, false, 1, mockPlatformCoreClient, mockCoreClient)
+		err = Logs("", ws, "", "keyword", true, true, true, true, false, nil, false, false, false, 1, mockPlatformCoreClient, mockCoreClient)
 		s.NoError(err)
 
 		mockPlatformCoreClient.AssertExpectations(s.T())
@@ -960,7 +960,7 @@ func (s *Suite) TestLogs() {
 		// Mock GetDeploymentLogsWithResponse to return an error
 		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockGetDeploymentLogsResponse, errMock).Once()
 
-		err := Logs(deploymentID, ws, "", "", true, true, true, true, false, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, false, nil, false, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
 		s.ErrorIs(err, errMock)
 
 		mockPlatformCoreClient.AssertExpectations(s.T())
@@ -968,7 +968,7 @@ func (s *Suite) TestLogs() {
 	})
 
 	s.Run("query for more than one log level error", func() {
-		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, true, true, logCount, mockPlatformCoreClient, mockCoreClient)
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, false, nil, true, true, true, logCount, mockPlatformCoreClient, mockCoreClient)
 		s.Error(err)
 		s.Equal(err.Error(), "cannot query for more than one log level and/or keyword at a time")
 	})
@@ -978,7 +978,7 @@ func (s *Suite) TestLogs() {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
 		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&mockGetDeploymentLogsMultipleComponentsResponse, nil).Once()
 
-		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, false, nil, true, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
 		s.NoError(err)
 
 		mockPlatformCoreClient.AssertExpectations(s.T())
@@ -1017,7 +1017,7 @@ func (s *Suite) TestLogs() {
 		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&page1Response, nil).Once()
 		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&page2Response, nil).Once()
 
-		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, false, false, 10, mockPlatformCoreClient, mockCoreClient)
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, false, nil, true, false, false, 10, mockPlatformCoreClient, mockCoreClient)
 		s.NoError(err)
 
 		mockPlatformCoreClient.AssertExpectations(s.T())
@@ -1060,7 +1060,7 @@ func (s *Suite) TestLogs() {
 			mock.MatchedBy(func(p *astrocore.GetDeploymentLogsParams) bool { return p.Limit != nil && *p.Limit == 1 }),
 		).Return(&page2Response, nil).Once()
 
-		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, false, false, 3, mockPlatformCoreClient, mockCoreClient)
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, false, nil, true, false, false, 3, mockPlatformCoreClient, mockCoreClient)
 		s.NoError(err)
 		mockPlatformCoreClient.AssertExpectations(s.T())
 		mockCoreClient.AssertExpectations(s.T())
@@ -1087,7 +1087,7 @@ func (s *Suite) TestLogs() {
 		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
 		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&oversizedResponse, nil).Once()
 
-		err := Logs(deploymentID, ws, "", "", true, true, true, true, true, false, false, 2, mockPlatformCoreClient, mockCoreClient)
+		err := Logs(deploymentID, ws, "", "", true, true, true, true, false, nil, true, false, false, 2, mockPlatformCoreClient, mockCoreClient)
 		s.NoError(err)
 		mockPlatformCoreClient.AssertExpectations(s.T())
 		mockCoreClient.AssertExpectations(s.T())
@@ -1105,7 +1105,50 @@ func (s *Suite) TestLogs() {
 		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(&astrocore.GetDeploymentLogsResponse{JSON200: &astrocore.DeploymentLog{Results: []astrocore.DeploymentLogEntry{{Raw: "apiserver log", Timestamp: 1, Source: astrocore.DeploymentLogEntrySourceApiserver}}}, HTTPResponse: &http.Response{StatusCode: 200}}, nil).Once()
 
-		err := Logs("test-id-1", ws, "", "", true, false, false, false, false, false, false, 1, mockPlatformCoreClient, mockCoreClient)
+		err := Logs("test-id-1", ws, "", "", true, false, false, false, false, nil, false, false, false, 1, mockPlatformCoreClient, mockCoreClient)
+		s.NoError(err)
+	})
+	s.Run("dag-processor flag requests dag-processor source", func() {
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything,
+			mock.MatchedBy(func(p *astrocore.GetDeploymentLogsParams) bool {
+				return len(p.Sources) == 1 && p.Sources[0] == astrocore.GetDeploymentLogsParamsSourcesDagProcessor
+			}),
+		).Return(&mockGetDeploymentLogsResponse, nil).Once()
+
+		err := Logs(deploymentID, ws, "", "", false, false, false, false, true, nil, false, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
+		s.NoError(err)
+	})
+	s.Run("generic component flag passes through arbitrary sources", func() {
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything,
+			mock.MatchedBy(func(p *astrocore.GetDeploymentLogsParams) bool {
+				return len(p.Sources) == 2 &&
+					p.Sources[0] == astrocore.GetDeploymentLogsParamsSources("scheduler") &&
+					p.Sources[1] == astrocore.GetDeploymentLogsParamsSources("future-component")
+			}),
+		).Return(&mockGetDeploymentLogsResponse, nil).Once()
+
+		err := Logs(deploymentID, ws, "", "", false, false, false, false, false, []string{"scheduler", "future-component"}, false, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
+		s.NoError(err)
+	})
+	s.Run("default sources include dag-processor when no flags set", func() {
+		mockPlatformCoreClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockListDeploymentsResponse, nil).Once()
+		mockPlatformCoreClient.On("GetDeploymentWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&deploymentResponse, nil).Once()
+		mockCoreClient.On("GetDeploymentLogsWithResponse", mock.Anything, mock.Anything, mock.Anything,
+			mock.MatchedBy(func(p *astrocore.GetDeploymentLogsParams) bool {
+				for _, src := range p.Sources {
+					if src == astrocore.GetDeploymentLogsParamsSourcesDagProcessor {
+						return true
+					}
+				}
+				return false
+			}),
+		).Return(&mockGetDeploymentLogsResponse, nil).Once()
+
+		err := Logs(deploymentID, ws, "", "", false, false, false, false, false, nil, false, false, false, logCount, mockPlatformCoreClient, mockCoreClient)
 		s.NoError(err)
 	})
 }

--- a/cmd/cloud/deployment.go
+++ b/cmd/cloud/deployment.go
@@ -83,6 +83,8 @@ var (
 	logScheduler                  bool
 	logWorkers                    bool
 	logTriggerer                  bool
+	logDagProcessor               bool
+	logComponents                 []string
 	flagRemoteExecutionEnabled    bool
 	flagAllowedIPAddressRanges    string
 	flagTaskLogBucket             string
@@ -424,6 +426,8 @@ func newDeploymentLogsCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&logScheduler, "scheduler", false, "Show logs from the scheduler")
 	cmd.Flags().BoolVar(&logWorkers, "workers", false, "Show logs from the workers")
 	cmd.Flags().BoolVar(&logTriggerer, "triggerer", false, "Show logs from the triggerer")
+	cmd.Flags().BoolVar(&logDagProcessor, "dag-processor", false, "Show logs from the DAG processor")
+	cmd.Flags().StringSliceVar(&logComponents, "component", nil, "Show logs from a component by name (repeatable or comma-separated). Alternative to passing individual flags like --scheduler or --triggerer.")
 	return cmd
 }
 
@@ -712,7 +716,7 @@ func deploymentLogs(cmd *cobra.Command, args []string) error {
 	}
 	logServer := logWebserver || logApiserver
 
-	return deployment.Logs(deploymentID, ws, deploymentName, logsKeyword, logServer, logScheduler, logTriggerer, logWorkers, warnLogs, errorLogs, infoLogs, logCount, platformCoreClient, astroCoreClient)
+	return deployment.Logs(deploymentID, ws, deploymentName, logsKeyword, logServer, logScheduler, logTriggerer, logWorkers, logDagProcessor, logComponents, warnLogs, errorLogs, infoLogs, logCount, platformCoreClient, astroCoreClient)
 }
 
 func deploymentCreate(cmd *cobra.Command, _ []string, out io.Writer) error { //nolint:gocognit,gocyclo


### PR DESCRIPTION
## Summary
- Adds a `--dag-processor` flag to `astro deployment logs`. The platform API has supported this source for a while; the CLI just never exposed it.
- Adds a generic `--component` flag (repeatable/comma-separated) so future API sources can be opted into without a CLI release.
- Adds `dag-processor` to the default fallback set when no component flag is passed.

## Test plan
- [x] `go test ./cloud/deployment ./cmd/cloud` — all green, including 3 new subtests covering `--dag-processor`, `--component`, and the updated default fallback
- [x] Smoke tests against a real Airflow 3 deployment:
  - `astro deployment logs <id> --dag-processor` returns dag-processor logs
  - `astro deployment logs <id> --component dag-processor` returns dag-processor logs
  - `astro deployment logs <id> --component scheduler,dag-processor` accepts comma-separated values
  - default fallback (no flag) returns logs tagged with both `apiserver` and `dag-processor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)