### PR TITLE
fix(standalone): unbounded child log pumps + never-empty version

### DIFF
--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -488,12 +488,12 @@ func (s *Standalone) startForeground(cmd *exec.Cmd, waitTime time.Duration, sett
 		close(done)
 	}()
 
-	// Pump child output with io.Copy rather than a line scanner. bufio.Scanner
-	// silently stops at the first line longer than its token limit (64KB by
-	// default, and Airflow can log more than that on a single line). If the
-	// pump goroutine exits while the child lives, the child's 16KB stdout pipe
-	// fills and its next write() blocks forever, wedging the process mid-loop.
-	// io.Copy never stops reading until EOF.
+	// Pump child output with io.Copy rather than a line scanner: bufio.Scanner
+	// silently stops at the first line over its 64KB token limit (Airflow can
+	// log more than that on one line), and a stopped pump lets the child's
+	// stdout pipe fill until its next write() blocks forever. io.Copy reads
+	// until EOF. Copy errors are ignored: output pumping is best-effort and
+	// child failures are surfaced by Wait().
 	var wg sync.WaitGroup
 	wg.Add(2) //nolint:mnd
 	go func() {

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -488,21 +488,21 @@ func (s *Standalone) startForeground(cmd *exec.Cmd, waitTime time.Duration, sett
 		close(done)
 	}()
 
+	// Pump child output with io.Copy rather than a line scanner. bufio.Scanner
+	// silently stops at the first line longer than its token limit (64KB by
+	// default, and Airflow can log more than that on a single line). If the
+	// pump goroutine exits while the child lives, the child's 16KB stdout pipe
+	// fills and its next write() blocks forever, wedging the process mid-loop.
+	// io.Copy never stops reading until EOF.
 	var wg sync.WaitGroup
 	wg.Add(2) //nolint:mnd
 	go func() {
 		defer wg.Done()
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			fmt.Println(scanner.Text())
-		}
+		io.Copy(os.Stdout, stdout) //nolint:errcheck
 	}()
 	go func() {
 		defer wg.Done()
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			fmt.Fprintln(os.Stderr, scanner.Text())
-		}
+		io.Copy(os.Stderr, stderr) //nolint:errcheck
 	}()
 
 	// Run health check in background

--- a/version/version.go
+++ b/version/version.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -15,6 +16,33 @@ import (
 )
 
 var CurrVersion string
+
+const shortSHALen = 7
+
+func init() {
+	if CurrVersion != "" {
+		return
+	}
+	// CurrVersion was not set via -ldflags (e.g. a plain `go build` or
+	// `go install` outside the Makefile). Fall back to metadata embedded by
+	// the Go toolchain so `astro version` never prints an empty version.
+	// The SNAPSHOT prefix keeps CompareVersions treating it as a local build.
+	CurrVersion = "SNAPSHOT"
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		CurrVersion = v
+		return
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" && len(s.Value) >= shortSHALen {
+			CurrVersion = "SNAPSHOT-" + s.Value[:shortSHALen]
+			return
+		}
+	}
+}
 
 const (
 	cliCurrentVersion  = "Astro CLI Version: "


### PR DESCRIPTION
## Summary
Two hardening fixes found while chasing a local scheduler wedge (whose actual root cause turned out to be machine-level kernel pipe-pool exhaustion, not the CLI; details in the commit message):

- **`airflow/standalone.go`**: the foreground-mode child stdout/stderr pumps used `bufio.Scanner`, whose default 64KB token limit makes `Scan()` return false silently on a single long log line. The pump goroutine then exits, the pipe fills, and the child process blocks forever in `write()`. Airflow's scheduler routinely emits very long single-line records (task lists), so this is a real latent wedge. Replaced with `io.Copy`, which never stops reading until EOF
- **`version/version.go`**: builds without the Makefile's `-ldflags` (e.g. plain `go install`) printed an empty string for `astro version`. Added an `init()` fallback chain: module version, then `vcs.revision` short SHA, then `SNAPSHOT`

## Validation
- `go vet` clean
- `./version` and standalone tests pass; the one pre-existing `./airflow` failure (`TestRegistryLogin`, macOS keychain) fails identically on untouched main

🤖 Generated with [Claude Code](https://claude.com/claude-code)