### PR TITLE
fix(deploy): preserve symlinks and honor .dockerignore in client build context

### DIFF
--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/patternmatcher"
+	"github.com/moby/patternmatcher/ignorefile"
 	"github.com/pkg/errors"
 
 	"github.com/astronomer/astro-cli/airflow"
@@ -861,8 +863,18 @@ func prepareClientBuildContext(sourcePath string) (*ClientBuildContext, error) {
 		return buildContext, fmt.Errorf("source directory does not exist: %s", sourcePath)
 	}
 
+	// Build a skip predicate from the project's .dockerignore so excluded
+	// paths (e.g. infra/ with terragrunt provider-cache symlinks) are not
+	// copied into the build context. This mirrors what the Docker builder does
+	// for in-place builds; the client deploy copies the context first, so it
+	// must honor .dockerignore itself.
+	skip, err := dockerignoreSkipFunc(sourcePath)
+	if err != nil {
+		return buildContext, fmt.Errorf("failed to read .dockerignore: %w", err)
+	}
+
 	// Copy all project files to the temporary directory
-	err = fileutil.CopyDirectory(sourcePath, tempBuildDir)
+	err = fileutil.CopyDirectoryFiltered(sourcePath, tempBuildDir, skip)
 	if err != nil {
 		return buildContext, fmt.Errorf("failed to copy project files to temporary directory: %w", err)
 	}
@@ -874,6 +886,58 @@ func prepareClientBuildContext(sourcePath string) (*ClientBuildContext, error) {
 	}
 
 	return buildContext, nil
+}
+
+// alwaysIncludedBuildFiles are never excluded from the client build context,
+// even if a user's .dockerignore would match them. The Docker builder applies
+// the same special-casing to the Dockerfile and .dockerignore, and the client
+// deploy additionally needs its client dependency files.
+var alwaysIncludedBuildFiles = map[string]bool{
+	"Dockerfile.client":       true,
+	".dockerignore":           true,
+	"requirements-client.txt": true,
+	"packages-client.txt":     true,
+}
+
+// dockerignoreSkipFunc parses the .dockerignore at sourcePath (if any) and
+// returns a predicate, suitable for fileutil.CopyDirectoryFiltered, that
+// reports whether a path should be excluded from the build context. It returns
+// nil (copy everything) when there is no .dockerignore file.
+func dockerignoreSkipFunc(sourcePath string) (func(relPath string, isDir bool) bool, error) {
+	f, err := os.Open(filepath.Join(sourcePath, ".dockerignore"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	patterns, err := ignorefile.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	pm, err := patternmatcher.New(patterns)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(relPath string, isDir bool) bool {
+		if alwaysIncludedBuildFiles[relPath] {
+			return false
+		}
+		matched, err := pm.MatchesOrParentMatches(relPath)
+		if err != nil || !matched {
+			return false
+		}
+		// When exclusion ("!") patterns exist, a child of a matched directory
+		// may be re-included, so we must descend rather than prune the dir.
+		if isDir && pm.Exclusions() {
+			return false
+		}
+		return true
+	}, nil
 }
 
 // setupClientDependencyFiles processes client-specific dependency files in the build context

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -1867,6 +1867,131 @@ func TestPrepareClientBuildContext(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, regularPackagesContent, string(originalPackagesContent))
 	})
