### PR TITLE
PLX-575: Deprecate hard delete flag from APC

### DIFF
--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -17,7 +17,7 @@ const (
 	kubernetesExecutorArg = "kubernetes"
 	k8sExecutorArg        = "k8s"
 
-	cliDeploymentHardDeletePrompt              = "\nWarning: This action permanently deletes all data associated with this Deployment, including the database. You will not be able to recover it. Proceed with hard delete?"
+	cliDeploymentHardDeletePrompt              = "\nWarning: This action permanently deletes all data associated with this Deployment, including the database. You will not be able to recover it. Proceed with delete?"
 	deploymentTypeCmdMessage                   = "DAG Deployment mechanism: image, volume, git_sync, dag_deploy"
 	continueSubMsg                             = " for more details. Do you want to continue?"
 	CreateDeploymentWithTypeDagDeployPromptMsg = "\nthis is an experimental feature. Please use with caution. See the Software documentation at " + houston.DagDeployDocsLink + continueSubMsg

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -224,9 +224,11 @@ func newDeploymentDeleteCmd(out io.Writer) *cobra.Command {
 			return deploymentDelete(cmd, args, out)
 		},
 	}
-	if appConfig != nil && appConfig.Flags.HardDeleteDeployment {
-		cmd.Flags().BoolVar(&hardDelete, "hard", false, "Deletes all infrastructure and records for this Deployment")
-	}
+	// Deprecated (PLX-575): deletions are always hard deletes now, so --hard is a
+	// no-op. It is kept (hidden + deprecation notice) so existing scripts that
+	// pass --hard keep working; remove it in a future major release.
+	cmd.Flags().BoolVar(&hardDelete, "hard", false, "Deprecated: deletions always remove all infrastructure and records for the Deployment")
+	_ = cmd.Flags().MarkDeprecated("hard", "deletions are always hard deletes; the --hard flag no longer has any effect")
 	return cmd
 }
 
@@ -484,15 +486,15 @@ func deploymentCreate(cmd *cobra.Command, out io.Writer) error {
 func deploymentDelete(cmd *cobra.Command, args []string, out io.Writer) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
-	if hardDelete {
-		i, _ := input.Confirm(cliDeploymentHardDeletePrompt)
-
-		if !i {
-			fmt.Println("Exit: This command was not executed and your Deployment was not hard deleted.\n If you want to delete your Deployment but not permanently, try\n $ astro deployment delete without the --hard flag.")
-			return nil
-		}
+	// Deletions are always hard deletes now (PLX-575): all data associated with
+	// the Deployment, including the database, is permanently removed. Confirm
+	// before proceeding.
+	i, _ := input.Confirm(cliDeploymentHardDeletePrompt)
+	if !i {
+		fmt.Println("Exit: This command was not executed and your Deployment was not deleted.")
+		return nil
 	}
-	return deployment.Delete(args[0], hardDelete, houstonClient, out)
+	return deployment.Delete(args[0], true, houstonClient, out)
 }
 
 func deploymentList(cmd *cobra.Command, out io.Writer) error {

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -905,8 +905,21 @@ func (s *Suite) TestDeploymentDelete() {
 
 	api := new(mocks.ClientInterface)
 	api.On("GetAppConfig", mock.Anything).Return(mockAppConfig, nil)
-	api.On("DeleteDeployment", houston.DeleteDeploymentRequest{DeploymentID: mockDeployment.ID, HardDelete: false}).Return(mockDeployment, nil)
+	// Deletions are always hard deletes now (PLX-575).
+	api.On("DeleteDeployment", houston.DeleteDeploymentRequest{DeploymentID: mockDeployment.ID, HardDelete: true}).Return(mockDeployment, nil)
 	api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
+
+	// Delete now always prompts for confirmation; answer "y".
+	input := []byte("y")
+	r, w, err := os.Pipe()
+	s.Require().NoError(err)
+	_, err = w.Write(input)
+	s.NoError(err)
+	w.Close()
+	stdin := os.Stdin
+	defer func() { os.Stdin = stdin }()
+	os.Stdin = r
+
 	houstonClient = api
 	output, err := execDeploymentCmd("delete", mockDeployment.ID)
 	s.NoError(err)


### PR DESCRIPTION
## Description

Deprecate hard delete flag from APC. We now default to hard delete so this flag is not needed. Will be removed in future versions.

## 🎟 Issue(s)

Resolves [PLX-575](https://linear.app/astronomer/issue/PLX-575/remove-soft-delete-and-default-to-hard-delete-in-apc)

## 🧪 Functional Testing

- Unit tests

## 📸 Screenshots

NA

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
