### PR TITLE
Standalone: set PYTHONPATH=AIRFLOW_HOME to match runtime image

### DIFF
--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -759,13 +759,15 @@ func (s *Standalone) buildEnv() []string {
 	// Layer 2: Standalone-critical settings — these MUST take precedence over
 	// both inherited env and .env to prevent standalone mode from breaking.
 	overrides["PATH"] = fmt.Sprintf("%s:%s", venvBin, os.Getenv("PATH"))
-	// Add include/ to PYTHONPATH so user modules are importable — mirrors
-	// the Docker image which bakes /usr/local/airflow/include into PYTHONPATH.
-	includePath := filepath.Join(s.airflowHome, "include")
+	// Mirror the production runtime image, which sets PYTHONPATH=AIRFLOW_HOME
+	// (see astro-runtime image/Dockerfile). This makes every subdirectory of
+	// the project root importable as a namespace package — e.g.
+	// `from include.utils import x` or `from dags.my_blueprints import Extract`
+	// — matching what users get at deploy time.
 	if existing := os.Getenv("PYTHONPATH"); existing != "" {
-		overrides["PYTHONPATH"] = fmt.Sprintf("%s:%s", includePath, existing)
+		overrides["PYTHONPATH"] = fmt.Sprintf("%s:%s", s.airflowHome, existing)
 	} else {
-		overrides["PYTHONPATH"] = includePath
+		overrides["PYTHONPATH"] = s.airflowHome
 	}
 	overrides["AIRFLOW_HOME"] = standaloneHome
 	overrides["ASTRONOMER_ENVIRONMENT"] = "local"

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -545,6 +545,11 @@ func TestStripQuotes(t *testing.T) {
 }
 
 func (s *Suite) TestStandaloneBuildEnv() {
+	// Clear inherited PYTHONPATH so the assertion below is deterministic
+	// regardless of the developer's / CI's shell environment. buildEnv()
+	// prepends AIRFLOW_HOME to whatever PYTHONPATH is in the process env.
+	s.T().Setenv("PYTHONPATH", "")
+
 	handler, err := StandaloneInit("/tmp/test-project", "", "Dockerfile")
 	s.NoError(err)
 	handler.airflowMajorVersion = "3"
@@ -569,6 +574,11 @@ func (s *Suite) TestStandaloneBuildEnv() {
 	s.Equal("d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw=", envMap["AIRFLOW__CORE__FERNET_KEY"])
 	s.NotEmpty(envMap["AIRFLOW__API__SECRET_KEY"])
 	s.NotEmpty(envMap["AIRFLOW__API_AUTH__JWT_SECRET"])
+
+	// PYTHONPATH must mirror the production runtime image, which sets
+	// PYTHONPATH=AIRFLOW_HOME so every subdirectory (dags/, include/, etc.)
+	// is importable as a namespace package.
+	s.Equal("/tmp/test-project", envMap["PYTHONPATH"], "PYTHONPATH should be exactly AIRFLOW_HOME")
 }
 
 func (s *Suite) TestStandaloneBuildEnv_NoDuplicateKeys() {
@@ -1780,9 +1790,9 @@ func (s *Suite) TestStandalonePytest_Success() {
 	s.Equal("", exitCode)
 	s.Equal([]string{"pytest", "tests/"}, capturedArgs)
 
-	// Verify PYTHONPATH includes the include/ directory so user modules
-	// in include/ are importable during test runs.
-	expectedInclude := filepath.Join(tmpDir, "include")
+	// Verify PYTHONPATH includes AIRFLOW_HOME so user modules under any
+	// subdirectory (dags/, include/, etc.) are importable as namespace
+	// packages during test runs — mirroring the production runtime image.
 	var pythonPath string
 	for _, kv := range capturedEnv {
 		if strings.HasPrefix(kv, "PYTHONPATH=") {
@@ -1791,7 +1801,7 @@ func (s *Suite) TestStandalonePytest_Success() {
 		}
 	}
 	s.NotEmpty(pythonPath, "PYTHONPATH should be set in pytest env")
-	s.Contains(pythonPath, expectedInclude, "PYTHONPATH should contain include/ directory")
+	s.Contains(strings.Split(pythonPath, ":"), tmpDir, "PYTHONPATH should contain AIRFLOW_HOME")
 }
 
 func (s *Suite) TestStandalonePytest_WithFileAndArgs() {


### PR DESCRIPTION
## Summary

Aligns standalone-mode `PYTHONPATH` with the production Astro runtime Docker image.

Standalone mode previously set `PYTHONPATH=AIRFLOW_HOME/include` only. That diverged from the runtime image, which sets `PYTHONPATH=AIRFLOW_HOME` ([astro-runtime/image/Dockerfile#L19](https://github.com/astronomer/astro-runtime/blob/main/image/Dockerfile#L19)). This change brings standalone in line with the image.

## Why

The previous behavior was introduced by #2060 with the stated intent of "mirroring the docker image" — but the docker image actually bakes `AIRFLOW_HOME` into `PYTHONPATH`, not `AIRFLOW_HOME/include`. The comment in the original code was also factually inaccurate. So in practice, imports that work in production (and pass `astro deploy --parse`) could fail when the same project was tested locally with `astro dev start --standalone` or `astro dev pytest --standalone`.

Concrete example that breaks under the current code but works in production:

```python
# dags/hybrid_dag.py
from dags.my_blueprints import Extract  # works in prod, fails under --standalone
```

The prefixed `from include.<module> import …` pattern that the official docs recommend ([Custom hooks and operators](https://www.astronomer.io/docs/learn/airflow-importing-custom-hooks-operators)) continues to work both before and after this change.

## Behavior change

- ✅ `from include.foo import bar` — continues to work (include/ is findable as a namespace package under AIRFLOW_HOME).
- ✅ `from dags.foo import bar` — now works (matches production).
- ⚠️ `import foo` where `foo.py` lives flat in `include/` — no longer resolves under standalone. This only ever worked under standalone (never in docker mode), so the breakage surface is small. The fix for users is to switch to `from include.foo import …`, which the docs already teach as the canonical pattern.

## Test plan

- [x] `go test ./airflow/ -run 'TestAirflow/TestStandaloneBuildEnv'` (12 subtests, all pass)
- [x] Verified test is robust to inherited `PYTHONPATH`: `PYTHONPATH=/some/inherited/path go test ./airflow/ -run 'TestAirflow/TestStandaloneBuildEnv$'` passes (the test now calls `t.Setenv("PYTHONPATH", "")` so the strict equality assertion doesn't flake on developer/CI envs)
- [x] End-to-end: built a local binary, ran an integration test suite against it that uses `from dags.<module> import …` in a Python DAG under `astro dev pytest --standalone`. Live scheduler loads the DAG; `astro dev pytest --standalone` (DagBag scan) passes