### PR TITLE
Add `astro deploy --include` to deploy include/ without an image build (PM-1577)

### DIFF
--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -2,6 +2,8 @@ package cloud
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -21,6 +23,7 @@ var (
 	pytest            bool
 	parse             bool
 	dags              bool
+	includeBundle     bool
 	waitForDeploy     bool
 	waitTime          time.Duration
 	image             bool
@@ -52,6 +55,10 @@ const (
 	deployWaitTime = 300 * time.Second
 
 	imageNameFlag = "image-name"
+
+	includeDirName    = "include"
+	includeMountPath  = "/usr/local/airflow/include"
+	includeBundleType = "include"
 )
 
 func NewDeployCmd() *cobra.Command {
@@ -78,6 +85,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&pytestFile, "test", "t", "", "Location of Pytests or specific Pytest file. All Pytest files must be located in the tests directory")
 	cmd.Flags().StringVarP(&imageName, imageNameFlag, "i", "", "Name of a custom image to deploy, or image name with custom tag when used with --client")
 	cmd.Flags().BoolVarP(&dags, "dags", "d", false, "Push only DAGs to your Astro Deployment")
+	cmd.Flags().BoolVar(&includeBundle, "include", false, "Push only the include/ directory to your Astro Deployment as a bundle, without an image build")
 	cmd.Flags().BoolVar(&noDagsBaseDir, "no-dags-base-dir", false, "Exclude the dags directory prefix from the bundle. Use for Airflow 3.x deployments where sys.path includes the bundle root")
 	cmd.Flags().BoolVarP(&image, "image", "", false, "Push only an image to your Astro Deployment. If you have DAG Deploy enabled your DAGs will not be affected.")
 	cmd.Flags().StringVar(&dagsPath, "dags-path", "", "If set deploy dags from this path instead of the dags from working directory")
@@ -115,6 +123,17 @@ func deploy(cmd *cobra.Command, args []string) error {
 	// Get deploymentId from args, if passed
 	if len(args) > 0 {
 		deploymentID = args[0]
+	}
+
+	// astro deploy --include: bundle-deploy the include/ directory only, no image build.
+	// Routes through the same non-DAG bundle flow used by 'astro dbt deploy'.
+	if includeBundle {
+		for _, f := range []string{"dags", "image", imageNameFlag, "dags-path"} {
+			if cmd.Flags().Changed(f) {
+				return fmt.Errorf("cannot use --%s with --include", f)
+			}
+		}
+		return deployInclude(cmd, args)
 	}
 
 	if cmd.Flags().Changed("wait-time") && !waitForDeploy {
@@ -187,4 +206,48 @@ func deploy(cmd *cobra.Command, args []string) error {
 	}
 
 	return DeployImage(deployInput, astroV1Client)
+}
+
+// deployInclude bundle-deploys the project's include/ directory to
+// /usr/local/airflow/include, so shared utility code can be updated without a
+// full image build. It reuses the non-DAG bundle flow (see 'astro dbt deploy').
+func deployInclude(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
+	// The include/ directory lives inside the Astro project, unlike dbt projects.
+	includePath := filepath.Join(config.WorkingPath, includeDirName)
+	if info, err := os.Stat(includePath); err != nil || !info.IsDir() {
+		return fmt.Errorf("include directory not found at %s. Run this command from the root of your Astro project", includePath)
+	}
+
+	// if the workspace ID is not provided, try to find a valid workspace
+	if workspaceID == "" {
+		var err error
+		workspaceID, err = coalesceWorkspace()
+		if err != nil {
+			return errors.Wrap(err, "failed to find a valid workspace")
+		}
+	}
+
+	if cmd.Flags().Changed("wait-time") && !waitForDeploy {
+		return errors.New("cannot use --wait-time with --wait=false")
+	}
+
+	deploymentID, err := resolveDeploymentIDFromDbtArgsFlags(args, workspaceID, deploymentName)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Initiating include deploy for deployment ID: " + deploymentID)
+
+	deployBundleInput := &cloud.DeployBundleInput{
+		BundlePath:    includePath,
+		MountPath:     includeMountPath,
+		DeploymentID:  deploymentID,
+		BundleType:    includeBundleType,
+		Description:   deployDescription,
+		Wait:          waitForDeploy,
+		WaitTime:      waitTime,
+		AstroV1Client: astroV1Client,
+	}
+	return DeployBundle(deployBundleInput)
 }

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -1,6 +1,8 @@
 package cloud
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	cloud "github.com/astronomer/astro-cli/cloud/deploy"
+	"github.com/astronomer/astro-cli/config"
 	testUtil "github.com/astronomer/astro-cli/pkg/testing"
 )
 
@@ -65,6 +68,85 @@ func TestDeployImage(t *testing.T) {
 
 	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--parse", "--pytest")
 	assert.NoError(t, err)
+}
+
+func TestDeployInclude(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
+
+	// Isolated project dir containing an include/ directory.
+	projectDir, err := os.MkdirTemp("", "include-deploy")
+	assert.NoError(t, err)
+	defer os.RemoveAll(projectDir)
+	assert.NoError(t, os.Mkdir(filepath.Join(projectDir, includeDirName), 0o755))
+
+	origWorkingPath := config.WorkingPath
+	config.WorkingPath = projectDir
+	defer func() { config.WorkingPath = origWorkingPath }()
+
+	origDeployBundle := DeployBundle
+	defer func() { DeployBundle = origDeployBundle }()
+
+	var captured *cloud.DeployBundleInput
+	DeployBundle = func(deployInput *cloud.DeployBundleInput) error {
+		captured = deployInput
+		return nil
+	}
+
+	err = execDeployCmd("test-deployment-id", "--include", "--workspace-id", "test-ws")
+	assert.NoError(t, err)
+	if assert.NotNil(t, captured) {
+		assert.Equal(t, includeBundleType, captured.BundleType)
+		assert.Equal(t, includeMountPath, captured.MountPath)
+		assert.Equal(t, filepath.Join(projectDir, includeDirName), captured.BundlePath)
+		assert.Equal(t, "test-deployment-id", captured.DeploymentID)
+	}
+}
+
+func TestDeployIncludeMissingDir(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
+
+	// Project dir without an include/ directory.
+	projectDir, err := os.MkdirTemp("", "include-deploy-missing")
+	assert.NoError(t, err)
+	defer os.RemoveAll(projectDir)
+
+	origWorkingPath := config.WorkingPath
+	config.WorkingPath = projectDir
+	defer func() { config.WorkingPath = origWorkingPath }()
+
+	err = execDeployCmd("test-deployment-id", "--include", "--workspace-id", "test-ws")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "include directory not found")
+}
+
+func TestDeployIncludeRejectsIncompatibleFlags(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
+	DeployImage = func(deployInput cloud.InputDeploy, astroV1Client astrov1.APIClient) error {
+		return nil
+	}
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"dags", []string{"-f", "test-deployment-id", "--include", "--dags"}},
+		{"image", []string{"-f", "test-deployment-id", "--include", "--image"}},
+		{"image-name", []string{"-f", "test-deployment-id", "--include", "--image-name", "img:1"}},
+		{"dags-path", []string{"-f", "test-deployment-id", "--include", "--dags-path", "./dags"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := execDeployCmd(tc.args...)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "--include")
+		})
+	}
 }
 
 func TestDeploySkipsEnsureProjectDirWhenImageNameSet(t *testing.T) {


### PR DESCRIPTION
## What

Adds an `--include` flag to `astro deploy`. `astro deploy --include [deployment-id]` pushes only the project's `include/` directory to the Deployment as a non-DAG bundle (mounted at `/usr/local/airflow/include`), with no image build — the `include/` analogue of `astro deploy --dags`.

## How

Routes through the **existing** generic `DeployBundle` flow used by `astro dbt deploy` (`cloud/deploy/bundle.go`), with `BundleType: "include"` and `MountPath: /usr/local/airflow/include`. No new deploy plumbing — the CLI→Core→Harmony→bundle-backend pipeline is already bundle-type-agnostic.

- New `--include` bool flag on `astro deploy`.
- Short-circuits to `deployInclude()` (mirrors `deployDbt`): validates `include/` exists in the project, resolves workspace + deployment, calls `DeployBundle`.
- Mutually exclusive with `--dags`, `--image`, `--image-name`, `--dags-path`.

## Status — draft

- [x] Tests (`deploy_test.go`: happy path, missing `include/`, flag exclusivity).
- [ ] Docs / help-text review.

⚠️ **Do not enable/GA this until the staleness problem has a durable fix** — see [PM-1577](https://linear.app/astronomer/issue/PM-1577). This flag can merge early (it's inert until the feature is enabled), but an `include/` bundle is imported Python cached in `sys.modules`; live-updating it runs stale code in long-lived processes until version-keyed invalidation lands. Enablement is intended to be all-at-once, gated on that fix.

Companion PRs: astro-bundle-backend (atomic symlink swap), astro (harmony) deploy-completion annotation stub.

> Note: the local sandbox can't fetch one transitive docker/containerd dependency (`klauspost/compress`), so `go build`/lint couldn't complete here; `gofmt -e` is clean. CI runs the authoritative build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)