### PR TITLE
Fix astro deployment update command for kubernetes based deployment by omitting worker queues.

### DIFF
--- a/cloud/deployment/fromfile/fromfile.go
+++ b/cloud/deployment/fromfile/fromfile.go
@@ -590,11 +590,14 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				DefaultTaskPodMemory: defaultTaskPodMemory,
 				ResourceQuotaCpu:     resourceQuotaCPU,
 				ResourceQuotaMemory:  resourceQuotaMemory,
-				WorkerQueues:         new(deployment.ConvertCreateQueuesToUpdate(listQueuesRequest)),
 				SchedulerSize:        schedulerSize,
 				ContactEmails:        &deploymentFromFile.Deployment.AlertEmails,
 				EnvironmentVariables: envVars,
 				WorkloadIdentity:     deplWorkloadIdentity,
+			}
+			if len(listQueuesRequest) > 0 {
+				updateQueues := deployment.ConvertCreateQueuesToUpdate(listQueuesRequest)
+				standardDeploymentRequest.WorkerQueues = &updateQueues
 			}
 			if existingDeployment.IsDevelopmentMode != nil && *existingDeployment.IsDevelopmentMode {
 				hibernationSchedules := ToDeploymentHibernationSchedules(deploymentFromFile.Deployment.HibernationSchedules)
@@ -650,12 +653,15 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				DefaultTaskPodMemory: defaultTaskPodMemory,
 				ResourceQuotaCpu:     resourceQuotaCPU,
 				ResourceQuotaMemory:  resourceQuotaMemory,
-				WorkerQueues:         new(deployment.ConvertCreateQueuesToUpdate(listQueuesRequest)),
 				SchedulerSize:        schedulerSize,
 				ContactEmails:        &deploymentFromFile.Deployment.AlertEmails,
 				EnvironmentVariables: envVars,
 				WorkloadIdentity:     deplWorkloadIdentity,
 				RemoteExecution:      remoteExecution,
+			}
+			if len(listQueuesRequest) > 0 {
+				updateQueues := deployment.ConvertCreateQueuesToUpdate(listQueuesRequest)
+				dedicatedDeploymentRequest.WorkerQueues = &updateQueues
 			}
 			if existingDeployment.IsDevelopmentMode != nil && *existingDeployment.IsDevelopmentMode {
 				hibernationSchedules := ToDeploymentHibernationSchedules(deploymentFromFile.Deployment.HibernationSchedules)
@@ -693,8 +699,11 @@ func createOrUpdateDeployment(deploymentFromFile *inspect.FormattedDeployment, c
 				Type:                 astrov1.UpdateHybridDeploymentRequestTypeHYBRID,
 				ContactEmails:        &deploymentFromFile.Deployment.AlertEmails,
 				EnvironmentVariables: envVars,
-				WorkerQueues:         new(deployment.ConvertHybridQueuesToUpdate(listHybridQueuesRequest)),
 				WorkloadIdentity:     &deploymentFromFile.Deployment.Configuration.WorkloadIdentity,
+			}
+			if len(listHybridQueuesRequest) > 0 {
+				updateQueues := deployment.ConvertHybridQueuesToUpdate(listHybridQueuesRequest)
+				hybridDeploymentRequest.WorkerQueues = &updateQueues
 			}
 			if requestedExecutor == astrov1.UpdateHybridDeploymentRequestExecutorKUBERNETES {
 				taskPodNodePoolID, err := getNodePoolIDFromWorkerType(deploymentFromFile.Deployment.Configuration.DefaultWorkerType, deploymentFromFile.Deployment.Configuration.ClusterName, nodePools)


### PR DESCRIPTION
## Description

- This PR changes fixes an issue with `astro deployment update` command where`astro deployment update --deployment-file` fails on Kubernetes-executor deployments with: `Invalid field values: field workerQueues failed check on length; workerQueues should be min: 1; field workerQueues failed check on workerQueuesExcludedForKubernetes`
- There was a regression where current code let the update path unconditionally set `WorkerQueues: new(deployment.ConvertCreateQueuesToUpdate (listQueuesRequest))`, sending `worker_queues: []` on the wire even when no queues were requested. The v1 API rejects both empty arrays (`min: 1`) and any worker-queue payload for Kubernetes executors (`workerQueuesExcludedForKubernetes`).
- Now assign `WorkerQueues` only when the queue slice is non-empty, mirroring the create-path guard already in the same file and the `updateWorkerQueuesForExecutor` helper used by the direct `astro deployment update` command.
- Applied consistently to all three update request shapes: `UpdateStandardDeploymentRequest`, `UpdateDedicatedDeploymentRequest`, `UpdateHybridDeploymentRequest`.


## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Tested these changes locally:

Before:

Deployment file:

```
deployment:
    configuration:
        name: pritt-test
        description: ""
        runtime_version: 3.2-5
        dag_deploy_enabled: true
        ci_cd_enforcement: false
        scheduler_size: SMALL
        is_high_availability: false
        is_development_mode: true
        executor: KUBERNETES
        scheduler_au: 5
        scheduler_count: 1
        workspace_name: pritt-test
        deployment_type: STANDARD
        cloud_provider: AZURE
        region: eastus2
        default_task_pod_cpu: "0.25"
        default_task_pod_memory: 0.5Gi
        resource_quota_cpu: "10"
        resource_quota_memory: 20Gi
        workload_identity: ""
    worker_queues: []
    alert_emails:
        - pritesh@astronomer.io
    hibernation_schedules:
        - hibernate_at: 0 17 * * 1,2,3,4,5
          wake_at: 0 9 * * 1,2,3,4,5
          description: work_day_hours_07_01_2026
          enabled: true
```

```
astro deployment update cmr29s00r00mk01ne518v8t94 --deployment-file pritt-test.yaml

Error: Invalid field values: field workerQueues failed check on length; workerQueues should be min: 1;,field workerQueues failed check on workerQueuesExcludedForKubernetes;
```

After the change:

```
astro deployment update cmr29s00r00mk01ne518v8t94 --deployment-file pritt-test.yaml
deployment:
    configuration:
        name: pritt-test
        description: ""
        runtime_version: 3.2-5
        dag_deploy_enabled: false
        ci_cd_enforcement: false
        scheduler_size: SMALL
        is_high_availability: false
        is_development_mode: true
        executor: KUBERNETES
        scheduler_au: 5
        scheduler_count: 1
        workspace_name: pritt-test
        deployment_type: STANDARD
        cloud_provider: AZURE
        region: eastus2
        default_task_pod_cpu: "0.25"
        default_task_pod_memory: 0.5Gi
        resource_quota_cpu: "10"
        resource_quota_memory: 20Gi
        workload_identity: ""
    worker_queues: []
    metadata:
        deployment_id: cmr29s00r00mk01ne518v8t94
        workspace_id: cmaqtfqdg027401l16aaxp909
        cluster_id: N/A
        release_name: N/A
        airflow_version: 3.2.2
        current_tag: 3.2-5
        status: HEALTHY
        created_at: 2026-07-01T16:08:08.568Z
        updated_at: 2026-07-01T16:34:29.86Z
        deployment_url: cloud.astronomer-dev.io/cmaqtfqdg027401l16aaxp909/deployments/cmr29s00r00mk01ne518v8t94
        webserver_url: cmr29s00r00mk01ne518v8t94.94.astronomer-dev.run/d18v8t94
        airflow_api_url: cmr29s00r00mk01ne518v8t94.94.astronomer-dev.run/d18v8t94/api/v2
    alert_emails:
        - pritesh@astronomer.io
    hibernation_schedules:
        - hibernate_at: 0 17 * * 1,2,3,4,5
          wake_at: 0 9 * * 1,2,3,4,5
          description: work_day_hours_07_01_2026
          enabled: true
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
