### PR TITLE
Support Airflow 3 monitoring DAG on Hybrid

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -29,6 +29,9 @@ var (
 	//go:embed include/airflow2/composeyml.go.tmpl
 	Af2Composeyml string
 
+	//go:embed include/airflow3/astronomermonitoringdag.py
+	Af3MonitoringDag string
+
 	//go:embed include/airflow3/composeyml.go.tmpl
 	Af3Composeyml string
 )

--- a/airflow/include/airflow3/astronomermonitoringdag.py
+++ b/airflow/include/airflow3/astronomermonitoringdag.py
@@ -1,0 +1,26 @@
+"""A Monitoring DAG used and maintained by Astronomer. All tasks in this DAG are executed by workers in the default worker queue. When tasks in the Monitoring DAG fail, it might indicate a problem with your Deployment. Astronomer will alert you via email."""
+
+import os
+from datetime import timedelta
+
+import pendulum
+from airflow import DAG
+from airflow.providers.standard.operators.bash import BashOperator
+
+with DAG(
+    dag_id="astronomer_monitoring_dag",
+    schedule=os.environ.get("AIRFLOW_MONITORING_DAG_SCHEDULE_INTERVAL", "*/5 * * * *"),
+    catchup=False,
+    is_paused_upon_creation=os.environ.get("PAUSE_ASTRONOMER_MONITORING_DAG", "False").lower() == "true",
+    dagrun_timeout=timedelta(minutes=30),
+    description=__doc__,
+    doc_md=__doc__,
+    tags=["monitoring"],
+):
+    hello = BashOperator(
+        task_id="hello",
+        bash_command="echo Hello from Astronomer!",
+        depends_on_past=False,
+        priority_weight=2**31 - 1,
+        do_xcom_push=False,
+    )

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -175,8 +175,18 @@ func deployDags(path, dagsPath, dagsUploadURL, currentRuntimeVersion string, dep
 	if shouldIncludeMonitoringDag(deploymentType) {
 		monitoringDagPath := filepath.Join(dagsPath, "astronomer_monitoring_dag.py")
 
+		var monitoringDag string
+		switch airflowversions.AirflowMajorVersionForRuntimeVersion(currentRuntimeVersion) {
+		case "2":
+			monitoringDag = airflow.Af2MonitoringDag
+		case "3":
+			monitoringDag = airflow.Af3MonitoringDag
+		default:
+			return "", errors.New("unsupported Airflow major version for runtime version " + currentRuntimeVersion)
+		}
+
 		// Create monitoring dag file
-		err := fileutil.WriteStringToFile(monitoringDagPath, airflow.Af2MonitoringDag)
+		err := fileutil.WriteStringToFile(monitoringDagPath, monitoringDag)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Description

`astro deploy` on hybrid injects `astronomer_monitoring_dag.py` into the DAG bundle at deploy time. We only support an Airflow-2 Dag. This PR adds support for an Airflow-3 Dag and explicitly fails on major versions other than 2 & 3.

Some code written with Claude, manually verified monitoring Dag on Astro Runtime 3.0-1 (Airflow 3.0.0) and Astro Runtime 3.3-2 (Airflow 3.3.0).

## 🎟 Issue(s)

N/A

## 🧪 Functional Testing

- `go build ./airflow/... ./cloud/deploy/...`
- `go test ./cloud/deploy/...` (existing monitoring DAG tests pass unchanged, since they use an Airflow 2-mapped runtime version)
- `python3 -m py_compile airflow/include/airflow3/astronomermonitoringdag.py`

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)