### PR TITLE
fix(otto): preflight org membership before launching Otto (AI-992)

### DIFF
--- a/cmd/otto.go
+++ b/cmd/otto.go
@@ -91,5 +91,10 @@ func ottoRun(cmd *cobra.Command, args []string) error {
 	if errors.Is(err, otto.ErrNotLoggedIn) {
 		os.Exit(1)
 	}
+	// Start already printed org-mismatch guidance to stderr; exit quietly so
+	// cobra doesn't tack on a redundant "Error: ..." line.
+	if errors.Is(err, otto.ErrNotOrgMember) {
+		os.Exit(1)
+	}
 	return err
 }

--- a/pkg/otto/preflight.go
+++ b/pkg/otto/preflight.go
@@ -1,0 +1,98 @@
+package otto
+
+import (
+	http_context "context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	astrov1 "github.com/astronomer/astro-cli/astro-client-v1"
+	"github.com/astronomer/astro-cli/pkg/httputil"
+	"github.com/astronomer/astro-cli/pkg/logger"
+)
+
+// ErrNotOrgMember signals that the signed-in user isn't a member of the
+// organization `astro otto` is about to launch against. ottoRun intercepts it
+// and exits silently (guidance is already printed), mirroring ErrNotLoggedIn.
+var ErrNotOrgMember = errors.New("not a member of the target organization")
+
+// effectiveOrganization returns the organization id BuildEnv will actually hand
+// to Otto. The login context wins when it carries an org; otherwise a value
+// inherited from the shell's ASTRO_ORGANIZATION passes through, because
+// BuildEnv's set() only overwrites when the context value is non-empty. The
+// preflight must validate whichever of the two Otto will really run under.
+func effectiveOrganization(cfg *Config) string {
+	if cfg.Organization != "" {
+		return cfg.Organization
+	}
+	return os.Getenv("ASTRO_ORGANIZATION")
+}
+
+// verifyOrgMembership confirms the current token can access the organization
+// Otto will run against, and fails fast with actionable guidance when it can't.
+// This closes the gap where `astro otto` would spawn with a token/organization
+// mismatch (a stale ASTRO_ORGANIZATION export, or an org selected under a
+// different login) and only surface it much later as a confusing skills 403 —
+// the LLM gateway isn't RBAC-gated, so the mismatch stays invisible until the
+// first org-scoped, permission-checked call.
+//
+// It fails CLOSED only on a definitive 403/404 (the subject isn't a member of,
+// or can't see, the org). Any other outcome — request error, 5xx, unexpected
+// shape — is treated as inconclusive and lets the launch proceed. The preflight
+// must never become a new way for `astro otto` to break on a transient blip.
+func verifyOrgMembership(cfg *Config, client astrov1.APIClient, out io.Writer) error {
+	org := effectiveOrganization(cfg)
+	if org == "" || cfg.Token == "" {
+		// Nothing to check: no target org (server-side/login handles resolution),
+		// or not logged in (already gated by the caller).
+		return nil
+	}
+
+	resp, err := client.GetOrganizationWithResponse(http_context.Background(), org, &astrov1.GetOrganizationParams{})
+	if err != nil {
+		logger.Debugf("otto: org membership preflight skipped (request error): %v", err)
+		return nil
+	}
+	if resp.HTTPResponse == nil {
+		return nil
+	}
+
+	switch resp.HTTPResponse.StatusCode {
+	case http.StatusForbidden, http.StatusNotFound:
+		printOrgMismatch(org, client, out)
+		return ErrNotOrgMember
+	default:
+		// 2xx (member) or anything inconclusive: don't block the launch.
+		return nil
+	}
+}
+
+// printOrgMismatch writes actionable guidance naming the signed-in user, so the
+// failure reads as "wrong logged-in user for this org" rather than a mystery.
+// The self-user lookup is best-effort: if it fails we fall back to a generic
+// subject rather than swallowing the guidance.
+func printOrgMismatch(org string, client astrov1.APIClient, out io.Writer) {
+	who := "The Astro account you're signed in as"
+	createIfNotExist := false
+	if self, err := client.GetSelfUserWithResponse(http_context.Background(), &astrov1.GetSelfUserParams{CreateIfNotExist: &createIfNotExist}); err == nil &&
+		self.JSON200 != nil && self.JSON200.Username != "" {
+		who = self.JSON200.Username
+	}
+
+	fmt.Fprintf(out, "%s isn't a member of organization %s, so Otto can't run against it.\n", who, org)
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "This usually means a stale ASTRO_ORGANIZATION is exported in your shell, or the")
+	fmt.Fprintln(out, "org was last selected under a different login. To fix:")
+	fmt.Fprintln(out, "  • Switch org:              astro organization switch")
+	fmt.Fprintln(out, "  • Sign in as another user: astro login")
+	fmt.Fprintln(out, "  • Clear a stale export:    unset ASTRO_ORGANIZATION")
+}
+
+// newV1Client builds a v1 public-API client bound to the current login context
+// (token + REST base resolved by astrov1's request editor). Split out so the
+// preflight is easy to exercise with a mock client in tests.
+func newV1Client() astrov1.APIClient {
+	return astrov1.NewV1Client(httputil.NewHTTPClient())
+}

