### PR TITLE
Fix GHA release job to use correct tag for GA release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,6 +91,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ steps.homebrew-token.outputs.token }}
+          GORELEASER_CURRENT_TAG: ${{ needs.detect.outputs.tag }}
 
   update-godownloader:
     needs: [detect, release]


### PR DESCRIPTION
## Description

We noticed that during release of GA CLI version using github action workflow the tag used by release job was incorrect and hence the job failed to create the release. This PR fixes this issue by supplying the correct tag to the release job.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
