### PR TITLE
ci: speed up nightly release builds

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -23,6 +23,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: write
   id-token: write  # Required for Octo STS OIDC token exchange
 
@@ -31,23 +32,37 @@ jobs:
     name: Pre-flight summary (review before approving)
     runs-on: ubuntu-latest
     outputs:
+      type: ${{ steps.release-inputs.outputs.type }}
+      version: ${{ steps.release-inputs.outputs.version }}
       tag: ${{ steps.compute.outputs.tag }}
       prev_ga: ${{ steps.compute.outputs.prev_ga }}
-      type: ${{ steps.resolve-type.outputs.type }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - name: Resolve type
-        id: resolve-type
-        run: echo "type=${{ inputs.type || 'nightly' }}" >> "$GITHUB_OUTPUT"
+      - name: Resolve release inputs
+        id: release-inputs
+        env:
+          REQUESTED_TYPE: ${{ inputs.type }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            TYPE="nightly"
+            VERSION=""
+          else
+            TYPE="$REQUESTED_TYPE"
+            VERSION="$REQUESTED_VERSION"
+          fi
+          echo "type=$TYPE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Validate inputs
+        env:
+          TYPE: ${{ steps.release-inputs.outputs.type }}
+          VERSION: ${{ steps.release-inputs.outputs.version }}
         run: |
           set -e
-          TYPE="${{ steps.resolve-type.outputs.type }}"
-          VERSION="${{ inputs.version }}"
           BRANCH="${GITHUB_REF_NAME}"
 
           if [ "$TYPE" = "nightly" ]; then
@@ -65,7 +80,7 @@ jobs:
               exit 1
             fi
             BRANCH_MAJOR_MINOR="${BASH_REMATCH[1]}"
-            ESCAPED_MM=$(echo "$BRANCH_MAJOR_MINOR" | sed 's/\./\\./g')
+            ESCAPED_MM="${BRANCH_MAJOR_MINOR//./\\.}"
             if [[ ! "$VERSION" =~ ^${ESCAPED_MM}\.[0-9]+$ ]]; then
               echo "::error::Version '$VERSION' does not match branch '$BRANCH'. Expected ${BRANCH_MAJOR_MINOR}.Z"
               exit 1
@@ -73,16 +88,48 @@ jobs:
           fi
           echo "Validated: type=$TYPE branch=$BRANCH version=$VERSION"
 
-      - name: Compute tag
-        id: compute
+      - name: Require successful CI for the nightly commit
+        if: steps.release-inputs.outputs.type == 'nightly'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
-          case "${{ steps.resolve-type.outputs.type }}" in
+          CI_RUN=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow ci.yaml \
+            --commit "$GITHUB_SHA" \
+            --event push \
+            --limit 1 \
+            --json status,conclusion,url \
+            --jq '.[0] // empty')
+
+          if [ -z "$CI_RUN" ]; then
+            echo "::error::No push CI run found for commit $GITHUB_SHA."
+            exit 1
+          fi
+
+          STATUS=$(jq -r '.status' <<< "$CI_RUN")
+          CONCLUSION=$(jq -r '.conclusion' <<< "$CI_RUN")
+          URL=$(jq -r '.url' <<< "$CI_RUN")
+          if [ "$STATUS" != "completed" ] || [ "$CONCLUSION" != "success" ]; then
+            echo "::error::CI for commit $GITHUB_SHA is $STATUS/$CONCLUSION: $URL"
+            exit 1
+          fi
+          echo "CI passed for commit $GITHUB_SHA: $URL"
+
+      - name: Compute tag
+        id: compute
+        env:
+          TYPE: ${{ steps.release-inputs.outputs.type }}
+          VERSION: ${{ steps.release-inputs.outputs.version }}
+        run: |
+          set -e
+          case "$TYPE" in
             nightly) TAG=$(make nightly-tag) ;;
