### PR TITLE
Populate routes.json on Windows when proxy daemon is unavailable

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -394,29 +394,32 @@ func (d *DockerCompose) Start(opts *airflowTypes.StartOptions) error {
 
 	spinner.StopWithCheckmark(s, "Project started")
 
-	// Register route with the proxy and start the daemon. If either step fails
-	// (e.g. proxy daemon unsupported on Windows), fall back to printing the
-	// localhost URL using the actual webserver port that compose bound.
+	// Register route with the proxy and start the daemon. The route is always
+	// persisted to routes.json so that other tools can discover this project.
+	// If the daemon fails to start (e.g. on Windows where it is not supported),
+	// we fall back to printing the localhost URL.
 	proxyActive := useProxy && proxyHostname != ""
 	if proxyActive {
-		if _, ensureErr := proxy.EnsureRunning(proxyPort); ensureErr != nil {
-			fmt.Printf("Warning: could not start proxy: %s\n", ensureErr.Error())
+		services := map[string]string{}
+		if portOvr != nil && portOvr.PostgresPort != "" {
+			services["postgres"] = portOvr.PostgresPort
+		}
+		route := proxy.Route{
+			Hostname:   proxyHostname,
+			Port:       portOvr.WebserverPort,
+			ProjectDir: d.airflowHome,
+			PID:        0, // Docker routes don't track PID — CLI exits after start
+			Services:   services,
+			Mode:       "docker",
+		}
+		if addErr := proxy.AddRoute(&route); addErr != nil {
+			fmt.Printf("Warning: could not register proxy route: %s\n", addErr.Error())
 			proxyActive = false
-		} else {
-			services := map[string]string{}
-			if portOvr != nil && portOvr.PostgresPort != "" {
-				services["postgres"] = portOvr.PostgresPort
-			}
-			route := proxy.Route{
-				Hostname:   proxyHostname,
-				Port:       portOvr.WebserverPort,
-				ProjectDir: d.airflowHome,
-				PID:        0, // Docker routes don't track PID — CLI exits after start
-				Services:   services,
-				Mode:       "docker",
-			}
-			if addErr := proxy.AddRoute(&route); addErr != nil {
-				fmt.Printf("Warning: could not register proxy route: %s\n", addErr.Error())
+		}
+
+		if proxyActive {
+			if _, ensureErr := proxy.EnsureRunning(proxyPort); ensureErr != nil {
+				fmt.Printf("Warning: could not start proxy: %s\n", ensureErr.Error())
 				proxyActive = false
 			}
 		}

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -415,13 +415,9 @@ func (d *DockerCompose) Start(opts *airflowTypes.StartOptions) error {
 		if addErr := proxy.AddRoute(&route); addErr != nil {
 			fmt.Printf("Warning: could not register proxy route: %s\n", addErr.Error())
 			proxyActive = false
-		}
-
-		if proxyActive {
-			if _, ensureErr := proxy.EnsureRunning(proxyPort); ensureErr != nil {
-				fmt.Printf("Warning: could not start proxy: %s\n", ensureErr.Error())
-				proxyActive = false
-			}
+		} else if _, ensureErr := proxy.EnsureRunning(proxyPort); ensureErr != nil {
+			fmt.Printf("Warning: could not start proxy: %s\n", ensureErr.Error())
+			proxyActive = false
 		}
 	}
 

--- a/airflow/proxy/proxy_test.go
+++ b/airflow/proxy/proxy_test.go
@@ -59,6 +59,48 @@ func TestProxy_NotFound(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "unknown.localhost")
 }
 
+func TestAddRoute_PersistsWhenDaemonFails(t *testing.T) {
+	setupTestDir(t)
+
+	// Simulate the docker.go flow where AddRoute is called before EnsureRunning.
+	// Even when the daemon cannot start (as on Windows), routes.json must be
+	// populated so other tools can discover the project.
+	origStartDaemon := StartDaemon
+	defer func() { StartDaemon = origStartDaemon }()
+	StartDaemon = func(_ string) error {
+		return fmt.Errorf("proxy daemon is not supported on Windows")
+	}
+
+	route := &Route{
+		Hostname:   "my-project.localhost",
+		Port:       "12345",
+		ProjectDir: "/home/user/my-project",
+		PID:        0,
+		Services:   map[string]string{"postgres": "15432"},
+		Mode:       "docker",
+	}
+	err := AddRoute(route)
+	require.NoError(t, err)
+
+	// EnsureRunning fails — but route must still be in routes.json.
+	_, err = EnsureRunning("6563")
+	assert.Error(t, err)
+
+	routes, err := ListRoutes()
+	require.NoError(t, err)
+	require.Len(t, routes, 1)
+	assert.Equal(t, "my-project.localhost", routes[0].Hostname)
+	assert.Equal(t, "12345", routes[0].Port)
+	assert.Equal(t, "docker", routes[0].Mode)
+	assert.Equal(t, "15432", routes[0].Services["postgres"])
+
+	// GetRouteByProject should also find it.
+	found, err := GetRouteByProject("/home/user/my-project")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, "my-project.localhost", found.Hostname)
+}
+
 func TestProxy_ReverseProxy(t *testing.T) {
 	setupTestDir(t)
 

--- a/airflow/proxy/routes_windows.go
+++ b/airflow/proxy/routes_windows.go
@@ -2,19 +2,6 @@
 
 package proxy
 
-import (
-	"os"
-
-	pkgproxy "github.com/astronomer/astro-cli/pkg/proxy"
-)
-
-func acquireLock() (*os.File, error) {
-	ensureInit()
-	return pkgproxy.AcquireLock()
-}
-
-func releaseLock(f *os.File) {
-	pkgproxy.ReleaseLock(f)
-}
+import pkgproxy "github.com/astronomer/astro-cli/pkg/proxy"
 
 var isPIDAlive = pkgproxy.IsPIDAlive

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -686,15 +686,12 @@ func (s *Standalone) startBackground(cmd *exec.Cmd, waitTime time.Duration, sett
 	return nil
 }
 
-// registerProxyRoute ensures the proxy daemon is running and registers a route
-// for this standalone instance. Returns the proxy URL on success, or "" if the
-// proxy is disabled or registration failed.
+// registerProxyRoute registers a route for this standalone instance so that
+// other tools can discover it via routes.json, then starts the proxy daemon.
+// Returns the proxy URL on success, or "" if the proxy is disabled or
+// registration failed.
 func (s *Standalone) registerProxyRoute(pid int) string {
 	if !s.useProxy || s.proxyHostname == "" {
-		return ""
-	}
-	if _, err := proxy.EnsureRunning(s.proxyPort); err != nil {
-		fmt.Printf("Warning: could not start proxy: %s\n", err.Error())
 		return ""
 	}
 	route := &proxy.Route{
@@ -705,6 +702,10 @@ func (s *Standalone) registerProxyRoute(pid int) string {
 	}
 	if err := proxy.AddRoute(route); err != nil {
 		fmt.Printf("Warning: could not register proxy route: %s\n", err.Error())
+		return ""
+	}
+	if _, err := proxy.EnsureRunning(s.proxyPort); err != nil {
+		fmt.Printf("Warning: could not start proxy: %s\n", err.Error())
 		return ""
 	}
 	return fmt.Sprintf("http://%s:%s", s.proxyHostname, s.proxyPort)

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -248,6 +248,37 @@ func TestPruneStaleRoutes_DockerNotPruned(t *testing.T) {
 	assert.Equal(t, "docker.localhost", pruned[0].Hostname)
 }
 
+func TestAddRoute_DockerRouteSurvivesPruningWithDeadPID(t *testing.T) {
+	setupTestDir(t)
+
+	// Simulate the docker.go flow: AddRoute is called with PID 0 and Mode "docker".
+	// Even when IsPIDAlive returns false (as it does on Windows), docker routes
+	// must not be pruned — they are cleaned up explicitly via RemoveRoute.
+	origIsPIDAlive := IsPIDAlive
+	defer func() { IsPIDAlive = origIsPIDAlive }()
+	IsPIDAlive = func(_ int) bool { return false }
+
+	route := &Route{
+		Hostname:   "my-project.localhost",
+		Port:       "12345",
+		ProjectDir: "/home/user/my-project",
+		PID:        0,
+		Services:   map[string]string{"postgres": "15432"},
+		Mode:       "docker",
+	}
+	err := AddRoute(route)
+	require.NoError(t, err)
+
+	// ListRoutes prunes stale routes internally — docker routes must survive.
+	routes, err := ListRoutes()
+	require.NoError(t, err)
+	require.Len(t, routes, 1)
+	assert.Equal(t, "my-project.localhost", routes[0].Hostname)
+	assert.Equal(t, "12345", routes[0].Port)
+	assert.Equal(t, "docker", routes[0].Mode)
+	assert.Equal(t, "15432", routes[0].Services["postgres"])
+}
+
 func TestAddRoute_WithServices(t *testing.T) {
 	setupTestDir(t)
 


### PR DESCRIPTION
## Description

  - Decouple route registration (`routes.json`) from proxy daemon startup so
    that Docker/Podman projects are discoverable on Windows where the daemon
    is not supported
  - Remove unused `acquireLock`/`releaseLock` scaffolding from
    `routes_windows.go`

 ## Problem

  On Windows, `proxy.EnsureRunning()` returns `errUnsupportedWindows`, and
  because `AddRoute()` was gated behind the daemon starting successfully,
  `routes.json` was never populated. This prevented other tools from
  discovering local CLI projects.

## 🧪 Functional Testing

Tested the change on windows and change is working as expected:

```
PS D:\astro-test> ..\astro.exe dev start
✔ Project image has been updated
✔ Project started
Warning: could not start proxy: proxy daemon is not supported on Windows
➤ Airflow UI: http://localhost:8080
➤ Postgres Database: postgresql://localhost:5432/postgres
➤ The default Postgres DB credentials are: postgres:postgres

PS D:\af-test> ..\astro.exe dev start
✔ Project image has been updated
✔ Project started
Warning: could not start proxy: proxy daemon is not supported on Windows
➤ Airflow UI: http://localhost:14908
➤ Postgres Database: postgresql://localhost:10080/postgres
➤ The default Postgres DB credentials are: postgres:p
```

routes.json

```
[
  {
    "hostname": "astro-test.localhost",
    "port": "8080",
    "projectDir": "D:\\astro-test",
    "pid": 0,
    "services": {
      "postgres": "5432"
    },
    "mode": "docker"
  },
  {
    "hostname": "af-test.localhost",
    "port": "14908",
    "projectDir": "D:\\af-test",
    "pid": 0,
    "services": {
      "postgres": "10080"
    },
    "mode": "docker"
  }

```
## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
