### PR TITLE
Expand `astro api`: full `describe` fields + `--json` for describe & ls

### DIFF
--- a/cmd/api/airflow.go
+++ b/cmd/api/airflow.go
@@ -578,6 +578,7 @@ func NewAirflowListCmd(out io.Writer, parentOpts *AirflowOptions) *cobra.Command
 	var filter string
 	var verbose bool
 	var refresh bool
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:     "ls [filter]",
@@ -615,7 +616,9 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 				return err
 			}
 
-			fmt.Fprintf(out, "Airflow version: %s\n\n", parentOpts.detectedVersion)
+			if !jsonOut {
+				fmt.Fprintf(out, "Airflow version: %s\n\n", parentOpts.detectedVersion)
+			}
 
 			// Create list options
 			listOpts := &ListOptions{
@@ -624,6 +627,7 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 				Filter:    filter,
 				Verbose:   verbose,
 				Refresh:   refresh,
+				JSON:      jsonOut,
 			}
 
 			return runList(listOpts)
@@ -632,6 +636,7 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show additional details like summaries and tags")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint list as JSON for programmatic use")
 
 	return cmd
 }

--- a/cmd/api/airflow.go
+++ b/cmd/api/airflow.go
@@ -641,6 +641,7 @@ func NewAirflowDescribeCmd(out io.Writer, parentOpts *AirflowOptions) *cobra.Com
 	var method string
 	var refresh bool
 	var verbose bool
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "describe <endpoint>",
@@ -680,6 +681,7 @@ The endpoint can be specified as a path or as an operation ID.`,
 				Method:    method,
 				Refresh:   refresh,
 				Verbose:   verbose,
+				JSON:      jsonOut,
 			}
 
 			return runDescribe(descOpts)
@@ -689,6 +691,7 @@ The endpoint can be specified as a path or as an operation ID.`,
 	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (GET, POST, PUT, PATCH, DELETE)")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show spec URL and additional details")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint's schema as JSON (with $refs resolved) for programmatic use")
 
 	return cmd
 }

--- a/cmd/api/airflow.go
+++ b/cmd/api/airflow.go
@@ -636,7 +636,7 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show additional details like summaries and tags")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint list as JSON for programmatic use")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint list as JSON")
 
 	return cmd
 }
@@ -696,7 +696,7 @@ The endpoint can be specified as a path or as an operation ID.`,
 	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (GET, POST, PUT, PATCH, DELETE)")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show spec URL and additional details")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint's schema as JSON (with $refs resolved) for programmatic use")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint schema as JSON")
 
 	return cmd
 }

--- a/cmd/api/cloud.go
+++ b/cmd/api/cloud.go
@@ -499,6 +499,7 @@ func NewCloudDescribeCmd(out io.Writer, parentOpts *CloudOptions) *cobra.Command
 	var method string
 	var refresh bool
 	var verbose bool
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "describe <endpoint>",
@@ -539,6 +540,7 @@ The endpoint can be specified as a path or as an operation ID.`,
 				Method:    method,
 				Refresh:   refresh,
 				Verbose:   verbose,
+				JSON:      jsonOut,
 			}
 			return runDescribe(descOpts)
 		},
@@ -547,6 +549,7 @@ The endpoint can be specified as a path or as an operation ID.`,
 	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (GET, POST, PUT, PATCH, DELETE)")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show spec URL and additional details")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint's schema as JSON (with $refs resolved) for programmatic use")
 
 	return cmd
 }

--- a/cmd/api/cloud.go
+++ b/cmd/api/cloud.go
@@ -436,6 +436,7 @@ func initCloudSpecCache(opts *CloudOptions, ctx *config.Context) error {
 func NewCloudListCmd(out io.Writer, parentOpts *CloudOptions) *cobra.Command {
 	var verbose bool
 	var refresh bool
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:     "ls [filter]",
@@ -482,6 +483,7 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 				Filter:    filter,
 				Verbose:   verbose,
 				Refresh:   refresh,
+				JSON:      jsonOut,
 			}
 			return runList(listOpts)
 		},
@@ -489,6 +491,7 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show additional details like summaries and tags")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint list as JSON for programmatic use")
 
 	return cmd
 }

--- a/cmd/api/cloud.go
+++ b/cmd/api/cloud.go
@@ -491,7 +491,7 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show additional details like summaries and tags")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint list as JSON for programmatic use")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint list as JSON")
 
 	return cmd
 }
@@ -552,7 +552,7 @@ The endpoint can be specified as a path or as an operation ID.`,
 	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (GET, POST, PUT, PATCH, DELETE)")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show spec URL and additional details")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint's schema as JSON (with $refs resolved) for programmatic use")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint schema as JSON")
 
 	return cmd
 }

--- a/cmd/api/describe.go
+++ b/cmd/api/describe.go
@@ -321,7 +321,7 @@ func printResponseSchema(out io.Writer, entry *openapi.ResponseEntry, resolver *
 	if refName != "" {
 		fmt.Fprintf(out, "    Schema: %s\n", color.CyanString(refName))
 	}
-	if resolved != nil && hasExpandableFields(resolved) {
+	if resolved != nil && hasExpandableFields(resolved, resolver) {
 		printSchema(out, mt.Schema, resolver, baseResponseDepth, make(map[string]bool), responseSchemaPrintOpts())
 	}
 }
@@ -380,30 +380,12 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 	// Handle oneOf / anyOf / allOf when composition is enabled
 	if opts.ShowComposition {
 		if len(schema.OneOf) > 0 {
-			fmt.Fprintf(out, "%s%s\n", prefix, color.HiBlackString("One of the following:"))
-			for i, childRef := range schema.OneOf {
-				_, childName := resolver.ResolveSchema(childRef)
-				if childName != "" {
-					fmt.Fprintf(out, "\n%s%s %s\n", prefix, color.CyanString("Option %d:", i+1), childName)
-				} else {
-					fmt.Fprintf(out, "\n%s%s\n", prefix, color.CyanString("Option %d:", i+1))
-				}
-				printSchema(out, childRef, resolver, indent+2, ancestors, opts)
-			}
+			printSchemaOptions(out, "One of the following:", schema.OneOf, resolver, indent, ancestors, opts)
 			return
 		}
 
 		if len(schema.AnyOf) > 0 {
-			fmt.Fprintf(out, "%s%s\n", prefix, color.HiBlackString("Any of the following:"))
-			for i, childRef := range schema.AnyOf {
-				_, childName := resolver.ResolveSchema(childRef)
-				if childName != "" {
-					fmt.Fprintf(out, "\n%s%s %s\n", prefix, color.CyanString("Option %d:", i+1), childName)
-				} else {
-					fmt.Fprintf(out, "\n%s%s\n", prefix, color.CyanString("Option %d:", i+1))
-				}
-				printSchema(out, childRef, resolver, indent+2, ancestors, opts)
-			}
+			printSchemaOptions(out, "Any of the following:", schema.AnyOf, resolver, indent, ancestors, opts)
 			return
 		}
 
@@ -420,7 +402,7 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 	// Arrays can appear at the schema root or as nested properties. Render their
 	// element fields at the array's current indentation level.
 	if schema.Type == schemaTypeArray && schema.Items != nil {
-		if item, _ := resolver.ResolveSchema(schema.Items); hasExpandableFields(item) {
+		if item, _ := resolver.ResolveSchema(schema.Items); hasExpandableFields(item, resolver) {
 			printSchema(out, schema.Items, resolver, indent, ancestors, opts)
 		}
 	}
@@ -484,20 +466,62 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 				continue
 			}
 
-			if hasExpandableFields(prop) {
+			if hasExpandableFields(prop, resolver) {
 				printSchema(out, propRef, resolver, indent+indentIncrement, ancestors, opts)
 			}
 		}
 	}
 }
 
+// printSchemaOptions prints composition branches and expands branches with
+// nested fields. Leaf branches still include their type, such as "null".
+func printSchemaOptions(out io.Writer, heading string, children []*openapi.SchemaRef, resolver *openapi.SchemaResolver, indent int, ancestors map[string]bool, opts schemaPrintOpts) {
+	prefix := strings.Repeat(" ", indent)
+	fmt.Fprintf(out, "%s%s\n", prefix, color.HiBlackString(heading))
+	for i, childRef := range children {
+		child, childName := resolver.ResolveSchema(childRef)
+		childType := getTypeString(child, childName)
+		fmt.Fprintf(out, "\n%s%s %s\n", prefix, color.CyanString("Option %d:", i+1), childType)
+		if (childName != "" && ancestors[childName]) || hasExpandableFields(child, resolver) {
+			printSchema(out, childRef, resolver, indent+2, ancestors, opts)
+		}
+	}
+}
+
 // hasExpandableFields reports whether a schema has nested structure worth
 // printing.
