### PR TITLE
Honor `--workspace-id` before requiring a current workspace context

### DIFF
--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -844,8 +844,7 @@ func addOrgTokenToWorkspace(cmd *cobra.Command, args []string, out io.Writer) er
 }
 
 func coalesceWorkspace() (string, error) {
-	// An explicit --workspace-id takes precedence and must be honored even when
-	// there is no current workspace context (e.g. an org-scoped API token in CI).
+	// An explicit --workspace-id takes precedence/honored even when there is no current workspace context
 	if wsFlag := workspaceID; wsFlag != "" {
 		return wsFlag, nil
 	}

--- a/cmd/cloud/workspace.go
+++ b/cmd/cloud/workspace.go
@@ -844,14 +844,15 @@ func addOrgTokenToWorkspace(cmd *cobra.Command, args []string, out io.Writer) er
 }
 
 func coalesceWorkspace() (string, error) {
-	wsFlag := workspaceID
+	// An explicit --workspace-id takes precedence and must be honored even when
+	// there is no current workspace context (e.g. an org-scoped API token in CI).
+	if wsFlag := workspaceID; wsFlag != "" {
+		return wsFlag, nil
+	}
+
 	wsCfg, err := workspace.GetCurrentWorkspace()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get current Workspace")
-	}
-
-	if wsFlag != "" {
-		return wsFlag, nil
 	}
 
 	if wsCfg != "" {

--- a/cmd/cloud/workspace_test.go
+++ b/cmd/cloud/workspace_test.go
@@ -13,6 +13,7 @@ import (
 	astrov1 "github.com/astronomer/astro-cli/astro-client-v1"
 	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
 	"github.com/astronomer/astro-cli/cloud/workspace"
+	"github.com/astronomer/astro-cli/config"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -24,6 +25,51 @@ func execWorkspaceCmd(args ...string) (string, error) {
 	testUtil.SetupOSArgsForGinkgo()
 	_, err := cmd.ExecuteC()
 	return buf.String(), err
+}
+
+func TestCoalesceWorkspace(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	origWorkspaceID := workspaceID
+	defer func() { workspaceID = origWorkspaceID }()
+
+	setWorkspaceContext := func(ws string) {
+		c, err := config.GetCurrentContext()
+		assert.NoError(t, err)
+		assert.NoError(t, c.SetContextKey("workspace", ws))
+	}
+
+	t.Run("honors --workspace-id flag when no current workspace context", func(t *testing.T) {
+		setWorkspaceContext("")
+		workspaceID = "flag-ws-id"
+		ws, err := coalesceWorkspace()
+		assert.NoError(t, err)
+		assert.Equal(t, "flag-ws-id", ws)
+	})
+
+	t.Run("honors --workspace-id flag over current workspace context", func(t *testing.T) {
+		setWorkspaceContext("ctx-ws-id")
+		workspaceID = "flag-ws-id"
+		ws, err := coalesceWorkspace()
+		assert.NoError(t, err)
+		assert.Equal(t, "flag-ws-id", ws)
+	})
+
+	t.Run("falls back to current workspace context when no flag", func(t *testing.T) {
+		setWorkspaceContext("ctx-ws-id")
+		workspaceID = ""
+		ws, err := coalesceWorkspace()
+		assert.NoError(t, err)
+		assert.Equal(t, "ctx-ws-id", ws)
+	})
+
+	t.Run("errors when no flag and no current workspace context", func(t *testing.T) {
+		setWorkspaceContext("")
+		workspaceID = ""
+		_, err := coalesceWorkspace()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "current workspace context not set")
+	})
 }
 
 func TestWorkspaceRootCommand(t *testing.T) {


### PR DESCRIPTION
## Description

  `--workspace-id` is now authoritative, it short-circuits the context lookup rather than acting as a fallback. When no flag is passed, behavior is unchanged: fall back to the current workspace context, then error.


## 🎟 Issue(s)

Closes [#2181](https://github.com/astronomer/astro-cli/issues/2181)

## 🧪 Functional Testing

```
astro-cli % astro deployment variable update --deployment-id cmqmREDACTEDoqomydhwho --workspace-id cmqmREDACTEDoqomydhwho --key TESTVAR --value updatedval  
Using an Astro API Token
Error: failed to find a valid workspace: failed to get current Workspace: current workspace context not set, you can switch to a workspace with 
	astro workspace switch WORKSPACEID
Usage:
  astro deployment variable update [key1=update_val1 key2=update_val2] [flags]

Examples:

		# Update a deployment variable
		$ astro deployment variable update FOO=NEWBAR FOO2=NEWBAR2 --deployment-id <deployment-id> --secret
		# Update a deployment variables from a file
		$ astro deployment variable update --deployment-id <deployment-id> --load --env .env.my-deployment
		

Flags:
  -d, --deployment-id string     Deployment assigned to variables. Run 'astro deployment list' to find valid IDs
  -n, --deployment-name string   Name of the deployment to update variables from
  -e, --env string               Location of file to load environment variables to update from (default ".env")
  -h, --help                     help for update
  -l, --load                     Update environment variables loaded from an environment file
  -s, --secret                   Set updated environment variables as secrets

Global Flags:
      --verbosity string      Log level (debug, info, warn, error, fatal, panic (default "warning")
      --workspace-id string   workspace assigned to deployment

After fix:

./astro deployment variable update --deployment-id cmqmREDACTEDoqomydhwho --workspace-id cmqmREDACTEDoqomydhwho --key TESTVAR --value updatedval
Using an Astro API Token
updating variable TESTVAR 

Updated list of your Deployment's variables:
 #     KEY         VALUE          SECRET     
 1     TESTVAR     updatedval     false      
 
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
