### PR TITLE
fix(otto): pin auto-update download to cached version

### DIFF
--- a/pkg/otto/binary.go
+++ b/pkg/otto/binary.go
@@ -28,6 +28,7 @@ const (
 	binaryName    = "otto"
 	pkgJSON       = "package.json"
 	windowsGOOS   = "windows"
+	latestVersion = "latest"
 	dirPerm       = 0o755
 	binPerm       = 0o755
 	logFilePerm   = 0o644
@@ -117,16 +118,16 @@ func EnsureBinary() error {
 	}
 	if version == "" {
 		fmt.Println("Downloading Otto...")
-		return downloadAndInstall()
+		return downloadAndInstall(latestVersion)
 	}
 	iv, err := semver.NewVersion(version)
 	if err != nil {
-		return downloadAndInstall()
+		return downloadAndInstall(latestVersion)
 	}
 	minVer, _ := semver.NewVersion(MinVersion)
 	if iv.LessThan(minVer) {
 		fmt.Printf("Otto %s is below minimum required version %s, updating...\n", version, MinVersion)
-		return downloadAndInstall()
+		return downloadAndInstall(latestVersion)
 	}
 	return nil
 }
@@ -134,25 +135,30 @@ func EnsureBinary() error {
 // Update downloads and installs the latest Otto binary.
 func Update() error {
 	fmt.Println("Updating Otto...")
-	return downloadAndInstall()
+	return downloadAndInstall(latestVersion)
 }
 
-// downloadURL constructs the CDN URL for the latest Otto on this platform.
-func downloadURL() string {
+// downloadURL constructs the CDN URL for an Otto release on this platform.
+// version is "latest" or a semver (with or without the v prefix).
+func downloadURL(version string) string {
 	goos := runtime.GOOS   // "darwin", "linux", "windows"
 	arch := runtime.GOARCH // "arm64", "amd64"
 	if arch == "amd64" {
 		arch = "x64"
 	}
-	if goos == windowsGOOS {
-		return fmt.Sprintf("%s/latest/%s-%s-%s.exe.zip", cdnBaseURL, binaryName, goos, arch)
+	versionPath := version
+	if version != latestVersion && !strings.HasPrefix(version, "v") {
+		versionPath = "v" + version
 	}
-	return fmt.Sprintf("%s/latest/%s-%s-%s.tar.gz", cdnBaseURL, binaryName, goos, arch)
+	if goos == windowsGOOS {
+		return fmt.Sprintf("%s/%s/%s-%s-%s.exe.zip", cdnBaseURL, versionPath, binaryName, goos, arch)
+	}
+	return fmt.Sprintf("%s/%s/%s-%s-%s.tar.gz", cdnBaseURL, versionPath, binaryName, goos, arch)
 }
 
 // downloadAndInstall fetches the Otto archive and extracts it to BinDir().
-func downloadAndInstall() error {
-	url := downloadURL()
+func downloadAndInstall(version string) error {
+	url := downloadURL(version)
 	client := &http.Client{Timeout: 120 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {

--- a/pkg/otto/binary_test.go
+++ b/pkg/otto/binary_test.go
@@ -93,12 +93,26 @@ func (s *BinarySuite) TestInstalledVersion_InvalidJSON() {
 	s.Contains(err.Error(), "parsing otto metadata")
 }
 
-func (s *BinarySuite) TestDownloadURL() {
-	url := downloadURL()
+func (s *BinarySuite) TestDownloadURL_Latest() {
+	url := downloadURL(latestVersion)
 	s.Contains(url, cdnBaseURL)
 	s.Contains(url, "/latest/")
 	s.Contains(url, "otto-")
 	s.Contains(url, ".tar.gz")
+}
+
+func (s *BinarySuite) TestDownloadURL_PinnedVersion() {
+	url := downloadURL("0.1.8")
+	s.Contains(url, cdnBaseURL)
+	s.Contains(url, "/v0.1.8/")
+	s.NotContains(url, "/latest/")
+}
+
+// Already-prefixed versions must not double up to /vv0.1.8/.
+func (s *BinarySuite) TestDownloadURL_PinnedVersion_AlreadyPrefixed() {
+	url := downloadURL("v0.1.8")
+	s.Contains(url, "/v0.1.8/")
+	s.NotContains(url, "/vv0.1.8/")
 }
 
 func (s *BinarySuite) TestIsUpdateAvailable_NotInstalled() {

--- a/pkg/otto/update.go
+++ b/pkg/otto/update.go
@@ -50,10 +50,12 @@ func hintUpdateAvailable(w io.Writer) {
 // disk) prints a notice and returns, letting the caller continue with the
 // existing binary.
 //
-// `download` is parameterized so tests can swap in a stub — production
-// callers pass downloadAndInstall. Gating on the `otto.auto_update` flag
-// is the caller's responsibility; this function always applies when called.
-func autoUpdate(w io.Writer, download func() error) {
+// `download` is passed the target version so the "Updating Otto X → Y" log
+// line matches what lands on disk: the CDN's /latest/ alias can race past
+// the cached value when a release ships between refreshes. Gating on the
+// `otto.auto_update` flag is the caller's responsibility; this function
+// always applies when called.
+func autoUpdate(w io.Writer, download func(version string) error) {
 	installed, err := InstalledVersion()
 	if err != nil || installed == "" {
 		return // first-run case — EnsureBinary already fetched latest
@@ -66,7 +68,7 @@ func autoUpdate(w io.Writer, download func() error) {
 		return
 	}
 	fmt.Fprintf(w, "Updating Otto %s → %s...\n", installed, state.LatestKnown)
-	if err := download(); err != nil {
+	if err := download(state.LatestKnown); err != nil {
 		fmt.Fprintf(w, "Otto update failed (%v); continuing with %s\n", err, installed)
 	}
 }

--- a/pkg/otto/update_test.go
+++ b/pkg/otto/update_test.go
@@ -169,37 +169,55 @@ func (s *UpdateSuite) TestUpdateStateFile_PathIsBinDirSibling() {
 // The gating on `otto.auto_update` lives in Start() and is covered by the
 // real-auth smoke path.
 
-// stubDownloader returns a downloader that records whether it was called and
-// returns a fixed error (nil for success). The install side-effect is
-// simulated by rewriting package.json to the given version.
-func (s *UpdateSuite) stubDownloader(installAs string, returnErr error) (download func() error, called *bool) {
+// stubDownloader returns a downloader that records whether it was called,
+// captures the version it was invoked with, and returns a fixed error (nil
+// for success). The install side-effect is simulated by rewriting
+// package.json to the given version.
+func (s *UpdateSuite) stubDownloader(installAs string, returnErr error) (download func(string) error, called *bool, requestedVersion *string) {
 	flag := false
-	return func() error {
+	ver := ""
+	return func(v string) error {
 		flag = true
+		ver = v
 		if returnErr != nil {
 			return returnErr
 		}
 		s.writeInstalled(installAs)
 		return nil
-	}, &flag
+	}, &flag, &ver
 }
 
 func (s *UpdateSuite) TestAutoUpdate_NewerCached_DownloadsAndReportsProgress() {
 	s.writeInstalled("0.0.5")
 	s.writeCache(updateState{LatestKnown: "0.0.9"})
-	download, called := s.stubDownloader("0.0.9", nil)
+	download, called, requested := s.stubDownloader("0.0.9", nil)
 
 	var buf bytes.Buffer
 	autoUpdate(&buf, download)
 
 	s.True(*called, "downloader should fire when cache is newer")
 	s.Contains(buf.String(), "Updating Otto 0.0.5 → 0.0.9")
+	s.Equal("0.0.9", *requested, "downloader should be pinned to the version we logged")
+}
+
+// Regression: the original bug logged "→ 0.1.8" but downloaded /latest/,
+// which by then had advanced to 0.1.10. Pinning the download to the cached
+// version keeps the log honest.
+func (s *UpdateSuite) TestAutoUpdate_PinsDownloadToCachedVersion() {
+	s.writeInstalled("0.1.7")
+	s.writeCache(updateState{LatestKnown: "0.1.8"})
+	download, _, requested := s.stubDownloader("0.1.8", nil)
+
+	var buf bytes.Buffer
+	autoUpdate(&buf, download)
+
+	s.Equal("0.1.8", *requested)
 }
 
 func (s *UpdateSuite) TestAutoUpdate_CacheEqualToInstalled_SkipsDownload() {
 	s.writeInstalled("0.0.5")
 	s.writeCache(updateState{LatestKnown: "0.0.5"})
-	download, called := s.stubDownloader("0.0.5", nil)
+	download, called, _ := s.stubDownloader("0.0.5", nil)
 
 	var buf bytes.Buffer
 	autoUpdate(&buf, download)
@@ -211,7 +229,7 @@ func (s *UpdateSuite) TestAutoUpdate_CacheEqualToInstalled_SkipsDownload() {
 func (s *UpdateSuite) TestAutoUpdate_CacheOlderThanInstalled_SkipsDownload() {
 	s.writeInstalled("0.0.7")
 	s.writeCache(updateState{LatestKnown: "0.0.5"})
-	download, called := s.stubDownloader("0.0.5", nil)
+	download, called, _ := s.stubDownloader("0.0.5", nil)
 
 	var buf bytes.Buffer
 	autoUpdate(&buf, download)
@@ -223,7 +241,7 @@ func (s *UpdateSuite) TestAutoUpdate_CacheOlderThanInstalled_SkipsDownload() {
 func (s *UpdateSuite) TestAutoUpdate_NoInstalled_SkipsDownload() {
 	// First-run case — EnsureBinary is responsible for the initial install.
 	s.writeCache(updateState{LatestKnown: "0.0.9"})
-	download, called := s.stubDownloader("0.0.9", nil)
+	download, called, _ := s.stubDownloader("0.0.9", nil)
 
 	var buf bytes.Buffer
 	autoUpdate(&buf, download)
@@ -236,7 +254,7 @@ func (s *UpdateSuite) TestAutoUpdate_NoCachedVersion_SkipsDownload() {
 	s.writeInstalled("0.0.5")
 	// cache has LastCheck but no LatestKnown (old schema)
 	s.writeCache(updateState{LastCheck: time.Now().UTC().Format(time.RFC3339)})
-	download, called := s.stubDownloader("0.0.9", nil)
+	download, called, _ := s.stubDownloader("0.0.9", nil)
 
 	var buf bytes.Buffer
 	autoUpdate(&buf, download)
@@ -248,7 +266,7 @@ func (s *UpdateSuite) TestAutoUpdate_NoCachedVersion_SkipsDownload() {
 func (s *UpdateSuite) TestAutoUpdate_DownloadFails_SoftFallsBack() {
 	s.writeInstalled("0.0.5")
 	s.writeCache(updateState{LatestKnown: "0.0.9"})
-	download, called := s.stubDownloader("", errStubNetwork)
+	download, called, _ := s.stubDownloader("", errStubNetwork)
 
 	var buf bytes.Buffer
 	autoUpdate(&buf, download)


### PR DESCRIPTION
## Summary

User feedback: `astro otto` printed
```
Updating Otto 0.1.7 → 0.1.8...
Otto 0.1.10 installed
```

`autoUpdate` logged `state.LatestKnown` from the cached `.update-check` file, but `downloadAndInstall` always fetched the CDN's `/latest/` alias. When a release shipped between cache refreshes, the two paths diverged.

## Changes

- `downloadURL(version)` and `downloadAndInstall(version)` now take a version string. The CDN already hosts versioned paths (`/vX.Y.Z/...`), so `autoUpdate` passes `state.LatestKnown` and the download URL matches the log line.
- `EnsureBinary` and `Update()` keep using `"latest"` via a new sentinel const.
- v-prefix add is idempotent (`!strings.HasPrefix(v, "v")`) so callers can pass either form.

## Test plan

- [x] `go build ./pkg/otto/...`
- [x] `go vet ./pkg/otto/...`
- [x] `go test ./pkg/otto/...`
- [x] New regression test `TestAutoUpdate_PinsDownloadToCachedVersion` fails on the old downloader signature
- [x] New `TestDownloadURL_PinnedVersion` + `_AlreadyPrefixed` cover both v-prefix forms