### PR TITLE
Fix release workflow: resolve tag ambiguity, partial-failure recovery and approver context

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,5 +1,7 @@
 name: Create Release Tag
 
+run-name: "${{ inputs.type }} release${{ inputs.version && format(' v{0}', inputs.version) || '' }} from ${{ github.ref_name }} (by @${{ github.actor }})"
+
 on:
   workflow_dispatch:
     inputs:
@@ -22,7 +24,109 @@ permissions:
   id-token: write  # Required for Octo STS OIDC token exchange
 
 jobs:
+  preflight:
+    name: Pre-flight summary (review before approving)
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+      prev_ga: ${{ steps.compute.outputs.prev_ga }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate inputs
+        run: |
+          set -e
+          TYPE="${{ inputs.type }}"
+          VERSION="${{ inputs.version }}"
+          BRANCH="${GITHUB_REF_NAME}"
+
+          if [ "$TYPE" = "nightly" ]; then
+            if [ "$BRANCH" != "main" ]; then
+              echo "::error::Nightly tags must be created from the main branch. Current branch: $BRANCH"
+              exit 1
+            fi
+          else
+            if [[ ! "$BRANCH" =~ ^release-([0-9]+\.[0-9]+)$ ]]; then
+              echo "::error::RC and GA tags must be created from a release-X.Y branch. Current branch: $BRANCH"
+              exit 1
+            fi
+            if [ -z "$VERSION" ]; then
+              echo "::error::VERSION is required for $TYPE releases."
+              exit 1
+            fi
+            BRANCH_MAJOR_MINOR="${BASH_REMATCH[1]}"
+            ESCAPED_MM=$(echo "$BRANCH_MAJOR_MINOR" | sed 's/\./\\./g')
+            if [[ ! "$VERSION" =~ ^${ESCAPED_MM}\.[0-9]+$ ]]; then
+              echo "::error::Version '$VERSION' does not match branch '$BRANCH'. Expected ${BRANCH_MAJOR_MINOR}.Z"
+              exit 1
+            fi
+          fi
+          echo "Validated: type=$TYPE branch=$BRANCH version=$VERSION"
+
+      - name: Compute tag
+        id: compute
+        run: |
+          set -e
+          case "${{ inputs.type }}" in
+            nightly) TAG=$(make nightly-tag) ;;
+            rc)      TAG=$(make rc-tag VERSION=${{ inputs.version }}) ;;
+            ga)      TAG=$(make release-tag VERSION=${{ inputs.version }}) ;;
+          esac
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Computed tag: $TAG"
+
+          PREV_GA=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" \
+            | grep -v -- '-' \
+            | sed 's/^v//' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            | tail -1 \
+            | sed 's/^/v/')
+          echo "prev_ga=$PREV_GA" >> $GITHUB_OUTPUT
+          echo "Previous GA tag: $PREV_GA"
+
+      - name: Write release summary
+        env:
+          TAG: ${{ steps.compute.outputs.tag }}
+          PREV_GA: ${{ steps.compute.outputs.prev_ga }}
+        run: |
+          set -e
+          COMMIT_SHORT=$(git rev-parse --short HEAD)
+          COMMIT_FULL=$(git rev-parse HEAD)
+          REPO_URL="https://github.com/${{ github.repository }}"
+
+          {
+            echo "## Release Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Tag | \`$TAG\` |"
+            echo "| Type | **${{ inputs.type }}** |"
+            echo "| Branch | \`${GITHUB_REF_NAME}\` |"
+            echo "| Commit | [\`$COMMIT_SHORT\`]($REPO_URL/commit/$COMMIT_FULL) |"
+            echo "| Triggered by | @${{ github.actor }} |"
+            if [ "${{ inputs.type }}" = "ga" ]; then
+              echo "| Previous GA | [\`$PREV_GA\`]($REPO_URL/releases/tag/$PREV_GA) |"
+            fi
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${{ inputs.type }}" = "ga" ]; then
+            {
+              echo "### Approver checklist"
+              echo ""
+              echo "- [ ] Latest RC for this version was tested and validated"
+              echo "- [ ] Release branch is at the correct commit"
+              echo "- [ ] No outstanding bug fixes to cherry-pick before GA"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "_Full changelog will be auto-generated on the GitHub release page once the tag is pushed._" >> "$GITHUB_STEP_SUMMARY"
+
   create-tag:
+    needs: preflight
     runs-on: ubuntu-latest
     environment: ${{ inputs.type == 'ga' && 'release' || '' }}
     steps:
@@ -38,64 +142,9 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.sts-token.outputs.token }}
 
