### PR TITLE
PLX-644: [APC] Adds adopt and unadopt deployment commands for adopted deployments

### DIFF
--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -264,7 +264,7 @@ func newDeploymentAdoptCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&adoptCRName, "cr-name", "", "", "metadata.name of the existing Airflow custom resource")
 	cmd.Flags().StringVarP(&adoptCRNamespace, "cr-namespace", "", "", "Kubernetes namespace of the existing Airflow custom resource")
 	cmd.Flags().StringVarP(&adoptLabel, "label", "l", "", "Label for the adopted Deployment; defaults to --cr-name when omitted")
-	cmd.Flags().StringVarP(&adoptDescription, "description", "d", "", "Description for the adopted Deployment")
+	cmd.Flags().StringVarP(&adoptDescription, "description", "", "", "Description for the adopted Deployment")
 	cmd.Flags().BoolVarP(&adoptUseApcLogging, "use-apc-logging", "", false, "Route the adopted Deployment's logs through APC logging")
 	cmd.Flags().BoolVarP(&adoptUseApcRegistry, "use-apc-registry", "", false, "Use the APC in-cluster registry for the adopted Deployment; you must pre-sync its images")
 	cmd.Flags().BoolVarP(&adoptAcceptIncompatibilities, "accept-incompatibilities", "", true, "Adopt even if the custom resource has fields with no APC representation")

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -583,7 +583,7 @@ func deploymentUnadopt(cmd *cobra.Command, out io.Writer) error {
 
 	i, _ := input.Confirm(cliDeploymentUnadoptPrompt)
 	if !i {
-		fmt.Println("Exit: This command was not executed and your Deployment was not unadopted.")
+		fmt.Fprintln(out, "Exit: This command was not executed and your Deployment was not unadopted.")
 		return nil
 	}
 	return deployment.Unadopt(deploymentID, houstonClient, out)

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -18,12 +18,12 @@ const (
 	k8sExecutorArg        = "k8s"
 
 	cliDeploymentHardDeletePrompt              = "\nWarning: This action permanently deletes all data associated with this Deployment, including the database. You will not be able to recover it. Proceed with delete?"
-	cliDeploymentUnadoptPrompt                 = "\nWarning: This permanently removes the Deployment record from Astronomer Software. The Airflow custom resource, its namespace, and its metadata database are left untouched, but this action cannot be undone from the CLI. Proceed with unadopt?"
+	cliDeploymentUnadoptPrompt                 = "\nWarning: This permanently removes the Deployment record from APC. The Airflow custom resource, its namespace, and its metadata database are left untouched, but this action cannot be undone from the CLI. Proceed with unadopt?"
 	deploymentTypeCmdMessage                   = "DAG Deployment mechanism: image, volume, git_sync, dag_deploy"
 	continueSubMsg                             = " for more details. Do you want to continue?"
-	CreateDeploymentWithTypeDagDeployPromptMsg = "\nthis is an experimental feature. Please use with caution. See the Software documentation at " + houston.DagDeployDocsLink + continueSubMsg
-	UpdateDeploymentTypeToDagDeployPromptMsg   = "\nthis is an experimental feature. Please use with caution. Changing to a DAG-only Deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the Software documentation at " + houston.DagDeployDocsLink + continueSubMsg
-	UpdateDeploymentTypeFromDagDeployPromptMsg = "\nchanging from a DAG-only deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the Software documentation at " + houston.DeployViaCLIDocsLink + continueSubMsg
+	CreateDeploymentWithTypeDagDeployPromptMsg = "\nthis is an experimental feature. Please use with caution. See the APC documentation at " + houston.DagDeployDocsLink + continueSubMsg
+	UpdateDeploymentTypeToDagDeployPromptMsg   = "\nthis is an experimental feature. Please use with caution. Changing to a DAG-only Deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the APC documentation at " + houston.DagDeployDocsLink + continueSubMsg
+	UpdateDeploymentTypeFromDagDeployPromptMsg = "\nchanging from a DAG-only deployment will erase all of the currently deployed DAGs in this deployment. To keep running your DAGs, you must redeploy them to the deployment. See the APC documentation at " + houston.DeployViaCLIDocsLink + continueSubMsg
 	SkipUserPromptMsgForCreateDeployment       = "Skip user confirmation prompt for creating a deployment with type: dag_deploy (experimental feature)"
 	SkipUserPromptMsgForUpdateDeployment       = "Skip user confirmation prompt for updating the deployment type to/from dag_deploy (experimental feature)"
 )
@@ -253,8 +253,8 @@ func newDeploymentDeleteCmd(out io.Writer) *cobra.Command {
 func newDeploymentAdoptCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "adopt",
-		Short:   "Adopt an existing operator-managed Airflow custom resource into Astronomer Software",
-		Long:    "Adopt an existing operator-managed Airflow custom resource into Astronomer Software. The custom resource, its namespace, and its metadata database are left untouched; adopting only creates the corresponding Deployment record in Astronomer Software.",
+		Short:   "Adopt an existing operator-managed Airflow custom resource into APC",
+		Long:    "Adopt an existing operator-managed Airflow custom resource into APC. The custom resource, its namespace, and its metadata database are left untouched; adopting only creates the corresponding Deployment record in APC.",
 		Example: deploymentAdoptExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentAdopt(cmd, out)
@@ -265,9 +265,9 @@ func newDeploymentAdoptCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&adoptCRNamespace, "cr-namespace", "", "", "Kubernetes namespace of the existing Airflow custom resource")
 	cmd.Flags().StringVarP(&adoptLabel, "label", "l", "", "Label for the adopted Deployment; defaults to --cr-name when omitted")
 	cmd.Flags().StringVarP(&adoptDescription, "description", "d", "", "Description for the adopted Deployment")
-	cmd.Flags().BoolVarP(&adoptUseApcLogging, "use-apc-logging", "", false, "Route the adopted Deployment's logs through Astronomer Software logging")
-	cmd.Flags().BoolVarP(&adoptUseApcRegistry, "use-apc-registry", "", false, "Use the Astronomer Software in-cluster registry for the adopted Deployment; you must pre-sync its images")
-	cmd.Flags().BoolVarP(&adoptAcceptIncompatibilities, "accept-incompatibilities", "", true, "Adopt even if the custom resource has fields with no Astronomer Software representation")
+	cmd.Flags().BoolVarP(&adoptUseApcLogging, "use-apc-logging", "", false, "Route the adopted Deployment's logs through APC logging")
+	cmd.Flags().BoolVarP(&adoptUseApcRegistry, "use-apc-registry", "", false, "Use the APC in-cluster registry for the adopted Deployment; you must pre-sync its images")
+	cmd.Flags().BoolVarP(&adoptAcceptIncompatibilities, "accept-incompatibilities", "", true, "Adopt even if the custom resource has fields with no APC representation")
 	_ = cmd.MarkFlagRequired("cluster-id")
 	_ = cmd.MarkFlagRequired("cr-name")
 	_ = cmd.MarkFlagRequired("cr-namespace")
@@ -278,7 +278,7 @@ func newDeploymentUnadoptCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "unadopt",
 		Short:   "Release an adopted Deployment back to operator-only management",
-		Long:    "Release an adopted Deployment back to operator-only management. The Airflow custom resource, its namespace, and its metadata database are left untouched; only the Astronomer Software Deployment record is removed.",
+		Long:    "Release an adopted Deployment back to operator-only management. The Airflow custom resource, its namespace, and its metadata database are left untouched; only the APC Deployment record is removed.",
 		Example: deploymentUnadoptExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return deploymentUnadopt(cmd, out)

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -18,6 +18,7 @@ const (
 	k8sExecutorArg        = "k8s"
 
 	cliDeploymentHardDeletePrompt              = "\nWarning: This action permanently deletes all data associated with this Deployment, including the database. You will not be able to recover it. Proceed with delete?"
+	cliDeploymentUnadoptPrompt                 = "\nWarning: This permanently removes the Deployment record from Astronomer Software. The Airflow custom resource, its namespace, and its metadata database are left untouched, but this action cannot be undone from the CLI. Proceed with unadopt?"
 	deploymentTypeCmdMessage                   = "DAG Deployment mechanism: image, volume, git_sync, dag_deploy"
 	continueSubMsg                             = " for more details. Do you want to continue?"
 	CreateDeploymentWithTypeDagDeployPromptMsg = "\nthis is an experimental feature. Please use with caution. See the Software documentation at " + houston.DagDeployDocsLink + continueSubMsg
@@ -57,6 +58,21 @@ var (
 	runtimeVersion          string
 	desiredRuntimeVersion   string
 	clusterID               string
+
+	adoptCRName                  string
+	adoptCRNamespace             string
+	adoptLabel                   string
+	adoptDescription             string
+	adoptUseApcLogging           bool
+	adoptUseApcRegistry          bool
+	adoptAcceptIncompatibilities bool
+
+	deploymentAdoptExample = `
+$ astro deployment adopt --cluster-id=<cluster-id> --cr-name=<cr-name> --cr-namespace=<cr-namespace> --workspace-id=<workspace-id>
+`
+	deploymentUnadoptExample = `
+$ astro deployment unadopt --deployment-id=<deployment-id>
+`
 	deploymentCreateExample = `
 # Create new deployment with Celery executor (default: celery without params).
 $ astro deployment create --label=new-deployment-name --executor=celery
@@ -124,6 +140,8 @@ func newDeploymentRootCmd(out io.Writer) *cobra.Command {
 		newDeploymentListCmd(out),
 		newDeploymentUpdateCmd(out),
 		newDeploymentDeleteCmd(out),
+		newDeploymentAdoptCmd(out),
+		newDeploymentUnadoptCmd(out),
 		newLogsCmd(out),
 		newDeploymentSaRootCmd(out),
 		newDeploymentUserRootCmd(out),
@@ -229,6 +247,45 @@ func newDeploymentDeleteCmd(out io.Writer) *cobra.Command {
 	// pass --hard keep working; remove it in a future major release.
 	cmd.Flags().BoolVar(&hardDelete, "hard", false, "Deprecated: deletions always remove all infrastructure and records for the Deployment")
 	_ = cmd.Flags().MarkDeprecated("hard", "deletions are always hard deletes; the --hard flag no longer has any effect")
+	return cmd
+}
+
+func newDeploymentAdoptCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "adopt",
+		Short:   "Adopt an existing operator-managed Airflow custom resource into Astronomer Software",
+		Long:    "Adopt an existing operator-managed Airflow custom resource into Astronomer Software. The custom resource, its namespace, and its metadata database are left untouched; adopting only creates the corresponding Deployment record in Astronomer Software.",
+		Example: deploymentAdoptExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentAdopt(cmd, out)
+		},
+	}
+	cmd.Flags().StringVarP(&clusterID, "cluster-id", "", "", "ID of the cluster the Airflow custom resource is running on")
+	cmd.Flags().StringVarP(&adoptCRName, "cr-name", "", "", "metadata.name of the existing Airflow custom resource")
+	cmd.Flags().StringVarP(&adoptCRNamespace, "cr-namespace", "", "", "Kubernetes namespace of the existing Airflow custom resource")
+	cmd.Flags().StringVarP(&adoptLabel, "label", "l", "", "Label for the adopted Deployment; defaults to --cr-name when omitted")
+	cmd.Flags().StringVarP(&adoptDescription, "description", "d", "", "Description for the adopted Deployment")
+	cmd.Flags().BoolVarP(&adoptUseApcLogging, "use-apc-logging", "", false, "Route the adopted Deployment's logs through Astronomer Software logging")
+	cmd.Flags().BoolVarP(&adoptUseApcRegistry, "use-apc-registry", "", false, "Use the Astronomer Software in-cluster registry for the adopted Deployment; you must pre-sync its images")
+	cmd.Flags().BoolVarP(&adoptAcceptIncompatibilities, "accept-incompatibilities", "", true, "Adopt even if the custom resource has fields with no Astronomer Software representation")
+	_ = cmd.MarkFlagRequired("cluster-id")
+	_ = cmd.MarkFlagRequired("cr-name")
+	_ = cmd.MarkFlagRequired("cr-namespace")
+	return cmd
+}
+
+func newDeploymentUnadoptCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "unadopt",
+		Short:   "Release an adopted Deployment back to operator-only management",
+		Long:    "Release an adopted Deployment back to operator-only management. The Airflow custom resource, its namespace, and its metadata database are left untouched; only the Astronomer Software Deployment record is removed.",
+		Example: deploymentUnadoptExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deploymentUnadopt(cmd, out)
+		},
+	}
+	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "d", "", "ID of the adopted Deployment to release")
+	_ = cmd.MarkFlagRequired("deployment-id")
 	return cmd
 }
 
@@ -495,6 +552,41 @@ func deploymentDelete(cmd *cobra.Command, args []string, out io.Writer) error {
 		return nil
 	}
 	return deployment.Delete(args[0], true, houstonClient, out)
+}
+
+func deploymentAdopt(cmd *cobra.Command, out io.Writer) error {
+	ws, err := coalesceWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to find a valid workspace: %w", err)
+	}
+
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+
+	req := &houston.AdoptDeploymentRequest{
+		WorkspaceID:             ws,
+		ClusterID:               clusterID,
+		CRNamespace:             adoptCRNamespace,
+		CRName:                  adoptCRName,
+		Label:                   adoptLabel,
+		Description:             adoptDescription,
+		UseApcLogging:           adoptUseApcLogging,
+		UseApcRegistry:          adoptUseApcRegistry,
+		AcceptIncompatibilities: adoptAcceptIncompatibilities,
+	}
+	return deployment.Adopt(req, houstonClient, out)
+}
+
+func deploymentUnadopt(cmd *cobra.Command, out io.Writer) error {
+	// Silence Usage as we have now validated command input
+	cmd.SilenceUsage = true
+
+	i, _ := input.Confirm(cliDeploymentUnadoptPrompt)
+	if !i {
+		fmt.Println("Exit: This command was not executed and your Deployment was not unadopted.")
+		return nil
+	}
+	return deployment.Unadopt(deploymentID, houstonClient, out)
 }
 
 func deploymentList(cmd *cobra.Command, out io.Writer) error {

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -263,7 +263,7 @@ func newDeploymentAdoptCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&clusterID, "cluster-id", "", "", "ID of the cluster the Airflow custom resource is running on")
 	cmd.Flags().StringVarP(&adoptName, "name", "", "", "metadata.name of the existing Airflow custom resource (CR)")
 	cmd.Flags().StringVarP(&adoptNamespace, "namespace", "", "", "Kubernetes namespace of the existing Airflow custom resource (CR)")
-	cmd.Flags().StringVarP(&adoptLabel, "label", "l", "", "Label for the adopted Deployment; defaults to --name when omitted")
+	cmd.Flags().StringVarP(&adoptLabel, "label", "l", "", "Label for the adopted Deployment; if omitted, APC defaults it to the --name value")
 	cmd.Flags().StringVarP(&adoptDescription, "description", "", "", "Description for the adopted Deployment")
 	cmd.Flags().BoolVarP(&adoptUseApcLogging, "use-apc-logging", "", false, "Route the adopted Deployment's logs through APC logging")
 	cmd.Flags().BoolVarP(&adoptUseApcRegistry, "use-apc-registry", "", false, "Use the APC in-cluster registry for the adopted Deployment; you must pre-sync its images")

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -59,8 +59,8 @@ var (
 	desiredRuntimeVersion   string
 	clusterID               string
 
-	adoptCRName                  string
-	adoptCRNamespace             string
+	adoptName                    string
+	adoptNamespace               string
 	adoptLabel                   string
 	adoptDescription             string
 	adoptUseApcLogging           bool
@@ -68,7 +68,7 @@ var (
 	adoptAcceptIncompatibilities bool
 
 	deploymentAdoptExample = `
-$ astro deployment adopt --cluster-id=<cluster-id> --cr-name=<cr-name> --cr-namespace=<cr-namespace> --workspace-id=<workspace-id>
+$ astro deployment adopt --cluster-id=<cluster-id> --name=<cr-name> --namespace=<cr-namespace> --workspace-id=<workspace-id>
 `
 	deploymentUnadoptExample = `
 $ astro deployment unadopt --deployment-id=<deployment-id>
@@ -261,16 +261,16 @@ func newDeploymentAdoptCmd(out io.Writer) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&clusterID, "cluster-id", "", "", "ID of the cluster the Airflow custom resource is running on")
-	cmd.Flags().StringVarP(&adoptCRName, "cr-name", "", "", "metadata.name of the existing Airflow custom resource")
-	cmd.Flags().StringVarP(&adoptCRNamespace, "cr-namespace", "", "", "Kubernetes namespace of the existing Airflow custom resource")
-	cmd.Flags().StringVarP(&adoptLabel, "label", "l", "", "Label for the adopted Deployment; defaults to --cr-name when omitted")
+	cmd.Flags().StringVarP(&adoptName, "name", "", "", "metadata.name of the existing Airflow custom resource (CR)")
+	cmd.Flags().StringVarP(&adoptNamespace, "namespace", "", "", "Kubernetes namespace of the existing Airflow custom resource (CR)")
+	cmd.Flags().StringVarP(&adoptLabel, "label", "l", "", "Label for the adopted Deployment; defaults to --name when omitted")
 	cmd.Flags().StringVarP(&adoptDescription, "description", "", "", "Description for the adopted Deployment")
 	cmd.Flags().BoolVarP(&adoptUseApcLogging, "use-apc-logging", "", false, "Route the adopted Deployment's logs through APC logging")
 	cmd.Flags().BoolVarP(&adoptUseApcRegistry, "use-apc-registry", "", false, "Use the APC in-cluster registry for the adopted Deployment; you must pre-sync its images")
 	cmd.Flags().BoolVarP(&adoptAcceptIncompatibilities, "accept-incompatibilities", "", true, "Adopt even if the custom resource has fields with no APC representation")
 	_ = cmd.MarkFlagRequired("cluster-id")
-	_ = cmd.MarkFlagRequired("cr-name")
-	_ = cmd.MarkFlagRequired("cr-namespace")
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("namespace")
 	return cmd
 }
 
@@ -566,8 +566,8 @@ func deploymentAdopt(cmd *cobra.Command, out io.Writer) error {
 	req := &houston.AdoptDeploymentRequest{
 		WorkspaceID:             ws,
 		ClusterID:               clusterID,
-		CRNamespace:             adoptCRNamespace,
-		CRName:                  adoptCRName,
+		CRNamespace:             adoptNamespace,
+		CRName:                  adoptName,
 		Label:                   adoptLabel,
 		Description:             adoptDescription,
 		UseApcLogging:           adoptUseApcLogging,

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -1048,8 +1048,9 @@ func (s *Suite) TestDeploymentUnadopt() {
 		defer testUtil.MockUserInput(s.T(), "n")()
 
 		houstonClient = api
-		_, err := execDeploymentCmd("unadopt", "--deployment-id", mockDeployment.ID)
+		output, err := execDeploymentCmd("unadopt", "--deployment-id", mockDeployment.ID)
 		s.NoError(err)
+		s.Contains(output, "was not executed and your Deployment was not unadopted")
 		api.AssertNotCalled(s.T(), "UnadoptDeployment", mock.Anything)
 	})
 

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -926,6 +926,155 @@ func (s *Suite) TestDeploymentDelete() {
 	s.Contains(output, expectedOut)
 }
 
+func (s *Suite) TestDeploymentAdopt() {
+	expectedOut := `Successfully adopted deployment`
+	mockAdoptedDeployment := &houston.Deployment{
+		ID:          "cknz133ra49758zr9w34b87ua",
+		Label:       "prod-airflow-4",
+		ReleaseName: "prod-airflow-4",
+		Namespace:   "airflow-prod4",
+		ClusterID:   "cluster-test-id",
+	}
+
+	s.Run("success with only required flags", func() {
+		api := new(mocks.ClientInterface)
+		api.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+		api.On("AdoptDeployment", &houston.AdoptDeploymentRequest{
+			// InitTestConfig("software") sets this workspace as the current context's workspace.
+			WorkspaceID:             "ck05r3bor07h40d02y2hw4n4v",
+			ClusterID:               "cluster-test-id",
+			CRNamespace:             "airflow-prod4",
+			CRName:                  "prod-airflow-4",
+			AcceptIncompatibilities: true,
+		}).Return(mockAdoptedDeployment, nil)
+
+		houstonClient = api
+		output, err := execDeploymentCmd("adopt", "--cluster-id=cluster-test-id", "--cr-name=prod-airflow-4", "--cr-namespace=airflow-prod4")
+		s.NoError(err)
+		s.Contains(output, expectedOut)
+		s.Contains(output, mockAdoptedDeployment.ReleaseName)
+		api.AssertExpectations(s.T())
+	})
+
+	s.Run("success with optional flags and an explicit workspace", func() {
+		api := new(mocks.ClientInterface)
+		api.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+		api.On("AdoptDeployment", &houston.AdoptDeploymentRequest{
+			WorkspaceID:             "some-other-workspace-id",
+			ClusterID:               "cluster-test-id",
+			CRNamespace:             "airflow-prod4",
+			CRName:                  "prod-airflow-4",
+			Label:                   "My Adopted Deployment",
+			Description:             "adopted from standalone operator",
+			UseApcLogging:           true,
+			UseApcRegistry:          true,
+			AcceptIncompatibilities: false,
+		}).Return(mockAdoptedDeployment, nil)
+
+		houstonClient = api
+		output, err := execDeploymentCmd(
+			"adopt",
+			"--workspace-id=some-other-workspace-id",
+			"--cluster-id=cluster-test-id",
+			"--cr-name=prod-airflow-4",
+			"--cr-namespace=airflow-prod4",
+			"--label=My Adopted Deployment",
+			"--description=adopted from standalone operator",
+			"--use-apc-logging",
+			"--use-apc-registry",
+			"--accept-incompatibilities=false",
+		)
+		s.NoError(err)
+		s.Contains(output, expectedOut)
+		api.AssertExpectations(s.T())
+	})
+
+	s.Run("missing required flags", func() {
+		api := new(mocks.ClientInterface)
+		api.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+
+		myTests := []struct {
+			cmdArgs       []string
+			expectedError string
+		}{
+			{cmdArgs: []string{"adopt", "--cr-name=prod-airflow-4", "--cr-namespace=airflow-prod4"}, expectedError: `required flag(s) "cluster-id" not set`},
+			{cmdArgs: []string{"adopt", "--cluster-id=cluster-test-id", "--cr-namespace=airflow-prod4"}, expectedError: `required flag(s) "cr-name" not set`},
+			{cmdArgs: []string{"adopt", "--cluster-id=cluster-test-id", "--cr-name=prod-airflow-4"}, expectedError: `required flag(s) "cr-namespace" not set`},
+		}
+		for _, tt := range myTests {
+			houstonClient = api
+			_, err := execDeploymentCmd(tt.cmdArgs...)
+			s.EqualError(err, tt.expectedError)
+		}
+	})
+
+	s.Run("api error", func() {
+		api := new(mocks.ClientInterface)
+		api.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+		api.On("AdoptDeployment", mock.Anything).Return(nil, errMockHouston)
+
+		houstonClient = api
+		_, err := execDeploymentCmd("adopt", "--cluster-id=cluster-test-id", "--cr-name=prod-airflow-4", "--cr-namespace=airflow-prod4")
+		s.EqualError(err, errMockHouston.Error())
+	})
+}
+
+func (s *Suite) TestDeploymentUnadopt() {
+	expectedOut := `Successfully unadopted deployment`
+	mockUnadoptedDeployment := &houston.Deployment{
+		ID:          mockDeployment.ID,
+		Label:       mockDeployment.Label,
+		ReleaseName: mockDeployment.ReleaseName,
+	}
+
+	s.Run("success", func() {
+		api := new(mocks.ClientInterface)
+		api.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+		api.On("UnadoptDeployment", houston.UnadoptDeploymentRequest{DeploymentID: mockDeployment.ID}).Return(mockUnadoptedDeployment, nil)
+
+		defer testUtil.MockUserInput(s.T(), "y")()
+
+		houstonClient = api
+		output, err := execDeploymentCmd("unadopt", "--deployment-id", mockDeployment.ID)
+		s.NoError(err)
+		s.Contains(output, expectedOut)
+		api.AssertExpectations(s.T())
+	})
+
+	s.Run("user declines the confirmation prompt", func() {
+		api := new(mocks.ClientInterface)
+		api.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+
+		defer testUtil.MockUserInput(s.T(), "n")()
+
+		houstonClient = api
+		_, err := execDeploymentCmd("unadopt", "--deployment-id", mockDeployment.ID)
+		s.NoError(err)
+		api.AssertNotCalled(s.T(), "UnadoptDeployment", mock.Anything)
+	})
+
+	s.Run("missing required flag", func() {
+		api := new(mocks.ClientInterface)
+		api.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+
+		houstonClient = api
+		_, err := execDeploymentCmd("unadopt")
+		s.EqualError(err, `required flag(s) "deployment-id" not set`)
+	})
+
+	s.Run("api error", func() {
+		api := new(mocks.ClientInterface)
+		api.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+		api.On("UnadoptDeployment", houston.UnadoptDeploymentRequest{DeploymentID: mockDeployment.ID}).Return(nil, errMockHouston)
+
+		defer testUtil.MockUserInput(s.T(), "y")()
+
+		houstonClient = api
+		_, err := execDeploymentCmd("unadopt", "--deployment-id", mockDeployment.ID)
+		s.EqualError(err, errMockHouston.Error())
+	})
+}
+
 func (s *Suite) TestDeploymentList() {
 	expectedRequest := houston.PaginatedDeploymentsRequest{
 		Take: -1,

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -949,7 +949,7 @@ func (s *Suite) TestDeploymentAdopt() {
 		}).Return(mockAdoptedDeployment, nil)
 
 		houstonClient = api
-		output, err := execDeploymentCmd("adopt", "--cluster-id=cluster-test-id", "--cr-name=prod-airflow-4", "--cr-namespace=airflow-prod4")
+		output, err := execDeploymentCmd("adopt", "--cluster-id=cluster-test-id", "--name=prod-airflow-4", "--namespace=airflow-prod4")
 		s.NoError(err)
 		s.Contains(output, expectedOut)
 		s.Contains(output, mockAdoptedDeployment.ReleaseName)
@@ -976,8 +976,8 @@ func (s *Suite) TestDeploymentAdopt() {
 			"adopt",
 			"--workspace-id=some-other-workspace-id",
 			"--cluster-id=cluster-test-id",
-			"--cr-name=prod-airflow-4",
-			"--cr-namespace=airflow-prod4",
+			"--name=prod-airflow-4",
+			"--namespace=airflow-prod4",
 			"--label=My Adopted Deployment",
 			"--description=adopted from standalone operator",
 			"--use-apc-logging",
@@ -997,9 +997,9 @@ func (s *Suite) TestDeploymentAdopt() {
 			cmdArgs       []string
 			expectedError string
 		}{
-			{cmdArgs: []string{"adopt", "--cr-name=prod-airflow-4", "--cr-namespace=airflow-prod4"}, expectedError: `required flag(s) "cluster-id" not set`},
-			{cmdArgs: []string{"adopt", "--cluster-id=cluster-test-id", "--cr-namespace=airflow-prod4"}, expectedError: `required flag(s) "cr-name" not set`},
-			{cmdArgs: []string{"adopt", "--cluster-id=cluster-test-id", "--cr-name=prod-airflow-4"}, expectedError: `required flag(s) "cr-namespace" not set`},
+			{cmdArgs: []string{"adopt", "--name=prod-airflow-4", "--namespace=airflow-prod4"}, expectedError: `required flag(s) "cluster-id" not set`},
+			{cmdArgs: []string{"adopt", "--cluster-id=cluster-test-id", "--namespace=airflow-prod4"}, expectedError: `required flag(s) "name" not set`},
+			{cmdArgs: []string{"adopt", "--cluster-id=cluster-test-id", "--name=prod-airflow-4"}, expectedError: `required flag(s) "namespace" not set`},
 		}
 		for _, tt := range myTests {
 			houstonClient = api
@@ -1014,7 +1014,7 @@ func (s *Suite) TestDeploymentAdopt() {
 		api.On("AdoptDeployment", mock.Anything).Return(nil, errMockHouston)
 
 		houstonClient = api
-		_, err := execDeploymentCmd("adopt", "--cluster-id=cluster-test-id", "--cr-name=prod-airflow-4", "--cr-namespace=airflow-prod4")
+		_, err := execDeploymentCmd("adopt", "--cluster-id=cluster-test-id", "--name=prod-airflow-4", "--namespace=airflow-prod4")
 		s.EqualError(err, errMockHouston.Error())
 	})
 }

--- a/cmd/software/utils.go
+++ b/cmd/software/utils.go
@@ -37,6 +37,7 @@ func VersionMatchCmds(rootCmd *cobra.Command, parent []string) {
 func removeCmd(c *cobra.Command) {
 	c.Hidden = true                                   // hide the command in help output
 	c.RunE = nil                                      // cobra prefers RunE over Run when both are set, so clear it for leaf commands (e.g. "team update", "deployment adopt") that define their own RunE
+	c.Args = cobra.ArbitraryArgs                      // clear any Args validator (e.g. cobra.ExactArgs) so a missing/extra positional arg doesn't error out before our custom Run handler below
 	c.Run = func(cmd *cobra.Command, args []string) { // define the error response when the command is executed
 		fmt.Printf("Error: unknown command \"%s\" for \"astro\" \nRun 'astro --help' for usage.\n\nAstro Private Cloud Version: %s\nMake sure you are using right set of commands for the connected platform version\n\n", c.Name(), houstonVersion)
 	}

--- a/cmd/software/utils.go
+++ b/cmd/software/utils.go
@@ -14,6 +14,9 @@ var cmdAvailabilityByVersion = map[string]houston.VersionRestrictions{
 
 	"astro deployment runtime": {GTE: "0.29.0"},
 
+	"astro deployment adopt":   {GTE: "2.1.0"},
+	"astro deployment unadopt": {GTE: "2.1.0"},
+
 	"astro deployment team": {GTE: "0.28.0"},
 	"astro workspace team":  {GTE: "0.28.0"},
 	"astro team":            {GTE: "0.28.0"},
@@ -33,6 +36,7 @@ func VersionMatchCmds(rootCmd *cobra.Command, parent []string) {
 
 func removeCmd(c *cobra.Command) {
 	c.Hidden = true                                   // hide the command in help output
+	c.RunE = nil                                      // cobra prefers RunE over Run when both are set, so clear it for leaf commands (e.g. "team update", "deployment adopt") that define their own RunE
 	c.Run = func(cmd *cobra.Command, args []string) { // define the error response when the command is executed
 		fmt.Printf("Error: unknown command \"%s\" for \"astro\" \nRun 'astro --help' for usage.\n\nAstro Private Cloud Version: %s\nMake sure you are using right set of commands for the connected platform version\n\n", c.Name(), houstonVersion)
 	}

--- a/cmd/software/utils_test.go
+++ b/cmd/software/utils_test.go
@@ -68,6 +68,118 @@ func (s *Suite) TestVersionMatchCmds() {
 		io.Copy(b, r)
 		s.Contains(b.String(), "Teams represents a team or a group from an IDP in the Astronomer Platform")
 	})
+
+	s.Run("1.0.1 platform with deployment adopt command", func() {
+		buf := new(bytes.Buffer)
+		mockAPI := new(houston_mocks.ClientInterface)
+		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "1.0.1"}, nil)
+		mockAPI.On("GetPlatformVersion", nil).Return("1.0.1", nil)
+		cmd := &cobra.Command{Use: "astro"}
+		childCMDs := AddCmds(mockAPI, buf)
+		cmd.AddCommand(childCMDs...)
+
+		VersionMatchCmds(cmd, []string{"astro"})
+		buf.Reset()
+		b := new(bytes.Buffer)
+		cmd.SetArgs([]string{"deployment", "adopt", "--help"})
+
+		r, w, err := os.Pipe()
+		s.NoError(err)
+
+		realStdout := os.Stdout
+		os.Stdout = w
+		defer func() { os.Stdout = realStdout }()
+
+		_, err = cmd.ExecuteC()
+		w.Close()
+		s.NoError(err)
+		io.Copy(b, r)
+		s.Contains(b.String(), "unknown command \"adopt\" for \"astro\"")
+	})
+
+	s.Run("2.1.0 platform with deployment adopt command", func() {
+		buf := new(bytes.Buffer)
+		mockAPI := new(houston_mocks.ClientInterface)
+		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "2.1.0"}, nil)
+		mockAPI.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+		cmd := &cobra.Command{Use: "astro"}
+		childCMDs := AddCmds(mockAPI, buf)
+		cmd.AddCommand(childCMDs...)
+
+		VersionMatchCmds(cmd, []string{"astro"})
+		buf.Reset()
+		b := new(bytes.Buffer)
+		cmd.SetArgs([]string{"deployment", "adopt", "--help"})
+
+		r, w, err := os.Pipe()
+		s.NoError(err)
+
+		realStdout := os.Stdout
+		os.Stdout = w
+		defer func() { os.Stdout = realStdout }()
+
+		_, err = cmd.ExecuteC()
+		w.Close()
+		s.NoError(err)
+		io.Copy(b, r)
+		s.Contains(b.String(), "Adopt an existing operator-managed Airflow custom resource")
+	})
+
+	s.Run("1.0.1 platform with deployment unadopt command", func() {
+		buf := new(bytes.Buffer)
+		mockAPI := new(houston_mocks.ClientInterface)
+		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "1.0.1"}, nil)
+		mockAPI.On("GetPlatformVersion", nil).Return("1.0.1", nil)
+		cmd := &cobra.Command{Use: "astro"}
+		childCMDs := AddCmds(mockAPI, buf)
+		cmd.AddCommand(childCMDs...)
+
+		VersionMatchCmds(cmd, []string{"astro"})
+		buf.Reset()
+		b := new(bytes.Buffer)
+		cmd.SetArgs([]string{"deployment", "unadopt", "--help"})
+
+		r, w, err := os.Pipe()
+		s.NoError(err)
+
+		realStdout := os.Stdout
+		os.Stdout = w
+		defer func() { os.Stdout = realStdout }()
+
+		_, err = cmd.ExecuteC()
+		w.Close()
+		s.NoError(err)
+		io.Copy(b, r)
+		s.Contains(b.String(), "unknown command \"unadopt\" for \"astro\"")
+	})
+
+	s.Run("2.1.0 platform with deployment unadopt command", func() {
+		buf := new(bytes.Buffer)
+		mockAPI := new(houston_mocks.ClientInterface)
+		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "2.1.0"}, nil)
+		mockAPI.On("GetPlatformVersion", nil).Return("2.1.0", nil)
+		cmd := &cobra.Command{Use: "astro"}
+		childCMDs := AddCmds(mockAPI, buf)
+		cmd.AddCommand(childCMDs...)
+
+		VersionMatchCmds(cmd, []string{"astro"})
+		buf.Reset()
+		b := new(bytes.Buffer)
+		cmd.SetArgs([]string{"deployment", "unadopt", "--help"})
+
+		r, w, err := os.Pipe()
+		s.NoError(err)
+
+		realStdout := os.Stdout
+		os.Stdout = w
+		defer func() { os.Stdout = realStdout }()
+
+		_, err = cmd.ExecuteC()
+		w.Close()
+		s.NoError(err)
+		io.Copy(b, r)
+		s.Contains(b.String(), "Release an adopted Deployment back to operator-only management")
+	})
 }
 
 func (s *Suite) TestRemoveCmd() {

--- a/cmd/software/utils_test.go
+++ b/cmd/software/utils_test.go
@@ -41,6 +41,38 @@ func (s *Suite) TestVersionMatchCmds() {
 		s.Contains(b.String(), "unknown command \"team\" for \"astro\"")
 	})
 
