### PR TITLE
test: make dbt cmd suite hermetic to avoid false "within Astro project" failures

### DIFF
--- a/cmd/cloud/dbt_test.go
+++ b/cmd/cloud/dbt_test.go
@@ -24,10 +24,28 @@ type DbtSuite struct {
 	origV1Client     astrov1.APIClient
 	origDeployBundle func(deployInput *cloud.DeployBundleInput) error
 	origDeleteBundle func(deleteInput *cloud.DeleteBundleInput) error
+	origWorkingPath  string
+	origWd           string
+	tmpWorkingDir    string
 }
 
 func (s *DbtSuite) SetupTest() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	// Run each test from an isolated temp directory that is not within an Astro
+	// project. dbt deploy/delete default the project path to config.WorkingPath
+	// and reject paths nested under an Astro project (detected by walking up the
+	// real filesystem for a .astro/config.yaml). Relying on the package's own
+	// directory makes the suite fail whenever an ancestor of the repo happens to
+	// be an Astro project, so we point WorkingPath/cwd at a clean temp dir.
+	tmpDir, err := os.MkdirTemp("", "dbt-test")
+	s.Require().NoError(err)
+	s.tmpWorkingDir = tmpDir
+	s.origWd, err = os.Getwd()
+	s.Require().NoError(err)
+	s.Require().NoError(os.Chdir(tmpDir))
+	s.origWorkingPath = config.WorkingPath
+	config.WorkingPath = tmpDir
 
 	// the package depends on global variables so we need to manage overriding those
 	s.origV1Client = astroV1Client
@@ -42,6 +60,14 @@ func (s *DbtSuite) TearDownTest() {
 	astroV1Client = s.origV1Client
 	DeployBundle = s.origDeployBundle
 	DeleteBundle = s.origDeleteBundle
+
+	config.WorkingPath = s.origWorkingPath
+	if s.origWd != "" {
+		_ = os.Chdir(s.origWd)
+	}
+	if s.tmpWorkingDir != "" {
+		_ = os.RemoveAll(s.tmpWorkingDir)
+	}
 }
 
 func TestDbt(t *testing.T) {


### PR DESCRIPTION
## Description

`cmd/cloud` `TestDbt` fails in any environment where an ancestor directory of the repo checkout is itself an Astro project.

The dbt deploy/delete commands default the project path to `config.WorkingPath` (the package's own directory) and reject any path nested under an Astro project. That check (`config.IsWithinProjectDir`) walks **up the real filesystem** looking for a `.astro/config.yaml` in any ancestor. So when the checkout lives under a directory that contains `.astro/config.yaml` (e.g. `~/Documents/.astro/config.yaml`), the deploy/delete tests that expect success instead fail with:

```
dbt project is within an Astro project. Use 'astro deploy' to deploy your Astro project
```

This reproduces on `main` and is unrelated to any feature work — it's purely a test-isolation gap.

### Fix
Make the `DbtSuite` hermetic: each test now runs from an isolated temp working directory by overriding `config.WorkingPath` and the process cwd in `SetupTest`, and restoring them (plus removing the temp dir) in `TearDownTest`. This mirrors what `TestDbtDeploy_CustomProjectPath` already does, and also stops the suite from creating `dbt_project.yml` inside the repo tree.

## 🎟 Issue(s)

N/A — test-isolation fix.

## 🧪 Functional Testing

- Before: `go test ./cmd/cloud/ -run TestDbt` fails on a machine where an ancestor of the checkout has `.astro/config.yaml`.
- After: `go test ./cmd/cloud/ -run TestDbt` passes (all 11 subtests), and the full `cmd/cloud` package passes.

## 📸 Screenshots

N/A

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)