-func hasExpandableFields(s *openapi.Schema) bool {
+func hasExpandableFields(s *openapi.Schema, resolver *openapi.SchemaResolver) bool {
+	return hasExpandableFieldsSeen(s, resolver, make(map[*openapi.Schema]bool))
+}
+
+func hasExpandableFieldsSeen(s *openapi.Schema, resolver *openapi.SchemaResolver, seen map[*openapi.Schema]bool) bool {
 	if s == nil {
 		return false
 	}
-	return len(s.Properties) > 0 || s.Items != nil || len(s.OneOf) > 0 || len(s.AnyOf) > 0 || len(s.AllOf) > 0
+	if seen[s] {
+		return false
+	}
+	seen[s] = true
+	defer delete(seen, s)
+
+	if len(s.Properties) > 0 || len(s.AllOf) > 0 {
+		return true
+	}
+	if s.Items != nil {
+		item, _ := resolver.ResolveSchema(s.Items)
+		if hasExpandableFieldsSeen(item, resolver, seen) {
+			return true
+		}
+	}
+	for _, children := range [][]*openapi.SchemaRef{s.OneOf, s.AnyOf} {
+		for _, childRef := range children {
+			child, _ := resolver.ResolveSchema(childRef)
+			if hasExpandableFieldsSeen(child, resolver, seen) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // getTypeString returns a human-readable type string for a schema.
@@ -508,6 +532,9 @@ func getTypeString(schema *openapi.Schema, refName string) string {
 
 	if schema == nil {
 		return "any"
+	}
+	if typeStr := getCompositionTypeString(schema); typeStr != "" {
+		return typeStr
 	}
 
 	typeStr := schema.Type
@@ -536,4 +563,35 @@ func getTypeString(schema *openapi.Schema, refName string) string {
 	}
 
 	return typeStr
+}
+
+// getCompositionTypeString returns a compact type union for oneOf/anyOf leaf
+// branches, such as "string or null" or "TaskInstanceState or null".
+func getCompositionTypeString(schema *openapi.Schema) string {
+	children := schema.OneOf
+	if len(children) == 0 {
+		children = schema.AnyOf
+	}
+	if len(children) == 0 {
+		return ""
+	}
+
+	types := make([]string, 0, len(children))
+	seen := make(map[string]bool, len(children))
+	for _, childRef := range children {
+		if childRef == nil {
+			continue
+		}
+		childName := ""
+		if childRef.Ref != "" {
+			parts := strings.Split(childRef.Ref, "/")
+			childName = parts[len(parts)-1]
+		}
+		childType := getTypeString(childRef.Value, childName)
+		if childType != "any" && !seen[childType] {
+			types = append(types, childType)
+			seen[childType] = true
+		}
+	}
+	return strings.Join(types, " or ")
 }

--- a/cmd/api/describe.go
+++ b/cmd/api/describe.go
@@ -321,7 +321,7 @@ func printResponseSchema(out io.Writer, entry *openapi.ResponseEntry, resolver *
 	if refName != "" {
 		fmt.Fprintf(out, "    Schema: %s\n", color.CyanString(refName))
 	}
-	if resolved != nil && len(resolved.Properties) > 0 {
+	if resolved != nil && hasExpandableFields(resolved) {
 		printSchema(out, mt.Schema, resolver, baseResponseDepth, make(map[string]bool), responseSchemaPrintOpts())
 	}
 }
@@ -355,7 +355,7 @@ func printResponses(out io.Writer, responses *openapi.Responses, resolver *opena
 // The schemaPrintOpts control which features (composition, defaults, etc.) are rendered.
 //
 //nolint:gocognit,gocyclo // Complex but necessary for comprehensive schema display
-func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.SchemaResolver, indent int, visited map[string]bool, opts schemaPrintOpts) {
+func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.SchemaResolver, indent int, ancestors map[string]bool, opts schemaPrintOpts) {
 	if schemaRef == nil {
 		return
 	}
@@ -369,11 +369,12 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 
 	// Handle $ref (cycle detection)
 	if refName != "" {
-		if visited[refName] {
+		if ancestors[refName] {
 			fmt.Fprintf(out, "%s(see %s above)\n", prefix, refName)
 			return
 		}
-		visited[refName] = true
+		ancestors[refName] = true
+		defer delete(ancestors, refName)
 	}
 
 	// Handle oneOf / anyOf / allOf when composition is enabled
@@ -387,7 +388,7 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 				} else {
 					fmt.Fprintf(out, "\n%s%s\n", prefix, color.CyanString("Option %d:", i+1))
 				}
-				printSchema(out, childRef, resolver, indent+2, visited, opts)
+				printSchema(out, childRef, resolver, indent+2, ancestors, opts)
 			}
 			return
 		}
@@ -401,7 +402,7 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 				} else {
 					fmt.Fprintf(out, "\n%s%s\n", prefix, color.CyanString("Option %d:", i+1))
 				}
-				printSchema(out, childRef, resolver, indent+2, visited, opts)
+				printSchema(out, childRef, resolver, indent+2, ancestors, opts)
 			}
 			return
 		}
@@ -409,10 +410,18 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 		if len(schema.AllOf) > 0 {
 			fmt.Fprintf(out, "%s%s\n", prefix, color.HiBlackString("All of the following:"))
 			for _, childRef := range schema.AllOf {
-				printSchema(out, childRef, resolver, indent, visited, opts)
+				printSchema(out, childRef, resolver, indent, ancestors, opts)
 			}
 			// Fall through: an allOf schema commonly also defines its own
 			// top-level properties (extend-a-base pattern), which must print too.
+		}
+	}
+
+	// Arrays can appear at the schema root or as nested properties. Render their
+	// element fields at the array's current indentation level.
+	if schema.Type == schemaTypeArray && schema.Items != nil {
+		if item, _ := resolver.ResolveSchema(schema.Items); hasExpandableFields(item) {
+			printSchema(out, schema.Items, resolver, indent, ancestors, opts)
 		}
 	}
 
@@ -475,33 +484,20 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 				continue
 			}
 
-			// Expand nested object properties, including those reached via $ref.
-			if len(prop.Properties) > 0 {
-				printSchema(out, propRef, resolver, indent+indentIncrement, visited, opts)
-			}
-
-			// Expand the element schema of arrays of objects (including $ref items).
-			if prop.Type == schemaTypeArray && prop.Items != nil {
-				if item, _ := resolver.ResolveSchema(prop.Items); item != nil && hasExpandableFields(item) {
-					printSchema(out, prop.Items, resolver, indent+indentIncrement, visited, opts)
-				}
-			}
-
-			// Handle nested composition in properties.
-			if opts.ShowComposition && (len(prop.OneOf) > 0 || len(prop.AnyOf) > 0 || len(prop.AllOf) > 0) {
-				printSchema(out, propRef, resolver, indent+indentIncrement, visited, opts)
+			if hasExpandableFields(prop) {
+				printSchema(out, propRef, resolver, indent+indentIncrement, ancestors, opts)
 			}
 		}
 	}
 }
 
 // hasExpandableFields reports whether a schema has nested structure worth
-// printing (properties or a composition of sub-schemas).
+// printing.
 func hasExpandableFields(s *openapi.Schema) bool {
 	if s == nil {
 		return false
 	}
-	return len(s.Properties) > 0 || len(s.OneOf) > 0 || len(s.AnyOf) > 0 || len(s.AllOf) > 0
+	return len(s.Properties) > 0 || s.Items != nil || len(s.OneOf) > 0 || len(s.AnyOf) > 0 || len(s.AllOf) > 0
 }
 
 // getTypeString returns a human-readable type string for a schema.

--- a/cmd/api/describe.go
+++ b/cmd/api/describe.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	schemaTypeObject  = "object"
+	schemaTypeArray   = "array"
 	separatorWidth    = 60
 	indentIncrement   = 4
 	maxSchemaIndent   = 10
@@ -28,6 +28,7 @@ type DescribeOptions struct {
 	Method    string
 	Refresh   bool
 	Verbose   bool
+	JSON      bool
 }
 
 // runDescribe executes the describe command.
@@ -36,7 +37,7 @@ func runDescribe(opts *DescribeOptions) error {
 		return fmt.Errorf("API specification not initialized. Ensure you are logged in and try again")
 	}
 
