### PR TITLE
fix(cli): paginate org/workspace/deployment lists past the first page

### DIFF
--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -17,6 +17,7 @@ import (
 	airflowversions "github.com/astronomer/astro-cli/airflow_versions"
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	"github.com/astronomer/astro-cli/cloud/organization"
+	"github.com/astronomer/astro-cli/cloud/pagination"
 	"github.com/astronomer/astro-cli/cloud/workspace"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/ansi"
@@ -70,10 +71,6 @@ var (
 	listLimit        = 1000
 	dagDeployEnabled bool
 )
-
-// maxListPages caps a single paginated list call at maxListPages pages as a safety
-// bound against a server that mis-reports TotalCount (mirrors cloud/env).
-const maxListPages = 100
 
 // defaultWorkerMachineName is the machine type UpdateDeployment falls back to when
 // an executor change forces it to synthesize a replacement worker queue.
@@ -1693,35 +1690,20 @@ var ListDeployments = func(ws, orgID string, astroV1Client astrov1.APIClient) ([
 		}
 		orgID = c.Organization
 	}
-	offset := 0
-	var deployments []astrov1.Deployment
-	for page := 0; page < maxListPages; page++ {
-		deploymentListParams := &astrov1.ListDeploymentsParams{
-			Limit:  &listLimit,
-			Offset: &offset,
-		}
+	return pagination.Collect("deployments", func(offset int) ([]astrov1.Deployment, int, error) {
+		params := &astrov1.ListDeploymentsParams{Limit: &listLimit, Offset: &offset}
 		if ws != "" {
-			deploymentListParams.WorkspaceIds = &[]string{ws}
+			params.WorkspaceIds = &[]string{ws}
 		}
-
-		resp, err := astroV1Client.ListDeploymentsWithResponse(context.Background(), orgID, deploymentListParams)
+		resp, err := astroV1Client.ListDeploymentsWithResponse(context.Background(), orgID, params)
 		if err != nil {
-			return []astrov1.Deployment{}, err
+			return nil, 0, err
 		}
-		err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
-		if err != nil {
-			return []astrov1.Deployment{}, err
+		if err := astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body); err != nil {
+			return nil, 0, err
 		}
-
-		deploymentResponse := *resp.JSON200
-		deployments = append(deployments, deploymentResponse.Deployments...)
-		if len(deploymentResponse.Deployments) == 0 || len(deployments) >= deploymentResponse.TotalCount {
-			return deployments, nil
-		}
-		offset = len(deployments)
-	}
-
-	return []astrov1.Deployment{}, fmt.Errorf("aborted listing deployments after %d pages", maxListPages)
+		return resp.JSON200.Deployments, resp.JSON200.TotalCount, nil
+	})
 }
 
 //nolint:dupl

--- a/cloud/deployment/deployment.go
+++ b/cloud/deployment/deployment.go
@@ -71,6 +71,10 @@ var (
 	dagDeployEnabled bool
 )
 
+// maxListPages caps a single paginated list call at maxListPages pages as a safety
+// bound against a server that mis-reports TotalCount (mirrors cloud/env).
+const maxListPages = 100
+
 // defaultWorkerMachineName is the machine type UpdateDeployment falls back to when
 // an executor change forces it to synthesize a replacement worker queue.
 const defaultWorkerMachineName = "A5"
@@ -1679,6 +1683,8 @@ var CoreDeleteDeploymentHibernationOverride = func(orgID, deploymentID string, a
 	return nil
 }
 
