### PR TITLE
fix: Forward host environment to the compose loader so bare env passthrough resolves

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -1641,6 +1641,7 @@ var createDockerProject = func(projectName, airflowHome, envFile, buildImage, se
 	project, err := loader.LoadWithContext(context.Background(), composetypes.ConfigDetails{
 		ConfigFiles: configs,
 		WorkingDir:  airflowHome,
+		Environment: composetypes.NewMapping(os.Environ()),
 	}, loadOptions...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load project")
@@ -1702,6 +1703,7 @@ var createDockerProjectWithPorts = func(projectName, airflowHome, envFile, build
 	project, err := loader.LoadWithContext(context.Background(), composetypes.ConfigDetails{
 		ConfigFiles: configs,
 		WorkingDir:  airflowHome,
+		Environment: composetypes.NewMapping(os.Environ()),
 	}, loadOptions...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load project")

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -2246,6 +2246,18 @@ func (s *Suite) TestCreateDockerProject() {
 		s.Equal("postgres", postgresService.Name)
 		s.Equal("5433", postgresService.Ports[len(prj.Services["postgres"].Ports)-1].Published)
 	})
+
+	s.Run("bare host-env passthrough in an override resolves from the process env", func() {
+		s.T().Setenv("ASTRO_TEST_PASSTHROUGH", "from-host")
+		prev := composeOverrideFilename
+		composeOverrideFilename = "./testfiles/docker-compose.passthrough.override.yml"
+		defer func() { composeOverrideFilename = prev }()
+		prj, err := createDockerProject("test", "", "", "test-image:latest", "", "", labels)
+		s.NoError(err)
+		got := prj.Services["webserver"].Environment["ASTRO_TEST_PASSTHROUGH"]
+		s.Require().NotNil(got)
+		s.Equal("from-host", *got)
+	})
 }
 
 func (s *Suite) TestUpgradeDockerfile() {

--- a/airflow/testfiles/docker-compose.passthrough.override.yml
+++ b/airflow/testfiles/docker-compose.passthrough.override.yml
@@ -1,0 +1,4 @@
+services:
+  webserver:
+    environment:
+      - ASTRO_TEST_PASSTHROUGH


### PR DESCRIPTION
## Description

`astro dev start` in Docker mode builds its Compose project with `loader.LoadWithContext` but leaves `ConfigDetails.Environment` unset. compose-go resolves the bare host-env passthrough form (`environment: [VAR]` or `build.args: [VAR]`, with no value) by looking the variable name up in that project `Environment` mapping (`loader/environment.go` `resolveServicesEnvironment`, and `loader/normalize.go`). That is a separate code path from `${VAR}` interpolation. With the mapping empty, every bare passthrough silently resolves to nothing, which diverges from the plain `docker compose` CLI (it forwards the host environment) and from astro's own standalone mode.

`${VAR}` interpolation was unaffected because it already uses `Interpolate.LookupValue = os.LookupEnv`.

This sets `Environment: composetypes.NewMapping(os.Environ())` on both `ConfigDetails` literals (`createDockerProject` and `createDockerProjectWithPorts`), so bare passthrough resolves to the host value, matching `docker compose`.

**No new leakage surface:** a host variable still reaches a container only when it is explicitly declared in the compose YAML (`environment:` or `env_file:`). Undeclared host vars are never injected. Per Docker's precedence docs, the host environment and `.env` "don't result in a variable in the container by itself, but in conjunction with either the `environment` or `env_file` attribute."

### References (Docker Compose behavior)

- [Environment variables precedence](https://docs.docker.com/compose/how-tos/environment-variables/envvars-precedence/): the host environment populates a container only via the `environment`/`env_file` attributes.
- [Set environment variables](https://docs.docker.com/compose/how-tos/environment-variables/set-environment-variables/): a bare `environment: [VAR]` with no value passes the host variable through, mirroring `docker run -e VAR`.
- [Variable interpolation](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/): `${VAR}` substitution reads the shell environment, a path distinct from the bare passthrough resolved here.

## 🎟 Issue(s)

n/a

## 🧪 Functional Testing

Given a project `docker-compose.override.yml`:
```yaml
services:
  scheduler:
    environment:
      - MY_VAR
```
With `MY_VAR=hello astro dev start`: before this change `$MY_VAR` is empty inside the scheduler container; after, it is `hello`, matching `docker compose up` with the same override. `${VAR}` interpolation is unchanged.

Added a regression subtest (`TestCreateDockerProject`, case "bare host-env passthrough in an override resolves from the process env") with a `testfiles/docker-compose.passthrough.override.yml` fixture. It fails before the change (resolved value is nil) and passes after. No Docker daemon required.

## 📋 Checklist

- [x] Rebased from the main branch (before testing)
- [x] Ran `make test` (full `go test ./...`: 49 packages pass)
- [x] Ran lint and gofmt (`golangci-lint` + `gofmt` clean for this change; no new findings). See note below.
- [x] Added/updated applicable tests
- [ ] Tested against Astro-API (n/a)
- [ ] Tested against Houston-API / Astronomer (n/a)
- [ ] Communicated to/tagged owners of impacted clients (n/a)
- [ ] Updated related documentation (n/a)

> Lint note: `make lint` shells out to a `prek`-pinned `golangci-lint` that could not bootstrap in my local environment (it needs Go >= 1.25, the box has Go 1.24 under `GOTOOLCHAIN=local`), so I ran `golangci-lint` and `gofmt` directly instead. Both are clean for this change; the only reports are pre-existing `goconst` findings on unrelated lines. CI runs the canonical `make lint`.
