### PR TITLE
fix: don't print stale context before login, stack context output vertically

### DIFF
--- a/config/cloud.go
+++ b/config/cloud.go
@@ -23,13 +23,10 @@ func (c *Context) PrintCloudContext(out io.Writer) error {
 	if workspace == "" {
 		workspace = noApply
 	}
-	tab := printutil.Table{
-		Padding: []int{36, 36},
-		Header:  []string{"CONTROLPLANE", "WORKSPACE"},
-	}
-
-	tab.AddRow([]string{ctx, workspace}, false)
-	tab.Print(out)
+	printutil.PrintKeyValues(out, [][2]string{
+		{"CONTROLPLANE", ctx},
+		{"WORKSPACE", workspace},
+	})
 
 	return nil
 }

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -56,7 +56,7 @@ contexts:
 	buf := new(bytes.Buffer)
 	err = ctx.PrintCloudContext(buf)
 	s.NoError(err)
-	expected := " CONTROLPLANE                        WORKSPACE                           \n example.com                         ck05r3bor07h40d02y2hw4n4v           \n"
+	expected := " CONTROLPLANE     example.com\n WORKSPACE        ck05r3bor07h40d02y2hw4n4v\n"
 	s.Equal(expected, buf.String())
 }
 
@@ -90,7 +90,7 @@ contexts:
 	buf := new(bytes.Buffer)
 	err = ctx.PrintCloudContext(buf)
 	s.NoError(err)
-	expected := " CONTROLPLANE                        WORKSPACE                           \n example.com                         N/A                                 \n"
+	expected := " CONTROLPLANE     example.com\n WORKSPACE        N/A\n"
 	s.Equal(expected, buf.String())
 }
 

--- a/config/software.go
+++ b/config/software.go
@@ -26,13 +26,10 @@ func (c *Context) PrintSoftwareContext(out io.Writer) error {
 	if workspace == "" {
 		workspace = noApply
 	}
-	tab := printutil.Table{
-		Padding: []int{36, 36},
-		Header:  []string{"CLUSTER", "WORKSPACE"},
-	}
-
-	tab.AddRow([]string{ctx, workspace}, false)
-	tab.Print(out)
+	printutil.PrintKeyValues(out, [][2]string{
+		{"CLUSTER", ctx},
+		{"WORKSPACE", workspace},
+	})
 
 	return nil
 }

--- a/context/context.go
+++ b/context/context.go
@@ -30,14 +30,6 @@ var tab = printutil.Table{
 	ColorRowCode: [2]string{"\033[1;32m", "\033[0m"},
 }
 