+
+	// Reproduces https://github.com/astronomer/astro-cli/issues/2161: a
+	// .dockerignore-excluded directory containing a symlink to a directory
+	// (e.g. terragrunt provider-cache symlinks under infra/) must not cause the
+	// build-context copy to fail with "is a directory".
+	t.Run("excludes dockerignored directory containing symlink to directory", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "test-client-dockerignore-*")
+		assert.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		// Required client/regular dependency files.
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "requirements-client.txt"), []byte(""), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "packages-client.txt"), []byte(""), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "requirements.txt"), []byte(""), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "packages.txt"), []byte(""), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "Dockerfile.client"), []byte("FROM scratch"), 0o644))
+
+		// .dockerignore excludes infra/.
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, ".dockerignore"), []byte("infra/\n"), 0o644))
+
+		// A symlink-to-directory living outside the project, mirroring a
+		// terragrunt provider cache symlinked into .terragrunt-cache.
+		cacheDir := filepath.Join(tempDir, "provider-cache", "darwin_arm64")
+		assert.NoError(t, os.MkdirAll(cacheDir, 0o755))
+		assert.NoError(t, os.WriteFile(filepath.Join(cacheDir, "terraform-provider"), []byte("binary"), 0o644))
+
+		linkDir := filepath.Join(tempDir, "infra", "agent", ".terragrunt-cache", "hash")
+		assert.NoError(t, os.MkdirAll(linkDir, 0o755))
+		assert.NoError(t, os.Symlink(cacheDir, filepath.Join(linkDir, "darwin_arm64")))
+
+		// Previously failed with "is a directory"; now succeeds.
+		buildContext, err := prepareClientBuildContext(tempDir)
+		assert.NotNil(t, buildContext)
+		defer buildContext.CleanupFunc()
+		assert.NoError(t, err)
+
+		// infra/ is excluded entirely from the build context.
+		_, statErr := os.Stat(filepath.Join(buildContext.TempDir, "infra"))
+		assert.True(t, os.IsNotExist(statErr), "expected infra/ to be excluded from build context")
+
+		// The Dockerfile.client is preserved.
+		_, statErr = os.Stat(filepath.Join(buildContext.TempDir, "Dockerfile.client"))
+		assert.NoError(t, statErr)
+	})
+
+	// Even when .dockerignore does NOT exclude a symlink-to-directory, the copy
+	// must recreate it as a symlink rather than dereference it.
+	t.Run("copies symlink to directory without dereferencing when not ignored", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "test-client-symlink-*")
+		assert.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "requirements-client.txt"), []byte(""), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "packages-client.txt"), []byte(""), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "requirements.txt"), []byte(""), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "packages.txt"), []byte(""), 0o644))
+
+		target := filepath.Join(tempDir, "target-dir")
+		assert.NoError(t, os.MkdirAll(target, 0o755))
+		assert.NoError(t, os.Symlink(target, filepath.Join(tempDir, "link-to-dir")))
+
+		buildContext, err := prepareClientBuildContext(tempDir)
+		assert.NotNil(t, buildContext)
+		defer buildContext.CleanupFunc()
+		assert.NoError(t, err)
+
+		info, lerr := os.Lstat(filepath.Join(buildContext.TempDir, "link-to-dir"))
+		assert.NoError(t, lerr)
+		assert.NotZero(t, info.Mode()&os.ModeSymlink, "expected link-to-dir to remain a symlink")
+	})
+}
+
+func TestDockerignoreSkipFunc(t *testing.T) {
+	t.Run("returns nil skip func when no .dockerignore exists", func(t *testing.T) {
+		dir := t.TempDir()
+		skip, err := dockerignoreSkipFunc(dir)
+		assert.NoError(t, err)
+		assert.Nil(t, skip)
+	})
+
+	t.Run("matches files and prunes directories", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, ".dockerignore"), []byte("infra/\n*.log\n"), 0o644))
+
+		skip, err := dockerignoreSkipFunc(dir)
+		assert.NoError(t, err)
+		assert.NotNil(t, skip)
+
+		assert.True(t, skip("infra", true))
+		assert.True(t, skip("infra/agent/main.tf", false))
+		assert.True(t, skip("debug.log", false))
+		assert.False(t, skip("dags/example.py", false))
+		assert.False(t, skip("requirements.txt", false))
+	})
+
+	t.Run("never excludes the Dockerfile and dependency files", func(t *testing.T) {
+		dir := t.TempDir()
+		// A pathological .dockerignore that would otherwise exclude build files.
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, ".dockerignore"), []byte("Dockerfile*\n*.txt\n.dockerignore\n"), 0o644))
+
+		skip, err := dockerignoreSkipFunc(dir)
+		assert.NoError(t, err)
+		assert.NotNil(t, skip)
+
+		assert.False(t, skip("Dockerfile.client", false))
+		assert.False(t, skip(".dockerignore", false))
+		assert.False(t, skip("requirements-client.txt", false))
+		assert.False(t, skip("packages-client.txt", false))
+	})
+
+	t.Run("descends into matched directory when exclusion patterns exist", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, ".dockerignore"), []byte("infra/\n!infra/keep.txt\n"), 0o644))
+
+		skip, err := dockerignoreSkipFunc(dir)
+		assert.NoError(t, err)
+		assert.NotNil(t, skip)
+
+		// Directory is not pruned (so the re-included child can be reached)...
+		assert.False(t, skip("infra", true))
+		// ...the re-included file survives...
+		assert.False(t, skip("infra/keep.txt", false))
+		// ...but other files inside stay excluded.
+		assert.True(t, skip("infra/secret.tf", false))
+	})
 }
 
 func TestSetupClientDependencyFiles(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -49,8 +49,10 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/itchyny/gojq v0.12.18
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/moby/patternmatcher v0.6.1
 	github.com/neilotoole/jsoncolor v0.7.1
 	github.com/oapi-codegen/runtime v1.4.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/pb33f/libopenapi v0.34.0
 	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/whilp/git-urls v1.0.0
@@ -228,7 +230,6 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.1.0 // indirect
-	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
@@ -248,7 +249,6 @@ require (
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pb33f/jsonpath v0.8.1 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -442,17 +443,35 @@ func CopyFile(src, dst string) error {
 	return os.Chmod(dst, sourceInfo.Mode())
 }
 
-// CopyDirectory recursively copies a directory from src to dst
+// CopyDirectory recursively copies a directory from src to dst.
 func CopyDirectory(src, dst string) error {
-	// Get source directory info
-	srcInfo, err := os.Stat(src)
+	return CopyDirectoryFiltered(src, dst, nil)
+}
+
+// CopyDirectoryFiltered recursively copies a directory from src to dst.
+//
+// If skip is non-nil it is invoked for every entry with the entry's path
+// relative to the original src root (slash-delimited) and whether the entry is
+// a directory. Returning true skips that entry; skipping a directory also skips
+// its contents.
+//
+// Symlinks are recreated as symlinks rather than dereferenced. Following a
+// symlink that resolves to a directory previously caused a cryptic
+// "is a directory" read error (the link was treated as a regular file and
+// os.Open followed it to its target directory).
+func CopyDirectoryFiltered(src, dst string, skip func(relPath string, isDir bool) bool) error {
+	return copyDirectory(src, dst, "", skip)
+}
+
+func copyDirectory(src, dst, relBase string, skip func(relPath string, isDir bool) bool) error {
+	// Use Lstat so we do not dereference src itself if it is a symlink.
+	srcInfo, err := os.Lstat(src)
 	if err != nil {
 		return err
 	}
 
 	// Create destination directory
-	err = os.MkdirAll(dst, srcInfo.Mode())
-	if err != nil {
+	if err := os.MkdirAll(dst, srcInfo.Mode().Perm()); err != nil {
 		return err
 	}
 
@@ -465,21 +484,42 @@ func CopyDirectory(src, dst string) error {
 	for _, entry := range entries {
 		srcPath := filepath.Join(src, entry.Name())
 		dstPath := filepath.Join(dst, entry.Name())
+		relPath := path.Join(relBase, entry.Name())
+		isDir := entry.IsDir()
 
-		if entry.IsDir() {
-			// Recursively copy subdirectory
-			err = CopyDirectory(srcPath, dstPath)
-			if err != nil {
+		if skip != nil && skip(relPath, isDir) {
+			continue
+		}
+
+		switch {
+		case entry.Type()&os.ModeSymlink != 0:
+			// Recreate the symlink instead of following it. Dereferencing a
+			// symlink that points at a directory caused "is a directory" errors.
+			if err := copySymlink(srcPath, dstPath); err != nil {
 				return err
 			}
-		} else {
+		case isDir:
+			// Recursively copy subdirectory
+			if err := copyDirectory(srcPath, dstPath, relPath, skip); err != nil {
+				return err
+			}
+		default:
 			// Copy file
-			err = CopyFile(srcPath, dstPath)
-			if err != nil {
+			if err := CopyFile(srcPath, dstPath); err != nil {
 				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+// copySymlink recreates the symlink at src as a symlink at dst, preserving its
+// target verbatim (without following it).
+func copySymlink(src, dst string) error {
+	target, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(target, dst)
 }

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -955,4 +955,59 @@ func (s *Suite) TestCopyDirectory() {
 		err := CopyDirectory(srcDir, dstDir)
 		s.Error(err)
 	})
+
+	s.Run("copies symlink to directory without dereferencing it", func() {
+		root := s.T().TempDir()
+		srcDir := filepath.Join(root, "src")
+		dstDir := filepath.Join(root, "dst")
+
+		// A real directory the symlink points at, plus the symlink itself.
+		// This reproduces terragrunt provider-cache symlinks that previously
+		// triggered "read ...: is a directory".
+		target := filepath.Join(root, "target-dir")
+		s.NoError(os.MkdirAll(target, 0o755))
+		s.NoError(os.WriteFile(filepath.Join(target, "inside.txt"), []byte("hi"), 0o644))
+
+		s.NoError(os.MkdirAll(srcDir, 0o755))
+		s.NoError(os.WriteFile(filepath.Join(srcDir, "regular.txt"), []byte("ok"), 0o644))
+		s.NoError(os.Symlink(target, filepath.Join(srcDir, "link-to-dir")))
+
+		err := CopyDirectory(srcDir, dstDir)
+		s.NoError(err)
+
+		// The regular file is copied.
+		content, err := os.ReadFile(filepath.Join(dstDir, "regular.txt"))
+		s.NoError(err)
+		s.Equal("ok", string(content))
+
+		// The symlink is recreated as a symlink, not dereferenced.
+		info, err := os.Lstat(filepath.Join(dstDir, "link-to-dir"))
+		s.NoError(err)
+		s.NotZero(info.Mode()&os.ModeSymlink, "expected link-to-dir to remain a symlink")
+		linkTarget, err := os.Readlink(filepath.Join(dstDir, "link-to-dir"))
+		s.NoError(err)
+		s.Equal(target, linkTarget)
+	})
+
+	s.Run("skip predicate excludes matching files and prunes directories", func() {
+		root := s.T().TempDir()
+		srcDir := filepath.Join(root, "src")
+		dstDir := filepath.Join(root, "dst")
+
+		s.NoError(os.MkdirAll(filepath.Join(srcDir, "infra", "agent"), 0o755))
+		s.NoError(os.WriteFile(filepath.Join(srcDir, "keep.txt"), []byte("keep"), 0o644))
+		s.NoError(os.WriteFile(filepath.Join(srcDir, "infra", "agent", "secret.tf"), []byte("x"), 0o644))
+
+		skip := func(relPath string, isDir bool) bool {
+			return relPath == "infra"
+		}
+
+		err := CopyDirectoryFiltered(srcDir, dstDir, skip)
+		s.NoError(err)
+
+		_, err = os.Stat(filepath.Join(dstDir, "keep.txt"))
+		s.NoError(err)
+		_, err = os.Stat(filepath.Join(dstDir, "infra"))
+		s.True(os.IsNotExist(err), "expected infra/ to be pruned")
+	})
 }


### PR DESCRIPTION
## Description

Client deploys failed with a cryptic `is a directory` error when the project tree contained a symlink pointing at a directory (e.g. terragrunt provider-cache symlinks under `infra/`), because `CopyDirectory` followed symlinks via `os.Open` and tried to read the target directory as a file. `CopyDirectory` now recreates symlinks as symlinks rather than dereferencing them, and gains a `CopyDirectoryFiltered` variant accepting a skip predicate. `prepareClientBuildContext` uses it to honor the project's `.dockerignore` (via `moby/patternmatcher`) so excluded paths are not copied into the build context, mirroring the Docker builder while always keeping `Dockerfile.client`, `.dockerignore`, and the client dependency files.

## 🎟 Issue(s)

Fixes #2161

## 🧪 Functional Testing

> Create an Astro project, add an `infra/` directory containing a symlink to a directory (e.g. a terragrunt provider cache), add `infra/` to `.dockerignore`, and run a client deploy. The build context copy should succeed (previously failed with "is a directory"), and `infra/` should be absent from the build context.

## 📸 Screenshots

> N/A
