### PR TITLE
feat(dev): persist build secrets via config to avoid repeating --build-secrets flags

### DIFF
--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -810,7 +810,7 @@ func airflowUpgradeTest(cmd *cobra.Command, astroV1Client astrov1.APIClient) err
 		fmt.Printf("failed to add 'upgrade-test*' to .gitignore: %s", err.Error())
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets)
+	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
 	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, lintDeprecations, lintFix, lintConfigFile, astroV1Client)
 	if err != nil {
@@ -845,7 +845,7 @@ func airflowStart(cmd *cobra.Command, args []string, astroV1Client astrov1.APICl
 		return err
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets)
+	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
 	return containerHandler.Start(&airflow.StartOptions{
 		ImageName:         customImageName,
@@ -1051,7 +1051,7 @@ func airflowRestart(cmd *cobra.Command, args []string, astroV1Client astrov1.API
 		}
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets)
+	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
 	return containerHandler.Start(&airflow.StartOptions{
 		ImageName:         customImageName,
@@ -1105,7 +1105,7 @@ func airflowPytest(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets)
+	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
 	exitCode, err := containerHandler.Pytest(pytestFile, customImageName, "", pytestArgs, buildSecretString)
 	if err != nil {
@@ -1134,7 +1134,7 @@ func airflowParse(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets)
+	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
 	return containerHandler.Parse(customImageName, "", buildSecretString)
 }
@@ -1155,7 +1155,7 @@ func airflowBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets)
+	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
 	return containerHandler.Build(customImageName, buildSecretString, noCache)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,7 @@ var (
 		RemoteBaseImageRegistry: newCfg("remote.base_image_registry", "images.astronomer.cloud"),
 		DeployGitMetadata:       newCfg("deploy.git_metadata", "true"),
 		DevMode:                 newCfg("dev.mode", "docker"),
+		DevBuildSecrets:         newCfg("dev.build_secrets", ""),
 		TelemetryEnabled:        newCfg("telemetry.enabled", "true"),
 		TelemetryAnonymousID:    newCfg("telemetry.anonymous_id", ""),
 		TelemetryNoticeShown:    newCfg("telemetry.notice_shown", ""),

--- a/config/types.go
+++ b/config/types.go
@@ -57,6 +57,7 @@ type cfgs struct {
 	RemoteBaseImageRegistry cfg
 	DeployGitMetadata       cfg
 	DevMode                 cfg
+	DevBuildSecrets         cfg
 	TelemetryEnabled        cfg
 	TelemetryAnonymousID    cfg
 	TelemetryNoticeShown    cfg

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -103,12 +103,20 @@ func ParseAPIToken(astroAPIToken string) (*CustomClaims, error) {
 	return claims, nil
 }
 
-func GetbuildSecretString(buildSecret []string) (buildSecretString string) {
+func GetbuildSecretString(buildSecret []string, fallbacks ...string) (buildSecretString string) {
 	for i, secret := range buildSecret {
 		if i == 0 {
 			buildSecretString = secret
 		} else {
 			buildSecretString = buildSecretString + "," + secret
+		}
+	}
+	if buildSecretString == "" {
+		for _, fb := range fallbacks {
+			if fb != "" {
+				buildSecretString = fb
+				break
+			}
 		}
 	}
 	if os.Getenv("BUILD_SECRET_INPUT") != "" && buildSecretString == "" {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -241,6 +241,22 @@ func (s *Suite) TestGetbuildSecretString() {
 		s.Equal("secret1,secret2,secret3", GetbuildSecretString([]string{"secret1", "secret2", "secret3"}))
 	})
 
+	s.Run("uses fallback when buildSecret is empty and fallback is provided", func() {
+		s.Equal("fallback-secret", GetbuildSecretString([]string{}, "fallback-secret"))
+	})
+
+	s.Run("flag takes priority over fallback", func() {
+		s.Equal("flag-secret", GetbuildSecretString([]string{"flag-secret"}, "fallback-secret"))
+	})
+
+	s.Run("fallback takes priority over BUILD_SECRET_INPUT", func() {
+		originalBuildSecretInput := os.Getenv("BUILD_SECRET_INPUT")
+		defer os.Setenv("BUILD_SECRET_INPUT", originalBuildSecretInput)
+		os.Setenv("BUILD_SECRET_INPUT", "env-secret")
+
+		s.Equal("fallback-secret", GetbuildSecretString([]string{}, "fallback-secret"))
+	})
+
 	s.Run("overrides buildSecretString with BUILD_SECRET_INPUT if set", func() {
 		// Save the original value of BUILD_SECRET_INPUT
 		originalBuildSecretInput := os.Getenv("BUILD_SECRET_INPUT")


### PR DESCRIPTION
> Disclaimer: I do not know Go and relied heavily on Claude for this. I think it's a small enough change that it's conceivable this just works, but please treat this more like a glorified issue than a vetted solution.

## Summary

PR [astronomer/astro-runtime#2974](https://github.com/astronomer/astro-runtime/pull/2974) added support for a `netrc` Docker build secret to enable private pip installs. However, users must pass `--build-secrets id=netrc,env=NETRC_CONTENT` on every `astro dev` invocation (`start`, `restart`, `parse`, `pytest`, `build`, `upgrade-test`).

This PR adds a `dev.build_secrets` config key so the secret can be declared once and picked up automatically:

```bash
# One-time setup (project-scoped):
astro config set dev.build_secrets "id=netrc,env=NETRC_CONTENT"

# Or globally:
astro config set --global dev.build_secrets "id=netrc,env=NETRC_CONTENT"

# Then all dev commands just work without extra flags:
astro dev start
astro dev pytest
astro dev parse
```

**Fallback priority order:**
1. `--build-secrets` flag (explicit, highest priority)
2. `dev.build_secrets` in `.astro/config.yaml` (project config)
3. `dev.build_secrets` in `~/.astro/config.yaml` (global config)
4. `BUILD_SECRET_INPUT` env var (existing undocumented fallback, preserved)

Cloud deploy commands (`astro deploy`, `astro remote deploy`) intentionally do **not** read this config key — secrets for cloud builds should remain explicit.

## Changes

- `config/types.go` — add `DevBuildSecrets cfg` field to the `cfgs` struct
- `config/config.go` — register `dev.build_secrets` config key with empty default
- `pkg/util/util.go` — add variadic `fallbacks ...string` to `GetbuildSecretString` (backwards-compatible; existing callers without a fallback are unaffected)
- `cmd/airflow.go` — pass `config.CFG.DevBuildSecrets.GetString()` as fallback at all 6 `astro dev` call sites

## Test plan

- [ ] `go test ./config/... ./pkg/util/... ./cmd/...` passes (verified locally)
- [ ] `astro config set dev.build_secrets "id=netrc,env=NETRC_CONTENT"` persists to `.astro/config.yaml`
- [ ] `astro dev start` without `--build-secrets` picks up the config value
- [ ] Explicit `--build-secrets` flag overrides the config value
- [ ] `astro deploy` does not pick up the dev config value

🤖 Generated with [Claude Code](https://claude.com/claude-code)