-	if opts.Verbose {
+	if opts.Verbose && !opts.JSON {
 		fmt.Fprintf(opts.Out, "Spec URL: %s\n\n", opts.specCache.GetSpecURL())
 	}
 
@@ -90,8 +91,14 @@ func runDescribe(opts *DescribeOptions) error {
 		return fmt.Errorf("no endpoint found matching '%s'", opts.Endpoint)
 	}
 
-	// If multiple matches and no method specified, show all
-	resolver := openapi.NewSchemaResolver()
+	// If multiple matches and no method specified, show all.
+	// Build the resolver with the spec's component schemas so $ref references
+	// in request/response bodies expand to their fields.
+	resolver := openapi.NewSchemaResolverWithSchemas(opts.specCache.GetSchemas())
+
+	if opts.JSON {
+		return writeEndpointsJSON(opts.Out, matches, resolver)
+	}
 
 	for i := range matches {
 		if i > 0 {
@@ -237,11 +244,11 @@ func printRequestBody(out io.Writer, body *openapi.RequestBody, resolver *openap
 	// Get the JSON schema
 	if body.Content != nil {
 		if mt, ok := body.Content["application/json"]; ok && mt.Schema != nil {
-			_, refName := resolver.ResolveSchema(mt.Schema)
+			resolved, refName := resolver.ResolveSchema(mt.Schema)
 			if refName != "" {
 				fmt.Fprintf(out, "  Schema: %s\n", color.CyanString(refName))
 			}
-			if mt.Schema.Value != nil {
+			if resolved != nil {
 				printSchema(out, mt.Schema, resolver, 2, make(map[string]bool), requestSchemaPrintOpts())
 			}
 		}
@@ -310,11 +317,11 @@ func printResponseSchema(out io.Writer, entry *openapi.ResponseEntry, resolver *
 	if !ok || mt.Schema == nil {
 		return
 	}
-	_, refName := resolver.ResolveSchema(mt.Schema)
+	resolved, refName := resolver.ResolveSchema(mt.Schema)
 	if refName != "" {
 		fmt.Fprintf(out, "    Schema: %s\n", color.CyanString(refName))
 	}
-	if mt.Schema.Value != nil && len(mt.Schema.Value.Properties) > 0 {
+	if resolved != nil && len(resolved.Properties) > 0 {
 		printSchema(out, mt.Schema, resolver, baseResponseDepth, make(map[string]bool), responseSchemaPrintOpts())
 	}
 }
@@ -349,16 +356,19 @@ func printResponses(out io.Writer, responses *openapi.Responses, resolver *opena
 //
 //nolint:gocognit,gocyclo // Complex but necessary for comprehensive schema display
 func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.SchemaResolver, indent int, visited map[string]bool, opts schemaPrintOpts) {
-	if schemaRef == nil || schemaRef.Value == nil {
+	if schemaRef == nil {
 		return
 	}
 
-	schema := schemaRef.Value
+	// Resolve through the resolver so $ref schemas expand to their fields.
+	schema, refName := resolver.ResolveSchema(schemaRef)
+	if schema == nil {
+		return
+	}
 	prefix := strings.Repeat(" ", indent)
 
 	// Handle $ref (cycle detection)
-	if schemaRef.Ref != "" {
-		_, refName := resolver.ResolveSchema(schemaRef)
+	if refName != "" {
 		if visited[refName] {
 			fmt.Fprintf(out, "%s(see %s above)\n", prefix, refName)
 			return
@@ -371,22 +381,13 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 		if len(schema.OneOf) > 0 {
 			fmt.Fprintf(out, "%s%s\n", prefix, color.HiBlackString("One of the following:"))
 			for i, childRef := range schema.OneOf {
-				_, refName := resolver.ResolveSchema(childRef)
-				if refName != "" {
-					fmt.Fprintf(out, "\n%s%s %s\n", prefix, color.CyanString("Option %d:", i+1), refName)
+				_, childName := resolver.ResolveSchema(childRef)
+				if childName != "" {
+					fmt.Fprintf(out, "\n%s%s %s\n", prefix, color.CyanString("Option %d:", i+1), childName)
 				} else {
 					fmt.Fprintf(out, "\n%s%s\n", prefix, color.CyanString("Option %d:", i+1))
 				}
-				if childRef.Value != nil {
-					if visited[refName] {
-						fmt.Fprintf(out, "%s  (see %s above)\n", prefix, refName)
-					} else {
-						if refName != "" {
-							visited[refName] = true
-						}
-						printSchema(out, childRef, resolver, indent+2, visited, opts)
-					}
-				}
+				printSchema(out, childRef, resolver, indent+2, visited, opts)
 			}
 			return
 		}
@@ -394,18 +395,13 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 		if len(schema.AnyOf) > 0 {
 			fmt.Fprintf(out, "%s%s\n", prefix, color.HiBlackString("Any of the following:"))
 			for i, childRef := range schema.AnyOf {
-				_, refName := resolver.ResolveSchema(childRef)
-				if refName != "" {
-					fmt.Fprintf(out, "\n%s%s %s\n", prefix, color.CyanString("Option %d:", i+1), refName)
+				_, childName := resolver.ResolveSchema(childRef)
+				if childName != "" {
+					fmt.Fprintf(out, "\n%s%s %s\n", prefix, color.CyanString("Option %d:", i+1), childName)
 				} else {
 					fmt.Fprintf(out, "\n%s%s\n", prefix, color.CyanString("Option %d:", i+1))
 				}
-				if childRef.Value != nil {
-					if refName != "" {
-						visited[refName] = true
-					}
-					printSchema(out, childRef, resolver, indent+2, visited, opts)
-				}
+				printSchema(out, childRef, resolver, indent+2, visited, opts)
 			}
 			return
 		}
@@ -413,13 +409,7 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 		if len(schema.AllOf) > 0 {
 			fmt.Fprintf(out, "%s%s\n", prefix, color.HiBlackString("All of the following:"))
 			for _, childRef := range schema.AllOf {
-				if childRef.Value != nil {
-					_, refName := resolver.ResolveSchema(childRef)
-					if refName != "" {
-						visited[refName] = true
-					}
-					printSchema(out, childRef, resolver, indent, visited, opts)
-				}
+				printSchema(out, childRef, resolver, indent, visited, opts)
 			}
 			return
 		}
@@ -438,10 +428,12 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 
 		for _, name := range propNames {
 			propRef := propMap[name]
-			if propRef == nil || propRef.Value == nil {
+			// Resolve through the resolver so $ref properties expand to the
+			// referenced schema's fields rather than showing just a name.
+			prop, refName := resolver.ResolveSchema(propRef)
+			if prop == nil {
 				continue
 			}
-			prop := propRef.Value
 
 			// Skip read-only properties in request schemas
 			if opts.SkipReadOnly && prop.ReadOnly {
@@ -451,12 +443,6 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 			required := ""
 			if openapi.IsRequired(name, schema.Required) {
 				required = color.RedString("*")
-			}
-
-			// Extract ref name if this is a $ref property
-			refName := ""
-			if propRef.Ref != "" {
-				_, refName = resolver.ResolveSchema(propRef)
 			}
 
 			typeStr := getTypeString(prop, refName)
@@ -478,19 +464,37 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 				fmt.Fprintf(out, "%s    Default: %v\n", prefix, prop.Default)
 			}
 
-			propType := prop.Type
+			if indent >= opts.MaxIndent {
+				continue
+			}
 
-			// Show nested object properties (but limit depth)
-			if indent < opts.MaxIndent && propType == schemaTypeObject && len(prop.Properties) > 0 {
+			// Expand nested object properties, including those reached via $ref.
+			if len(prop.Properties) > 0 {
 				printSchema(out, propRef, resolver, indent+indentIncrement, visited, opts)
 			}
 
-			// Handle nested composition in properties
+			// Expand the element schema of arrays of objects (including $ref items).
+			if prop.Type == schemaTypeArray && prop.Items != nil {
+				if item, _ := resolver.ResolveSchema(prop.Items); item != nil && hasExpandableFields(item) {
+					printSchema(out, prop.Items, resolver, indent+indentIncrement, visited, opts)
+				}
+			}
+
+			// Handle nested composition in properties.
 			if opts.ShowComposition && (len(prop.OneOf) > 0 || len(prop.AnyOf) > 0 || len(prop.AllOf) > 0) {
 				printSchema(out, propRef, resolver, indent+indentIncrement, visited, opts)
 			}
 		}
 	}
+}
+
+// hasExpandableFields reports whether a schema has nested structure worth
+// printing (properties or a composition of sub-schemas).
+func hasExpandableFields(s *openapi.Schema) bool {
+	if s == nil {
+		return false
+	}
+	return len(s.Properties) > 0 || len(s.OneOf) > 0 || len(s.AnyOf) > 0 || len(s.AllOf) > 0
 }
 
 // getTypeString returns a human-readable type string for a schema.
@@ -512,7 +516,7 @@ func getTypeString(schema *openapi.Schema, refName string) string {
 		typeStr += " (" + schema.Format + ")"
 	}
 
-	if schema.Type == "array" && schema.Items != nil {
+	if schema.Type == schemaTypeArray && schema.Items != nil {
 		itemType := ""
 		if schema.Items.Value != nil {
 			itemType = schema.Items.Value.Type

--- a/cmd/api/describe.go
+++ b/cmd/api/describe.go
@@ -411,7 +411,8 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 			for _, childRef := range schema.AllOf {
 				printSchema(out, childRef, resolver, indent, visited, opts)
 			}
-			return
+			// Fall through: an allOf schema commonly also defines its own
+			// top-level properties (extend-a-base pattern), which must print too.
 		}
 	}
 
@@ -431,18 +432,24 @@ func printSchema(out io.Writer, schemaRef *openapi.SchemaRef, resolver *openapi.
 			// Resolve through the resolver so $ref properties expand to the
 			// referenced schema's fields rather than showing just a name.
 			prop, refName := resolver.ResolveSchema(propRef)
+
+			required := ""
+			if openapi.IsRequired(name, schema.Required) {
+				required = color.RedString("*")
+			}
+
+			// Unresolved $ref (schema not in the registry): still show the
+			// property name and the referenced schema name, just don't recurse.
 			if prop == nil {
+				if refName != "" {
+					fmt.Fprintf(out, "%s%s%s  %s\n", prefix, color.GreenString(name), required, color.HiBlackString(getTypeString(nil, refName)))
+				}
 				continue
 			}
 
 			// Skip read-only properties in request schemas
 			if opts.SkipReadOnly && prop.ReadOnly {
 				continue
-			}
-
-			required := ""
-			if openapi.IsRequired(name, schema.Required) {
-				required = color.RedString("*")
 			}
 
 			typeStr := getTypeString(prop, refName)
@@ -499,12 +506,12 @@ func hasExpandableFields(s *openapi.Schema) bool {
 
 // getTypeString returns a human-readable type string for a schema.
 func getTypeString(schema *openapi.Schema, refName string) string {
-	if schema == nil {
-		return "any"
-	}
-
 	if refName != "" {
 		return refName
+	}
+
+	if schema == nil {
+		return "any"
 	}
 
 	typeStr := schema.Type

--- a/cmd/api/describe_json.go
+++ b/cmd/api/describe_json.go
@@ -12,6 +12,15 @@ import (
 // --json flag. Schemas are resolved down the $ref stack so an agent gets the
 // actual fields without needing the spec; genuine cycles are cut and marked
 // with "circular": true rather than recursing forever.
+//
+// A single matched endpoint is emitted as a JSON object; a path matching
+// multiple methods is emitted as an array of objects.
+
+// maxJSONSchemaDepth bounds resolveSchemaJSON's recursion. Cycles are already
+// cut via the ancestry set; this is a backstop against pathologically deep or
+// wide (diamond) acyclic schemas so output stays bounded. Real specs nest far
+// shallower than this.
+const maxJSONSchemaDepth = 40
 
 type endpointJSON struct {
 	Method      string           `json:"method"`
@@ -49,6 +58,7 @@ type responseJSON struct {
 type schemaJSON struct {
 	Ref         string         `json:"ref,omitempty"`
 	Circular    bool           `json:"circular,omitempty"`
+	Truncated   bool           `json:"truncated,omitempty"`
 	Type        string         `json:"type,omitempty"`
 	Format      string         `json:"format,omitempty"`
 	Description string         `json:"description,omitempty"`
@@ -149,7 +159,7 @@ func buildEndpointJSON(ep *openapi.Endpoint, resolver *openapi.SchemaResolver) e
 			In:          p.In,
 			Description: p.Description,
 			Required:    p.Required,
-			Schema:      resolveSchemaJSON(p.Schema, resolver, map[string]bool{}),
+			Schema:      resolveSchemaJSON(p.Schema, resolver, map[string]bool{}, 0),
 		})
 	}
 
@@ -159,7 +169,7 @@ func buildEndpointJSON(ep *openapi.Endpoint, resolver *openapi.SchemaResolver) e
 			Required:    ep.RequestBody.Required,
 		}
 		if mt, ok := ep.RequestBody.Content["application/json"]; ok && mt.Schema != nil {
-			rb.Schema = resolveSchemaJSON(mt.Schema, resolver, map[string]bool{})
+			rb.Schema = resolveSchemaJSON(mt.Schema, resolver, map[string]bool{}, 0)
 		}
 		e.RequestBody = rb
 	}
@@ -169,7 +179,7 @@ func buildEndpointJSON(ep *openapi.Endpoint, resolver *openapi.SchemaResolver) e
 			entry := &ep.Responses.Codes[i]
 			r := responseJSON{Code: entry.Code, Description: entry.Description}
 			if mt, ok := entry.Content["application/json"]; ok && mt.Schema != nil {
-				r.Schema = resolveSchemaJSON(mt.Schema, resolver, map[string]bool{})
+				r.Schema = resolveSchemaJSON(mt.Schema, resolver, map[string]bool{}, 0)
 			}
 			e.Responses = append(e.Responses, r)
 		}
@@ -181,8 +191,9 @@ func buildEndpointJSON(ep *openapi.Endpoint, resolver *openapi.SchemaResolver) e
 // resolveSchemaJSON converts a SchemaRef into its resolved JSON form, following
 // $ref references via the resolver. visited tracks the current ancestry so real
 // cycles are cut (marked circular) while a schema reused on sibling branches is
-// still expanded in full.
-func resolveSchemaJSON(ref *openapi.SchemaRef, resolver *openapi.SchemaResolver, visited map[string]bool) *schemaJSON {
+// still expanded in full. depth bounds recursion as a backstop for deep/wide
+// acyclic schemas (marked truncated).
+func resolveSchemaJSON(ref *openapi.SchemaRef, resolver *openapi.SchemaResolver, visited map[string]bool, depth int) *schemaJSON {
 	if ref == nil {
 		return nil
 	}
@@ -196,6 +207,12 @@ func resolveSchemaJSON(ref *openapi.SchemaRef, resolver *openapi.SchemaResolver,
 	}
 	if schema == nil {
 		// Unresolved ref (unknown schema or no registry): report the name only.
+		return node
+	}
+
+	if depth >= maxJSONSchemaDepth {
+		node.Type = schema.Type
+		node.Truncated = true
 		return node
 	}
 
@@ -217,20 +234,20 @@ func resolveSchemaJSON(ref *openapi.SchemaRef, resolver *openapi.SchemaResolver,
 	for _, p := range schema.Properties {
 		node.Properties = append(node.Properties, propertyJSON{
 			Name:   p.Name,
-			Schema: resolveSchemaJSON(p.Schema, resolver, visited),
+			Schema: resolveSchemaJSON(p.Schema, resolver, visited, depth+1),
 		})
 	}
 	if schema.Items != nil {
-		node.Items = resolveSchemaJSON(schema.Items, resolver, visited)
+		node.Items = resolveSchemaJSON(schema.Items, resolver, visited, depth+1)
 	}
 	for _, c := range schema.OneOf {
-		node.OneOf = append(node.OneOf, resolveSchemaJSON(c, resolver, visited))
+		node.OneOf = append(node.OneOf, resolveSchemaJSON(c, resolver, visited, depth+1))
 	}
 	for _, c := range schema.AnyOf {
-		node.AnyOf = append(node.AnyOf, resolveSchemaJSON(c, resolver, visited))
+		node.AnyOf = append(node.AnyOf, resolveSchemaJSON(c, resolver, visited, depth+1))
 	}
 	for _, c := range schema.AllOf {
-		node.AllOf = append(node.AllOf, resolveSchemaJSON(c, resolver, visited))
+		node.AllOf = append(node.AllOf, resolveSchemaJSON(c, resolver, visited, depth+1))
 	}
 
 	return node

--- a/cmd/api/describe_json.go
+++ b/cmd/api/describe_json.go
@@ -13,8 +13,8 @@ import (
 // actual fields without needing the spec; genuine cycles are cut and marked
 // with "circular": true rather than recursing forever.
 //
-// A single matched endpoint is emitted as a JSON object; a path matching
-// multiple methods is emitted as an array of objects.
+// Matched endpoints are always emitted as an array so callers can rely on a
+// stable top-level shape.
 
 // maxJSONSchemaDepth bounds resolveSchemaJSON's recursion. Cycles are already
 // cut via the ancestry set; this is a backstop against pathologically deep or
@@ -80,23 +80,16 @@ type propertyJSON struct {
 	Schema *schemaJSON `json:"schema"`
 }
 
-// writeEndpointsJSON marshals the matched endpoints as JSON. A single match is
-// emitted as an object; multiple matches (e.g. a path with several methods) are
-// emitted as an array.
+// writeEndpointsJSON marshals the matched endpoints as a JSON array.
 func writeEndpointsJSON(out io.Writer, matches []openapi.Endpoint, resolver *openapi.SchemaResolver) error {
 	eps := make([]endpointJSON, 0, len(matches))
 	for i := range matches {
 		eps = append(eps, buildEndpointJSON(&matches[i], resolver))
 	}
 
-	var payload any = eps
-	if len(eps) == 1 {
-		payload = eps[0]
-	}
-
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(payload); err != nil {
+	if err := enc.Encode(eps); err != nil {
 		return fmt.Errorf("encoding describe output as JSON: %w", err)
 	}
 	return nil

--- a/cmd/api/describe_json.go
+++ b/cmd/api/describe_json.go
@@ -1,0 +1,200 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/astronomer/astro-cli/pkg/openapi"
+)
+
+// The types below are the machine-readable form of `describe`, emitted with the
+// --json flag. Schemas are resolved down the $ref stack so an agent gets the
+// actual fields without needing the spec; genuine cycles are cut and marked
+// with "circular": true rather than recursing forever.
+
+type endpointJSON struct {
+	Method      string           `json:"method"`
+	Path        string           `json:"path"`
+	OperationID string           `json:"operationId,omitempty"`
+	Summary     string           `json:"summary,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Deprecated  bool             `json:"deprecated,omitempty"`
+	Tags        []string         `json:"tags,omitempty"`
+	Parameters  []parameterJSON  `json:"parameters,omitempty"`
+	RequestBody *requestBodyJSON `json:"requestBody,omitempty"`
+	Responses   []responseJSON   `json:"responses,omitempty"`
+}
+
+type parameterJSON struct {
+	Name        string      `json:"name"`
+	In          string      `json:"in,omitempty"`
+	Description string      `json:"description,omitempty"`
+	Required    bool        `json:"required,omitempty"`
+	Schema      *schemaJSON `json:"schema,omitempty"`
+}
+
+type requestBodyJSON struct {
+	Description string      `json:"description,omitempty"`
+	Required    bool        `json:"required,omitempty"`
+	Schema      *schemaJSON `json:"schema,omitempty"`
+}
+
+type responseJSON struct {
+	Code        string      `json:"code"`
+	Description string      `json:"description,omitempty"`
+	Schema      *schemaJSON `json:"schema,omitempty"`
+}
+
+type schemaJSON struct {
+	Ref         string         `json:"ref,omitempty"`
+	Circular    bool           `json:"circular,omitempty"`
+	Type        string         `json:"type,omitempty"`
+	Format      string         `json:"format,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Required    []string       `json:"required,omitempty"`
+	ReadOnly    bool           `json:"readOnly,omitempty"`
+	Deprecated  bool           `json:"deprecated,omitempty"`
+	Properties  []propertyJSON `json:"properties,omitempty"`
+	Items       *schemaJSON    `json:"items,omitempty"`
+	OneOf       []*schemaJSON  `json:"oneOf,omitempty"`
+	AnyOf       []*schemaJSON  `json:"anyOf,omitempty"`
+	AllOf       []*schemaJSON  `json:"allOf,omitempty"`
+	Enum        []any          `json:"enum,omitempty"`
+	Default     any            `json:"default,omitempty"`
+	Example     any            `json:"example,omitempty"`
+}
+
+type propertyJSON struct {
+	Name   string      `json:"name"`
+	Schema *schemaJSON `json:"schema"`
+}
+
+// writeEndpointsJSON marshals the matched endpoints as JSON. A single match is
+// emitted as an object; multiple matches (e.g. a path with several methods) are
+// emitted as an array.
+func writeEndpointsJSON(out io.Writer, matches []openapi.Endpoint, resolver *openapi.SchemaResolver) error {
+	eps := make([]endpointJSON, 0, len(matches))
+	for i := range matches {
+		eps = append(eps, buildEndpointJSON(&matches[i], resolver))
+	}
+
+	var payload any = eps
+	if len(eps) == 1 {
+		payload = eps[0]
+	}
+
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(payload); err != nil {
+		return fmt.Errorf("encoding describe output as JSON: %w", err)
+	}
+	return nil
+}
+
+func buildEndpointJSON(ep *openapi.Endpoint, resolver *openapi.SchemaResolver) endpointJSON {
+	e := endpointJSON{
+		Method:      ep.Method,
+		Path:        ep.Path,
+		OperationID: ep.OperationID,
+		Summary:     ep.Summary,
+		Description: ep.Description,
+		Deprecated:  ep.Deprecated,
+		Tags:        ep.Tags,
+	}
+
+	for _, p := range ep.Parameters {
+		if p == nil {
+			continue
+		}
+		e.Parameters = append(e.Parameters, parameterJSON{
+			Name:        p.Name,
+			In:          p.In,
+			Description: p.Description,
+			Required:    p.Required,
+			Schema:      resolveSchemaJSON(p.Schema, resolver, map[string]bool{}),
+		})
+	}
+
+	if ep.RequestBody != nil {
+		rb := &requestBodyJSON{
+			Description: ep.RequestBody.Description,
+			Required:    ep.RequestBody.Required,
+		}
+		if mt, ok := ep.RequestBody.Content["application/json"]; ok && mt.Schema != nil {
+			rb.Schema = resolveSchemaJSON(mt.Schema, resolver, map[string]bool{})
+		}
+		e.RequestBody = rb
+	}
+
+	if ep.Responses != nil {
+		for i := range ep.Responses.Codes {
+			entry := &ep.Responses.Codes[i]
+			r := responseJSON{Code: entry.Code, Description: entry.Description}
+			if mt, ok := entry.Content["application/json"]; ok && mt.Schema != nil {
+				r.Schema = resolveSchemaJSON(mt.Schema, resolver, map[string]bool{})
+			}
+			e.Responses = append(e.Responses, r)
+		}
+	}
+
+	return e
+}
+
+// resolveSchemaJSON converts a SchemaRef into its resolved JSON form, following
+// $ref references via the resolver. visited tracks the current ancestry so real
+// cycles are cut (marked circular) while a schema reused on sibling branches is
+// still expanded in full.
+func resolveSchemaJSON(ref *openapi.SchemaRef, resolver *openapi.SchemaResolver, visited map[string]bool) *schemaJSON {
+	if ref == nil {
+		return nil
+	}
+
+	schema, refName := resolver.ResolveSchema(ref)
+	node := &schemaJSON{Ref: refName}
+
+	if refName != "" && visited[refName] {
+		node.Circular = true
+		return node
+	}
+	if schema == nil {
+		// Unresolved ref (unknown schema or no registry): report the name only.
+		return node
+	}
+
+	if refName != "" {
+		visited[refName] = true
+		defer delete(visited, refName)
+	}
+
+	node.Type = schema.Type
+	node.Format = schema.Format
+	node.Description = schema.Description
+	node.Required = schema.Required
+	node.ReadOnly = schema.ReadOnly
+	node.Deprecated = schema.Deprecated
+	node.Enum = schema.Enum
+	node.Default = schema.Default
+	node.Example = schema.Example
+
+	for _, p := range schema.Properties {
+		node.Properties = append(node.Properties, propertyJSON{
+			Name:   p.Name,
+			Schema: resolveSchemaJSON(p.Schema, resolver, visited),
+		})
+	}
+	if schema.Items != nil {
+		node.Items = resolveSchemaJSON(schema.Items, resolver, visited)
+	}
+	for _, c := range schema.OneOf {
+		node.OneOf = append(node.OneOf, resolveSchemaJSON(c, resolver, visited))
+	}
+	for _, c := range schema.AnyOf {
+		node.AnyOf = append(node.AnyOf, resolveSchemaJSON(c, resolver, visited))
+	}
+	for _, c := range schema.AllOf {
+		node.AllOf = append(node.AllOf, resolveSchemaJSON(c, resolver, visited))
+	}
+
+	return node
+}

--- a/cmd/api/describe_json.go
+++ b/cmd/api/describe_json.go
@@ -92,6 +92,43 @@ func writeEndpointsJSON(out io.Writer, matches []openapi.Endpoint, resolver *ope
 	return nil
 }
 
+// listEndpointJSON is the machine-readable form of a single `ls` row. It is a
+// lean summary — use `describe --json` for the full resolved schema.
+type listEndpointJSON struct {
+	Method         string   `json:"method"`
+	Path           string   `json:"path"`
+	OperationID    string   `json:"operationId,omitempty"`
+	Summary        string   `json:"summary,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	Deprecated     bool     `json:"deprecated,omitempty"`
+	PathParameters []string `json:"pathParameters,omitempty"`
+}
+
+// writeEndpointListJSON marshals the endpoint list as a JSON array (always an
+// array, even for zero or one match, so consumers can rely on the shape).
+func writeEndpointListJSON(out io.Writer, endpoints []openapi.Endpoint) error {
+	items := make([]listEndpointJSON, 0, len(endpoints))
+	for i := range endpoints {
+		ep := &endpoints[i]
+		items = append(items, listEndpointJSON{
+			Method:         ep.Method,
+			Path:           ep.Path,
+			OperationID:    ep.OperationID,
+			Summary:        ep.Summary,
+			Tags:           ep.Tags,
+			Deprecated:     ep.Deprecated,
+			PathParameters: openapi.GetPathParameters(ep.Path),
+		})
+	}
+
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(items); err != nil {
+		return fmt.Errorf("encoding list output as JSON: %w", err)
+	}
+	return nil
+}
+
 func buildEndpointJSON(ep *openapi.Endpoint, resolver *openapi.SchemaResolver) endpointJSON {
 	e := endpointJSON{
 		Method:      ep.Method,

--- a/cmd/api/describe_test.go
+++ b/cmd/api/describe_test.go
@@ -34,6 +34,9 @@ func TestGetTypeString(t *testing.T) {
 		{"array of strings", &openapi.Schema{Type: "array", Items: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}}, "", "array of string"},
 		{"array with ref items", &openapi.Schema{Type: "array", Items: &openapi.SchemaRef{Ref: "#/components/schemas/DAG"}}, "", "array of DAG"},
 		{"array with empty items", &openapi.Schema{Type: "array", Items: &openapi.SchemaRef{Value: &openapi.Schema{}}}, "", "array of object"},
+		{"nullable string", &openapi.Schema{AnyOf: []*openapi.SchemaRef{{Value: &openapi.Schema{Type: "string"}}, {Value: &openapi.Schema{Type: "null"}}}}, "", "string or null"},
+		{"nullable string array", &openapi.Schema{AnyOf: []*openapi.SchemaRef{{Value: &openapi.Schema{Type: "array", Items: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}}}, {Value: &openapi.Schema{Type: "null"}}}}, "", "array of string or null"},
+		{"nullable ref", &openapi.Schema{AnyOf: []*openapi.SchemaRef{{Ref: "#/components/schemas/TaskState"}, {Value: &openapi.Schema{Type: "null"}}}}, "", "TaskState or null"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1008,6 +1011,65 @@ func TestPrintSchema_ExpandsSiblingRefsIndependently(t *testing.T) {
 
 	assert.Equal(t, 2, strings.Count(buf.String(), "value"), buf.String())
 	assert.NotContains(t, buf.String(), "(see Common above)")
+}
+
+func TestPrintSchema_NullablePrimitiveUsesCompactType(t *testing.T) {
+	root := &openapi.SchemaRef{Value: &openapi.Schema{
+		Type: "object",
+		Properties: []openapi.SchemaProperty{
+			{Name: "cursor", Schema: &openapi.SchemaRef{Value: &openapi.Schema{
+				AnyOf: []*openapi.SchemaRef{
+					{Value: &openapi.Schema{Type: "string"}},
+					{Value: &openapi.Schema{Type: "null"}},
+				},
+			}}},
+			{Name: "choices", Schema: &openapi.SchemaRef{Value: &openapi.Schema{
+				AnyOf: []*openapi.SchemaRef{
+					{Value: &openapi.Schema{Type: "array", Items: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}}},
+					{Value: &openapi.Schema{Type: "null"}},
+				},
+			}}},
+		},
+	}}
+
+	var buf bytes.Buffer
+	printSchema(&buf, root, openapi.NewSchemaResolver(), 0, map[string]bool{}, responseSchemaPrintOpts())
+
+	assert.Contains(t, buf.String(), "cursor  string or null")
+	assert.Contains(t, buf.String(), "choices  array of string or null")
+	assert.NotContains(t, buf.String(), "Any of the following")
+	assert.NotContains(t, buf.String(), "Option 1")
+}
+
+func TestPrintSchema_NullableObjectLabelsAndExpandsBranches(t *testing.T) {
+	resolver := openapi.NewSchemaResolverWithSchemas(map[string]*openapi.Schema{
+		"Detail": {
+			Type: "object",
+			Properties: []openapi.SchemaProperty{
+				{Name: "id", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+			},
+		},
+	})
+	root := &openapi.SchemaRef{Value: &openapi.Schema{
+		Type: "object",
+		Properties: []openapi.SchemaProperty{
+			{Name: "detail", Schema: &openapi.SchemaRef{Value: &openapi.Schema{
+				AnyOf: []*openapi.SchemaRef{
+					{Ref: "#/components/schemas/Detail"},
+					{Value: &openapi.Schema{Type: "null"}},
+				},
+			}}},
+		},
+	}}
+
+	var buf bytes.Buffer
+	printSchema(&buf, root, resolver, 0, map[string]bool{}, responseSchemaPrintOpts())
+	out := buf.String()
+
+	assert.Contains(t, out, "detail  Detail or null")
+	assert.Contains(t, out, "Option 1: Detail")
+	assert.Contains(t, out, "Option 2: null")
+	assert.Contains(t, out, "id  string")
 }
 
 // TestPrintSchema_UnresolvedRefKeepsName verifies a property whose $ref cannot be

--- a/cmd/api/describe_test.go
+++ b/cmd/api/describe_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -679,9 +680,10 @@ func TestRunDescribe_JSONOutput(t *testing.T) {
 	opts := &DescribeOptions{Out: &buf, specCache: cache, Endpoint: "CreateDeployment", JSON: true}
 	require.NoError(t, runDescribe(opts))
 
-	// A single match must be a JSON object, not an array.
-	var ep map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &ep), "output must be valid JSON")
+	var endpoints []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &endpoints), "output must be a JSON array")
+	require.Len(t, endpoints, 1)
+	ep := endpoints[0]
 
 	assert.Equal(t, "POST", ep["method"])
 	assert.Equal(t, "CreateDeployment", ep["operationId"])
@@ -701,6 +703,22 @@ func TestRunDescribe_JSONOutput(t *testing.T) {
 	assert.Equal(t, "Executor", byName["executor"]["ref"])                                  // nested $ref resolved
 	assert.NotEmpty(t, byName["executor"]["properties"])                                    // ...with its fields
 	assert.Equal(t, "WorkerQueue", byName["workerQueues"]["items"].(map[string]any)["ref"]) // array-of-$ref resolved
+}
+
+func TestRunDescribe_JSONOutputMultipleMatches(t *testing.T) {
+	ts := newTestSpecServerJSON(t, testSpecJSON())
+	defer ts.Close()
+
+	var buf bytes.Buffer
+	cache := openapi.NewCacheWithOptions(ts.URL, t.TempDir()+"/cache.json")
+	opts := &DescribeOptions{Out: &buf, specCache: cache, Endpoint: "/dags", JSON: true}
+	require.NoError(t, runDescribe(opts))
+
+	var endpoints []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &endpoints), "output must be a JSON array")
+	require.Len(t, endpoints, 2)
+	assert.Equal(t, "GET", endpoints[0]["method"])
+	assert.Equal(t, "POST", endpoints[1]["method"])
 }
 
 func TestResolveSchemaJSON_CutsCycles(t *testing.T) {
@@ -912,6 +930,84 @@ func TestPrintSchema_AllOfPlusProperties(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "baseField", "allOf base fields must print")
 	assert.Contains(t, out, "ownField", "sibling properties must also print")
+}
+
+func TestPrintSchema_NestedAllOfPlusPropertiesPrintsOnce(t *testing.T) {
+	child := &openapi.SchemaRef{Value: &openapi.Schema{
+		Type: "object",
+		AllOf: []*openapi.SchemaRef{{Value: &openapi.Schema{
+			Type: "object",
+			Properties: []openapi.SchemaProperty{
+				{Name: "baseField", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+			},
+		}}},
+		Properties: []openapi.SchemaProperty{
+			{Name: "ownField", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+		},
+	}}
+	root := &openapi.SchemaRef{Value: &openapi.Schema{
+		Type: "object",
+		Properties: []openapi.SchemaProperty{
+			{Name: "child", Schema: child},
+		},
+	}}
+
+	var buf bytes.Buffer
+	printSchema(&buf, root, openapi.NewSchemaResolver(), 0, map[string]bool{}, responseSchemaPrintOpts())
+
+	assert.Equal(t, 1, strings.Count(buf.String(), "baseField"), buf.String())
+	assert.Equal(t, 1, strings.Count(buf.String(), "ownField"), buf.String())
+}
+
+func TestPrintResponseSchema_ExpandsTopLevelArrayItems(t *testing.T) {
+	resolver := openapi.NewSchemaResolverWithSchemas(map[string]*openapi.Schema{
+		"Things": {
+			Type:  schemaTypeArray,
+			Items: &openapi.SchemaRef{Ref: "#/components/schemas/Thing"},
+		},
+		"Thing": {
+			Type: "object",
+			Properties: []openapi.SchemaProperty{
+				{Name: "id", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+			},
+		},
+	})
+	entry := &openapi.ResponseEntry{
+		Code: "200",
+		Content: map[string]*openapi.MediaType{
+			"application/json": {Schema: &openapi.SchemaRef{Ref: "#/components/schemas/Things"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	printResponseSchema(&buf, entry, resolver)
+
+	assert.Contains(t, buf.String(), "Schema: Things")
+	assert.Contains(t, buf.String(), "id")
+}
+
+func TestPrintSchema_ExpandsSiblingRefsIndependently(t *testing.T) {
+	resolver := openapi.NewSchemaResolverWithSchemas(map[string]*openapi.Schema{
+		"Common": {
+			Type: "object",
+			Properties: []openapi.SchemaProperty{
+				{Name: "value", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+			},
+		},
+	})
+	root := &openapi.SchemaRef{Value: &openapi.Schema{
+		Type: "object",
+		Properties: []openapi.SchemaProperty{
+			{Name: "a", Schema: &openapi.SchemaRef{Ref: "#/components/schemas/Common"}},
+			{Name: "b", Schema: &openapi.SchemaRef{Ref: "#/components/schemas/Common"}},
+		},
+	}}
+
+	var buf bytes.Buffer
+	printSchema(&buf, root, resolver, 0, map[string]bool{}, responseSchemaPrintOpts())
+
+	assert.Equal(t, 2, strings.Count(buf.String(), "value"), buf.String())
+	assert.NotContains(t, buf.String(), "(see Common above)")
 }
 
 // TestPrintSchema_UnresolvedRefKeepsName verifies a property whose $ref cannot be

--- a/cmd/api/describe_test.go
+++ b/cmd/api/describe_test.go
@@ -594,6 +594,145 @@ func testSpecJSON() []byte {
 	return data
 }
 
+// refSpecJSON returns a spec whose request/response bodies are $refs into
+// components.schemas, including a nested $ref and an array of $ref items, so the
+// full parse -> extract -> resolve -> print chain is exercised.
+func refSpecJSON() []byte {
+	spec := map[string]any{
+		"openapi": "3.0.0",
+		"info":    map[string]any{"title": "Test", "version": "1.0"},
+		"paths": map[string]any{
+			"/deployments": map[string]any{
+				"post": map[string]any{
+					"operationId": "CreateDeployment",
+					"summary":     "Create a deployment",
+					"requestBody": map[string]any{
+						"required": true,
+						"content": map[string]any{
+							"application/json": map[string]any{
+								"schema": map[string]any{"$ref": "#/components/schemas/CreateDeploymentRequest"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"components": map[string]any{
+			"schemas": map[string]any{
+				"CreateDeploymentRequest": map[string]any{
+					"type":     "object",
+					"required": []any{"name"},
+					"properties": map[string]any{
+						"name":               map[string]any{"type": "string", "description": "Deployment name"},
+						"isDagDeployEnabled": map[string]any{"type": "boolean"},
+						"executor":           map[string]any{"$ref": "#/components/schemas/Executor"},
+						"workerQueues": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"$ref": "#/components/schemas/WorkerQueue"},
+						},
+					},
+				},
+				"Executor": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"type": map[string]any{"type": "string"}},
+				},
+				"WorkerQueue": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"name": map[string]any{"type": "string"}},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(spec)
+	return data
+}
+
+func TestRunDescribe_ExpandsRefSchemas(t *testing.T) {
+	ts := newTestSpecServerJSON(t, refSpecJSON())
+	defer ts.Close()
+
+	var buf bytes.Buffer
+	cache := openapi.NewCacheWithOptions(ts.URL, t.TempDir()+"/cache.json")
+	opts := &DescribeOptions{Out: &buf, specCache: cache, Endpoint: "CreateDeployment"}
+
+	require.NoError(t, runDescribe(opts))
+	out := buf.String()
+
+	assert.Contains(t, out, "Schema: CreateDeploymentRequest")
+	// Request body fields expanded from the referenced schema.
+	assert.Contains(t, out, "name")
+	assert.Contains(t, out, "isDagDeployEnabled")
+	// Nested $ref expanded.
+	assert.Contains(t, out, "executor")
+	assert.Contains(t, out, "type")
+	// Array-of-$ref expanded.
+	assert.Contains(t, out, "workerQueues")
+	assert.Contains(t, out, "array of WorkerQueue")
+}
+
+func TestRunDescribe_JSONOutput(t *testing.T) {
+	ts := newTestSpecServerJSON(t, refSpecJSON())
+	defer ts.Close()
+
+	var buf bytes.Buffer
+	cache := openapi.NewCacheWithOptions(ts.URL, t.TempDir()+"/cache.json")
+	opts := &DescribeOptions{Out: &buf, specCache: cache, Endpoint: "CreateDeployment", JSON: true}
+	require.NoError(t, runDescribe(opts))
+
+	// A single match must be a JSON object, not an array.
+	var ep map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &ep), "output must be valid JSON")
+
+	assert.Equal(t, "POST", ep["method"])
+	assert.Equal(t, "CreateDeployment", ep["operationId"])
+
+	schema := ep["requestBody"].(map[string]any)["schema"].(map[string]any)
+	assert.Equal(t, "CreateDeploymentRequest", schema["ref"])
+	assert.Equal(t, []any{"name"}, schema["required"])
+
+	// Collect resolved property names and confirm nested/array refs expanded.
+	props := schema["properties"].([]any)
+	byName := map[string]map[string]any{}
+	for _, p := range props {
+		pm := p.(map[string]any)
+		byName[pm["name"].(string)] = pm["schema"].(map[string]any)
+	}
+	assert.Equal(t, "boolean", byName["isDagDeployEnabled"]["type"])
+	assert.Equal(t, "Executor", byName["executor"]["ref"])                                  // nested $ref resolved
+	assert.NotEmpty(t, byName["executor"]["properties"])                                    // ...with its fields
+	assert.Equal(t, "WorkerQueue", byName["workerQueues"]["items"].(map[string]any)["ref"]) // array-of-$ref resolved
+}
+
+func TestResolveSchemaJSON_CutsCycles(t *testing.T) {
+	// Node references itself via "next"; resolution must terminate and mark the
+	// repeat as circular.
+	registry := map[string]*openapi.Schema{
+		"Node": {
+			Type: "object",
+			Properties: []openapi.SchemaProperty{
+				{Name: "value", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+				{Name: "next", Schema: &openapi.SchemaRef{Ref: "#/components/schemas/Node"}},
+			},
+		},
+	}
+	resolver := openapi.NewSchemaResolverWithSchemas(registry)
+
+	node := resolveSchemaJSON(&openapi.SchemaRef{Ref: "#/components/schemas/Node"}, resolver, map[string]bool{})
+	require.NotNil(t, node)
+	assert.Equal(t, "Node", node.Ref)
+
+	var next *schemaJSON
+	for _, p := range node.Properties {
+		if p.Name == "next" {
+			next = p.Schema
+		}
+	}
+	require.NotNil(t, next)
+	assert.Equal(t, "Node", next.Ref)
+	assert.True(t, next.Circular, "self-reference should be marked circular")
+	assert.Empty(t, next.Properties, "circular node should not recurse into properties")
+}
+
 func TestRunDescribe(t *testing.T) {
 	body := testSpecJSON()
 	ts := newTestSpecServerJSON(t, body)
@@ -679,6 +818,80 @@ func TestRunDescribe_EmptySpec(t *testing.T) {
 	err := runDescribe(opts)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no endpoints found")
+}
+
+// --- registry-driven $ref resolution -----------------------------------------
+
+// TestPrintSchema_ResolvesRefsFromRegistry covers the case that motivated this
+// change: a schema whose SchemaRef carries only a $ref name (no inline Value),
+// which must be resolved through the registry so its fields are printed.
+func TestPrintSchema_ResolvesRefsFromRegistry(t *testing.T) {
+	// CreateDeploymentRequest references Executor (nested object) and has an
+	// array of WorkerQueue objects; WorkerQueue references itself to exercise
+	// cycle detection.
+	registry := map[string]*openapi.Schema{
+		"CreateDeploymentRequest": {
+			Type:     "object",
+			Required: []string{"name"},
+			Properties: []openapi.SchemaProperty{
+				{Name: "name", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string", Description: "Deployment name"}}},
+				{Name: "isDagDeployEnabled", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "boolean"}}},
+				{Name: "executor", Schema: &openapi.SchemaRef{Ref: "#/components/schemas/Executor"}},
+				{Name: "workerQueues", Schema: &openapi.SchemaRef{Value: &openapi.Schema{
+					Type:  "array",
+					Items: &openapi.SchemaRef{Ref: "#/components/schemas/WorkerQueue"},
+				}}},
+			},
+		},
+		"Executor": {
+			Type: "object",
+			Properties: []openapi.SchemaProperty{
+				{Name: "type", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+			},
+		},
+		"WorkerQueue": {
+			Type: "object",
+			Properties: []openapi.SchemaProperty{
+				{Name: "name", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+				// Self-reference to verify cycle detection.
+				{Name: "parent", Schema: &openapi.SchemaRef{Ref: "#/components/schemas/WorkerQueue"}},
+			},
+		},
+	}
+	resolver := openapi.NewSchemaResolverWithSchemas(registry)
+
+	var buf bytes.Buffer
+	body := &openapi.RequestBody{
+		Required: true,
+		Content: map[string]*openapi.MediaType{
+			// Pure $ref: no inline Value — this is what the live spec produces.
+			"application/json": {Schema: &openapi.SchemaRef{Ref: "#/components/schemas/CreateDeploymentRequest"}},
+		},
+	}
+	printRequestBody(&buf, body, resolver)
+	out := buf.String()
+
+	// Top-level ref name still shown.
+	assert.Contains(t, out, "CreateDeploymentRequest")
+	// Fields of the referenced request schema are now expanded.
+	assert.Contains(t, out, "name")
+	assert.Contains(t, out, "isDagDeployEnabled")
+	// Nested $ref (executor -> Executor) expands to its fields.
+	assert.Contains(t, out, "executor")
+	assert.Contains(t, out, "type")
+	// Array of $ref items (workerQueues -> WorkerQueue) expands.
+	assert.Contains(t, out, "workerQueues")
+	assert.Contains(t, out, "array of WorkerQueue")
+	// Self-referential schema is caught by cycle detection.
+	assert.Contains(t, out, "(see WorkerQueue above)")
+}
+
+func TestResolveSchema_LazyRefWithoutRegistry(t *testing.T) {
+	// Without a registry, a pure $ref resolves to no value but still reports its name.
+	resolver := openapi.NewSchemaResolver()
+	resolved, refName := resolver.ResolveSchema(&openapi.SchemaRef{Ref: "#/components/schemas/DAG"})
+	assert.Nil(t, resolved)
+	assert.Equal(t, "DAG", refName)
 }
 
 // --- requestSchemaPrintOpts / responseSchemaPrintOpts ------------------------

--- a/cmd/api/describe_test.go
+++ b/cmd/api/describe_test.go
@@ -717,7 +717,7 @@ func TestResolveSchemaJSON_CutsCycles(t *testing.T) {
 	}
 	resolver := openapi.NewSchemaResolverWithSchemas(registry)
 
-	node := resolveSchemaJSON(&openapi.SchemaRef{Ref: "#/components/schemas/Node"}, resolver, map[string]bool{})
+	node := resolveSchemaJSON(&openapi.SchemaRef{Ref: "#/components/schemas/Node"}, resolver, map[string]bool{}, 0)
 	require.NotNil(t, node)
 	assert.Equal(t, "Node", node.Ref)
 
@@ -884,6 +884,111 @@ func TestPrintSchema_ResolvesRefsFromRegistry(t *testing.T) {
 	assert.Contains(t, out, "array of WorkerQueue")
 	// Self-referential schema is caught by cycle detection.
 	assert.Contains(t, out, "(see WorkerQueue above)")
+}
+
+// TestPrintSchema_AllOfPlusProperties verifies an allOf schema that also has its
+// own top-level properties prints both (the extend-a-base pattern).
+func TestPrintSchema_AllOfPlusProperties(t *testing.T) {
+	registry := map[string]*openapi.Schema{
+		"Base": {
+			Type: "object",
+			Properties: []openapi.SchemaProperty{
+				{Name: "baseField", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+			},
+		},
+	}
+	resolver := openapi.NewSchemaResolverWithSchemas(registry)
+
+	schemaRef := &openapi.SchemaRef{Value: &openapi.Schema{
+		Type:  "object",
+		AllOf: []*openapi.SchemaRef{{Ref: "#/components/schemas/Base"}},
+		Properties: []openapi.SchemaProperty{
+			{Name: "ownField", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "integer"}}},
+		},
+	}}
+
+	var buf bytes.Buffer
+	printSchema(&buf, schemaRef, resolver, 0, map[string]bool{}, responseSchemaPrintOpts())
+	out := buf.String()
+	assert.Contains(t, out, "baseField", "allOf base fields must print")
+	assert.Contains(t, out, "ownField", "sibling properties must also print")
+}
+
+// TestPrintSchema_UnresolvedRefKeepsName verifies a property whose $ref cannot be
+// resolved still shows its name and the referenced schema name.
+func TestPrintSchema_UnresolvedRefKeepsName(t *testing.T) {
+	resolver := openapi.NewSchemaResolverWithSchemas(map[string]*openapi.Schema{}) // empty registry
+
+	schemaRef := &openapi.SchemaRef{Value: &openapi.Schema{
+		Type: "object",
+		Properties: []openapi.SchemaProperty{
+			{Name: "executor", Schema: &openapi.SchemaRef{Ref: "#/components/schemas/Executor"}},
+		},
+	}}
+
+	var buf bytes.Buffer
+	printSchema(&buf, schemaRef, resolver, 0, map[string]bool{}, responseSchemaPrintOpts())
+	out := buf.String()
+	assert.Contains(t, out, "executor", "property name must be kept")
+	assert.Contains(t, out, "Executor", "referenced schema name must be shown")
+}
+
+// TestReadOnly_RequestHidesButJSONShows pins the intentional asymmetry: text
+// request bodies hide read-only fields; --json keeps them flagged.
+func TestReadOnly_RequestHidesButJSONShows(t *testing.T) {
+	schema := &openapi.Schema{
+		Type: "object",
+		Properties: []openapi.SchemaProperty{
+			{Name: "serverGeneratedId", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string", ReadOnly: true}}},
+			{Name: "userName", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}},
+		},
+	}
+	resolver := openapi.NewSchemaResolver()
+
+	var buf bytes.Buffer
+	printSchema(&buf, &openapi.SchemaRef{Value: schema}, resolver, 0, map[string]bool{}, requestSchemaPrintOpts())
+	out := buf.String()
+	assert.NotContains(t, out, "serverGeneratedId", "read-only field hidden in request text")
+	assert.Contains(t, out, "userName")
+
+	node := resolveSchemaJSON(&openapi.SchemaRef{Value: schema}, resolver, map[string]bool{}, 0)
+	var ro *schemaJSON
+	for _, p := range node.Properties {
+		if p.Name == "serverGeneratedId" {
+			ro = p.Schema
+		}
+	}
+	require.NotNil(t, ro, "JSON must include the read-only field")
+	assert.True(t, ro.ReadOnly, "JSON must flag it read-only")
+}
+
+// TestResolveSchemaJSON_Composition verifies oneOf children that are $refs are
+// resolved to their fields in JSON output.
+func TestResolveSchemaJSON_Composition(t *testing.T) {
+	registry := map[string]*openapi.Schema{
+		"CeleryConfig": {
+			Type:       "object",
+			Properties: []openapi.SchemaProperty{{Name: "workerCount", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "integer"}}}},
+		},
+		"KubernetesConfig": {
+			Type:       "object",
+			Properties: []openapi.SchemaProperty{{Name: "namespace", Schema: &openapi.SchemaRef{Value: &openapi.Schema{Type: "string"}}}},
+		},
+	}
+	resolver := openapi.NewSchemaResolverWithSchemas(registry)
+
+	ref := &openapi.SchemaRef{Value: &openapi.Schema{
+		OneOf: []*openapi.SchemaRef{
+			{Ref: "#/components/schemas/CeleryConfig"},
+			{Ref: "#/components/schemas/KubernetesConfig"},
+		},
+	}}
+	node := resolveSchemaJSON(ref, resolver, map[string]bool{}, 0)
+	require.Len(t, node.OneOf, 2)
+	assert.Equal(t, "CeleryConfig", node.OneOf[0].Ref)
+	assert.NotEmpty(t, node.OneOf[0].Properties, "oneOf ref child must expand")
+	assert.Equal(t, "KubernetesConfig", node.OneOf[1].Ref)
+	assert.NotEmpty(t, node.OneOf[1].Properties)
 }
 
 func TestResolveSchema_LazyRefWithoutRegistry(t *testing.T) {

--- a/cmd/api/list.go
+++ b/cmd/api/list.go
@@ -22,6 +22,7 @@ type ListOptions struct {
 	Filter    string
 	Verbose   bool
 	Refresh   bool
+	JSON      bool
 }
 
 // runList executes the list command.
@@ -30,7 +31,7 @@ func runList(opts *ListOptions) error {
 		return fmt.Errorf("API specification not initialized. Ensure you are logged in and try again")
 	}
 
-	if opts.Verbose {
+	if opts.Verbose && !opts.JSON {
 		fmt.Fprintf(opts.Out, "Spec URL: %s\n\n", opts.specCache.GetSpecURL())
 	}
 
@@ -47,10 +48,16 @@ func runList(opts *ListOptions) error {
 	// Filter endpoints if a filter was provided
 	if opts.Filter != "" {
 		endpoints = openapi.FilterEndpoints(endpoints, opts.Filter)
-		if len(endpoints) == 0 {
-			fmt.Fprintf(opts.Out, "No endpoints found matching '%s'\n", opts.Filter)
-			return nil
-		}
+	}
+
+	// JSON output: emit the (possibly empty) list as an array and stop.
+	if opts.JSON {
+		return writeEndpointListJSON(opts.Out, endpoints)
+	}
+
+	if len(endpoints) == 0 {
+		fmt.Fprintf(opts.Out, "No endpoints found matching '%s'\n", opts.Filter)
+		return nil
 	}
 
 	// Print endpoints

--- a/cmd/api/list_test.go
+++ b/cmd/api/list_test.go
@@ -204,6 +204,40 @@ func TestRunList(t *testing.T) {
 		assert.Contains(t, buf.String(), "List DAGs")
 		assert.Contains(t, buf.String(), "Health check")
 	})
+
+	t.Run("json output", func(t *testing.T) {
+		var buf bytes.Buffer
+		cache := openapi.NewCacheWithOptions(ts.URL, t.TempDir()+"/cache.json")
+		opts := &ListOptions{Out: &buf, specCache: cache, JSON: true}
+
+		require.NoError(t, runList(opts))
+
+		var items []map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &items), "output must be a JSON array")
+		require.Len(t, items, 2)
+
+		byPath := map[string]map[string]any{}
+		for _, it := range items {
+			byPath[it["path"].(string)] = it
+		}
+		assert.Equal(t, "get_dags", byPath["/dags"]["operationId"])
+		assert.Equal(t, "GET", byPath["/dags"]["method"])
+		assert.Equal(t, []any{"DAGs"}, byPath["/dags"]["tags"])
+		// No human-readable trailer leaked into JSON output.
+		assert.NotContains(t, buf.String(), "Found")
+	})
+
+	t.Run("json empty array when filter matches nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		cache := openapi.NewCacheWithOptions(ts.URL, t.TempDir()+"/cache.json")
+		opts := &ListOptions{Out: &buf, specCache: cache, Filter: "nonexistent", JSON: true}
+
+		require.NoError(t, runList(opts))
+
+		var items []map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &items))
+		assert.Empty(t, items)
+	})
 }
 
 func TestRunList_EmptySpec(t *testing.T) {

--- a/cmd/api/registry.go
+++ b/cmd/api/registry.go
@@ -256,6 +256,7 @@ func NewRegistryDescribeCmd(out io.Writer, parentOpts *RegistryOptions) *cobra.C
 	var method string
 	var refresh bool
 	var verbose bool
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "describe <endpoint>",
@@ -281,6 +282,7 @@ The endpoint can be specified as a path or as an operation ID.`,
 				Method:    method,
 				Refresh:   refresh,
 				Verbose:   verbose,
+				JSON:      jsonOut,
 			}
 			return runDescribe(descOpts)
 		},
@@ -289,6 +291,7 @@ The endpoint can be specified as a path or as an operation ID.`,
 	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (GET)")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show spec URL and additional details")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint's schema as JSON (with $refs resolved) for programmatic use")
 
 	return cmd
 }

--- a/cmd/api/registry.go
+++ b/cmd/api/registry.go
@@ -249,7 +249,7 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show additional details like summaries and tags")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint list as JSON for programmatic use")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint list as JSON")
 
 	return cmd
 }
@@ -294,7 +294,7 @@ The endpoint can be specified as a path or as an operation ID.`,
 	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (GET)")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show spec URL and additional details")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint's schema as JSON (with $refs resolved) for programmatic use")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint schema as JSON")
 
 	return cmd
 }

--- a/cmd/api/registry.go
+++ b/cmd/api/registry.go
@@ -208,6 +208,7 @@ func runRegistryInteractive(opts *RegistryOptions) error {
 func NewRegistryListCmd(out io.Writer, parentOpts *RegistryOptions) *cobra.Command {
 	var verbose bool
 	var refresh bool
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:     "ls [filter]",
@@ -240,6 +241,7 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 				Filter:    filter,
 				Verbose:   verbose,
 				Refresh:   refresh,
+				JSON:      jsonOut,
 			}
 			return runList(listOpts)
 		},
@@ -247,6 +249,7 @@ The filter matches against endpoint paths, methods, operation IDs, summaries, an
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show additional details like summaries and tags")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force refresh of the OpenAPI specification cache")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output the endpoint list as JSON for programmatic use")
 
 	return cmd
 }

--- a/pkg/openapi/cache.go
+++ b/pkg/openapi/cache.go
@@ -251,6 +251,20 @@ func (c *Cache) GetEndpoints() []Endpoint {
 	return endpoints
 }
 
+// GetSchemas returns a registry of named component schemas from the loaded
+// spec, keyed by schema name (e.g. "CreateDeploymentRequest"). It is used to
+// resolve $ref references lazily when displaying endpoint details.
+func (c *Cache) GetSchemas() map[string]*Schema {
+	switch {
+	case c.doc != nil:
+		return ExtractComponentSchemas(c.doc)
+	case c.v2doc != nil:
+		return ExtractDefinitionsV2(c.v2doc)
+	default:
+		return nil
+	}
+}
+
 // IsLoaded returns true if a spec has been loaded.
 func (c *Cache) IsLoaded() bool {
 	return c.doc != nil || c.v2doc != nil

--- a/pkg/openapi/cache_test.go
+++ b/pkg/openapi/cache_test.go
@@ -731,3 +731,66 @@ func TestLoad_LocalFile_AlwaysFresh(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Version 2", cache.GetDoc().Info.Title)
 }
+
+// --- GetSchemas --------------------------------------------------------------
+
+func TestGetSchemas_V3(t *testing.T) {
+	spec := map[string]any{
+		"openapi": "3.0.0",
+		"info":    map[string]any{"title": "Test", "version": "1.0"},
+		"paths":   map[string]any{},
+		"components": map[string]any{
+			"schemas": map[string]any{
+				"Widget": map[string]any{
+					"type":     "object",
+					"required": []any{"id"},
+					"properties": map[string]any{
+						"id":      map[string]any{"type": "string"},
+						"enabled": map[string]any{"type": "boolean"},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(spec)
+	tmpFile := filepath.Join(t.TempDir(), "spec.json")
+	require.NoError(t, os.WriteFile(tmpFile, data, 0o600))
+
+	cache := NewCacheForLocalFile(tmpFile)
+	require.NoError(t, cache.Load(false))
+
+	schemas := cache.GetSchemas()
+	require.Contains(t, schemas, "Widget")
+	assert.Equal(t, "object", schemas["Widget"].Type)
+	assert.Equal(t, []string{"id"}, schemas["Widget"].Required)
+}
+
+func TestGetSchemas_V2(t *testing.T) {
+	spec := map[string]any{
+		"swagger":  "2.0",
+		"info":     map[string]any{"title": "Test", "version": "1.0"},
+		"basePath": "/api/v1",
+		"paths":    map[string]any{},
+		"definitions": map[string]any{
+			"Widget": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"id": map[string]any{"type": "string"}},
+			},
+		},
+	}
+	data, _ := json.Marshal(spec)
+	tmpFile := filepath.Join(t.TempDir(), "spec.json")
+	require.NoError(t, os.WriteFile(tmpFile, data, 0o600))
+
+	cache := NewCacheForLocalFile(tmpFile)
+	require.NoError(t, cache.Load(false))
+
+	schemas := cache.GetSchemas()
+	require.Contains(t, schemas, "Widget")
+	assert.Equal(t, "object", schemas["Widget"].Type)
+}
+
+func TestGetSchemas_NotLoaded(t *testing.T) {
+	cache := NewCache()
+	assert.Nil(t, cache.GetSchemas())
+}

--- a/pkg/openapi/endpoints.go
+++ b/pkg/openapi/endpoints.go
@@ -59,6 +59,23 @@ func v3MethodOps(pi *v3high.PathItem) []v3MethodOp {
 	}
 }
 
+// ExtractComponentSchemas returns a registry of all named component schemas
+// (#/components/schemas/*) keyed by name. Nested $ref references within each
+// schema are left unresolved (stored as ref names) so callers can resolve them
+// lazily via SchemaResolver and guard against cycles while walking.
+func ExtractComponentSchemas(doc *v3high.Document) map[string]*Schema {
+	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
+		return nil
+	}
+	schemas := make(map[string]*Schema)
+	for name, proxy := range doc.Components.Schemas.FromOldest() {
+		if ref := convertSchemaProxy(proxy); ref != nil && ref.Value != nil {
+			schemas[name] = ref.Value
+		}
+	}
+	return schemas
+}
+
 // newEndpoint creates an Endpoint from a libopenapi Operation.
 func newEndpoint(method, path string, op *v3high.Operation) Endpoint {
 	ep := Endpoint{

--- a/pkg/openapi/endpoints_v2.go
+++ b/pkg/openapi/endpoints_v2.go
@@ -43,6 +43,22 @@ func v2MethodOps(pi *v2high.PathItem) []v2MethodOp {
 	}
 }
 
+// ExtractDefinitionsV2 returns a registry of all named Swagger 2.0 definitions
+// (#/definitions/*) keyed by name, the v2 equivalent of component schemas. Nested
+// $refs are left unresolved for lazy resolution via SchemaResolver.
+func ExtractDefinitionsV2(doc *v2high.Swagger) map[string]*Schema {
+	if doc == nil || doc.Definitions == nil || doc.Definitions.Definitions == nil {
+		return nil
+	}
+	schemas := make(map[string]*Schema)
+	for name, proxy := range doc.Definitions.Definitions.FromOldest() {
+		if ref := convertSchemaProxy(proxy); ref != nil && ref.Value != nil {
+			schemas[name] = ref.Value
+		}
+	}
+	return schemas
+}
+
 // newEndpointV2 creates an Endpoint from a Swagger 2.0 Operation.
 func newEndpointV2(method, path string, op *v2high.Operation) Endpoint {
 	ep := Endpoint{

--- a/pkg/openapi/endpoints_v2_test.go
+++ b/pkg/openapi/endpoints_v2_test.go
@@ -186,6 +186,62 @@ func TestExtractEndpointsV2_NilDoc(t *testing.T) {
 	assert.Nil(t, endpoints)
 }
 
+func TestExtractDefinitionsV2(t *testing.T) {
+	spec := map[string]any{
+		"swagger":  "2.0",
+		"info":     map[string]any{"title": "Test", "version": "1.0"},
+		"basePath": "/api/v1",
+		"paths": map[string]any{
+			"/resources": map[string]any{
+				"post": map[string]any{
+					"operationId": "CreateResource",
+					"parameters": []any{
+						map[string]any{
+							"name":     "body",
+							"in":       "body",
+							"required": true,
+							"schema":   map[string]any{"$ref": "#/definitions/CreateResourceRequest"},
+						},
+					},
+					"responses": map[string]any{"200": map[string]any{"description": "OK"}},
+				},
+			},
+		},
+		"definitions": map[string]any{
+			"CreateResourceRequest": map[string]any{
+				"type":     "object",
+				"required": []any{"name"},
+				"properties": map[string]any{
+					"name":    map[string]any{"type": "string"},
+					"enabled": map[string]any{"type": "boolean"},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(spec)
+
+	_, v2doc, err := parseSpec(data)
+	require.NoError(t, err)
+	require.NotNil(t, v2doc)
+
+	registry := ExtractDefinitionsV2(v2doc)
+	require.Contains(t, registry, "CreateResourceRequest")
+	schema := registry["CreateResourceRequest"]
+	assert.Equal(t, "object", schema.Type)
+	assert.Equal(t, []string{"name"}, schema.Required)
+
+	names := make(map[string]string)
+	for _, p := range schema.Properties {
+		names[p.Name] = p.Schema.Value.Type
+	}
+	assert.Equal(t, "string", names["name"])
+	assert.Equal(t, "boolean", names["enabled"])
+}
+
+func TestExtractDefinitionsV2_NilDoc(t *testing.T) {
+	assert.Nil(t, ExtractDefinitionsV2(nil))
+}
+
 func TestExtractEndpointsV2_InlineParamType(t *testing.T) {
 	specJSON := minimalSwagger20JSON("/v1", map[string]any{
 		"/search": map[string]any{

--- a/pkg/openapi/schema.go
+++ b/pkg/openapi/schema.go
@@ -5,14 +5,31 @@ import (
 )
 
 // SchemaResolver provides helpers for working with OpenAPI schema references.
-type SchemaResolver struct{}
+// When constructed with a registry of named component schemas, it can resolve
+// $ref references lazily — returning the referenced schema's value even though
+// the SchemaRef itself only carries the ref name.
+type SchemaResolver struct {
+	// registry maps component schema names (e.g. "CreateDeploymentRequest") to
+	// their resolved schema. Nested $refs within these schemas are left as ref
+	// names, so callers must guard against cycles when walking recursively.
+	registry map[string]*Schema
+}
 
-// NewSchemaResolver creates a new schema resolver.
+// NewSchemaResolver creates a new schema resolver without a registry. Refs are
+// reported by name but not resolved to their value.
 func NewSchemaResolver() *SchemaResolver {
 	return &SchemaResolver{}
 }
 
+// NewSchemaResolverWithSchemas creates a resolver backed by a registry of named
+// component schemas, enabling lazy resolution of $ref references.
+func NewSchemaResolverWithSchemas(registry map[string]*Schema) *SchemaResolver {
+	return &SchemaResolver{registry: registry}
+}
+
 // ResolveSchema extracts the resolved schema and ref name from a SchemaRef.
+// If the ref has no inline value but names a schema present in the registry,
+// the registered schema is returned so callers can walk down the ref stack.
 func (r *SchemaResolver) ResolveSchema(ref *SchemaRef) (resolved *Schema, refName string) {
 	if ref == nil {
 		return nil, ""
@@ -20,7 +37,13 @@ func (r *SchemaResolver) ResolveSchema(ref *SchemaRef) (resolved *Schema, refNam
 	if ref.Ref != "" {
 		refName = extractRefName(ref.Ref)
 	}
-	return ref.Value, refName
+	if ref.Value != nil {
+		return ref.Value, refName
+	}
+	if refName != "" && r.registry != nil {
+		return r.registry[refName], refName
+	}
+	return nil, refName
 }
 
 // extractRefName extracts the schema name from a $ref string.


### PR DESCRIPTION
## Description

Improves `astro api <cloud|airflow|registry>` for both humans and agents/scripts.

### 1. `describe` now expands `$ref` schemas down the full stack

Previously `describe` stopped at the first `$ref`, printing only the schema name with no fields:

```
Request Body (required):
  Schema: CreateDeploymentRequest
```

The recursion was severed at the conversion layer (`convertSchemaProxy` stored a `$ref` name but never resolved it), so the (already cycle-safe) printer never received the referenced fields.

This resolves refs lazily via a component-schema registry:

- `pkg/openapi`: `ExtractComponentSchemas` (v3 `components.schemas`) / `ExtractDefinitionsV2` (v2 `definitions`) build a `name -> schema` registry, exposed via `Cache.GetSchemas()`.
- `SchemaResolver` gains `NewSchemaResolverWithSchemas`; `ResolveSchema` returns the registered schema when a `SchemaRef` carries only a ref name.
- The `describe` printer resolves through the resolver, expanding nested `$ref`s and array-of-`$ref` element schemas. Genuine cycles print `(see X above)`.

After:

```
Request Body (required):
  Schema: CreateDeploymentRequest
  executor  Executor
      type  string
  isDagDeployEnabled  boolean
  name*  string
      Deployment name
  workerQueues  array of WorkerQueue
      name  string
```

### 2. `--json` output for `describe` and `ls`

For programmatic use by agents and scripts, both subcommands gain a `--json` flag (all three API families).

- `describe --json` emits the endpoint with every `$ref` resolved inline: ordered `properties`, `readOnly` fields included and flagged, real cycles marked `"circular": true` (siblings still expand), and a depth backstop marks `"truncated": true` on pathologically deep schemas. A single match is a JSON object; a path matching multiple methods is an array.
- `ls --json` emits a lean array of endpoint summaries (`method`, `path`, `operationId`, `summary`, `tags`, `deprecated`, `pathParameters`) — always an array.
- No human-readable text (banners, trailers, verbose spec-URL, the Airflow version line) leaks into any `--json` output.

### 3. Review-driven correctness fixes

An adversarial review of the change surfaced (and this PR fixes):

- **`allOf` + sibling `properties`**: a schema that extends a base *and* adds its own fields now prints both in text output, instead of stopping after `allOf`.
- **Unresolved `$ref` property**: a property pointing at a schema absent from the registry now still shows its name and referenced schema name, instead of being silently dropped.
- **JSON depth backstop**: bounds recursion for deep/wide acyclic schemas (cycles were already cut).

## Issue(s)

Related #XXX

## Functional Testing

```
# Human-readable, now expands referenced schemas down the stack
astro api cloud describe CreateDeployment

# Machine-readable, refs resolved inline
astro api cloud describe CreateDeployment --json | jq '.requestBody.schema.properties'

# List endpoints as JSON
astro api cloud ls deployments --json | jq '.[].operationId'
```

## Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
