### PR TITLE
fix(organization): re-gzip audit-log export body (AI-978)

### DIFF
--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -1,6 +1,8 @@
 package organization
 
 import (
+	"bytes"
+	"compress/gzip"
 	http_context "context"
 	"errors"
 	"fmt"
@@ -293,14 +295,43 @@ func ExportAuditLogs(astroV1Client astrov1.APIClient, orgName, filePath string, 
 		return err
 	}
 
+	// The v1 audit-logs endpoint responds with Content-Encoding: gzip, so Go's
+	// HTTP transport transparently decompresses the body and resp.Body is raw
+	// NDJSON. Re-compress it here so the exported .gz file is a valid gzip, as
+	// it was before the v1 migration. Guard against an already-gzipped body in
+	// case the transport does not decompress it (e.g. a proxy strips the header).
+	body, err := ensureGzip(resp.Body)
+	if err != nil {
+		return err
+	}
+
 	filePerms := 0o644
-	err = os.WriteFile(filePath, resp.Body, os.FileMode(filePerms))
+	err = os.WriteFile(filePath, body, os.FileMode(filePerms))
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Finished exporting logs to local GZIP file")
 	return nil
+}
+
+// ensureGzip returns a gzip-compressed copy of body, unless body is already
+// gzip-compressed (identified by the 0x1f 0x8b magic bytes), in which case it
+// is returned unchanged.
+func ensureGzip(body []byte) ([]byte, error) {
+	if len(body) >= 2 && body[0] == 0x1f && body[1] == 0x8b {
+		return body, nil
+	}
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(body); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func pluralize(count int) string {

--- a/cloud/organization/organization_test.go
+++ b/cloud/organization/organization_test.go
@@ -2,6 +2,7 @@ package organization
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"io"
@@ -42,7 +43,9 @@ var (
 			Offset:     0,
 		},
 	}
-	auditLogsBody          = []byte{}
+	// Raw NDJSON, as delivered by the v1 endpoint after the HTTP transport
+	// transparently decompresses the Content-Encoding: gzip response body.
+	auditLogsBody          = []byte("{\"event\":\"one\"}\n{\"event\":\"two\"}\n")
 	mockOKAuditLogResponse = astrov1.GetOrganizationAuditLogsResponse{
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
@@ -498,6 +501,40 @@ func (s *Suite) TestExportAuditLogs() {
 		err := ExportAuditLogs(mockV1Client, "org1", "", 1)
 		s.NoError(err)
 		mockV1Client.AssertExpectations(s.T())
+	})
+	s.Run("exported file is valid gzip of the raw NDJSON body", func() {
+		mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
+		mockV1Client.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(&mockOKResponse, nil).Once()
+		mockV1Client.On("GetOrganizationAuditLogsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&mockOKAuditLogResponse, nil).Once()
+
+		filePath := s.T().TempDir() + "/audit-logs.ndjson.gz"
+		err := ExportAuditLogs(mockV1Client, "org1", filePath, 1)
+		s.NoError(err)
+
+		written, err := os.ReadFile(filePath)
+		s.NoError(err)
+		// File must be a real gzip stream, not raw JSON (the AI-978 regression).
+		s.Equal(byte(0x1f), written[0])
+		s.Equal(byte(0x8b), written[1])
+
+		zr, err := gzip.NewReader(bytes.NewReader(written))
+		s.NoError(err)
+		decompressed, err := io.ReadAll(zr)
+		s.NoError(err)
+		s.Equal(auditLogsBody, decompressed)
+		mockV1Client.AssertExpectations(s.T())
+	})
+	s.Run("already-gzipped body is not double-compressed", func() {
+		var buf bytes.Buffer
+		zw := gzip.NewWriter(&buf)
+		_, err := zw.Write(auditLogsBody)
+		s.NoError(err)
+		s.NoError(zw.Close())
+		alreadyGzipped := buf.Bytes()
+
+		out, err := ensureGzip(alreadyGzipped)
+		s.NoError(err)
+		s.Equal(alreadyGzipped, out)
 	})
 	s.Run("export failure", func() {
 		mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)


### PR DESCRIPTION
## Summary

Fixes [AI-978](https://linear.app/astronomer/issue/AI-978): `astro organization audit-logs export` writes raw JSON into a `.gz` file (and still prints "Finished exporting logs to local GZIP file"), whereas 1.42 produced a valid gzip.

## Root cause

Not a CLI logic change — a transparent-gzip-decompression side effect of the v1 API migration (#2093, shipped in 1.43).

The v1 audit-logs endpoint now sets `Content-Encoding: gzip`, which the legacy v1alpha1 endpoint did not. Both stream the *identical* gzipped NDJSON from Splunk — the only difference is that header.

The CLI uses a bare `&http.Client{}` (`pkg/httputil/http.go`) with no explicit `Accept-Encoding`, so Go's default transport auto-negotiates gzip and **transparently decompresses** any `Content-Encoding: gzip` response. As a result `resp.Body` is now raw NDJSON, which `ExportAuditLogs` writes verbatim into a `.ndjson.gz` file. Pre-v1, the missing header meant Go left the gzip bytes opaque, so the CLI saved a real gzip.

## Fix

Re-compress the body before writing, via a new `ensureGzip` helper, so the exported `.gz` is a valid gzip — byte-compatible with pre-v1 output. `ensureGzip` skips compression when the body already carries the gzip magic bytes (`0x1f 0x8b`), guarding against double-compression if a proxy strips the header or the server behavior changes.

## Tests

- Mock audit-log body is now realistic NDJSON (was empty, so it never exercised the format path).
- New subtest reads the exported file back and asserts it is a valid gzip that decompresses to the original NDJSON.
- New subtest asserts an already-gzipped body is not re-compressed.

- Tested on CLI using the following commands:
```
make build
astro login
astro organization audit-logs export --include 2
```
This produced a file with the name <org>-logs-2-days-20260709.ndjson.gz. Using `gzip -t` on it confirmed compression and `gunzip` confirmed output as text.

`go vet` clean; `cloud/organization` package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)