### PR TITLE
Fix: Show AF2 login hint on start for standalone mode

### DIFF
--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -225,6 +225,23 @@ func (s *Standalone) logFilePath() string {
 	return filepath.Join(s.airflowHome, standaloneDir, standaloneLogFile)
 }
 
+// printLoginHint prints a hint about the default Airflow UI credentials.
+// AF2 requires FAB auth: on macOS we seed admin/admin, and on other
+// platforms `airflow standalone` generates a random password into
+// standalone_admin_password.txt under $AIRFLOW_HOME. AF3 uses the simple auth
+// manager (any username is admin), so no hint is needed.
+func (s *Standalone) printLoginHint(bullet string) {
+	if s.airflowMajorVersion != "2" {
+		return
+	}
+	if runtime.GOOS == osDarwin {
+		fmt.Printf("%sLogin:      %s\n", bullet, ansi.Bold("admin / admin"))
+		return
+	}
+	passwordFile := filepath.Join(standaloneDir, "standalone_admin_password.txt")
+	fmt.Printf("%sLogin:      username %s, password in %s\n", bullet, ansi.Bold("admin"), ansi.Bold(passwordFile))
+}
+
 // Start runs airflow standalone locally without Docker.
 //
 //nolint:gocognit,gocyclo
@@ -527,6 +544,7 @@ func (s *Standalone) startForeground(cmd *exec.Cmd, waitTime time.Duration, sett
 
 		fmt.Println("\n" + ansi.Green("\u2714") + " Airflow is ready!")
 		fmt.Printf("%sAirflow UI: %s\n", bullet, ansi.Bold(uiURL))
+		s.printLoginHint(bullet)
 		fmt.Println()
 
 		if !(s.noBrowser || util.CheckEnvBool(os.Getenv("ASTRONOMER_NO_BROWSER"))) {
@@ -608,6 +626,7 @@ func (s *Standalone) startBackground(cmd *exec.Cmd, waitTime time.Duration, sett
 	fmt.Printf("%sAirflow UI: %s\n", bullet, ansi.Bold(uiURL))
 	fmt.Printf("%sView logs: %s\n", bullet, ansi.Bold("astro dev logs -f"))
 	fmt.Printf("%sStop:      %s\n", bullet, ansi.Bold("astro dev stop"))
+	s.printLoginHint(bullet)
 
 	if !(s.noBrowser || util.CheckEnvBool(os.Getenv("ASTRONOMER_NO_BROWSER"))) {
 		if err := standaloneOpenURL(uiURL); err != nil {


### PR DESCRIPTION
## Description

- Fixes a UX gap on Linux/WSL where `astro dev start` (standalone mode) reports "Airflow is ready!" but never tells the user how to log in. AF2 uses FAB auth, and on Linux upstream `airflow standalone` generates a random admin password into `$AIRFLOW_HOME/standalone_admin_password.txt` — users hit the login screen, guess `admin/admin`, and get "Invalid login."
- Adds `printLoginHint()` to the standalone startup output. Prints:
    - **AF2 macOS** → `Login: admin / admin` (matches the Darwin shim's seeded credentials)
    - **AF2 Linux/WSL** → `Login: username admin, password in .astro/standalone/standalone_admin_password.txt`
    - **AF3** → nothing (Simple Auth Manager accepts any username, no hint needed)
- Wired into both `startForeground` and `startBackground` paths so the hint appears whether the user runs with or without `-f`.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

Tested locally on both MacOS and Linux:

- Linux

```
astro dev start --standalone
Note: Standalone mode is experimental. Report issues at https://github.com/astronomer/astro-cli/issues

✔ Environment ready

Starting Airflow in standalone mode…

✔ Airflow is ready! (PID 90711)
➤ Airflow UI: http://af2.localhost:6563/
➤ View logs: astro dev logs -f
➤ Stop:      astro dev stop
➤ Login:      username admin, password in .astro/standalone/standalone_admin_password.txt
```

- MacOS

```
astro dev start --standalone
Note: Standalone mode is experimental. Report issues at https://github.com/astronomer/astro-cli/issues

✔ Environment ready

Starting Airflow in standalone mode…

✔ Airflow is ready! (PID 75754)
➤ Airflow UI: http://af2.localhost:6563
➤ View logs: astro dev logs -f
➤ Stop:      astro dev stop
➤ Login:      admin / admin
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