+// ListDeployments returns every Deployment in the given Workspace (or the whole
+// Organization when ws is empty), paging through the API as needed.
 var ListDeployments = func(ws, orgID string, astroV1Client astrov1.APIClient) ([]astrov1.Deployment, error) {
 	if orgID == "" {
 		c, err := config.GetCurrentContext()
@@ -1687,26 +1693,35 @@ var ListDeployments = func(ws, orgID string, astroV1Client astrov1.APIClient) ([
 		}
 		orgID = c.Organization
 	}
-	deploymentListParams := &astrov1.ListDeploymentsParams{
-		Limit: &listLimit,
-	}
-	if ws != "" {
-		deploymentListParams.WorkspaceIds = &[]string{ws}
+	offset := 0
+	var deployments []astrov1.Deployment
+	for page := 0; page < maxListPages; page++ {
+		deploymentListParams := &astrov1.ListDeploymentsParams{
+			Limit:  &listLimit,
+			Offset: &offset,
+		}
+		if ws != "" {
+			deploymentListParams.WorkspaceIds = &[]string{ws}
+		}
+
+		resp, err := astroV1Client.ListDeploymentsWithResponse(context.Background(), orgID, deploymentListParams)
+		if err != nil {
+			return []astrov1.Deployment{}, err
+		}
+		err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+		if err != nil {
+			return []astrov1.Deployment{}, err
+		}
+
+		deploymentResponse := *resp.JSON200
+		deployments = append(deployments, deploymentResponse.Deployments...)
+		if len(deploymentResponse.Deployments) == 0 || len(deployments) >= deploymentResponse.TotalCount {
+			return deployments, nil
+		}
+		offset = len(deployments)
 	}
 
-	resp, err := astroV1Client.ListDeploymentsWithResponse(context.Background(), orgID, deploymentListParams)
-	if err != nil {
-		return []astrov1.Deployment{}, err
-	}
-	err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
-	if err != nil {
-		return []astrov1.Deployment{}, err
-	}
-
-	deploymentResponse := *resp.JSON200
-	deployments := deploymentResponse.Deployments
-
-	return deployments, nil
+	return []astrov1.Deployment{}, fmt.Errorf("aborted listing deployments after %d pages", maxListPages)
 }
 
 //nolint:dupl

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -408,6 +410,40 @@ func (s *Suite) TestListDeploymentsPaginates() {
 	s.Equal("deployment-page1", got[0].Id)
 	s.Equal("deployment-page2", got[1].Id)
 	mockClient.AssertExpectations(s.T())
+}
+
+// TestListDeploymentsPaginatesOverHTTP drives a real astro-client-v1 client against
+// a stub API server, exercising the actual HTTP request building (offset/limit
+// query params), response parsing, and the pagination loop end-to-end.
+func (s *Suite) TestListDeploymentsPaginatesOverHTTP() {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	var seenOffsets, seenLimits []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		seenOffsets = append(seenOffsets, q.Get("offset"))
+		seenLimits = append(seenLimits, q.Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		if q.Get("offset") == "0" {
+			_, _ = io.WriteString(w, `{"deployments":[{"id":"dep-1"}],"limit":1000,"offset":0,"totalCount":2}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"deployments":[{"id":"dep-2"}],"limit":1000,"offset":1,"totalCount":2}`)
+	}))
+	defer ts.Close()
+
+	client, err := astrov1.NewClientWithResponses(ts.URL)
+	s.Require().NoError(err)
+
+	got, err := ListDeployments("", "test-org", client)
+	s.NoError(err)
+	s.Len(got, 2)
+	s.Equal("dep-1", got[0].Id)
+	s.Equal("dep-2", got[1].Id)
+	// The real client serialized limit and an advancing offset into the request query
+	// across two calls, proving pagination works over the wire (not just via mocks).
+	s.Equal([]string{"0", "1"}, seenOffsets)
+	s.Equal([]string{"1000", "1000"}, seenLimits)
 }
 
 func (s *Suite) TestListData() {

--- a/cloud/deployment/deployment_test.go
+++ b/cloud/deployment/deployment_test.go
@@ -376,6 +376,40 @@ func (s *Suite) TestList() {
 	})
 }
 