-            rc)      TAG=$(make rc-tag VERSION=${{ inputs.version }}) ;;
-            ga)      TAG=$(make release-tag VERSION=${{ inputs.version }}) ;;
+            rc)      TAG=$(make rc-tag VERSION="$VERSION") ;;
+            ga)      TAG=$(make release-tag VERSION="$VERSION") ;;
           esac
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Computed tag: $TAG"
 
           PREV_GA=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" \
@@ -91,13 +138,14 @@ jobs:
             | sort -t. -k1,1n -k2,2n -k3,3n \
             | tail -1 \
             | sed 's/^/v/')
-          echo "prev_ga=$PREV_GA" >> $GITHUB_OUTPUT
+          echo "prev_ga=$PREV_GA" >> "$GITHUB_OUTPUT"
           echo "Previous GA tag: $PREV_GA"
 
       - name: Write release summary
         env:
           TAG: ${{ steps.compute.outputs.tag }}
           PREV_GA: ${{ steps.compute.outputs.prev_ga }}
+          TYPE: ${{ steps.release-inputs.outputs.type }}
         run: |
           set -e
           COMMIT_SHORT=$(git rev-parse --short HEAD)
@@ -110,17 +158,17 @@ jobs:
             echo "| Field | Value |"
             echo "|-------|-------|"
             echo "| Tag | \`$TAG\` |"
-            echo "| Type | **${{ steps.resolve-type.outputs.type }}** |"
+            echo "| Type | **$TYPE** |"
             echo "| Branch | \`${GITHUB_REF_NAME}\` |"
             echo "| Commit | [\`$COMMIT_SHORT\`]($REPO_URL/commit/$COMMIT_FULL) |"
             echo "| Triggered by | @${{ github.actor }} |"
-            if [ "${{ steps.resolve-type.outputs.type }}" = "ga" ]; then
+            if [ "$TYPE" = "ga" ]; then
               echo "| Previous GA | [\`$PREV_GA\`]($REPO_URL/releases/tag/$PREV_GA) |"
             fi
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ steps.resolve-type.outputs.type }}" = "ga" ]; then
+          if [ "$TYPE" = "ga" ]; then
             {
               echo "### Approver checklist"
               echo ""
@@ -133,10 +181,48 @@ jobs:
 
           echo "_Full changelog will be auto-generated on the GitHub release page once the tag is pushed._" >> "$GITHUB_STEP_SUMMARY"
 
-  create-tag:
+  warm-release-cache:
+    name: Warm macOS release cache
     needs: preflight
+    if: needs.preflight.outputs.type == 'nightly'
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve source commit
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        id: setup-go
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Cache Go build outputs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/Library/Caches/go-build
+          key: release-go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}-${{ steps.source.outputs.sha }}
+          restore-keys: |
+            release-go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}-
+
+      - name: Build release artifacts without publishing
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          version: v2.15.2
+          args: release --snapshot --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  create-tag:
+    needs: [preflight, warm-release-cache]
+    if: always() && needs.preflight.result == 'success' && (needs.warm-release-cache.result == 'success' || needs.warm-release-cache.result == 'skipped')
     runs-on: ubuntu-latest
-    environment: ${{ inputs.type == 'ga' && 'release' || '' }}
+    environment: ${{ needs.preflight.outputs.type == 'ga' && 'release' || '' }}
     steps:
       - name: Get token via Octo STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-nightly.[0-9]*'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,6 +15,7 @@ permissions:
 
 jobs:
   detect:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       type: ${{ steps.parse.outputs.type }}