-// newTableOut construct new printutil.Table
-func newTableOut() *printutil.Table {
-	return &printutil.Table{
-		Padding: []int{36, 36},
-		Header:  []string{"CONTEXT DOMAIN", "WORKSPACE"},
-	}
-}
-
 // ContextExists checks to see if context exist in config
 func Exists(domain string) bool {
 	c := config.Context{Domain: domain}
@@ -126,10 +118,15 @@ func SwitchContext(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tab := newTableOut()
-	tab.AddRow([]string{ctx.Domain, ctx.Workspace}, false)
-	tab.SuccessMsg = "\n Switched context"
-	tab.Print(os.Stdout)
+	workspace := ctx.Workspace
+	if workspace == "" {
+		workspace = "N/A"
+	}
+	printutil.PrintKeyValues(os.Stdout, [][2]string{
+		{"CONTEXT DOMAIN", ctx.Domain},
+		{"WORKSPACE", workspace},
+	})
+	fmt.Println("\n Switched context")
 
 	return nil
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -20,12 +20,6 @@ func TestContext(t *testing.T) {
 	suite.Run(t, new(Suite))
 }
 
-func (s *Suite) TestNewTableOut() {
-	tab := newTableOut()
-	s.NotNil(tab)
-	s.Equal([]int{36, 36}, tab.Padding)
-}
-
 func (s *Suite) TestExists() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	// Check that we don't have localhost123 in test config from testUtils.NewTestConfig()

--- a/pkg/printutil/printutil.go
+++ b/pkg/printutil/printutil.go
@@ -142,6 +142,22 @@ func (t *Table) PrintRows(out io.Writer, pageNumber int) {
 	}
 }
 
+// PrintKeyValues prints each label/value pair on its own line, with values
+// aligned in a single column sized to the longest label. Unlike Table, output
+// width grows with the longest value only, so long values (e.g. cluster
+// domains) never collide with a neighboring column.
+func PrintKeyValues(out io.Writer, pairs [][2]string) {
+	width := 0
+	for _, p := range pairs {
+		if len(p[0]) > width {
+			width = len(p[0])
+		}
+	}
+	for _, p := range pairs {
+		fmt.Fprintf(out, " %-*s%s\n", width+5, p[0], p[1])
+	}
+}
+
 // GetPadding converts an array of ints into template padding for str fmting
 func getPadding(padding []int) string {
 	padStr := " "

--- a/software/auth/auth.go
+++ b/software/auth/auth.go
@@ -177,11 +177,6 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 	}
 
 	ctx := &config.Context{Domain: domain}
-	err = ctx.PrintSoftwareContext(out)
-	if err != nil {
-		return err
-	}
-
 	authConfig, err := houston.Call(client.GetAuthConfig)(ctx)
 	if err != nil {
 		return err
@@ -231,6 +226,9 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 		fmt.Printf(configSetDefaultWorkspace, w.Label)
 	}
 
+	// workspace.Switch prints the resulting context on success, so only print
+	// it here for the flows that haven't already done so
+	printContext := true
 	if len(workspaces) > 1 {
 		// try to switch to last used workspace in cluster
 		isSwitched := switchToLastUsedWorkspace(client, &c)
@@ -245,7 +243,15 @@ func Login(domain string, oAuthOnly bool, username, password, houstonVersion str
 			err := workspace.Switch("", pageSize, client, out)
 			if err != nil {
 				fmt.Fprint(out, cliSetWorkspaceExample)
+			} else {
+				printContext = false
 			}
+		}
+	}
+
+	if printContext {
+		if err := config.PrintCurrentSoftwareContext(out); err != nil {
+			return err
 		}
 	}
 

--- a/software/auth/auth_test.go
+++ b/software/auth/auth_test.go
@@ -463,9 +463,8 @@ func (s *Suite) TestLoginFailure() {
 		if !s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out), errMockRegistry) {
 			return
 		}
-		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
-			s.Fail("Login() = %v, want %v", gotOut, []string{"localhost"})
-		}
+		// no context is printed before authentication completes
+		s.Empty(out.String())
 		houstonMock.AssertExpectations(s.T())
 	})
 
@@ -478,9 +477,8 @@ func (s *Suite) TestLoginFailure() {
 		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out), errMockRegistry) {
 			return
 		}
-		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
-			s.Fail("Login() = %v, want %v", gotOut, []string{"localhost"})
-		}
+		// no context is printed before authentication completes
+		s.Empty(out.String())
 		houstonMock.AssertExpectations(s.T())
 	})
 
@@ -494,9 +492,8 @@ func (s *Suite) TestLoginFailure() {
 		if s.ErrorIs(Login("localhost", false, "test", "test", "0.30.0", houstonMock, out), errMockRegistry) {
 			return
 		}
-		if gotOut := out.String(); !testUtil.StringContains([]string{"localhost"}, gotOut) {
-			s.Fail("Login() = %v, want %v", gotOut, []string{"localhost"})
-		}
+		// no context is printed before authentication completes
+		s.Empty(out.String())
 		houstonMock.AssertExpectations(s.T())
 	})
 


### PR DESCRIPTION
## What does this PR do?

Two fixes for the `astro login` output from #2088:

**Don't print the context before auth.** Login used to print a CLUSTER/WORKSPACE block before authenticating, built from a context that doesn't exist yet — so you'd see `N/A` or stale data. It now prints once after login resolves the workspace (and skips it when the interactive workspace switch already printed it). Failed logins print nothing.

**Stack the context output instead of columns.** The old table used fixed 36-char padding, so a long cluster domain ran straight into the workspace value. Rather than guessing a bigger width (see #2098 — same bug comes back at 60+ chars), the single-record context displays (software, cloud, `context switch`) now print one label per line:

```
 CLUSTER       astro.cp-dr.test.us-east-2.astro-foo.example.com
 WORKSPACE     cmny8l7wh0008fc188aeh5aww
```

No domain length can break alignment, and output stays inside 80 columns.

## How to test

1. `astro login astro.cp-dr.test.us-east-2.astro-foo.example.com` — no context block before the auth prompt
2. Complete a login — cluster and workspace print aligned as above
3. `astro context switch <domain>` — same stacked format

Closes #2088