### PR TITLE
fix(brew): only depend on podman on Apple Silicon Macs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,10 +67,12 @@ brews:
     skip_upload: auto
     homepage: https://astronomer.io
     description: To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API.
-    dependencies:
-      - name: podman
-        type: recommended
-        os: mac
+    # Podman 6.0+ is arm64-only on macOS, so limit the dependency to Apple Silicon
+    # to keep Intel Macs installable (https://github.com/astronomer/astro-cli/issues/2199).
+    # goreleaser's `dependencies` supports an os filter but not an arch filter,
+    # so emit the guarded depends_on line via custom_block instead.
+    custom_block: |
+      depends_on "podman" => :recommended if OS.mac? && Hardware::CPU.arm?
     test: |
       system "#{bin}/astro version"
   - name: "astro@{{ .Version }}"
@@ -89,10 +91,9 @@ brews:
     skip_upload: auto
     homepage: https://astronomer.io
     description: To build and run Airflow DAGs locally via docker-compose and deploy DAGs to Astronomer-managed Airflow clusters and interact with the Astronomer API.
-    dependencies:
-      - name: podman
-        type: recommended
-        os: mac
+    # See the podman note on the `astro` formula above.
+    custom_block: |
+      depends_on "podman" => :recommended if OS.mac? && Hardware::CPU.arm?
     test: |
       system "#{bin}/astro version"
 archives:


### PR DESCRIPTION
## Description

Podman 6.0 dropped support for Intel Macs, but our generated Homebrew formulas declare podman as a recommended dependency on all of macOS. That means `brew upgrade astro` on an Intel Mac tries to pull in podman 6.0.1 and fails with "The arm64 architecture is required for this software", blocking any further CLI upgrades for those users.

This change limits the podman dependency to Apple Silicon. goreleaser's `dependencies` config can filter by OS but not by architecture, so the guarded `depends_on` line is emitted through `custom_block` instead. Intel Mac users can still use Docker (the default engine) or install an older podman themselves.

Fixes #2199

## Testing

- `goreleaser check` passes (the deprecation warnings it prints are pre-existing and unrelated)
- Built the exact formula this config will generate (current tap formula plus the new line) and evaluated it with Homebrew in a local tap: syntax is valid, and `brew deps` still resolves podman on an arm64 Mac. On Intel the guard evaluates to false, so podman is skipped.

Note: this only fixes the `astronomer/homebrew-tap` formulas on the next release. The already published 1.43.1 tap formula and the homebrew-core `astro` formula need separate one-line fixes.