### PR TITLE
fix(workspace): honor explicit --workspace-id before requiring current workspace context

### DIFF
--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -844,14 +844,17 @@ func addOrgTokenToWorkspace(cmd *cobra.Command, args []string, out io.Writer) er
 }
 
 func coalesceWorkspace() (string, error) {
-	wsFlag := workspaceID
+	// An explicit --workspace-id flag is authoritative and must win before we
+	// require a current-workspace context. Org-scoped API tokens leave that
+	// context empty (no workspaceId claim), so consulting it first would error
+	// out even when the caller supplied a valid workspace explicitly.
+	if wsFlag := workspaceID; wsFlag != "" {
+		return wsFlag, nil
+	}
+
 	wsCfg, err := workspace.GetCurrentWorkspace()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get current Workspace")
-	}
-
-	if wsFlag != "" {
-		return wsFlag, nil
 	}
 
 	if wsCfg != "" {

--- a/cmd/cloud/workspace_test.go
+++ b/cmd/cloud/workspace_test.go
@@ -13,6 +13,7 @@ import (
 	astrov1 "github.com/astronomer/astro-cli/astro-client-v1"
 	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
 	"github.com/astronomer/astro-cli/cloud/workspace"
+	"github.com/astronomer/astro-cli/config"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -125,4 +126,61 @@ func TestWorkspaceSwitch(t *testing.T) {
 	assert.Contains(t, resp, "workspace-id")
 	assert.Contains(t, resp, "test-workspace")
 	mockClient.AssertExpectations(t)
+}
+
+func TestCoalesceWorkspace(t *testing.T) {
+	// Save and restore the package-level workspaceID flag var so cases don't bleed.
+	origWorkspaceID := workspaceID
+	defer func() { workspaceID = origWorkspaceID }()
+
+	// setCurrentWorkspace mutates the current context's persisted workspace, mirroring
+	// what `astro workspace switch` (non-empty) or a fresh org-token CI home (empty) leave behind.
+	setCurrentWorkspace := func(t *testing.T, ws string) {
+		t.Helper()
+		ctx, err := config.GetCurrentContext()
+		assert.NoError(t, err)
+		ctx.Workspace = ws
+		assert.NoError(t, ctx.SetContext())
+	}
+
+	t.Run("explicit --workspace-id is honored when no current workspace context is set", func(t *testing.T) {
+		// Regression: org-scoped API tokens leave the current-workspace context empty.
+		// coalesceWorkspace must return the explicit flag instead of erroring out.
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		setCurrentWorkspace(t, "")
+		workspaceID = "explicit-workspace-id"
+
+		ws, err := coalesceWorkspace()
+		assert.NoError(t, err)
+		assert.Equal(t, "explicit-workspace-id", ws)
+	})
+
+	t.Run("explicit --workspace-id takes precedence over the current workspace context", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		setCurrentWorkspace(t, "context-workspace-id")
+		workspaceID = "explicit-workspace-id"
+
+		ws, err := coalesceWorkspace()
+		assert.NoError(t, err)
+		assert.Equal(t, "explicit-workspace-id", ws)
+	})
+
+	t.Run("falls back to the current workspace context when no flag is provided", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		setCurrentWorkspace(t, "context-workspace-id")
+		workspaceID = ""
+
+		ws, err := coalesceWorkspace()
+		assert.NoError(t, err)
+		assert.Equal(t, "context-workspace-id", ws)
+	})
+
+	t.Run("errors when neither a flag nor a current workspace context is available", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		setCurrentWorkspace(t, "")
+		workspaceID = ""
+
+		_, err := coalesceWorkspace()
+		assert.Error(t, err)
+	})
 }


### PR DESCRIPTION
## Problem

When authenticating non-interactively with an **organization-scoped** (workspace-operator) API token via `ASTRO_API_TOKEN`, commands like `astro deployment variable update` fail with:

```
Error: failed to find a valid workspace: failed to get current Workspace: current workspace context not set,
you can switch to a workspace with
	astro workspace switch WORKSPACEID
```

Passing `--workspace-id <id>` does **not** prevent the error — the flag is silently ignored on this path.

### Root cause

`coalesceWorkspace()` called `workspace.GetCurrentWorkspace()` first and returned its error *before* ever consulting the `--workspace-id` flag:

```go
wsFlag := workspaceID
wsCfg, err := workspace.GetCurrentWorkspace()   // called first
if err != nil {
    return "", errors.Wrap(err, "failed to get current Workspace")  // returns here — flag never consulted
}
if wsFlag != "" { return wsFlag, nil }           // flag only honored after
```

An org-scoped token has no `workspaceId` claim, so in a fresh CI home `checkAPIToken` leaves `c.Workspace` empty. `GetCurrentWorkspace()` then errors, and because the flag is checked *after*, `--workspace-id` cannot rescue it. This is deterministic given an empty current-workspace context (it only looks intermittent because a prior `astro workspace switch` may have persisted a workspace).

## Fix

Return an explicit `--workspace-id` **before** calling `GetCurrentWorkspace()`, making the flag authoritative in non-interactive flows. This covers every command routed through `coalesceWorkspace` (deployment variable update, deployment objects, worker queues, deploy, dbt, env, inspect) — not just `variable update`.

## Tests

Adds `TestCoalesceWorkspace` covering:
- explicit flag with no current context (**the regression** — fails before this change)
- explicit flag precedence over an existing context
- fallback to the current workspace context when no flag is provided
- error when neither source is available

## Workaround (pre-fix)

`astro workspace switch <id>` first persists `c.Workspace`, after which the command succeeds. Confirmed still valid on affected versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)