-      - name: Validate inputs
-        run: |
-          set -e
-          TYPE="${{ inputs.type }}"
-          VERSION="${{ inputs.version }}"
-          BRANCH="${GITHUB_REF_NAME}"
-
-          if [ "$TYPE" = "nightly" ]; then
-            # Nightlies must be created from main
-            if [ "$BRANCH" != "main" ]; then
-              echo "::error::Nightly tags must be created from the main branch. Current branch: $BRANCH"
-              exit 1
-            fi
-          else
-            # RC and GA must be created from a release-* branch
-            if [[ ! "$BRANCH" =~ ^release-([0-9]+\.[0-9]+)$ ]]; then
-              echo "::error::RC and GA tags must be created from a release-X.Y branch. Current branch: $BRANCH"
-              exit 1
-            fi
-
-            if [ -z "$VERSION" ]; then
-              echo "::error::VERSION is required for $TYPE releases."
-              exit 1
-            fi
-
-            BRANCH_MAJOR_MINOR="${BASH_REMATCH[1]}"
-            ESCAPED_MM=$(echo "$BRANCH_MAJOR_MINOR" | sed 's/\./\\./g')
-            if [[ ! "$VERSION" =~ ^${ESCAPED_MM}\.[0-9]+$ ]]; then
-              echo "::error::Version '$VERSION' does not match branch '$BRANCH'. Expected ${BRANCH_MAJOR_MINOR}.Z"
-              exit 1
-            fi
-          fi
-
-          echo "TYPE=$TYPE" >> $GITHUB_ENV
-          echo "Validated: type=$TYPE branch=$BRANCH version=$VERSION"
-
-      - name: Compute nightly tag
-        if: inputs.type == 'nightly'
-        run: |
-          TAG=$(make nightly-tag)
-          echo "TAG=$TAG" >> $GITHUB_ENV
-          echo "Computed nightly tag: $TAG"
-
-      - name: Compute RC tag
-        if: inputs.type == 'rc'
-        run: |
-          TAG=$(make rc-tag VERSION=${{ inputs.version }})
-          echo "TAG=$TAG" >> $GITHUB_ENV
-          echo "Computed RC tag: $TAG"
-
-      - name: Compute GA tag
-        if: inputs.type == 'ga'
-        run: |
-          TAG=$(make release-tag VERSION=${{ inputs.version }})
-          echo "TAG=$TAG" >> $GITHUB_ENV
-          echo "Computed GA tag: $TAG"
-
       - name: Create and push tag
+        env:
+          TAG: ${{ needs.preflight.outputs.tag }}
         run: |
           set -e
           git config user.name "github-actions[bot]"
@@ -103,10 +152,12 @@ jobs:
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
           echo "Pushed tag: $TAG"