--- a/pkg/otto/preflight_test.go
+++ b/pkg/otto/preflight_test.go
@@ -1,0 +1,163 @@
+package otto
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	astrov1 "github.com/astronomer/astro-cli/astro-client-v1"
+	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
+)
+
+func orgResp(status int) *astrov1.GetOrganizationResponse {
+	return &astrov1.GetOrganizationResponse{HTTPResponse: &http.Response{StatusCode: status}}
+}
+
+func selfResp(username string) *astrov1.GetSelfUserResponse {
+	return &astrov1.GetSelfUserResponse{
+		HTTPResponse: &http.Response{StatusCode: 200},
+		JSON200:      &astrov1.SelfUser{Username: username},
+	}
+}
+
+func TestEffectiveOrganization(t *testing.T) {
+	t.Run("context org wins over env", func(t *testing.T) {
+		t.Setenv("ASTRO_ORGANIZATION", "env-org")
+		assert.Equal(t, "ctx-org", effectiveOrganization(&Config{Organization: "ctx-org"}))
+	})
+
+	t.Run("falls back to env when context org empty", func(t *testing.T) {
+		t.Setenv("ASTRO_ORGANIZATION", "env-org")
+		assert.Equal(t, "env-org", effectiveOrganization(&Config{Organization: ""}))
+	})
+
+	t.Run("empty when neither set", func(t *testing.T) {
+		t.Setenv("ASTRO_ORGANIZATION", "")
+		assert.Equal(t, "", effectiveOrganization(&Config{Organization: ""}))
+	})
+}
+
+func TestVerifyOrgMembership(t *testing.T) {
+	t.Run("member (200) proceeds without error or output", func(t *testing.T) {
+		client := new(astrov1_mocks.ClientWithResponsesInterface)
+		client.On("GetOrganizationWithResponse", mock.Anything, "org-a", mock.Anything).
+			Return(orgResp(http.StatusOK), nil).Once()
+
+		var out bytes.Buffer
+		err := verifyOrgMembership(&Config{Token: "t", Organization: "org-a"}, client, &out)
+
+		assert.NoError(t, err)
+		assert.Empty(t, out.String())
+		client.AssertExpectations(t)
+		// A member must not trigger the self-user lookup.
+		client.AssertNotCalled(t, "GetSelfUserWithResponse", mock.Anything, mock.Anything)
+	})
+
+	forbiddenStatuses := map[string]int{
+		"forbidden": http.StatusForbidden,
+		"not found": http.StatusNotFound,
+	}
+	for name, status := range forbiddenStatuses {
+		t.Run(name+" fails closed with actionable, user-named guidance", func(t *testing.T) {
+			client := new(astrov1_mocks.ClientWithResponsesInterface)
+			client.On("GetOrganizationWithResponse", mock.Anything, "org-a", mock.Anything).
+				Return(orgResp(status), nil).Once()
+			client.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).
+				Return(selfResp("b@example.com"), nil).Once()
+
+			var out bytes.Buffer
+			err := verifyOrgMembership(&Config{Token: "t", Organization: "org-a"}, client, &out)
+
+			assert.ErrorIs(t, err, ErrNotOrgMember)
+			msg := out.String()
+			assert.Contains(t, msg, "b@example.com")
+			assert.Contains(t, msg, "org-a")
+			assert.Contains(t, msg, "astro organization switch")
+			client.AssertExpectations(t)
+		})
+	}
+
+	t.Run("forbidden validates the inherited env org, not the empty context org", func(t *testing.T) {
+		t.Setenv("ASTRO_ORGANIZATION", "stale-env-org")
+		client := new(astrov1_mocks.ClientWithResponsesInterface)
+		client.On("GetOrganizationWithResponse", mock.Anything, "stale-env-org", mock.Anything).
+			Return(orgResp(http.StatusForbidden), nil).Once()
+		client.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).
+			Return(selfResp("b@example.com"), nil).Once()
+
+		var out bytes.Buffer
+		err := verifyOrgMembership(&Config{Token: "t", Organization: ""}, client, &out)
+
+		assert.ErrorIs(t, err, ErrNotOrgMember)
+		assert.Contains(t, out.String(), "stale-env-org")
+		client.AssertExpectations(t)
+	})
+
+	t.Run("forbidden with failed self-user lookup still blocks, with generic subject", func(t *testing.T) {
+		client := new(astrov1_mocks.ClientWithResponsesInterface)
+		client.On("GetOrganizationWithResponse", mock.Anything, "org-a", mock.Anything).
+			Return(orgResp(http.StatusForbidden), nil).Once()
+		client.On("GetSelfUserWithResponse", mock.Anything, mock.Anything).
+			Return(nil, errors.New("network error")).Once()
+
+		var out bytes.Buffer
+		err := verifyOrgMembership(&Config{Token: "t", Organization: "org-a"}, client, &out)
+
+		assert.ErrorIs(t, err, ErrNotOrgMember)
+		assert.Contains(t, out.String(), "The Astro account you're signed in as")
+		client.AssertExpectations(t)
+	})
+
+	t.Run("no org to check: skips the API call entirely", func(t *testing.T) {
+		t.Setenv("ASTRO_ORGANIZATION", "")
+		client := new(astrov1_mocks.ClientWithResponsesInterface)
+
+		var out bytes.Buffer
+		err := verifyOrgMembership(&Config{Token: "t", Organization: ""}, client, &out)
+
+		assert.NoError(t, err)
+		client.AssertNotCalled(t, "GetOrganizationWithResponse", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("no token: skips the API call entirely", func(t *testing.T) {
+		client := new(astrov1_mocks.ClientWithResponsesInterface)
+
+		var out bytes.Buffer
+		err := verifyOrgMembership(&Config{Token: "", Organization: "org-a"}, client, &out)
+
+		assert.NoError(t, err)
+		client.AssertNotCalled(t, "GetOrganizationWithResponse", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	// Inconclusive outcomes must fail OPEN so the preflight never becomes a new
+	// way for `astro otto` to break.
+	t.Run("request error lets the launch proceed", func(t *testing.T) {
+		client := new(astrov1_mocks.ClientWithResponsesInterface)
+		client.On("GetOrganizationWithResponse", mock.Anything, "org-a", mock.Anything).
+			Return(nil, errors.New("network error")).Once()
+
+		var out bytes.Buffer
+		err := verifyOrgMembership(&Config{Token: "t", Organization: "org-a"}, client, &out)
+
+		assert.NoError(t, err)
+		assert.Empty(t, out.String())
+		client.AssertExpectations(t)
+	})
+
+	t.Run("5xx lets the launch proceed", func(t *testing.T) {
+		client := new(astrov1_mocks.ClientWithResponsesInterface)
+		client.On("GetOrganizationWithResponse", mock.Anything, "org-a", mock.Anything).
+			Return(orgResp(http.StatusInternalServerError), nil).Once()
+
+		var out bytes.Buffer
+		err := verifyOrgMembership(&Config{Token: "t", Organization: "org-a"}, client, &out)
+
+		assert.NoError(t, err)
+		assert.Empty(t, out.String())
+		client.AssertExpectations(t)
+	})
+}

--- a/pkg/otto/start.go
+++ b/pkg/otto/start.go
@@ -41,6 +41,14 @@ func Start(args []string) error {
 		return ErrNotLoggedIn
 	}
 
+	// Fail fast when the signed-in user isn't a member of the org Otto would run
+	// against, instead of spawning Otto and letting the mismatch surface later as
+	// a confusing skills 403. Only a definitive 403/404 blocks; anything else is
+	// inconclusive and lets the launch proceed.
+	if err := verifyOrgMembership(cfg, newV1Client(), os.Stderr); err != nil {
+		return err
+	}
+
 	if err := EnsureBinary(); err != nil {
 		return fmt.Errorf("setting up otto: %w", err)
 	}


### PR DESCRIPTION
## Summary

`astro otto` could launch Otto with a token whose user **isn't a member of `ASTRO_ORGANIZATION`**, and the mismatch was invisible until a downstream, RBAC-gated feature failed. A demo/interview user hit it as:

```
Failed to fetch skill "airflow-upgrade" and no cached version available:
403: organization with id cmrfr39s14zyl01jhp2mrcxnj is forbidden
```

Root cause: the org and the token identity are decoupled, and the only place that reconciles them is `astro login` (`resolveActiveOrg`), **not** `astro otto`. The org handed to Otto can come from the stored context block, an `ASTRO_DOMAIN`-selected block, or a stale shell-exported `ASTRO_ORGANIZATION` that `BuildEnv` passes through when the context org is empty. Core's LLM gateway isn't RBAC-gated, so Otto boots and chats fine; only the first org-scoped, permission-checked call (hosted skills) 403s — reading like a skills bug.

## Change

A launch-time membership preflight in `pkg/otto` (`preflight.go`), run in `Start()` right after the login check:

- Resolves the **effective** org exactly as `BuildEnv` does (context org, else inherited `ASTRO_ORGANIZATION`) and calls `GetOrganization` with the current token.
- On a definitive **403/404**, prints actionable guidance naming the signed-in user (`astro login` / `astro organization switch` / clear a stale export) and returns `ErrNotOrgMember`; `cmd/otto.go` exits quietly (mirrors `ErrNotLoggedIn`).
- **Fails closed only on 403/404.** Request errors, 5xx, and unexpected shapes are treated as inconclusive and let the launch proceed — the preflight must never become a new way for `astro otto` to break.

## Testing

`pkg/otto/preflight_test.go` (12 cases, all green): effective-org resolution; member proceeds silently; 403 **and** 404 fail closed with user-named guidance; the inherited-env-org path; self-user lookup failure still blocks with a generic subject; skip-when-no-org/token; and fail-open on request-error / 5xx. `go build`, `go vet`, and the full `pkg/otto` suite pass.

## Notes

- Core's 403 is **correct** RBAC behavior — a non-member has no org-scoped role binding, so no `organization.skills.get`. This PR fixes the client so the failure is caught early with a clear message instead of surfacing mid-session.
- Companion (defense-in-depth) change in `astronomer/otto` makes the skill-fetch 403 self-explain for callers that bypass `astro otto` (dev scripts, SDK).
- Tracked in AI-992.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
