### PR TITLE
feat(otto): add shell tab completion for astro otto

### DIFF
--- a/cmd/otto.go
+++ b/cmd/otto.go
@@ -37,6 +37,11 @@ func newOttoCmd() *cobra.Command {
 		SilenceUsage:       true,
 		DisableFlagParsing: true,
 		RunE:               ottoRun,
+		// ValidArgsFunction drives `astro otto <tab>` completion. Candidates
+		// come from a cache the Otto binary refreshes on every run, so new
+		// flags appear after the user's next `astro otto` call without an
+		// astro-cli release.
+		ValidArgsFunction: otto.Complete,
 	}
 
 	return cmd

--- a/pkg/otto/completion.go
+++ b/pkg/otto/completion.go
@@ -1,0 +1,161 @@
+package otto
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/astronomer/astro-cli/config"
+)
+
+// cacheSchemaVersion must match the value Otto writes in its completion-cache
+// module. Bump in lockstep; mismatch falls back to baseline.
+const cacheSchemaVersion = 1
+
+// completionCache mirrors the JSON schema Otto writes to
+// ~/.astro/otto/cache/completion.json on every invocation.
+type completionCache struct {
+	SchemaVersion int           `json:"schemaVersion"`
+	OttoVersion   string        `json:"ottoVersion"`
+	Flags         []flagSpec    `json:"flags"`
+}
+
+type flagSpec struct {
+	Name        string   `json:"name"`
+	Short       string   `json:"short,omitempty"`
+	Desc        string   `json:"desc"`
+	TakesValue  bool     `json:"takesValue"`
+	Values      []string `json:"values,omitempty"`
+	ValueSource string   `json:"valueSource,omitempty"`
+}
+
+func cachePath() string {
+	return filepath.Join(config.HomeConfigPath, "otto", "cache", "completion.json")
+}
+
+func sessionsDir() string {
+	return filepath.Join(config.HomeConfigPath, "otto", "sessions")
+}
+
+// loadCache returns the cached completion data when present and valid, or the
+// embedded baseline. Never returns an error: completion must never break the
+// shell.
+func loadCache() completionCache {
+	data, err := os.ReadFile(cachePath())
+	if err != nil {
+		return embeddedBaseline()
+	}
+	var c completionCache
+	if err := json.Unmarshal(data, &c); err != nil || c.SchemaVersion != cacheSchemaVersion {
+		return embeddedBaseline()
+	}
+	return c
+}
+
+// embeddedBaseline is the fallback when otto has never run (or the cache is
+// unreadable / schema-mismatched). Keep it tiny: just the flags that have
+// stayed stable across releases.
+func embeddedBaseline() completionCache {
+	return completionCache{
+		SchemaVersion: cacheSchemaVersion,
+		Flags: []flagSpec{
+			{Name: "--help", Short: "-h", Desc: "Show help and exit"},
+			{Name: "--version", Short: "-v", Desc: "Show version and exit"},
+			{Name: "--mode", Desc: "Output mode", TakesValue: true,
+				Values: []string{"interactive", "json", "text", "rpc"}},
+			{Name: "--continue", Short: "-c", Desc: "Resume the most recent session"},
+			{Name: "--resume", Short: "-r", Desc: "Open the session picker"},
+		},
+	}
+}
+
+// Complete is the Cobra ValidArgsFunction for `astro otto`. It inspects the
+// previously-typed args to decide whether the user is mid-value (e.g. after
+// `--mode`) or starting a new word, then returns matching candidates.
+func Complete(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cache := loadCache()
+
+	// If the previous arg is a flag that takes a value AND it wasn't given
+	// inline (`--mode=json`), we're completing that flag's value.
+	if len(args) > 0 {
+		prev := args[len(args)-1]
+		if spec := findFlag(cache.Flags, prev); spec != nil && spec.TakesValue {
+			return completeValue(spec, toComplete)
+		}
+	}
+
+	// `--flag=partial` form: split on the first `=`.
+	if strings.HasPrefix(toComplete, "--") && strings.Contains(toComplete, "=") {
+		eq := strings.IndexByte(toComplete, '=')
+		flag, partial := toComplete[:eq], toComplete[eq+1:]
+		if spec := findFlag(cache.Flags, flag); spec != nil && spec.TakesValue {
+			vals, dir := completeValue(spec, partial)
+			withPrefix := make([]string, 0, len(vals))
+			for _, v := range vals {
+				withPrefix = append(withPrefix, flag+"="+v)
+			}
+			return withPrefix, dir
+		}
+	}
+
+	// New word: offer flag names when the user has typed a dash, otherwise
+	// nothing (the positional slot is a free-text prompt, no candidates).
+	if strings.HasPrefix(toComplete, "-") {
+		return flagNames(cache.Flags), cobra.ShellCompDirectiveNoFileComp
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
+func findFlag(flags []flagSpec, name string) *flagSpec {
+	for i := range flags {
+		if flags[i].Name == name || (flags[i].Short != "" && flags[i].Short == name) {
+			return &flags[i]
+		}
+	}
+	return nil
+}
+
+func flagNames(flags []flagSpec) []string {
+	out := make([]string, 0, len(flags)*2)
+	for _, f := range flags {
+		out = append(out, f.Name+"\t"+f.Desc)
+		if f.Short != "" {
+			out = append(out, f.Short+"\t"+f.Desc)
+		}
+	}
+	return out
+}
+
+func completeValue(spec *flagSpec, _ string) ([]string, cobra.ShellCompDirective) {
+	if len(spec.Values) > 0 {
+		return spec.Values, cobra.ShellCompDirectiveNoFileComp
+	}
+	switch spec.ValueSource {
+	case "session":
+		return sessionIDs(), cobra.ShellCompDirectiveNoFileComp
+	case "file":
+		return nil, cobra.ShellCompDirectiveDefault
+	default:
+		// model / skill / tool / unknown: no cheap source yet. Let the user
+		// free-text; don't pollute the suggestion list with file paths.
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func sessionIDs() []string {
+	entries, err := os.ReadDir(sessionsDir())
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasSuffix(name, ".jsonl") {
+			out = append(out, strings.TrimSuffix(name, ".jsonl"))
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## summary
- adds a Cobra `ValidArgsFunction` to the otto subcommand, so `astro completion zsh|bash|powershell` now drives `astro otto <tab>` in addition to the rest of the astro CLI
- candidates come from a small cache that the Otto binary refreshes on every run, with an embedded baseline fallback for the first-run case (before the user has ever invoked `astro otto`)
- per-tab-press latency is shell-native: no subprocess spawn, one cache read

## what completes
- flag names with descriptions
- enum values for things like `--mode`, `--persona`, `--permission-mode`, `--extension`, `--thinking`
- session IDs from `~/.astro/otto/sessions/` for `--session`, `--fork`, `--export`
- shell file completion for file-path flags (`--mcp-config`, `--system-prompt`, etc.)

## drift property
the cache file is owned by the Otto binary, not embedded here. Otto refreshes it on every invocation, so a newly-added otto flag appears in tab completion after the user's next `astro otto` call. no coordinated astro-cli release needed when otto's surface grows

if the cache is missing, malformed, or schema-mismatched, completion silently falls back to a hardcoded baseline of stable flags (`--help`, `--version`, `--mode`, `-c`, `-r`). tab completion never breaks the shell

## how to install
no changes to the install flow. users source the existing cobra-generated script:
```
source <(astro completion zsh)
```

## test plan
- [ ] `go build ./...` and `go test ./pkg/otto/... ./cmd/...` pass locally
- [ ] `astro completion zsh > /tmp/_astro && source /tmp/_astro`
- [ ] `astro otto --<tab>` shows the full flag list with descriptions
- [ ] `astro otto --mode <tab>` shows `interactive json text rpc`
- [ ] `astro otto --persona <tab>` shows the available personas
- [ ] `astro otto --session <tab>` shows real session IDs from disk
- [ ] delete `~/.astro/otto/cache/completion.json` and confirm completion still works (baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)