### PR TITLE
fix(airflowrt): strip -slim image variant from runtime base tag

### DIFF
--- a/pkg/airflowrt/dockerfile.go
+++ b/pkg/airflowrt/dockerfile.go
@@ -43,15 +43,25 @@ func ParseDockerfile(projectPath string) (image, tag string, err error) {
 // full image tag. Returns an empty pythonVersion when the tag has no explicit
 // -python-X.Y suffix so the caller can fall back to other sources.
 //
+// Image-variant flavors (-slim, -base) are stripped from the base tag: they
+// identify a Docker base image, not a runtime version. The CDN constraints/
+// freeze files and the runtime index key on the bare version, so leaving the
+// flavor in would 404 the constraints fetch and miss the index lookup.
+//
 //	"3.1-12"                    → base="3.1-12", python=""
 //	"3.1-12-python-3.11"       → base="3.1-12", python="3.11"
 //	"3.1-12-python-3.11-base"  → base="3.1-12", python="3.11"
+//	"13.7.0-slim"              → base="13.7.0", python=""
+//	"13.7.0-slim-python-3.12"  → base="13.7.0", python="3.12"
 func ParseRuntimeTagPython(tag string) (baseTag, pythonVersion string) {
-	loc := RuntimePythonRe.FindStringSubmatchIndex(tag)
-	if loc == nil {
-		return strings.TrimSuffix(tag, "-base"), ""
+	if loc := RuntimePythonRe.FindStringSubmatchIndex(tag); loc != nil {
+		baseTag, pythonVersion = tag[:loc[0]], tag[loc[2]:loc[3]]
+	} else {
+		baseTag = tag
 	}
-	return tag[:loc[0]], tag[loc[2]:loc[3]]
+	baseTag = strings.TrimSuffix(baseTag, "-base")
+	baseTag = strings.TrimSuffix(baseTag, "-slim")
+	return baseTag, pythonVersion
 }
 
 // IsValidRuntimeTag checks if a tag looks like a valid pinned runtime version (X.Y-Z).

--- a/pkg/airflowrt/dockerfile_test.go
+++ b/pkg/airflowrt/dockerfile_test.go
@@ -21,6 +21,9 @@ func TestParseRuntimeTagPython(t *testing.T) {
 		{"3.1-12-base", "3.1-12", ""},
 		{"12.0.0", "12.0.0", ""},
 		{"12.0.0-python-3.12", "12.0.0", "3.12"},
+		{"13.7.0-slim", "13.7.0", ""},
+		{"13.7.0-slim-python-3.12", "13.7.0", "3.12"},
+		{"3.1-12-slim", "3.1-12", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.tag, func(t *testing.T) {


### PR DESCRIPTION
## Problem

Starting an Airflow 2 project whose Dockerfile pins a **slim** runtime image fails in local standalone mode:

```
FROM astrocrpublic.azurecr.io/astronomer/astro-runtime:13.7.0-slim
```

```
level=WARN msg="Astronomer constraints unavailable, using Apache constraints" tag=13.7.0-slim
  error="error fetching constraints from .../runtime-13.7.0-slim-python-3.12.txt: HTTP 404"
```

`ParseRuntimeTagPython` strips a trailing `-base` but **not `-slim`**, so the Docker image variant leaks into the base tag (`baseTag = "13.7.0-slim"`). That breaks startup in two places:

1. **Constraints fetch** builds `runtime-constraints/runtime-13.7.0-slim-python-3.12.txt` → **404** (this is the WARN).
2. **The Apache-constraints fallback then also fails**: the runtime index keys on the bare version (`13.7.0`), so `LookupAirflowVersion("13.7.0-slim")` returns *"runtime tag not found in index"* and the start aborts.

Verified against the live services — the bare version exists everywhere the `-slim` one 404s:

| URL / key | result |
|---|---|
| `runtime-constraints/runtime-13.7.0-slim-python-3.12.txt` | **404** |
| `runtime-constraints/runtime-13.7.0-python-3.12.txt` | **200** |
| `runtime-freeze/runtime-13.7.0-python-3.12.txt` | **200** |
| index key `13.7.0` | present |
| index key `13.7.0-slim` (any `*slim*`) | absent (0 of 205 keys carry a variant suffix) |

## Fix

`-slim`/`-base` identify a Docker base image, not a runtime version. Strip both from the base tag so the CDN constraints/freeze fetch **and** the index lookup resolve against the bare version. This also restores the *Astronomer* constraints path (the tested pin set) instead of silently degrading to the Apache fallback.

Handles `13.7.0-slim`, `13.7.0-slim-python-3.12`, and `3.1-12-slim`.

## Test

Extended `TestParseRuntimeTagPython` with the slim cases; full `pkg/airflowrt` suite green, `gofmt` clean, `golangci-lint` clean on changed files.