+	s.Run("0.29.0 platform with team update command and no TEAM ID arg", func() {
+		// "astro team" is gated at 0.28.0 (so it stays visible here), but "astro team
+		// update" specifically is gated at 0.29.2, so it should be the one removed. Its
+		// Args: cobra.ExactArgs(1) validator must not run before removeCmd's "unknown
+		// command" handler, even though no TEAM ID positional arg is supplied.
+		buf := new(bytes.Buffer)
+		mockAPI := new(houston_mocks.ClientInterface)
+		mockAPI.On("GetAppConfig", mock.Anything).Return(&houston.AppConfig{Version: "0.29.0"}, nil)
+		mockAPI.On("GetPlatformVersion", nil).Return("0.29.0", nil)
+		cmd := &cobra.Command{Use: "astro"}
+		childCMDs := AddCmds(mockAPI, buf)
+		cmd.AddCommand(childCMDs...)
+
+		VersionMatchCmds(cmd, []string{"astro"})
+		buf.Reset()
+		b := new(bytes.Buffer)
+		cmd.SetArgs([]string{"team", "update"})
+
+		r, w, err := os.Pipe()
+		s.NoError(err)
+
+		realStdout := os.Stdout
+		os.Stdout = w
+		defer func() { os.Stdout = realStdout }()
+
+		_, err = cmd.ExecuteC()
+		w.Close()
+		s.NoError(err)
+		io.Copy(b, r)
+		s.Contains(b.String(), "unknown command \"update\" for \"astro\"")
+	})
+
 	s.Run("0.30.0 platform with teams command", func() {
 		buf := new(bytes.Buffer)
 		mockAPI := new(houston_mocks.ClientInterface)

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -37,6 +37,24 @@ type DeleteDeploymentRequest struct {
 	HardDelete   bool   `json:"deploymentHardDelete"`
 }
 
+// AdoptDeploymentRequest - properties to adopt an existing operator-managed Airflow custom resource
+type AdoptDeploymentRequest struct {
+	WorkspaceID             string `json:"workspaceId"`
+	ClusterID               string `json:"clusterId"`
+	CRNamespace             string `json:"crNamespace"`
+	CRName                  string `json:"crName"`
+	Label                   string `json:"label"`
+	Description             string `json:"description"`
+	UseApcLogging           bool   `json:"useApcLogging"`
+	UseApcRegistry          bool   `json:"useApcRegistry"`
+	AcceptIncompatibilities bool   `json:"acceptIncompatibilities"`
+}
+
+// UnadoptDeploymentRequest - properties to release an adopted deployment back to operator-only management
+type UnadoptDeploymentRequest struct {
+	DeploymentID string `json:"deploymentId"`
+}
+
 var (
 	DeploymentCreateRequest = queryList{
 		{
@@ -752,6 +770,60 @@ var (
 		}
 	}`
 
+	AdoptDeploymentRequestMutation = `
+	mutation AdoptDeployment(
+		$workspaceId: Uuid!
+		$clusterId: Uuid!
+		$crNamespace: String!
+		$crName: String!
+		$label: String
+		$description: String
+		$useApcLogging: Boolean
+		$useApcRegistry: Boolean
+		$acceptIncompatibilities: Boolean
+	){
+		adoptDeployment(
+			workspaceUuid: $workspaceId
+			clusterId: $clusterId
+			crNamespace: $crNamespace
+			crName: $crName
+			label: $label
+			description: $description
+			useApcLogging: $useApcLogging
+			useApcRegistry: $useApcRegistry
+			acceptIncompatibilities: $acceptIncompatibilities
+		){
+			id
+			label
+			releaseName
+			namespace
+			clusterId
+			workspace {
+				id
+			}
+			createdAt
+			updatedAt
+		}
+	}`
+
+	UnadoptDeploymentRequestMutation = `
+	mutation UnadoptDeployment(
+		$deploymentId: Uuid!
+	){
+		unadoptDeployment(
+			deploymentUuid: $deploymentId
+		){
+			id
+			label
+			releaseName
+			namespace
+			clusterId
+			workspace {
+				id
+			}
+		}
+	}`
+
 	UpdateDeploymentAirflowRequest = `
 	mutation updateDeploymentAirflow($deploymentId: Uuid!, $desiredAirflowVersion: String!) {
 		updateDeploymentAirflow(deploymentUuid: $deploymentId, desiredAirflowVersion: $desiredAirflowVersion) {
@@ -928,6 +1000,36 @@ func (h ClientImplementation) DeleteDeployment(request DeleteDeploymentRequest) 
 	}
 
 	return res.Data.DeleteDeployment, nil
+}
+
+// AdoptDeployment - adopt an existing operator-managed Airflow custom resource into Houston
+func (h ClientImplementation) AdoptDeployment(request *AdoptDeploymentRequest) (*Deployment, error) {
+	req := Request{
+		Query:     AdoptDeploymentRequestMutation,
+		Variables: request,
+	}
+
+	res, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return res.Data.AdoptDeployment, nil
+}
+
+// UnadoptDeployment - release an adopted deployment back to operator-only management
+func (h ClientImplementation) UnadoptDeployment(request UnadoptDeploymentRequest) (*Deployment, error) {
+	req := Request{
+		Query:     UnadoptDeploymentRequestMutation,
+		Variables: request,
+	}
+
+	res, err := req.DoWithClient(h.client)
+	if err != nil {
+		return nil, handleAPIErr(err)
+	}
+
+	return res.Data.UnadoptDeployment, nil
 }
 
 // ListDeployments - List deployments from the API

--- a/houston/deployment_test.go
+++ b/houston/deployment_test.go
@@ -169,6 +169,114 @@ func (s *Suite) TestDeleteDeployment() {
 	})
 }
 
+func (s *Suite) TestAdoptDeployment() {
+	testUtil.InitTestConfig("software")
+
+	mockDeployment := &Response{
+		Data: ResponseData{
+			AdoptDeployment: &Deployment{
+				ID:          "deployment-test-id",
+				Label:       "test deployment",
+				ReleaseName: "prod-airflow-4",
+				Namespace:   "airflow-prod4",
+				ClusterID:   "cluster-test-id",
+				Workspace: Workspace{
+					ID: "test-workspace-id",
+				},
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockDeployment)
+	s.NoError(err)
+
+	req := &AdoptDeploymentRequest{
+		WorkspaceID:             "test-workspace-id",
+		ClusterID:               "cluster-test-id",
+		CRNamespace:             "airflow-prod4",
+		CRName:                  "prod-airflow-4",
+		AcceptIncompatibilities: true,
+	}
+
+	s.Run("success", func() {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		deployment, err := api.AdoptDeployment(req)
+		s.NoError(err)
+		s.Equal(deployment, mockDeployment.Data.AdoptDeployment)
+	})
+
+	s.Run("error", func() {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.AdoptDeployment(req)
+		s.Contains(err.Error(), "Internal Server Error")
+	})
+}
+
+func (s *Suite) TestUnadoptDeployment() {
+	testUtil.InitTestConfig("software")
+
+	mockDeployment := &Response{
+		Data: ResponseData{
+			UnadoptDeployment: &Deployment{
+				ID:          "deployment-test-id",
+				Label:       "test deployment",
+				ReleaseName: "prod-airflow-4",
+				Namespace:   "airflow-prod4",
+				ClusterID:   "cluster-test-id",
+				Workspace: Workspace{
+					ID: "test-workspace-id",
+				},
+			},
+		},
+	}
+	jsonResponse, err := json.Marshal(mockDeployment)
+	s.NoError(err)
+
+	s.Run("success", func() {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		deployment, err := api.UnadoptDeployment(UnadoptDeploymentRequest{DeploymentID: "deployment-test-id"})
+		s.NoError(err)
+		s.Equal(deployment, mockDeployment.Data.UnadoptDeployment)
+	})
+
+	s.Run("error", func() {
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 500,
+				Body:       io.NopCloser(bytes.NewBufferString("Internal Server Error")),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.UnadoptDeployment(UnadoptDeploymentRequest{DeploymentID: "deployment-test-id"})
+		s.Contains(err.Error(), "Internal Server Error")
+	})
+}
+
 func (s *Suite) TestListDeployments() {
 	testUtil.InitTestConfig("software")
 

--- a/houston/houston.go
+++ b/houston/houston.go
@@ -53,6 +53,8 @@ type ClientInterface interface {
 	// deployment
 	CreateDeployment(vars map[string]interface{}) (*Deployment, error)
 	DeleteDeployment(req DeleteDeploymentRequest) (*Deployment, error)
+	AdoptDeployment(req *AdoptDeploymentRequest) (*Deployment, error)
+	UnadoptDeployment(req UnadoptDeploymentRequest) (*Deployment, error)
 	ListDeployments(filters ListDeploymentsRequest) ([]Deployment, error)
 	UpdateDeployment(variables map[string]interface{}) (*Deployment, error)
 	GetDeployment(deploymentID string) (*Deployment, error)

--- a/houston/mocks/ClientInterface.go
+++ b/houston/mocks/ClientInterface.go
@@ -134,6 +134,36 @@ func (_m *ClientInterface) AddWorkspaceUser(req houston.AddWorkspaceUserRequest)
 	return r0, r1
 }
 
+// AdoptDeployment provides a mock function with given fields: req
+func (_m *ClientInterface) AdoptDeployment(req *houston.AdoptDeploymentRequest) (*houston.Deployment, error) {
+	ret := _m.Called(req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AdoptDeployment")
+	}
+
+	var r0 *houston.Deployment
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*houston.AdoptDeploymentRequest) (*houston.Deployment, error)); ok {
+		return rf(req)
+	}
+	if rf, ok := ret.Get(0).(func(*houston.AdoptDeploymentRequest) *houston.Deployment); ok {
+		r0 = rf(req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Deployment)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*houston.AdoptDeploymentRequest) error); ok {
+		r1 = rf(req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // AuthenticateWithBasicAuth provides a mock function with given fields: req
 func (_m *ClientInterface) AuthenticateWithBasicAuth(req houston.BasicAuthRequest) (string, error) {
 	ret := _m.Called(req)
@@ -1374,6 +1404,36 @@ func (_m *ClientInterface) RemoveDeploymentTeam(req houston.RemoveDeploymentTeam
 	}
 
 	if rf, ok := ret.Get(1).(func(houston.RemoveDeploymentTeamRequest) error); ok {
+		r1 = rf(req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UnadoptDeployment provides a mock function with given fields: req
+func (_m *ClientInterface) UnadoptDeployment(req houston.UnadoptDeploymentRequest) (*houston.Deployment, error) {
+	ret := _m.Called(req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UnadoptDeployment")
+	}
+
+	var r0 *houston.Deployment
+	var r1 error
+	if rf, ok := ret.Get(0).(func(houston.UnadoptDeploymentRequest) (*houston.Deployment, error)); ok {
+		return rf(req)
+	}
+	if rf, ok := ret.Get(0).(func(houston.UnadoptDeploymentRequest) *houston.Deployment); ok {
+		r0 = rf(req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*houston.Deployment)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(houston.UnadoptDeploymentRequest) error); ok {
 		r1 = rf(req)
 	} else {
 		r1 = ret.Error(1)

--- a/houston/types.go
+++ b/houston/types.go
@@ -28,6 +28,8 @@ type ResponseData struct {
 	CreateUser                     *AuthUser                   `json:"createUser,omitempty"`
 	CreateWorkspace                *Workspace                  `json:"createWorkspace,omitempty"`
 	DeleteDeployment               *Deployment                 `json:"deleteDeployment,omitempty"`
+	AdoptDeployment                *Deployment                 `json:"adoptDeployment,omitempty"`
+	UnadoptDeployment              *Deployment                 `json:"unadoptDeployment,omitempty"`
 	DeleteWorkspaceServiceAccount  *ServiceAccount             `json:"deleteWorkspaceServiceAccount,omitempty"`
 	DeleteDeploymentServiceAccount *ServiceAccount             `json:"deleteDeploymentServiceAccount,omitempty"`
 	DeleteWorkspace                *Workspace                  `json:"deleteWorkspace,omitempty"`
@@ -108,6 +110,7 @@ type Deployment struct {
 	Type                  string              `json:"type"`
 	Label                 string              `json:"label"`
 	ReleaseName           string              `json:"releaseName"`
+	Namespace             string              `json:"namespace"`
 	Version               string              `json:"version"`
 	AirflowVersion        string              `json:"airflowVersion"`
 	DesiredAirflowVersion string              `json:"desiredAirflowVersion"`

--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -211,12 +211,12 @@ func Adopt(req *houston.AdoptDeploymentRequest, client houston.ClientInterface, 
 // Unadopt releases an adopted deployment back to operator-only management, without touching
 // the underlying Airflow custom resource, namespace, or metadata database.
 func Unadopt(id string, client houston.ClientInterface, out io.Writer) error {
-	_, err := houston.Call(client.UnadoptDeployment)(houston.UnadoptDeploymentRequest{DeploymentID: id})
+	d, err := houston.Call(client.UnadoptDeployment)(houston.UnadoptDeploymentRequest{DeploymentID: id})
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(out, "\n Successfully unadopted deployment")
+	fmt.Fprintf(out, "\n Successfully unadopted deployment %s (%s)\n", d.ReleaseName, d.ID)
 
 	return nil
 }

--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -189,6 +189,38 @@ func Delete(id string, hardDelete bool, client houston.ClientInterface, out io.W
 	return nil
 }
 
+// Adopt an existing operator-managed Airflow custom resource into Houston
+func Adopt(req *houston.AdoptDeploymentRequest, client houston.ClientInterface, out io.Writer) error {
+	d, err := houston.Call(client.AdoptDeployment)(req)
+	if err != nil {
+		return err
+	}
+
+	tab := &printutil.Table{
+		Padding:        []int{30, 30, 30, 40, 40},
+		DynamicPadding: true,
+		Header:         []string{"NAME", "DEPLOYMENT NAME", "NAMESPACE", "CLUSTER ID", "DEPLOYMENT ID"},
+	}
+	tab.AddRow([]string{d.Label, d.ReleaseName, d.Namespace, d.ClusterID, d.ID}, false)
+	tab.SuccessMsg = "\n Successfully adopted deployment"
+	tab.Print(out)
+
+	return nil
+}
+
+// Unadopt releases an adopted deployment back to operator-only management, without touching
+// the underlying Airflow custom resource, namespace, or metadata database.
+func Unadopt(id string, client houston.ClientInterface, out io.Writer) error {
+	_, err := houston.Call(client.UnadoptDeployment)(houston.UnadoptDeploymentRequest{DeploymentID: id})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, "\n Successfully unadopted deployment")
+
+	return nil
+}
+
 // list all available namespaces
 func getDeploymentSelectionNamespaces(client houston.ClientInterface, out io.Writer, clusterID string) (string, error) {
 	tab := &printutil.Table{

--- a/software/deployment/deployment_test.go
+++ b/software/deployment/deployment_test.go
@@ -474,6 +474,76 @@ func (s *Suite) TestDelete() {
 	})
 }
 
+func (s *Suite) TestAdopt() {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	mockDeployment := &houston.Deployment{
+		ID:          "ckbv818oa00r107606ywhoqtw",
+		Label:       "prod-airflow-4",
+		ReleaseName: "prod-airflow-4",
+		Namespace:   "airflow-prod4",
+		ClusterID:   "cluster-test-id",
+	}
+	req := &houston.AdoptDeploymentRequest{
+		WorkspaceID:             "workspace-test-id",
+		ClusterID:               "cluster-test-id",
+		CRNamespace:             "airflow-prod4",
+		CRName:                  "prod-airflow-4",
+		AcceptIncompatibilities: true,
+	}
+
+	s.Run("adopt success", func() {
+		api := new(mocks.ClientInterface)
+		api.On("AdoptDeployment", req).Return(mockDeployment, nil)
+
+		buf := new(bytes.Buffer)
+		err := Adopt(req, api, buf)
+		s.NoError(err)
+		s.Contains(buf.String(), "Successfully adopted deployment")
+		s.Contains(buf.String(), mockDeployment.ReleaseName)
+		api.AssertExpectations(s.T())
+	})
+
+	s.Run("adopt api error", func() {
+		api := new(mocks.ClientInterface)
+		api.On("AdoptDeployment", req).Return(nil, errMock)
+
+		buf := new(bytes.Buffer)
+		err := Adopt(req, api, buf)
+		s.EqualError(err, errMock.Error())
+		api.AssertExpectations(s.T())
+	})
+}
+
+func (s *Suite) TestUnadopt() {
+	testUtil.InitTestConfig(testUtil.SoftwarePlatform)
+	mockDeployment := &houston.Deployment{
+		ID:          "ckbv818oa00r107606ywhoqtw",
+		Label:       "prod-airflow-4",
+		ReleaseName: "prod-airflow-4",
+	}
+
+	s.Run("unadopt success", func() {
+		api := new(mocks.ClientInterface)
+		api.On("UnadoptDeployment", houston.UnadoptDeploymentRequest{DeploymentID: mockDeployment.ID}).Return(mockDeployment, nil)
+
+		buf := new(bytes.Buffer)
+		err := Unadopt(mockDeployment.ID, api, buf)
+		s.NoError(err)
+		s.Contains(buf.String(), "Successfully unadopted deployment")
+		api.AssertExpectations(s.T())
+	})
+
+	s.Run("unadopt api error", func() {
+		api := new(mocks.ClientInterface)
+		api.On("UnadoptDeployment", houston.UnadoptDeploymentRequest{DeploymentID: mockDeployment.ID}).Return(nil, errMock)
+
+		buf := new(bytes.Buffer)
+		err := Unadopt(mockDeployment.ID, api, buf)
+		s.EqualError(err, errMock.Error())
+		api.AssertExpectations(s.T())
+	})
+}
+
 func (s *Suite) TestList() {
 	clusterID := "testClusterID"
 	testUtil.InitTestConfig(testUtil.SoftwarePlatform)


### PR DESCRIPTION
## Description

APC introduced feature to adopt the airflow deployments created via standalone operator into APC. For this, APC introduced two APIs
- Adopt deployment: To adopt the deployment into APC
- Unadopt deployment: To unadopt deployment from APC

This PR add support for those APIs in CLI

## 🎟 Issue(s)

Resolves PLX-644

## 🧪 Functional Testing

Build the CLI and tested against APC

### Adopt deployment

```
./astro deployment adopt --cluster-id=cmra8iy730008e519f0hma7nx  --cr-name=ce04  --cr-namespace=ce04 --use-apc-logging --use-apc-registry --label="My custom label fooo" --description="Adopted from standalone operator"
 NAME                     DEPLOYMENT NAME     NAMESPACE     CLUSTER ID                    DEPLOYMENT ID
 My custom label fooo     ce04                ce04          cmra8iy730008e519f0hma7nx     cmrccg2w80016hy197qptbj3a

 Successfully adopted deployment
```

<img width="1464" height="241" alt="Screenshot 2026-07-08 at 10 51 15 PM" src="https://github.com/user-attachments/assets/d3f636ad-40a9-4488-8c78-2698a1a4d606" />


### Unadopt deployment

```
./astro deployment unadopt --deployment-id cmrccaqdz0014hy190k24tivc

Warning: This permanently removes the Deployment record from Astronomer Software. The Airflow custom resource, its namespace, and its metadata database are left untouched, but this action cannot be undone from the CLI. Proceed with unadopt? (y/n) y

 Successfully unadopted deployment
```

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