@@ -108,6 +110,39 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ steps.homebrew-token.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ needs.detect.outputs.tag }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.prev-tag.outputs.tag }}
+
+  benchmark-macos:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Record runner details
+        run: |
+          sw_vers
+          uname -m
+          sysctl -n hw.ncpu
+          go version
+
+      - name: Use the native macOS compiler
+        run: |
+          sed -i '' 's/CC=o64-clang/CC=clang/' .goreleaser.yml
+          sed -i '' 's/CXX=o64-clang++/CXX=clang++/' .goreleaser.yml
+
+      - name: Benchmark GoReleaser without publishing
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          version: v2.15.2
+          args: release --snapshot --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-godownloader:
     needs: [detect, release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,10 +140,9 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: v2.15.2
-          args: release --snapshot --clean --skip=publish --parallelism=3
+          args: release --snapshot --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GOMAXPROCS: 1
 
   update-godownloader:
     needs: [detect, release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,7 @@ jobs:
 
   benchmark-macos:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -121,8 +121,18 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        id: setup-go
         with:
           go-version-file: go.mod
+          cache: false
+
+      - name: Cache Go build outputs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/Library/Caches/go-build
+          key: release-go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            release-go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}-
 
       - name: Record runner details
         run: |
@@ -143,6 +153,12 @@ jobs:
           args: release --snapshot --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Record Go cache sizes
+        if: always()
+        run: |
+          du -sh "$(go env GOCACHE)"
+          du -sh "$(go env GOMODCACHE)"
 
   update-godownloader:
     needs: [detect, release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,9 +140,10 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: v2.15.2
-          args: release --snapshot --clean --skip=publish
+          args: release --snapshot --clean --skip=publish --parallelism=3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOMAXPROCS: 1
 
   update-godownloader:
     needs: [detect, release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-nightly.[0-9]*'
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -15,7 +14,6 @@ permissions:
 
 jobs:
   detect:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       type: ${{ steps.parse.outputs.type }}
@@ -26,57 +24,50 @@ jobs:
         id: parse
         run: |
           TAG="${GITHUB_REF_NAME}"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
           if [[ "$TAG" =~ -nightly\. ]]; then
             TYPE="nightly"
-            VERSION=$(echo "$TAG" | sed 's/^v//')
+            VERSION="${TAG#v}"
           elif [[ "$TAG" =~ -rc\. ]]; then
             TYPE="rc"
-            VERSION=$(echo "$TAG" | sed 's/^v//; s/-rc\.[0-9]*$//')
+            VERSION="${TAG#v}"
+            VERSION="${VERSION%-rc.*}"
           else
             TYPE="ga"
-            VERSION=$(echo "$TAG" | sed 's/^v//')
+            VERSION="${TAG#v}"
           fi
 
-          echo "type=$TYPE" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "type=$TYPE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Parsed — Tag: $TAG | Type: $TYPE | Version: $VERSION"
 
   release:
     needs: detect
-    runs-on: ubuntu-latest
+    runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
+      - name: Resolve source commit
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        id: setup-go
         with:
           go-version-file: go.mod
+          cache: false
 
-      - name: Install cross-compilation tools
-        run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-            clang llvm cmake libssl-dev patch zlib1g-dev xz-utils
-
-      - name: Cache osxcross
-        id: cache-osxcross
+      - name: Cache Go build outputs
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: /tmp/osxcross
-          key: osxcross-macos12.3-${{ runner.os }}
-
-      - name: Build osxcross
-        if: steps.cache-osxcross.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/tpoechtrager/osxcross.git /tmp/osxcross
-          wget -q https://github.com/joseluisq/macosx-sdks/releases/download/12.3/MacOSX12.3.sdk.tar.xz \
-            -P /tmp/osxcross/tarballs/
-          cd /tmp/osxcross && UNATTENDED=yes ./build.sh
-
-      - name: Add osxcross to PATH
-        run: echo "/tmp/osxcross/target/bin" >> $GITHUB_PATH
+          path: ~/Library/Caches/go-build
+          key: release-go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}-${{ steps.source.outputs.sha }}
+          restore-keys: |
+            release-go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}-
 
       - name: Find previous GA tag for changelog
         id: prev-tag
@@ -90,7 +81,7 @@ jobs:
             | sort -t. -k1,1n -k2,2n -k3,3n \
             | tail -1 \
             | sed 's/^/v/')
-          echo "tag=$PREV_GA" >> $GITHUB_OUTPUT
+          echo "tag=$PREV_GA" >> "$GITHUB_OUTPUT"
           echo "Previous GA tag for changelog: $PREV_GA"
 
       - name: Get Homebrew token via Octo STS