-          echo "## Release Tag Created" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** \`$TAG\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Type:** ${{ inputs.type }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`$GITHUB_REF_NAME\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** \`$(git rev-parse --short HEAD)\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Actor:** @$GITHUB_ACTOR" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Release Tag Created"
+            echo ""
+            echo "**Tag:** \`$TAG\`"
+            echo "**Type:** ${{ inputs.type }}"
+            echo "**Branch:** \`$GITHUB_REF_NAME\`"
+            echo "**Commit:** \`$(git rev-parse --short HEAD)\`"
+            echo "**Actor:** @$GITHUB_ACTOR"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,6 +76,21 @@ jobs:
       - name: Add osxcross to PATH
         run: echo "/tmp/osxcross/target/bin" >> $GITHUB_PATH
 
+      - name: Find previous GA tag for changelog
+        id: prev-tag
+        run: |
+          # Find the latest GA tag (excluding the current tag and any prereleases).
+          # All release types (nightly/RC/GA) compare against the last GA for changelog continuity.
+          PREV_GA=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" \
+            | grep -v -- '-' \
+            | grep -v "^${{ needs.detect.outputs.tag }}$" \
+            | sed 's/^v//' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            | tail -1 \
+            | sed 's/^/v/')
+          echo "tag=$PREV_GA" >> $GITHUB_OUTPUT
+          echo "Previous GA tag for changelog: $PREV_GA"
+
       - name: Get Homebrew token via Octo STS
         if: needs.detect.outputs.type == 'ga'
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
@@ -92,12 +107,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ steps.homebrew-token.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ needs.detect.outputs.tag }}
+          GORELEASER_PREVIOUS_TAG: ${{ steps.prev-tag.outputs.tag }}
 
   update-godownloader:
     needs: [detect, release]
-    if: needs.detect.outputs.type == 'ga'
+    if: always() && !cancelled() && needs.detect.outputs.type == 'ga' && needs.release.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
+      - name: Verify GitHub release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.detect.outputs.tag }}"
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::GitHub release $TAG does not exist. Skipping godownloader update."
+            exit 1
+          fi
+          echo "Release $TAG confirmed."
+
       - name: Get token via Octo STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: godownloader-token
@@ -136,9 +163,21 @@ jobs:
 
   update-winget:
     needs: [detect, release]
-    if: needs.detect.outputs.type == 'ga'
+    if: always() && !cancelled() && needs.detect.outputs.type == 'ga' && needs.release.result != 'skipped'
     runs-on: windows-latest
     steps:
+      - name: Verify GitHub release exists
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.detect.outputs.tag }}"
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::GitHub release $TAG does not exist. Skipping winget update."
+            exit 1
+          fi
+          echo "Release $TAG confirmed."
+
       - name: Get Winget token via Octo STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: winget-token
@@ -188,25 +227,37 @@ jobs:
 
   notify:
     needs: [detect, release, update-godownloader, update-winget]
-    if: always() && needs.detect.outputs.type == 'ga' && needs.release.result == 'success'
+    if: always() && !cancelled() && needs.detect.outputs.type == 'ga' && needs.release.result != 'skipped'
     runs-on: ubuntu-latest
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
+      - name: Verify GitHub release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.detect.outputs.tag }}"
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::GitHub release $TAG does not exist. Skipping notification."
+            exit 1
+          fi
+          echo "Release $TAG confirmed."
+
       - name: Post release summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ needs.detect.outputs.version }}"
 
+          RELEASE_STATUS="${{ needs.release.result }}"
           GODOWNLOADER_STATUS="${{ needs.update-godownloader.result }}"
           WINGET_STATUS="${{ needs.update-winget.result }}"
 
           SUMMARY="## Post-Release Automation Summary"$'\n\n'
           SUMMARY+="| Task | Status |"$'\n'
           SUMMARY+="|------|--------|"$'\n'
+          SUMMARY+="| GoReleaser (binaries + Homebrew PR) | ${RELEASE_STATUS} |"$'\n'
           SUMMARY+="| Godownloader PR | ${GODOWNLOADER_STATUS} |"$'\n'
-          SUMMARY+="| Homebrew Tap PR | Handled by GoReleaser |"$'\n'
           SUMMARY+="| Winget PR | ${WINGET_STATUS} |"
 
           # Get the release ID by tag, then append the summary to the release body

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,7 +79,7 @@ brews:
       owner: astronomer
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-      branch: "bump-astro-{{ .Version }}"
+      branch: "bump-astro-versioned-{{ .Version }}"
       pull_request:
         enabled: true
         base:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,6 +57,7 @@ brews:
       owner: astronomer
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      branch: "bump-astro-{{ .Version }}"
       pull_request:
         enabled: true
         base:
@@ -78,6 +79,7 @@ brews:
       owner: astronomer
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      branch: "bump-astro-{{ .Version }}"
       pull_request:
         enabled: true
         base:


### PR DESCRIPTION
## Description

- **Tag ambiguity** — GoReleaser was picking the wrong tag (e.g., `v1.43.0-rc.2` when releasing `v1.43.0`) because GA and the latest RC share a commit by design. Now sets `GORELEASER_CURRENT_TAG` and `GORELEASER_PREVIOUS_TAG` explicitly so the changelog always compares against the last GA.
 - **Homebrew tap PR pushed to protected `main`** — added `branch: "bump-astro-{{ .Version }}"` under `repository` so GoReleaser pushes to a feature branch and opens a PR.
 - **Partial-failure recovery** — when the `release` job failed after creating the GitHub release (e.g., brew step), all downstream PRs (godownloader, winget, notify) were silently skipped. Updated their `if:` conditions and added a `Verify GitHub release exists` step so they continue when the release actually made it.
 - **Approver context** — `create-release.yaml` now has a dynamic `run-name` and a pre-flight job that writes a release summary (tag, commit, branch, previous GA, approver checklist) before the environment gate. GA approvers can read full context before clicking approve. 

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
