### PR TITLE
fix(standalone): auto-detect standalone mode for stop/kill/restart

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -25,6 +25,7 @@ import (
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/houston"
 	"github.com/astronomer/astro-cli/internal/telemetry"
+	"github.com/astronomer/astro-cli/pkg/airflowrt"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
@@ -190,7 +191,10 @@ func newDevRootCmd(astroV1Client astrov1.APIClient) *cobra.Command {
 	return cmd
 }
 
-// resolveDevMode returns "docker" or "standalone" based on flag priority then config.
+// resolveDevMode returns "docker" or "standalone" based on flag priority, then config,
+// then auto-detection. When no flag is set and the config is "docker" (default),
+// we check for a live standalone PID file so that stop/kill/restart work without
+// the user having to re-specify --standalone.
 func resolveDevMode() string {
 	if standaloneFlag {
 		return modeStandalone
@@ -198,7 +202,23 @@ func resolveDevMode() string {
 	if dockerFlag {
 		return "docker"
 	}
-	return config.CFG.DevMode.GetString()
+	mode := config.CFG.DevMode.GetString()
+	if mode != "docker" {
+		return mode
+	}
+	if standaloneIsRunning() {
+		return modeStandalone
+	}
+	return mode
+}
+
+// standaloneIsRunning checks whether a standalone Airflow process is currently
+// alive by reading the PID file. This enables auto-detection of standalone mode
+// so that stop/kill/restart/ps/logs commands work without --standalone.
+func standaloneIsRunning() bool {
+	pidPath := filepath.Join(config.WorkingPath, airflowrt.StandaloneDir, airflowrt.StandalonePIDFile)
+	_, alive := airflowrt.ReadPID(pidPath)
+	return alive
 }
 
 // setDevModeAnnotation writes the resolved dev mode into a cobra annotation
@@ -843,6 +863,12 @@ func airflowStart(cmd *cobra.Command, args []string, astroV1Client astrov1.APICl
 	containerHandler, err := handlerInit(config.WorkingPath, envFile, dockerfile, "")
 	if err != nil {
 		return err
+	}
+
+	if standaloneFlag {
+		fmt.Printf("%s To make standalone mode the default, run: %s\n\n",
+			ansi.Cyan("➤"),
+			ansi.Bold("astro config set -g dev.mode standalone"))
 	}
 
 	buildSecretString = util.GetbuildSecretString(buildSecrets)

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -163,6 +163,7 @@ func newDevRootCmd(astroV1Client astrov1.APIClient) *cobra.Command {
 		// clobber it with a no-op function.
 		PersistentPreRunE: utils.ChainRunEs(
 			SetupLogging,
+			stopStandaloneIfSwitching,
 			ConfigureContainerRuntime,
 			setDevModeAnnotation,
 			telemetry.CreateTrackingHook(),
@@ -219,6 +220,23 @@ func standaloneIsRunning() bool {
 	pidPath := filepath.Join(config.WorkingPath, airflowrt.StandaloneDir, airflowrt.StandalonePIDFile)
 	_, alive := airflowrt.ReadPID(pidPath)
 	return alive
+}
+
+// stopStandaloneIfSwitching stops a running standalone process when the user
+// explicitly passes --docker, preventing a zombie standalone process.
+func stopStandaloneIfSwitching(_ *cobra.Command, _ []string) error {
+	if !dockerFlag || !standaloneIsRunning() {
+		return nil
+	}
+	fmt.Println("Stopping standalone Airflow before switching to Docker mode…")
+	handler, err := localHandlerInit(config.WorkingPath, "", "", "")
+	if err != nil {
+		return fmt.Errorf("could not initialize standalone handler: %w", err)
+	}
+	if err := handler.Stop(false); err != nil {
+		return fmt.Errorf("could not stop standalone Airflow: %w", err)
+	}
+	return nil
 }
 
 // setDevModeAnnotation writes the resolved dev mode into a cobra annotation

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1842,6 +1842,55 @@ func (s *AirflowSuite) TestResolveDevMode() {
 	})
 }
 
+func (s *AirflowSuite) TestStopStandaloneIfSwitching() {
+	s.Run("stops standalone when docker flag is set", func() {
+		dockerFlag = true
+		defer func() { dockerFlag = false }()
+
+		mockHandler := new(mocks.ContainerHandler)
+		mockHandler.On("Stop", false).Return(nil).Once()
+
+		origInit := localHandlerInit
+		localHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
+			return mockHandler, nil
+		}
+		defer func() { localHandlerInit = origInit }()
+
+		// Create a live PID file
+		pidDir := filepath.Join(s.tempDir, airflowrt.StandaloneDir)
+		s.Require().NoError(os.MkdirAll(pidDir, 0o755))
+		pidFile := filepath.Join(pidDir, airflowrt.StandalonePIDFile)
+		s.Require().NoError(os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644))
+		defer os.RemoveAll(filepath.Join(s.tempDir, ".astro"))
+
+		err := stopStandaloneIfSwitching(nil, nil)
+		s.NoError(err)
+		mockHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("no-op when docker flag is not set", func() {
+		dockerFlag = false
+
+		// Create a live PID file — should be ignored
+		pidDir := filepath.Join(s.tempDir, airflowrt.StandaloneDir)
+		s.Require().NoError(os.MkdirAll(pidDir, 0o755))
+		pidFile := filepath.Join(pidDir, airflowrt.StandalonePIDFile)
+		s.Require().NoError(os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644))
+		defer os.RemoveAll(filepath.Join(s.tempDir, ".astro"))
+
+		err := stopStandaloneIfSwitching(nil, nil)
+		s.NoError(err)
+	})
+
+	s.Run("no-op when no standalone process running", func() {
+		dockerFlag = true
+		defer func() { dockerFlag = false }()
+
+		err := stopStandaloneIfSwitching(nil, nil)
+		s.NoError(err)
+	})
+}
+
 func (s *AirflowSuite) TestSetDevModeAnnotation() {
 	s.Run("sets standalone annotation", func() {
 		standaloneFlag = true

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -22,6 +23,7 @@ import (
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	v1Mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/airflowrt"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -1779,6 +1781,64 @@ func (s *AirflowSuite) TestResolveDevMode() {
 		dockerFlag = false
 		// Default config value is "docker"
 		s.Equal("docker", resolveDevMode())
+	})
+
+	s.Run("auto-detects standalone when PID file has live process", func() {
+		standaloneFlag = false
+		dockerFlag = false
+		// Default config is "docker", but a live PID file should auto-detect standalone.
+		pidDir := filepath.Join(s.tempDir, airflowrt.StandaloneDir)
+		s.Require().NoError(os.MkdirAll(pidDir, 0o755))
+		// Use our own PID — it's guaranteed to be alive.
+		pidFile := filepath.Join(pidDir, airflowrt.StandalonePIDFile)
+		s.Require().NoError(os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644))
+		defer os.RemoveAll(filepath.Join(s.tempDir, ".astro"))
+
+		s.Equal("standalone", resolveDevMode())
+	})
+
+	s.Run("no auto-detect when PID file is missing", func() {
+		standaloneFlag = false
+		dockerFlag = false
+		s.Equal("docker", resolveDevMode())
+	})
+
+	s.Run("no auto-detect when PID file has dead process", func() {
+		standaloneFlag = false
+		dockerFlag = false
+		pidDir := filepath.Join(s.tempDir, airflowrt.StandaloneDir)
+		s.Require().NoError(os.MkdirAll(pidDir, 0o755))
+		// PID 99999999 is almost certainly not alive.
+		pidFile := filepath.Join(pidDir, airflowrt.StandalonePIDFile)
+		s.Require().NoError(os.WriteFile(pidFile, []byte("99999999"), 0o644))
+		defer os.RemoveAll(filepath.Join(s.tempDir, ".astro"))
+
+		s.Equal("docker", resolveDevMode())
+	})
+
+	s.Run("docker flag overrides auto-detect", func() {
+		standaloneFlag = false
+		dockerFlag = true
+		defer func() { dockerFlag = false }()
+		// Even with a live PID file, --docker should force docker mode.
+		pidDir := filepath.Join(s.tempDir, airflowrt.StandaloneDir)
+		s.Require().NoError(os.MkdirAll(pidDir, 0o755))
+		pidFile := filepath.Join(pidDir, airflowrt.StandalonePIDFile)
+		s.Require().NoError(os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644))
+		defer os.RemoveAll(filepath.Join(s.tempDir, ".astro"))
+
+		s.Equal("docker", resolveDevMode())
+	})
+
+	s.Run("no auto-detect when config is standalone", func() {
+		standaloneFlag = false
+		dockerFlag = false
+		// When the config explicitly says standalone, use it directly
+		// (no need to check PID).
+		s.Require().NoError(config.CFG.DevMode.SetHomeString("standalone"))
+		defer func() { _ = config.CFG.DevMode.SetHomeString("docker") }()
+
+		s.Equal("standalone", resolveDevMode())
 	})
 }
 


### PR DESCRIPTION
## Summary

Improves how --standalone mode to match expected behavior as follows:
If a user runs astro dev start `--standalone`, they expect `astro dev stop/kill/restart` to just work without having to re-specify `--standalone` for each command. Today, if I attempt to `astro dev kill` on standalone without the argument, nothing happens. From a user standpoint, their "dev" session started in standalone mode; it's normal to expect it to continue in that mode.
This PR switches the default behavior of the commands to account for it by auto-detecting if a standalone process is running.
Also, for `astro dev restart`, it should restart with `--standalone` mode by default for the same reason.

When using the `--standalone` argument, it also informs the user that they can set standalone mode permanently by running `astro config set -g dev.mode standalone`.

Original callout here: https://github.com/astronomer/docs/pull/6820#issuecomment-4711066875

Fixes #2175

- **Auto-detect standalone mode**: `resolveDevMode()` now checks for a live standalone PID file (`.astro/standalone/airflow.pid`) when no explicit `--standalone`/`--docker` flag is set and the config is the default `"docker"`. This means `astro dev stop`, `astro dev kill`, `astro dev restart`, `astro dev ps`, and `astro dev logs` all work automatically after `astro dev start --standalone` — no need to re-specify the flag.
- **Config hint**: When `--standalone` is passed explicitly, a tip is shown suggesting `astro config set -g dev.mode standalone` to make it the default permanently.
- **Mode-switch safety**: When `--docker` is explicitly passed while a standalone process is running, the standalone process is stopped automatically before proceeding. This prevents zombie standalone processes when switching modes.
- **Flag override**: The `--docker` flag still takes priority over auto-detection, so users can force Docker mode even when a standalone process is running.

## How it works

Priority order for mode resolution:
1. `--standalone` flag → standalone
2. `--docker` flag → docker (+ stops any running standalone process)
3. Config `dev.mode` value (if not default "docker") → that value
4. **NEW**: Live standalone PID file detected → standalone
5. Default → docker

## Test plan

- [x] Added test: auto-detects standalone when PID file has a live process
- [x] Added test: no auto-detect when PID file is missing
- [x] Added test: no auto-detect when PID file has a dead process
- [x] Added test: `--docker` flag overrides auto-detection
- [x] Added test: config set to "standalone" skips auto-detection (returns standalone directly)
- [x] Added test: `--docker` stops standalone process when switching modes
- [x] Added test: no-op when `--docker` set but no standalone running
- [x] Added test: no-op when standalone running but `--docker` not set
- [x] All 181 cmd tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)