@@ -110,55 +101,6 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ steps.homebrew-token.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ needs.detect.outputs.tag }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.prev-tag.outputs.tag }}
-
-  benchmark-macos:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: macos-15
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        id: setup-go
-        with:
-          go-version-file: go.mod
-          cache: false
-
-      - name: Cache Go build outputs
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/Library/Caches/go-build
-          key: release-go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
-          restore-keys: |
-            release-go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}-
-
-      - name: Record runner details
-        run: |
-          sw_vers
-          uname -m
-          sysctl -n hw.ncpu
-          go version
-
-      - name: Use the native macOS compiler
-        run: |
-          sed -i '' 's/CC=o64-clang/CC=clang/' .goreleaser.yml
-          sed -i '' 's/CXX=o64-clang++/CXX=clang++/' .goreleaser.yml
-
-      - name: Benchmark GoReleaser without publishing
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
-        with:
-          version: v2.15.2
-          args: release --snapshot --clean --skip=publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Record Go cache sizes
-        if: always()
-        run: |
-          du -sh "$(go env GOCACHE)"
-          du -sh "$(go env GOMODCACHE)"
 
   update-godownloader:
     needs: [detect, release]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,8 @@ builds:
     binary: astro
     env:
       - CGO_ENABLED=1
-      - CC=o64-clang
-      - CXX=o64-clang++
+      - CC=clang
+      - CXX=clang++
     goos:
       - darwin
     goarch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,6 @@ version: 2
 before:
   hooks:
     - go mod download
-    - go mod tidy
 release:
   github:
     owner: astronomer

--- a/version/version.go
+++ b/version/version.go
@@ -14,6 +14,7 @@ import (
 	"github.com/astronomer/astro-cli/pkg/ansi"
 )
 
+// CurrVersion is injected at build time with the release version.
 var CurrVersion string
 
 const (

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,6 @@ import (
 	"github.com/astronomer/astro-cli/pkg/ansi"
 )
 
-// CurrVersion is injected at build time with the release version.
 var CurrVersion string
 
 const (


### PR DESCRIPTION
## Summary

- run GoReleaser natively on pinned `macos-15` runners and remove the per-release osxcross toolchain build
- cache only Go build outputs with a source-SHA key, then warm that exact cache before creating nightly tags
- build on #2202's 07:00 UTC nightly schedule and require successful push CI for the exact commit before tagging
- remove the redundant `go mod tidy` release hook and clean up the release shell scripts

## Why

The latest release job took 26m40s. Roughly 10m30s went to building osxcross and another 14m55s went to GoReleaser. A native macOS runner can build all seven release targets—including both CGO-enabled Darwin binaries—without osxcross.

## Measured results

| Scenario | Total |
| --- | ---: |
| Existing release job | 26m40s |
| Native macOS, cold combined cache | 13m25s |
| Native macOS, realistic source edit | 3m59s |
| Go build cache only, cold | 11m52s |
| Go build cache only, warm | 3m39s |

The expected warmed tag release is about four minutes, roughly 85% faster than the current job.

Benchmark runs:

- realistic source change: https://github.com/astronomer/astro-cli/actions/runs/29101052038
- build-cache-only cold: https://github.com/astronomer/astro-cli/actions/runs/29101346123
- build-cache-only warm: https://github.com/astronomer/astro-cli/actions/runs/29102153269

## Release behavior

Scheduled and manually triggered nightlies now:

1. verify that exact-SHA push CI completed successfully
2. build all release targets on macOS to warm the cache
3. create and push the nightly tag
4. restore the same exact-SHA cache in the tag-triggered release workflow

The daily 07:00 UTC schedule was introduced by #2202. RC and GA releases remain manually triggered.

## Validation

- completed live GoReleaser snapshot builds for all seven targets
- verified native Darwin amd64 and arm64 CGO builds
- ran `actionlint` on both changed workflows
- ran `goreleaser check` (it reports the repository's existing deprecated configuration fields)
- parsed all changed YAML files
- tested the exact-SHA CI lookup against the current main commit

## Rollout note

The preflight was tested against the previously failing main SHA and correctly rejected it. Keep this PR in draft until CI on the rebased branch is green.