+func (s *Suite) TestListDeploymentsPaginates() {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	page1 := astrov1.ListDeploymentsResponse{
+		HTTPResponse: &http.Response{StatusCode: 200},
+		JSON200: &astrov1.DeploymentsPaginated{
+			Deployments: []astrov1.Deployment{{Id: "deployment-page1"}},
+			TotalCount:  2,
+			Limit:       1000,
+			Offset:      0,
+		},
+	}
+	page2 := astrov1.ListDeploymentsResponse{
+		HTTPResponse: &http.Response{StatusCode: 200},
+		JSON200: &astrov1.DeploymentsPaginated{
+			Deployments: []astrov1.Deployment{{Id: "deployment-page2"}},
+			TotalCount:  2,
+			Limit:       1000,
+			Offset:      1000,
+		},
+	}
+	mockClient := new(astrov1_mocks.ClientWithResponsesInterface)
+	// First call returns page 1 (offset 0), second call returns page 2 (offset 1000).
+	mockClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&page1, nil).Once()
+	mockClient.On("ListDeploymentsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&page2, nil).Once()
+
+	got, err := ListDeployments("", "test-org", mockClient)
+	s.NoError(err)
+	s.Len(got, 2)
+	s.Equal("deployment-page1", got[0].Id)
+	s.Equal("deployment-page2", got[1].Id)
+	mockClient.AssertExpectations(s.T())
+}
+
 func (s *Suite) TestListData() {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -14,6 +14,7 @@ import (
 
 	astrov1 "github.com/astronomer/astro-cli/astro-client-v1"
 	"github.com/astronomer/astro-cli/cloud/auth"
+	"github.com/astronomer/astro-cli/cloud/pagination"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -45,37 +46,27 @@ var organizationTableConfig = output.BuildTableConfig(
 	output.WithPadding([]int{44, 50}),
 )
 
-// maxListPages caps a single paginated list call at maxListPages pages as a safety
-// bound against a server that mis-reports TotalCount (mirrors cloud/env).
-const maxListPages = 100
+// organizationPager fetches one page of Organizations at a time for the
+// pagination helpers.
+func organizationPager(astroV1Client astrov1.APIClient) pagination.FetchPage[astrov1.Organization] {
+	return func(offset int) ([]astrov1.Organization, int, error) {
+		pageSize := 100
+		params := &astrov1.ListOrganizationsParams{Limit: &pageSize, Offset: &offset}
+		resp, err := astroV1Client.ListOrganizationsWithResponse(http_context.Background(), params)
+		if err != nil {
+			return nil, 0, err
+		}
+		if err := astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body); err != nil {
+			return nil, 0, err
+		}
+		return resp.JSON200.Organizations, resp.JSON200.TotalCount, nil
+	}
+}
 
 // ListOrganizations returns every Organization the caller has access to, paging
 // through the API as needed.
 func ListOrganizations(astroV1Client astrov1.APIClient) ([]astrov1.Organization, error) {
-	pageSize := 100
-	offset := 0
-	var orgs []astrov1.Organization
-	for page := 0; page < maxListPages; page++ {
-		organizationListParams := &astrov1.ListOrganizationsParams{
-			Limit:  &pageSize,
-			Offset: &offset,
-		}
-		resp, err := astroV1Client.ListOrganizationsWithResponse(http_context.Background(), organizationListParams)
-		if err != nil {
-			return nil, err
-		}
-		err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
-		if err != nil {
-			return nil, err
-		}
-		orgsPaginated := *resp.JSON200
-		orgs = append(orgs, orgsPaginated.Organizations...)
-		if len(orgsPaginated.Organizations) == 0 || len(orgs) >= orgsPaginated.TotalCount {
-			return orgs, nil
-		}
-		offset = len(orgs)
-	}
-	return nil, fmt.Errorf("aborted listing organizations after %d pages", maxListPages)
+	return pagination.Collect("organizations", organizationPager(astroV1Client))
 }
 
 func GetOrganization(orgID string, astroV1Client astrov1.APIClient) (*astrov1.Organization, error) {
@@ -93,30 +84,9 @@ func GetOrganization(orgID string, astroV1Client astrov1.APIClient) (*astrov1.Or
 // findOrganizationByName pages through Organizations and returns as soon as it
 // finds a name match, so a match on an early page avoids fetching later pages.
 func findOrganizationByName(name string, astroV1Client astrov1.APIClient) (*astrov1.Organization, error) {
-	pageSize := 100
-	fetched := 0
-	for page := 0; page < maxListPages; page++ {
-		params := &astrov1.ListOrganizationsParams{Limit: &pageSize, Offset: &fetched}
-		resp, err := astroV1Client.ListOrganizationsWithResponse(http_context.Background(), params)
-		if err != nil {
-			return nil, err
-		}
-		err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
-		if err != nil {
-			return nil, err
-		}
-		paginated := *resp.JSON200
-		for i := range paginated.Organizations {
-			if paginated.Organizations[i].Name == name {
-				return &paginated.Organizations[i], nil
-			}
-		}
-		fetched += len(paginated.Organizations)
-		if len(paginated.Organizations) == 0 || fetched >= paginated.TotalCount {
-			break
-		}
-	}
-	return nil, nil
+	return pagination.Find("organizations", organizationPager(astroV1Client), func(o astrov1.Organization) bool {
+		return o.Name == name
+	})
 }
 
 // ListData returns organization list data for structured output

--- a/cloud/organization/organization.go
+++ b/cloud/organization/organization.go
@@ -45,22 +45,37 @@ var organizationTableConfig = output.BuildTableConfig(
 	output.WithPadding([]int{44, 50}),
 )
 
+// maxListPages caps a single paginated list call at maxListPages pages as a safety
+// bound against a server that mis-reports TotalCount (mirrors cloud/env).
+const maxListPages = 100
+
+// ListOrganizations returns every Organization the caller has access to, paging
+// through the API as needed.
 func ListOrganizations(astroV1Client astrov1.APIClient) ([]astrov1.Organization, error) {
-	limit := 100
-	organizationListParams := &astrov1.ListOrganizationsParams{
-		Limit: &limit,
+	pageSize := 100
+	offset := 0
+	var orgs []astrov1.Organization
+	for page := 0; page < maxListPages; page++ {
+		organizationListParams := &astrov1.ListOrganizationsParams{
+			Limit:  &pageSize,
+			Offset: &offset,
+		}
+		resp, err := astroV1Client.ListOrganizationsWithResponse(http_context.Background(), organizationListParams)
+		if err != nil {
+			return nil, err
+		}
+		err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		orgsPaginated := *resp.JSON200
+		orgs = append(orgs, orgsPaginated.Organizations...)
+		if len(orgsPaginated.Organizations) == 0 || len(orgs) >= orgsPaginated.TotalCount {
+			return orgs, nil
+		}
+		offset = len(orgs)
 	}
-	resp, err := astroV1Client.ListOrganizationsWithResponse(http_context.Background(), organizationListParams)
-	if err != nil {
-		return nil, err
-	}
-	err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	orgsPaginated := *resp.JSON200
-	orgs := orgsPaginated.Organizations
-	return orgs, nil
+	return nil, fmt.Errorf("aborted listing organizations after %d pages", maxListPages)
 }
 
 func GetOrganization(orgID string, astroV1Client astrov1.APIClient) (*astrov1.Organization, error) {
@@ -75,11 +90,13 @@ func GetOrganization(orgID string, astroV1Client astrov1.APIClient) (*astrov1.Or
 	return resp.JSON200, nil
 }
 
+// findOrganizationByName pages through Organizations and returns as soon as it
+// finds a name match, so a match on an early page avoids fetching later pages.
 func findOrganizationByName(name string, astroV1Client astrov1.APIClient) (*astrov1.Organization, error) {
 	pageSize := 100
-	offset := 0
-	for {
-		params := &astrov1.ListOrganizationsParams{Limit: &pageSize, Offset: &offset}
+	fetched := 0
+	for page := 0; page < maxListPages; page++ {
+		params := &astrov1.ListOrganizationsParams{Limit: &pageSize, Offset: &fetched}
 		resp, err := astroV1Client.ListOrganizationsWithResponse(http_context.Background(), params)
 		if err != nil {
 			return nil, err
@@ -94,8 +111,8 @@ func findOrganizationByName(name string, astroV1Client astrov1.APIClient) (*astr
 				return &paginated.Organizations[i], nil
 			}
 		}
-		offset += pageSize
-		if offset >= paginated.TotalCount {
+		fetched += len(paginated.Organizations)
+		if len(paginated.Organizations) == 0 || fetched >= paginated.TotalCount {
 			break
 		}
 	}

--- a/cloud/organization/organization_test.go
+++ b/cloud/organization/organization_test.go
@@ -175,6 +175,57 @@ func (s *Suite) TestListWithFormat() {
 	})
 }
 
+// orgOffsetIs matches ListOrganizationsParams whose Offset equals want.
+func orgOffsetIs(want int) any {
+	return mock.MatchedBy(func(p *astrov1.ListOrganizationsParams) bool {
+		return p != nil && p.Offset != nil && *p.Offset == want
+	})
+}
+
+func (s *Suite) TestListOrganizations() {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	s.Run("paginates across pages advancing the offset", func() {
+		page1 := astrov1.ListOrganizationsResponse{
+			HTTPResponse: &http.Response{StatusCode: 200},
+			JSON200: &astrov1.OrganizationsPaginated{
+				Organizations: []astrov1.Organization{{Id: "org1", Name: "org1", Product: &mockOrganizationProduct}},
+				TotalCount:    2,
+				Limit:         100,
+				Offset:        0,
+			},
+		}
+		page2 := astrov1.ListOrganizationsResponse{
+			HTTPResponse: &http.Response{StatusCode: 200},
+			JSON200: &astrov1.OrganizationsPaginated{
+				Organizations: []astrov1.Organization{{Id: "org2", Name: "org2", Product: &mockOrganizationProduct}},
+				TotalCount:    2,
+				Limit:         100,
+				Offset:        1,
+			},
+		}
+		mockClient := new(astrov1_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationsWithResponse", mock.Anything, orgOffsetIs(0)).Return(&page1, nil).Once()
+		mockClient.On("ListOrganizationsWithResponse", mock.Anything, orgOffsetIs(1)).Return(&page2, nil).Once()
+
+		orgs, err := ListOrganizations(mockClient)
+		s.NoError(err)
+		s.Len(orgs, 2)
+		s.Equal("org1", orgs[0].Id)
+		s.Equal("org2", orgs[1].Id)
+		mockClient.AssertExpectations(s.T())
+	})
+
+	s.Run("returns error on failure", func() {
+		mockClient := new(astrov1_mocks.ClientWithResponsesInterface)
+		mockClient.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(nil, errNetwork).Once()
+
+		_, err := ListOrganizations(mockClient)
+		s.ErrorIs(err, errNetwork)
+		mockClient.AssertExpectations(s.T())
+	})
+}
+
 func (s *Suite) TestGetOrganizationSelection() {
 	// initialize empty config
 	testUtil.InitTestConfig(testUtil.LocalPlatform)

--- a/cloud/pagination/pagination.go
+++ b/cloud/pagination/pagination.go
@@ -1,0 +1,57 @@
+// Package pagination provides helpers for reading every result from the paged
+// list endpoints of the Astro API, so callers don't each reimplement the loop.
+package pagination
+
+import "fmt"
+
+// MaxListPages caps a single paginated list call as a safety bound against a
+// server that mis-reports the total count.
+const MaxListPages = 100
+
+// FetchPage returns one page of items starting at offset, along with the total
+// number of items available across all pages.
+type FetchPage[T any] func(offset int) (items []T, total int, err error)
+
+// Collect pages through every item returned by fetch. It advances the offset by
+// the number of items returned and stops on an empty page or once the reported
+// total is reached, erroring if MaxListPages is exceeded. what names the entity
+// being listed, for the error message (e.g. "workspaces").
+func Collect[T any](what string, fetch FetchPage[T]) ([]T, error) {
+	var all []T
+	offset := 0
+	for page := 0; page < MaxListPages; page++ {
+		items, total, err := fetch(offset)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, items...)
+		if len(items) == 0 || len(all) >= total {
+			return all, nil
+		}
+		offset = len(all)
+	}
+	return nil, fmt.Errorf("aborted listing %s after %d pages", what, MaxListPages)
+}
+
+// Find pages through the items returned by fetch and returns the first one for
+// which pred is true, without fetching later pages once a match is found. It
+// returns (nil, nil) when no item matches.
+func Find[T any](what string, fetch FetchPage[T], pred func(T) bool) (*T, error) {
+	scanned := 0
+	for page := 0; page < MaxListPages; page++ {
+		items, total, err := fetch(scanned)
+		if err != nil {
+			return nil, err
+		}
+		for i := range items {
+			if pred(items[i]) {
+				return &items[i], nil
+			}
+		}
+		scanned += len(items)
+		if len(items) == 0 || scanned >= total {
+			return nil, nil
+		}
+	}
+	return nil, fmt.Errorf("aborted listing %s after %d pages", what, MaxListPages)
+}

--- a/cloud/pagination/pagination_test.go
+++ b/cloud/pagination/pagination_test.go
@@ -1,0 +1,76 @@
+package pagination
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// pagedSource serves items in pages of two, recording the offsets requested.
+func pagedSource(items []int, offsets *[]int) FetchPage[int] {
+	const pageSize = 2
+	return func(offset int) ([]int, int, error) {
+		*offsets = append(*offsets, offset)
+		if offset >= len(items) {
+			return nil, len(items), nil
+		}
+		end := offset + pageSize
+		if end > len(items) {
+			end = len(items)
+		}
+		return items[offset:end], len(items), nil
+	}
+}
+
+func TestCollect(t *testing.T) {
+	t.Run("aggregates across pages and advances offset", func(t *testing.T) {
+		var offsets []int
+		got, err := Collect("ints", pagedSource([]int{1, 2, 3, 4, 5}, &offsets))
+		assert.NoError(t, err)
+		assert.Equal(t, []int{1, 2, 3, 4, 5}, got)
+		assert.Equal(t, []int{0, 2, 4}, offsets)
+	})
+
+	t.Run("single full page stops without an extra call", func(t *testing.T) {
+		var offsets []int
+		got, err := Collect("ints", pagedSource([]int{1, 2}, &offsets))
+		assert.NoError(t, err)
+		assert.Equal(t, []int{1, 2}, got)
+		assert.Equal(t, []int{0}, offsets)
+	})
+
+	t.Run("propagates fetch errors", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		_, err := Collect("ints", func(int) ([]int, int, error) { return nil, 0, sentinel })
+		assert.ErrorIs(t, err, sentinel)
+	})
+
+	t.Run("aborts when the total is never reached (mis-reported total)", func(t *testing.T) {
+		// Always returns a full page but claims a huge total, so it never terminates
+		// naturally — the MaxListPages cap must stop it with an error.
+		_, err := Collect("ints", func(offset int) ([]int, int, error) {
+			return []int{offset}, 1 << 30, nil
+		})
+		assert.ErrorContains(t, err, "aborted listing ints")
+	})
+}
+
+func TestFind(t *testing.T) {
+	t.Run("returns match on a later page and stops early", func(t *testing.T) {
+		var offsets []int
+		got, err := Find("ints", pagedSource([]int{1, 2, 3, 4, 5}, &offsets), func(v int) bool { return v == 3 })
+		assert.NoError(t, err)
+		assert.NotNil(t, got)
+		assert.Equal(t, 3, *got)
+		// Found on page 2 (offsets 0 then 2); never requested page 3 (offset 4).
+		assert.Equal(t, []int{0, 2}, offsets)
+	})
+
+	t.Run("returns nil when nothing matches", func(t *testing.T) {
+		var offsets []int
+		got, err := Find("ints", pagedSource([]int{1, 2, 3}, &offsets), func(int) bool { return false })
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}

--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -375,6 +375,12 @@ func selectWorkspace(workspaces []astrov1.Workspace) (astrov1.Workspace, error) 
 	return selected, nil
 }
 
+// maxListPages caps a single paginated list call at maxListPages pages as a safety
+// bound against a server that mis-reports TotalCount (mirrors cloud/env).
+const maxListPages = 100
+
+// GetWorkspaces returns every Workspace in the current Organization, paging
+// through the API as needed.
 func GetWorkspaces(client astrov1.APIClient) ([]astrov1.Workspace, error) {
 	ctx, err := context.GetCurrentContext()
 	if err != nil {
@@ -382,22 +388,32 @@ func GetWorkspaces(client astrov1.APIClient) ([]astrov1.Workspace, error) {
 	}
 
 	sorts := []astrov1.ListWorkspacesParamsSorts{"name:asc"}
-	limit := 1000
-	workspaceListParams := &astrov1.ListWorkspacesParams{
-		Limit: &limit,
-		Sorts: &sorts,
+	pageSize := 1000
+	offset := 0
+	var workspaces []astrov1.Workspace
+	for page := 0; page < maxListPages; page++ {
+		workspaceListParams := &astrov1.ListWorkspacesParams{
+			Limit:  &pageSize,
+			Offset: &offset,
+			Sorts:  &sorts,
+		}
+
+		resp, err := client.ListWorkspacesWithResponse(httpContext.Background(), ctx.Organization, workspaceListParams)
+		if err != nil {
+			return []astrov1.Workspace{}, err
+		}
+		err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
+		if err != nil {
+			return []astrov1.Workspace{}, err
+		}
+
+		paginated := *resp.JSON200
+		workspaces = append(workspaces, paginated.Workspaces...)
+		if len(paginated.Workspaces) == 0 || len(workspaces) >= paginated.TotalCount {
+			return workspaces, nil
+		}
+		offset = len(workspaces)
 	}
 
-	resp, err := client.ListWorkspacesWithResponse(httpContext.Background(), ctx.Organization, workspaceListParams)
-	if err != nil {
-		return []astrov1.Workspace{}, err
-	}
-	err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
-	if err != nil {
-		return []astrov1.Workspace{}, err
-	}
-
-	workspaces := resp.JSON200.Workspaces
-
-	return workspaces, nil
+	return []astrov1.Workspace{}, fmt.Errorf("aborted listing workspaces after %d pages", maxListPages)
 }

--- a/cloud/workspace/workspace.go
+++ b/cloud/workspace/workspace.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/astronomer/astro-cli/astro-client-v1"
+	"github.com/astronomer/astro-cli/cloud/pagination"
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/context"
 	"github.com/astronomer/astro-cli/pkg/ansi"
@@ -152,7 +153,7 @@ func Switch(workspaceNameOrID string, client astrov1.APIClient, out io.Writer) e
 		}
 
 		if wsID == "" {
-			return errors.Wrap(err, "workspace id/name could not be found")
+			return errors.New("workspace id/name could not be found")
 		}
 	}
 
@@ -375,10 +376,6 @@ func selectWorkspace(workspaces []astrov1.Workspace) (astrov1.Workspace, error) 
 	return selected, nil
 }
 
-// maxListPages caps a single paginated list call at maxListPages pages as a safety
-// bound against a server that mis-reports TotalCount (mirrors cloud/env).
-const maxListPages = 100
-
 // GetWorkspaces returns every Workspace in the current Organization, paging
 // through the API as needed.
 func GetWorkspaces(client astrov1.APIClient) ([]astrov1.Workspace, error) {
@@ -388,32 +385,16 @@ func GetWorkspaces(client astrov1.APIClient) ([]astrov1.Workspace, error) {
 	}
 
 	sorts := []astrov1.ListWorkspacesParamsSorts{"name:asc"}
-	pageSize := 1000
-	offset := 0
-	var workspaces []astrov1.Workspace
-	for page := 0; page < maxListPages; page++ {
-		workspaceListParams := &astrov1.ListWorkspacesParams{
-			Limit:  &pageSize,
-			Offset: &offset,
-			Sorts:  &sorts,
-		}
-
-		resp, err := client.ListWorkspacesWithResponse(httpContext.Background(), ctx.Organization, workspaceListParams)
+	return pagination.Collect("workspaces", func(offset int) ([]astrov1.Workspace, int, error) {
+		pageSize := 1000
+		params := &astrov1.ListWorkspacesParams{Limit: &pageSize, Offset: &offset, Sorts: &sorts}
+		resp, err := client.ListWorkspacesWithResponse(httpContext.Background(), ctx.Organization, params)
 		if err != nil {
-			return []astrov1.Workspace{}, err
+			return nil, 0, err
 		}
-		err = astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body)
-		if err != nil {
-			return []astrov1.Workspace{}, err
+		if err := astrov1.NormalizeAPIError(resp.HTTPResponse, resp.Body); err != nil {
+			return nil, 0, err
 		}
-
-		paginated := *resp.JSON200
-		workspaces = append(workspaces, paginated.Workspaces...)
-		if len(paginated.Workspaces) == 0 || len(workspaces) >= paginated.TotalCount {
-			return workspaces, nil
-		}
-		offset = len(workspaces)
-	}
-
-	return []astrov1.Workspace{}, fmt.Errorf("aborted listing workspaces after %d pages", maxListPages)
+		return resp.JSON200.Workspaces, resp.JSON200.TotalCount, nil
+	})
 }

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -70,6 +70,38 @@ func (s *Suite) TestList() {
 	s.Equal(buf.String(), expected)
 }
 
+func (s *Suite) TestGetWorkspacesPaginates() {
+	page1 := astrov1.ListWorkspacesResponse{
+		HTTPResponse: &http.Response{StatusCode: 200},
+		JSON200: &astrov1.WorkspacesPaginated{
+			Workspaces: []astrov1.Workspace{{Name: "ws-page1", Id: "ws-1"}},
+			TotalCount: 2,
+			Limit:      1000,
+			Offset:     0,
+		},
+	}
+	page2 := astrov1.ListWorkspacesResponse{
+		HTTPResponse: &http.Response{StatusCode: 200},
+		JSON200: &astrov1.WorkspacesPaginated{
+			Workspaces: []astrov1.Workspace{{Name: "ws-page2", Id: "ws-2"}},
+			TotalCount: 2,
+			Limit:      1000,
+			Offset:     1000,
+		},
+	}
+	mockClient := new(astrov1_mocks.ClientWithResponsesInterface)
+	// First call returns page 1 (offset 0), second call returns page 2 (offset 1000).
+	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&page1, nil).Once()
+	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&page2, nil).Once()
+
+	got, err := GetWorkspaces(mockClient)
+	s.NoError(err)
+	s.Len(got, 2)
+	s.Equal("ws-1", got[0].Id)
+	s.Equal("ws-2", got[1].Id)
+	mockClient.AssertExpectations(s.T())
+}
+
 func (s *Suite) TestListError() {
 	mockClient := new(astrov1_mocks.ClientWithResponsesInterface)
 	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errMock).Once()

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -86,13 +86,14 @@ func (s *Suite) TestGetWorkspacesPaginates() {
 			Workspaces: []astrov1.Workspace{{Name: "ws-page2", Id: "ws-2"}},
 			TotalCount: 2,
 			Limit:      1000,
-			Offset:     1000,
+			Offset:     1,
 		},
 	}
 	mockClient := new(astrov1_mocks.ClientWithResponsesInterface)
-	// First call returns page 1 (offset 0), second call returns page 2 (offset 1000).
-	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&page1, nil).Once()
-	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&page2, nil).Once()
+	// Assert the request offset advances: page 1 is fetched at offset 0, and after
+	// one result is collected page 2 is fetched at offset 1.
+	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, offsetIs(0)).Return(&page1, nil).Once()
+	mockClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, offsetIs(1)).Return(&page2, nil).Once()
 
 	got, err := GetWorkspaces(mockClient)
 	s.NoError(err)
@@ -100,6 +101,13 @@ func (s *Suite) TestGetWorkspacesPaginates() {
 	s.Equal("ws-1", got[0].Id)
 	s.Equal("ws-2", got[1].Id)
 	mockClient.AssertExpectations(s.T())
+}
+
+// offsetIs matches ListWorkspacesParams whose Offset equals want.
+func offsetIs(want int) any {
+	return mock.MatchedBy(func(p *astrov1.ListWorkspacesParams) bool {
+		return p != nil && p.Offset != nil && *p.Offset == want
+	})
 }
 
 func (s *Suite) TestListError() {

--- a/cloud/workspace/workspace_test.go
+++ b/cloud/workspace/workspace_test.go
@@ -263,6 +263,37 @@ func (s *Suite) TestSwitch() {
 		mockV1Client.AssertExpectations(s.T())
 	})
 
+	s.Run("switch finds workspace on a later page", func() {
+		page1 := astrov1.ListWorkspacesResponse{
+			HTTPResponse: &http.Response{StatusCode: 200},
+			JSON200: &astrov1.WorkspacesPaginated{
+				Workspaces: []astrov1.Workspace{workspace1},
+				TotalCount: 2,
+				Limit:      1000,
+				Offset:     0,
+			},
+		}
+		page2 := astrov1.ListWorkspacesResponse{
+			HTTPResponse: &http.Response{StatusCode: 200},
+			JSON200: &astrov1.WorkspacesPaginated{
+				Workspaces: []astrov1.Workspace{workspace2},
+				TotalCount: 2,
+				Limit:      1000,
+				Offset:     1,
+			},
+		}
+		freshClient := new(astrov1_mocks.ClientWithResponsesInterface)
+		// target is only on the second page
+		freshClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&page1, nil).Once()
+		freshClient.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&page2, nil).Once()
+
+		buf := new(bytes.Buffer)
+		err := Switch("workspace-id-2", freshClient, buf)
+		s.NoError(err)
+		s.Contains(buf.String(), "workspace-id-2")
+		freshClient.AssertExpectations(s.T())
+	})
+
 	s.Run("list workspace failure", func() {
 		mockV1Client.On("ListWorkspacesWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil, errMock).Once()
 


### PR DESCRIPTION
## Description

The CLI only fetched the first page of organizations, workspaces, and deployments, so `astro organization switch` and `astro workspace switch` failed with "could not be found" when the target wasn't on the first page.

`ListOrganizations`, `GetWorkspaces`, and `ListDeployments` now page through all results; switch-by-name returns as soon as the match is found. Follows the existing `cloud/env` pagination pattern (page-count safety cap, offset advanced by rows returned, stop once the total is reached).

## 🧪 Functional Testing

With more orgs/workspaces than a single API page, run `astro organization switch <name/id>` and `astro workspace switch <name/id>` against a target that isn't on the first page — the switch now succeeds instead of erroring. Covered by unit tests for multi-page retrieval, an end-to-end switch to a later-page target, and an HTTP-level test driving a real client against a stub API to confirm correct `offset`/`limit` query params and multi-page aggregation.

## 📸 Screenshots

N/A

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
