### PR TITLE
Multiple build secrets

### DIFF
--- a/airflow/container.go
+++ b/airflow/container.go
@@ -33,14 +33,14 @@ type ContainerHandler interface {
 	Logs(follow bool, containerNames ...string) error
 	Run(args []string, user string) error
 	Bash(container string) error
-	Build(customImageName, buildSecretString string, noCache bool) error
+	Build(customImageName string, buildSecrets []string, noCache bool) error
 	RunDAG(dagID, settingsFile, dagFile, executionDate string, noCache, taskLogs bool) error
 	ImportSettings(settingsFile, envFile string, connections, variables, pools bool) error
 	ExportSettings(settingsFile, envFile string, connections, variables, pools, envExport bool) error
 	ComposeExport(settingsFile, composeFile string) error
-	Pytest(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString string) (string, error)
-	Parse(customImageName, deployImageName, buildSecretString string) error
-	UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroV1Client astrov1.ClientWithResponsesInterface) error
+	Pytest(pytestFile, customImageName, deployImageName, pytestArgsString string, buildSecrets []string) (string, error)
+	Parse(customImageName, deployImageName string, buildSecrets []string) error
+	UpgradeTest(runtimeVersion, deploymentID, customImageName string, buildSecrets []string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroV1Client astrov1.ClientWithResponsesInterface) error
 }
 
 // RegistryHandler defines methods require to handle all operations with registry
@@ -50,7 +50,7 @@ type RegistryHandler interface {
 
 // ImageHandler defines methods require to handle all operations on/for container images
 type ImageHandler interface {
-	Build(dockerfile, buildSecretString string, config types.ImageBuildConfig) error
+	Build(dockerfile string, buildSecrets []string, config types.ImageBuildConfig) error
 	Push(remoteImage, username, token string, getImageRepoSha bool) (string, error)
 	Pull(remoteImage, username, token string) error
 	GetLabel(altImageName, labelName string) (string, error)

--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -241,7 +241,7 @@ func (d *DockerCompose) Start(opts *airflowTypes.StartOptions) error {
 	imageName := opts.ImageName
 	settingsFile := opts.SettingsFile
 	composeFile := opts.ComposeFile
-	buildSecretString := opts.BuildSecretString
+	buildSecrets := opts.BuildSecrets
 	noCache := opts.NoCache
 	noBrowser := opts.NoBrowser
 	waitTime := opts.WaitTime
@@ -257,7 +257,7 @@ func (d *DockerCompose) Start(opts *airflowTypes.StartOptions) error {
 				fmt.Printf("Adding 'astro-run-dag' package to requirements.txt unsuccessful: %s\nManually add package to requirements.txt", err.Error())
 			}
 		}
-		imageBuildErr := d.imageHandler.Build(d.dockerfile, buildSecretString, airflowTypes.ImageBuildConfig{Path: d.airflowHome, NoCache: noCache})
+		imageBuildErr := d.imageHandler.Build(d.dockerfile, buildSecrets, airflowTypes.ImageBuildConfig{Path: d.airflowHome, NoCache: noCache})
 		if !config.CFG.DisableAstroRun.GetBool() {
 			// remove astro-run-dag from requirments.txt
 			err := fileutil.RemoveLineFromFile("./requirements.txt", "astro-run-dag", " # This package is needed for the astro run command. It will be removed before a deploy")
@@ -663,12 +663,12 @@ func (d *DockerCompose) Run(args []string, user string) error {
 
 // Pytest creates and runs a container containing the users airflow image, requirments, packages, and volumes(DAGs folder, etc...)
 // These containers runs pytest on a specified pytest file (pytestFile). This function is used in the dev parse and dev pytest commands
-func (d *DockerCompose) Pytest(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString string) (string, error) {
+func (d *DockerCompose) Pytest(pytestFile, customImageName, deployImageName, pytestArgsString string, buildSecrets []string) (string, error) {
 	// deployImageName may be provided to the function if it is being used in the deploy command
 	if deployImageName == "" {
 		// build image
 		if customImageName == "" {
-			err := d.imageHandler.Build(d.dockerfile, buildSecretString, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
+			err := d.imageHandler.Build(d.dockerfile, buildSecrets, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
 			if err != nil {
 				return "", err
 			}
@@ -704,7 +704,7 @@ func (d *DockerCompose) Pytest(pytestFile, customImageName, deployImageName, pyt
 	return exitCode, errors.New("something went wrong while Pytesting your DAGs")
 }
 
-func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, buildSecretString string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroV1Client astrov1.APIClient) error { //nolint:gocognit,gocyclo
+func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage string, buildSecrets []string, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix bool, lintConfigFile string, astroV1Client astrov1.APIClient) error { //nolint:gocognit,gocyclo
 	// figure out which tests to run
 	if !versionTest && !dagTest && !lintTest {
 		versionTest = true
@@ -729,7 +729,7 @@ func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, build
 	} else {
 		// build image for current Airflow version to get current Airflow version
 		fmt.Println("\nBuilding image for current version")
-		imageBuildErr := d.imageHandler.Build(d.dockerfile, buildSecretString, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
+		imageBuildErr := d.imageHandler.Build(d.dockerfile, buildSecrets, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
 		if imageBuildErr != nil {
 			return imageBuildErr
 		}
@@ -758,7 +758,7 @@ func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, build
 	newDockerFile := destFolder + "/Dockerfile"
 
 	if versionTest {
-		err := d.versionTest(testHomeDirectory, currentVersion, deploymentImage, newDockerFile, newVersion, customImage, buildSecretString)
+		err := d.versionTest(testHomeDirectory, currentVersion, deploymentImage, newDockerFile, newVersion, customImage, buildSecrets)
 		if err != nil {
 			return err
 		}
@@ -767,7 +767,7 @@ func (d *DockerCompose) UpgradeTest(newVersion, deploymentID, customImage, build
 	var failed bool
 
 	if dagTest {
-		dagTestPassed, err := d.dagTest(testHomeDirectory, newVersion, newDockerFile, customImage, buildSecretString)
+		dagTestPassed, err := d.dagTest(testHomeDirectory, newVersion, newDockerFile, customImage, buildSecrets)
 		if err != nil {
 			return err
 		}
@@ -829,7 +829,7 @@ func (d *DockerCompose) pullImageFromDeployment(deploymentID string, astroV1Clie
 	return nil
 }
 
-func (d *DockerCompose) versionTest(testHomeDirectory, currentVersion, deploymentImage, newDockerFile, newVersion, customImage, buildSecretString string) error {
+func (d *DockerCompose) versionTest(testHomeDirectory, currentVersion, deploymentImage, newDockerFile, newVersion, customImage string, buildSecrets []string) error {
 	fmt.Println("\nComparing dependency versions between current and upgraded environment")
 	// pip freeze old Airflow image
 	fmt.Println("\nObtaining pip freeze for current version")
@@ -845,7 +845,7 @@ func (d *DockerCompose) versionTest(testHomeDirectory, currentVersion, deploymen
 		return err
 	}
 	fmt.Println("\nBuilding image for new version")
-	imageBuildErr := d.imageHandler.Build(newDockerFile, buildSecretString, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
+	imageBuildErr := d.imageHandler.Build(newDockerFile, buildSecrets, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
 	if imageBuildErr != nil {
 		return imageBuildErr
 	}
@@ -867,7 +867,7 @@ func (d *DockerCompose) versionTest(testHomeDirectory, currentVersion, deploymen
 	return nil
 }
 
-func (d *DockerCompose) dagTest(testHomeDirectory, newVersion, newDockerFile, customImage, buildSecretString string) (bool, error) {
+func (d *DockerCompose) dagTest(testHomeDirectory, newVersion, newDockerFile, customImage string, buildSecrets []string) (bool, error) {
 	fmt.Printf("\nChecking the DAGs in this project for errors against the new Airflow version %s\n", newVersion)
 
 	// build image with the new runtime version
@@ -883,7 +883,7 @@ func (d *DockerCompose) dagTest(testHomeDirectory, newVersion, newDockerFile, cu
 		fmt.Printf("Adding 'pytest-html' package to requirements.txt unsuccessful: %s\nManually add package to requirements.txt", err.Error())
 	}
 	fmt.Println("\nBuilding image for new version")
-	imageBuildErr := d.imageHandler.Build(newDockerFile, buildSecretString, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
+	imageBuildErr := d.imageHandler.Build(newDockerFile, buildSecrets, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
 
 	// remove pytest-html to the requirements
 	err = fileutil.RemoveLineFromFile(reqFile, "pytest-html", " # This package is needed for the upgrade dag test. It will be removed once the test is over")
@@ -1314,7 +1314,7 @@ func checkVersionChange(before, after string) (change bool, updateType string, e
 	}
 }
 
-func (d *DockerCompose) Parse(customImageName, deployImageName, buildSecretString string) error {
+func (d *DockerCompose) Parse(customImageName, deployImageName string, buildSecrets []string) error {
 	// check for file
 	path := d.airflowHome + "/" + DefaultTestPath
 
@@ -1331,7 +1331,7 @@ func (d *DockerCompose) Parse(customImageName, deployImageName, buildSecretStrin
 	fmt.Println("Checking your DAGs for errors…")
 
 	pytestFile := DefaultTestPath
-	exitCode, err := d.Pytest(pytestFile, customImageName, deployImageName, "", buildSecretString)
+	exitCode, err := d.Pytest(pytestFile, customImageName, deployImageName, "", buildSecrets)
 	if err != nil {
 		if code, convErr := strconv.Atoi(exitCode); convErr == nil && code == 1 { // exit code 1 means tests failed
 			return errors.New("See above for errors detected in your DAGs")
@@ -1342,14 +1342,14 @@ func (d *DockerCompose) Parse(customImageName, deployImageName, buildSecretStrin
 	return err
 }
 
-func (d *DockerCompose) Build(customImageName, buildSecretString string, noCache bool) error {
+func (d *DockerCompose) Build(customImageName string, buildSecrets []string, noCache bool) error {
 	// If a custom image name is provided, tag it as our project image
 	if customImageName != "" {
 		return d.imageHandler.TagLocalImage(customImageName)
 	}
 
 	// Build the image
-	return d.imageHandler.Build(d.dockerfile, buildSecretString, airflowTypes.ImageBuildConfig{
+	return d.imageHandler.Build(d.dockerfile, buildSecrets, airflowTypes.ImageBuildConfig{
 		Path:    d.airflowHome,
 		NoCache: noCache,
 	})
@@ -1551,7 +1551,7 @@ func (d *DockerCompose) RunDAG(dagID, settingsFile, dagFile, executionDate strin
 			fmt.Printf("Removing line 'astro-run-dag' package from requirements.txt unsuccessful: %s\n", err.Error())
 		}
 	}()
-	err = d.imageHandler.Build(d.dockerfile, "", airflowTypes.ImageBuildConfig{Path: d.airflowHome, NoCache: noCache})
+	err = d.imageHandler.Build(d.dockerfile, nil, airflowTypes.ImageBuildConfig{Path: d.airflowHome, NoCache: noCache})
 	if err != nil {
 		return err
 	}

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -87,7 +87,7 @@ func shouldAddPullFlag(dockerfilePath string) (bool, error) {
 	return true, nil
 }
 
-func (d *DockerImage) Build(dockerfilePath, buildSecretString string, buildConfig airflowTypes.ImageBuildConfig) error {
+func (d *DockerImage) Build(dockerfilePath string, buildSecrets []string, buildConfig airflowTypes.ImageBuildConfig) error {
 	// Start the spinner.
 	s := spinner.NewSpinner("Building project image…")
 	if !logger.IsLevelEnabled(logrus.DebugLevel) {
@@ -135,12 +135,8 @@ func (d *DockerImage) Build(dockerfilePath, buildSecretString string, buildConfi
 	if len(buildConfig.TargetPlatforms) > 0 {
 		args = append(args, fmt.Sprintf("--platform=%s", strings.Join(buildConfig.TargetPlatforms, ",")))
 	}
-	if buildSecretString != "" {
-		buildSecretArgs := []string{
-			"--secret",
-			buildSecretString,
-		}
-		args = append(args, buildSecretArgs...)
+	for _, secret := range buildSecrets {
+		args = append(args, "--secret", secret)
 	}
 
 	// Route output streams according to verbosity.

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -26,6 +26,15 @@ import (
 
 var errMock = errors.New("build error")
 
+func countOccurrences(haystack []string, needle string) (count int) {
+	for _, s := range haystack {
+		if s == needle {
+			count++
+		}
+	}
+	return count
+}
+
 func (s *Suite) TestDockerImageBuild() {
 	handler := DockerImage{
 		imageName: "testing",
@@ -48,7 +57,7 @@ func (s *Suite) TestDockerImageBuild() {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 			return nil
 		}
-		err = handler.Build("", "secret", options)
+		err = handler.Build("", []string{"secret"}, options)
 		s.NoError(err)
 	})
 
@@ -58,7 +67,7 @@ func (s *Suite) TestDockerImageBuild() {
 			s.Contains(args, "--no-cache")
 			return nil
 		}
-		err = handler.Build("", "", options)
+		err = handler.Build("", nil, options)
 		s.NoError(err)
 	})
 
@@ -71,7 +80,7 @@ func (s *Suite) TestDockerImageBuild() {
 			s.NotContains(args, "--pull")
 			return nil
 		}
-		err = handler.Build(dockerfile.Name(), "", options)
+		err = handler.Build(dockerfile.Name(), nil, options)
 		s.NoError(err)
 	})
 
@@ -85,7 +94,7 @@ FROM quay.io/astronomer/astro-runtime:12.0.0`
 			s.NotContains(args, "--pull")
 			return nil
 		}
-		err = handler.Build(dockerfile.Name(), "", options)
+		err = handler.Build(dockerfile.Name(), nil, options)
 		s.NoError(err)
 	})
 
@@ -98,7 +107,34 @@ FROM quay.io/astronomer/astro-runtime:12.0.0`
 			s.Contains(args, "--pull")
 			return nil
 		}
-		err = handler.Build(dockerfile.Name(), "", options)
+		err = handler.Build(dockerfile.Name(), nil, options)
+		s.NoError(err)
+	})
+
+	s.Run("build with a single build secret", func() {
+		dockerfile, _ := os.CreateTemp(os.TempDir(), "temp-Dockerfile")
+		defer os.Remove(dockerfile.Name())
+		dockerfile.WriteString("FROM nginx")
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			s.Equal(1, countOccurrences(args, "--secret"))
+			s.Contains(args, "id=mysecret,src=secrets.txt")
+			return nil
+		}
+		err = handler.Build(dockerfile.Name(), []string{"id=mysecret,src=secrets.txt"}, options)
+		s.NoError(err)
+	})
+
+	s.Run("build with multiple build secrets", func() {
+		dockerfile, _ := os.CreateTemp(os.TempDir(), "temp-Dockerfile")
+		defer os.Remove(dockerfile.Name())
+		dockerfile.WriteString("FROM nginx")
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			s.Equal(2, countOccurrences(args, "--secret"))
+			s.Contains(args, "id=aws,src=credentials")
+			s.Contains(args, "id=PLATFORM_PASSWORD,env=PLATFORM_PASSWORD")
+			return nil
+		}
+		err = handler.Build(dockerfile.Name(), []string{"id=aws,src=credentials", "id=PLATFORM_PASSWORD,env=PLATFORM_PASSWORD"}, options)
 		s.NoError(err)
 	})
 
@@ -108,14 +144,14 @@ FROM quay.io/astronomer/astro-runtime:12.0.0`
 			s.Contains(args, "--label", "io.astronomer.skip.revision=true")
 			return nil
 		}
-		err = handler.Build("", "", options)
+		err = handler.Build("", nil, options)
 		s.NoError(err)
 	})
 	s.Run("build error", func() {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 			return errMock
 		}
-		err = handler.Build("", "", options)
+		err = handler.Build("", nil, options)
 		s.Errorf(err, "expected build error")
 	})
 	s.Run("unable to read file error", func() {
@@ -125,7 +161,7 @@ FROM quay.io/astronomer/astro-runtime:12.0.0`
 			NoCache:         false,
 		}
 
-		err = handler.Build("", "", options)
+		err = handler.Build("", nil, options)
 		s.Error(err)
 	})
 }

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1207,12 +1207,12 @@ func (s *Suite) TestDockerComposePytest() {
 	s.Run("internal error exit code 10 reported as failure", func() {
 		// exit code 10 substring-contains "0"; the old check reported it as a pass
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("10", nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("", "", "", "", "")
+		resp, err := mockDockerCompose.Pytest("", "", "", "", nil)
 		s.Contains(err.Error(), "something went wrong while Pytesting your DAGs")
 		s.Equal("10", resp)
 		imageHandler.AssertExpectations(s.T())
@@ -1220,12 +1220,12 @@ func (s *Suite) TestDockerComposePytest() {
 
 	s.Run("interrupt exit code 130 reported as failure", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("130", nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("", "", "", "", "")
+		resp, err := mockDockerCompose.Pytest("", "", "", "", nil)
 		s.Contains(err.Error(), "something went wrong while Pytesting your DAGs")
 		s.Equal("130", resp)
 		imageHandler.AssertExpectations(s.T())
@@ -1634,7 +1634,7 @@ func (s *Suite) TestDockerComposeParse() {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("", "test", "")
+		err := mockDockerCompose.Parse("", "test", nil)
 		s.Contains(err.Error(), "something went wrong while parsing your DAGs")
 		composeMock.AssertExpectations(s.T())
 		imageHandler.AssertExpectations(s.T())
@@ -1651,7 +1651,7 @@ func (s *Suite) TestDockerComposeParse() {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("", "test", "")
+		err := mockDockerCompose.Parse("", "test", nil)
 		s.Contains(err.Error(), "something went wrong while parsing your DAGs")
 		composeMock.AssertExpectations(s.T())
 		imageHandler.AssertExpectations(s.T())

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -561,7 +561,7 @@ func (s *Suite) TestDockerComposeStart() {
 	s.Run("success", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(labels, nil).Times(4)
 		imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
 
@@ -589,7 +589,7 @@ func (s *Suite) TestDockerComposeStart() {
 		defaultTimeOut := 1 * time.Minute
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(labels, nil).Times(2)
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -614,7 +614,7 @@ func (s *Suite) TestDockerComposeStart() {
 		expectedTimeout := 10 * time.Minute
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(labels, nil).Times(2)
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -639,7 +639,7 @@ func (s *Suite) TestDockerComposeStart() {
 		userProvidedTimeOut := 8 * time.Minute
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(labels, nil).Times(2)
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -663,7 +663,7 @@ func (s *Suite) TestDockerComposeStart() {
 	s.Run("success with invalid airflow version label", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{airflowVersionLabelName: "2.3.4.dev+astro1", runtimeVersionLabelName: runtimeVersionLabel}, nil).Times(4)
 		imageHandler.On("TagLocalImage", mock.Anything).Return(nil).Once()
 
@@ -690,7 +690,7 @@ func (s *Suite) TestDockerComposeStart() {
 	s.Run("image build failure", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(errMockDocker).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 
@@ -711,7 +711,7 @@ func (s *Suite) TestDockerComposeStart() {
 	s.Run("list label failure", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(map[string]string{}, errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -733,7 +733,7 @@ func (s *Suite) TestDockerComposeStart() {
 	s.Run("compose up failure", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(labels, nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -756,7 +756,7 @@ func (s *Suite) TestDockerComposeStart() {
 	s.Run("webserver health check failure", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("ListLabels").Return(labels, nil).Twice()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -1164,12 +1164,12 @@ func (s *Suite) TestDockerComposePytest() {
 	mockDockerCompose := DockerCompose{projectName: "test"}
 	s.Run("success", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("0", nil).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("", "", "", "", "")
+		resp, err := mockDockerCompose.Pytest("", "", "", "", nil)
 
 		s.NoError(err)
 		s.Equal("", resp)
@@ -1183,7 +1183,7 @@ func (s *Suite) TestDockerComposePytest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("", "custom-image-name", "", "", "")
+		resp, err := mockDockerCompose.Pytest("", "custom-image-name", "", "", nil)
 
 		s.NoError(err)
 		s.Equal("", resp)
@@ -1192,13 +1192,13 @@ func (s *Suite) TestDockerComposePytest() {
 
 	s.Run("unexpected exit code", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("1", nil).Once()
 
 		mockResponse := "1"
 		mockDockerCompose.imageHandler = imageHandler
 
-		resp, err := mockDockerCompose.Pytest("", "", "", "", "")
+		resp, err := mockDockerCompose.Pytest("", "", "", "", nil)
 		s.Contains(err.Error(), "something went wrong while Pytesting your DAGs")
 		s.Equal(mockResponse, resp)
 		imageHandler.AssertExpectations(s.T())
@@ -1233,11 +1233,11 @@ func (s *Suite) TestDockerComposePytest() {
 
 	s.Run("image build failure", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(errMockDocker).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(errMockDocker).Once()
 
 		mockDockerCompose.imageHandler = imageHandler
 
-		_, err := mockDockerCompose.Pytest("", "", "", "", "")
+		_, err := mockDockerCompose.Pytest("", "", "", "", nil)
 		s.ErrorIs(err, errMockDocker)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1276,7 +1276,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // All tests enabled by default
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", nil, true, true, true, false, false, "", nil) // All tests enabled by default
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
@@ -1297,7 +1297,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", true, true, true, false, false, "", mockV1Client) // All tests enabled by default
+		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", nil, true, true, true, false, false, "", mockV1Client) // All tests enabled by default
 
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
@@ -1309,7 +1309,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", nil, true, true, true, false, false, "", nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1321,7 +1321,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", nil, true, true, true, false, false, "", nil)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1334,7 +1334,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", nil, true, true, true, false, false, "", nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1349,7 +1349,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", nil, true, true, true, false, false, "", nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1365,7 +1365,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // dagTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", nil, true, true, true, false, false, "", nil) // dagTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1380,7 +1380,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, true, true, false, false, "", nil) // dagTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", nil, true, true, true, false, false, "", nil) // dagTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1392,7 +1392,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", mockV1Client)
+		err := mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", nil, false, false, false, false, false, "", mockV1Client)
 		s.Error(err)
 		// No image handler expectations needed as it fails before pull/build
 	})
@@ -1406,7 +1406,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", "", false, false, false, false, false, "", mockV1Client)
+		err := mockDockerCompose.UpgradeTest("new-version", "test-deployment-id", "", nil, false, false, false, false, false, "", mockV1Client)
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T()) // Only Pull is called
 	})
@@ -1420,7 +1420,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 		mockDockerCompose.imageHandler = imageHandler
 		// Add default values for new lint flags
-		err := mockDockerCompose.UpgradeTest("new-version", "", "", "", true, false, false, false, false, "", nil) // versionTest=true is required for this path
+		err := mockDockerCompose.UpgradeTest("new-version", "", "", nil, true, false, false, false, false, "", nil) // versionTest=true is required for this path
 		s.Error(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1432,7 +1432,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		s.NoError(err)
 
 		// Add default values for new lint flags
-		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", "", false, false, false, false, false, "", nil)
+		err = mockDockerCompose.UpgradeTest("new-version", "deployment-id", "", nil, false, false, false, false, false, "", nil)
 		s.Error(err) // Expect error due to missing context/domain
 	})
 
@@ -1440,7 +1440,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 	s.Run("success with lint test (default)", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "Dockerfile", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
@@ -1450,7 +1450,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", nil, false, false, true, false, false, "", nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1459,7 +1459,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 	s.Run("success with lint test including deprecations", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "Dockerfile", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
@@ -1469,7 +1469,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=true, lintFix=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, true, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", nil, false, false, true, true, false, "", nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1484,7 +1484,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		defer os.Remove(dummyConfigFile) // Clean up dummy file
 
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "Dockerfile", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
@@ -1503,7 +1503,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		originalWorkingPath := config.WorkingPath
 		config.WorkingPath = cwd
 		defer func() { config.WorkingPath = originalWorkingPath }()
-		err = mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "my-custom-ruff.toml", nil)
+		err = mockDockerCompose.UpgradeTest("3.0-1", "", "", nil, false, false, true, false, false, "my-custom-ruff.toml", nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1512,7 +1512,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 	s.Run("lint test failure", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "Dockerfile", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
@@ -1522,7 +1522,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", nil, false, false, true, false, false, "", nil)
 		s.Error(err)
 		s.Contains(err.Error(), "one of the tests run above failed")
 
@@ -1532,7 +1532,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 	s.Run("lint test skipped for Airflow 2", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "Dockerfile", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler) // Lint handler should not be called
@@ -1541,7 +1541,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=false, lintConfigFile=""
 		// Target version is 2.0.0, so lint test should be skipped internally
-		err := mockDockerCompose.UpgradeTest("2.0.0", "", "", "", false, false, true, false, false, "", nil)
+		err := mockDockerCompose.UpgradeTest("2.0.0", "", "", nil, false, false, true, false, false, "", nil)
 		s.NoError(err) // Should succeed without running lint
 
 		imageHandler.AssertExpectations(s.T())
@@ -1550,7 +1550,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 
 	s.Run("success with lint test and fix flag", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "Dockerfile", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", "Dockerfile", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
 		imageHandler.On("GetLabel", mock.Anything, mock.Anything).Return("old-version", nil)
 
 		ruffImageHandler := new(mocks.ImageHandler)
@@ -1561,7 +1561,7 @@ func (s *Suite) TestDockerComposeUpgradeTest() {
 		mockDockerCompose.imageHandler = imageHandler
 		mockDockerCompose.ruffImageHandler = ruffImageHandler
 		// Call with lintTest=true, includeLintDeprecations=false, lintFix=true, lintConfigFile=""
-		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", "", false, false, true, false, true, "", nil)
+		err := mockDockerCompose.UpgradeTest("3.0-1", "", "", nil, false, false, true, false, true, "", nil)
 		s.NoError(err)
 
 		imageHandler.AssertExpectations(s.T())
@@ -1585,7 +1585,7 @@ func (s *Suite) TestDockerComposeParse() {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("", "test", "")
+		err := mockDockerCompose.Parse("", "test", nil)
 		s.NoError(err)
 		composeMock.AssertExpectations(s.T())
 		imageHandler.AssertExpectations(s.T())
@@ -1601,7 +1601,7 @@ func (s *Suite) TestDockerComposeParse() {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("", "test", "")
+		err := mockDockerCompose.Parse("", "test", nil)
 		s.Contains(err.Error(), "See above for errors detected in your DAGs")
 		composeMock.AssertExpectations(s.T())
 		imageHandler.AssertExpectations(s.T())
@@ -1617,7 +1617,7 @@ func (s *Suite) TestDockerComposeParse() {
 		mockDockerCompose.composeService = composeMock
 		mockDockerCompose.imageHandler = imageHandler
 
-		err := mockDockerCompose.Parse("", "test", "")
+		err := mockDockerCompose.Parse("", "test", nil)
 		s.Contains(err.Error(), "something went wrong while parsing your DAGs")
 		composeMock.AssertExpectations(s.T())
 		imageHandler.AssertExpectations(s.T())
@@ -1663,7 +1663,7 @@ func (s *Suite) TestDockerComposeParse() {
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 
-		err := mockDockerCompose.Parse("", "test", "")
+		err := mockDockerCompose.Parse("", "test", nil)
 		s.NoError(err)
 
 		w.Close()
@@ -1675,7 +1675,7 @@ func (s *Suite) TestDockerComposeParse() {
 	s.Run("invalid file name", func() {
 		DefaultTestPath = "\x0004"
 
-		err := mockDockerCompose.Parse("", "test", "")
+		err := mockDockerCompose.Parse("", "test", nil)
 		s.Contains(err.Error(), "invalid argument")
 	})
 }
@@ -1683,26 +1683,26 @@ func (s *Suite) TestDockerComposeParse() {
 func (s *Suite) TestDockerComposeBuild() {
 	s.Run("success", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, "", airflowTypes.ImageBuildConfig{Path: "", NoCache: false}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: "", NoCache: false}).Return(nil).Once()
 
 		mockDockerCompose := DockerCompose{
 			imageHandler: imageHandler,
 		}
 
-		err := mockDockerCompose.Build("", "", false)
+		err := mockDockerCompose.Build("", nil, false)
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("success with no-cache", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, "", airflowTypes.ImageBuildConfig{Path: "", NoCache: true}).Return(nil).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: "", NoCache: true}).Return(nil).Once()
 
 		mockDockerCompose := DockerCompose{
 			imageHandler: imageHandler,
 		}
 
-		err := mockDockerCompose.Build("", "", true)
+		err := mockDockerCompose.Build("", nil, true)
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1715,20 +1715,20 @@ func (s *Suite) TestDockerComposeBuild() {
 			imageHandler: imageHandler,
 		}
 
-		err := mockDockerCompose.Build("my-custom-image:latest", "", false)
+		err := mockDockerCompose.Build("my-custom-image:latest", nil, false)
 		s.NoError(err)
 		imageHandler.AssertExpectations(s.T())
 	})
 
 	s.Run("build failure", func() {
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", mock.Anything, "", airflowTypes.ImageBuildConfig{Path: "", NoCache: false}).Return(errMock).Once()
+		imageHandler.On("Build", mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: "", NoCache: false}).Return(errMock).Once()
 
 		mockDockerCompose := DockerCompose{
 			imageHandler: imageHandler,
 		}
 
-		err := mockDockerCompose.Build("", "", false)
+		err := mockDockerCompose.Build("", nil, false)
 		s.ErrorIs(err, errMock)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -1741,7 +1741,7 @@ func (s *Suite) TestDockerComposeBuild() {
 			imageHandler: imageHandler,
 		}
 
-		err := mockDockerCompose.Build("my-custom-image:latest", "", false)
+		err := mockDockerCompose.Build("my-custom-image:latest", nil, false)
 		s.ErrorIs(err, errMock)
 		imageHandler.AssertExpectations(s.T())
 	})
@@ -2014,7 +2014,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 	s.Run("success without container", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("RunDAG", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -2033,7 +2033,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 	s.Run("error without container", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(nil).Once()
 		imageHandler.On("RunDAG", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
@@ -2052,7 +2052,7 @@ func (s *Suite) TestDockerComposeRunDAG() {
 	s.Run("build error without container", func() {
 		noCache := false
 		imageHandler := new(mocks.ImageHandler)
-		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(errMockDocker).Once()
+		imageHandler.On("Build", "", mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: noCache}).Return(errMockDocker).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		composeMock.On("Ps", mock.Anything, mockDockerCompose.projectName, api.PsOptions{All: true}).Return([]api.ContainerSummary{}, nil).Once()

--- a/airflow/mocks/ContainerHandler.go
+++ b/airflow/mocks/ContainerHandler.go
@@ -32,17 +32,17 @@ func (_m *ContainerHandler) Bash(container string) error {
 	return r0
 }
 
-// Build provides a mock function with given fields: customImageName, buildSecretString, noCache
-func (_m *ContainerHandler) Build(customImageName string, buildSecretString string, noCache bool) error {
-	ret := _m.Called(customImageName, buildSecretString, noCache)
+// Build provides a mock function with given fields: customImageName, buildSecrets, noCache
+func (_m *ContainerHandler) Build(customImageName string, buildSecrets []string, noCache bool) error {
+	ret := _m.Called(customImageName, buildSecrets, noCache)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Build")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, bool) error); ok {
-		r0 = rf(customImageName, buildSecretString, noCache)
+	if rf, ok := ret.Get(0).(func(string, []string, bool) error); ok {
+		r0 = rf(customImageName, buildSecrets, noCache)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -177,17 +177,17 @@ func (_m *ContainerHandler) PS() (*types.PSStatus, error) {
 	return r0, r1
 }
 
-// Parse provides a mock function with given fields: customImageName, deployImageName, buildSecretString
-func (_m *ContainerHandler) Parse(customImageName string, deployImageName string, buildSecretString string) error {
-	ret := _m.Called(customImageName, deployImageName, buildSecretString)
+// Parse provides a mock function with given fields: customImageName, deployImageName, buildSecrets
+func (_m *ContainerHandler) Parse(customImageName string, deployImageName string, buildSecrets []string) error {
+	ret := _m.Called(customImageName, deployImageName, buildSecrets)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Parse")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = rf(customImageName, deployImageName, buildSecretString)
+	if rf, ok := ret.Get(0).(func(string, string, []string) error); ok {
+		r0 = rf(customImageName, deployImageName, buildSecrets)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -195,9 +195,9 @@ func (_m *ContainerHandler) Parse(customImageName string, deployImageName string
 	return r0
 }
 
-// Pytest provides a mock function with given fields: pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString
-func (_m *ContainerHandler) Pytest(pytestFile string, customImageName string, deployImageName string, pytestArgsString string, buildSecretString string) (string, error) {
-	ret := _m.Called(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString)
+// Pytest provides a mock function with given fields: pytestFile, customImageName, deployImageName, pytestArgsString, buildSecrets
+func (_m *ContainerHandler) Pytest(pytestFile string, customImageName string, deployImageName string, pytestArgsString string, buildSecrets []string) (string, error) {
+	ret := _m.Called(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecrets)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Pytest")
@@ -205,17 +205,17 @@ func (_m *ContainerHandler) Pytest(pytestFile string, customImageName string, de
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, string) (string, error)); ok {
-		return rf(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, []string) (string, error)); ok {
+		return rf(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecrets)
 	}
-	if rf, ok := ret.Get(0).(func(string, string, string, string, string) string); ok {
-		r0 = rf(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, []string) string); ok {
+		r0 = rf(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecrets)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string, string, string, string) error); ok {
-		r1 = rf(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecretString)
+	if rf, ok := ret.Get(1).(func(string, string, string, string, []string) error); ok {
+		r1 = rf(pytestFile, customImageName, deployImageName, pytestArgsString, buildSecrets)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -295,17 +295,17 @@ func (_m *ContainerHandler) Stop(waitForExit bool) error {
 	return r0
 }
 
-// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client
-func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, customImageName string, buildSecretString string, versionTest bool, dagTest bool, lintTest bool, includeLintDeprecations bool, lintFix bool, lintConfigFile string, astroV1Client astrov1.ClientWithResponsesInterface) error {
-	ret := _m.Called(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client)
+// UpgradeTest provides a mock function with given fields: runtimeVersion, deploymentID, customImageName, buildSecrets, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client
+func (_m *ContainerHandler) UpgradeTest(runtimeVersion string, deploymentID string, customImageName string, buildSecrets []string, versionTest bool, dagTest bool, lintTest bool, includeLintDeprecations bool, lintFix bool, lintConfigFile string, astroV1Client astrov1.ClientWithResponsesInterface) error {
+	ret := _m.Called(runtimeVersion, deploymentID, customImageName, buildSecrets, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpgradeTest")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, bool, bool, bool, bool, bool, string, astrov1.ClientWithResponsesInterface) error); ok {
-		r0 = rf(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client)
+	if rf, ok := ret.Get(0).(func(string, string, string, []string, bool, bool, bool, bool, bool, string, astrov1.ClientWithResponsesInterface) error); ok {
+		r0 = rf(runtimeVersion, deploymentID, customImageName, buildSecrets, versionTest, dagTest, lintTest, includeLintDeprecations, lintFix, lintConfigFile, astroV1Client)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/airflow/mocks/ImageHandler.go
+++ b/airflow/mocks/ImageHandler.go
@@ -14,17 +14,17 @@ type ImageHandler struct {
 	mock.Mock
 }
 
-// Build provides a mock function with given fields: dockerfile, buildSecretString, config
-func (_m *ImageHandler) Build(dockerfile string, buildSecretString string, config types.ImageBuildConfig) error {
-	ret := _m.Called(dockerfile, buildSecretString, config)
+// Build provides a mock function with given fields: dockerfile, buildSecrets, config
+func (_m *ImageHandler) Build(dockerfile string, buildSecrets []string, config types.ImageBuildConfig) error {
+	ret := _m.Called(dockerfile, buildSecrets, config)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Build")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, types.ImageBuildConfig) error); ok {
-		r0 = rf(dockerfile, buildSecretString, config)
+	if rf, ok := ret.Get(0).(func(string, []string, types.ImageBuildConfig) error); ok {
+		r0 = rf(dockerfile, buildSecrets, config)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -1084,7 +1084,7 @@ func standaloneExecDefault(dir string, env, args []string, stdin io.Reader, stdo
 	return airflowrt.ExecWithEnv(dir, env, args, stdin, stdout, stderr)
 }
 
-func (s *Standalone) Build(_, _ string, _ bool) error {
+func (s *Standalone) Build(_ string, _ []string, _ bool) error {
 	return errors.New("astro dev build builds a Docker image and is not available in standalone mode")
 }
 
@@ -1193,7 +1193,7 @@ func (s *Standalone) ComposeExport(_, _ string) error {
 }
 
 // Pytest runs pytest on DAGs using the local venv.
-func (s *Standalone) Pytest(pytestFile, _, _, pytestArgsString, _ string) (string, error) {
+func (s *Standalone) Pytest(pytestFile, _, _, pytestArgsString string, _ []string) (string, error) {
 	if err := s.ensureVenv(); err != nil {
 		return "", err
 	}
@@ -1223,7 +1223,7 @@ func (s *Standalone) Pytest(pytestFile, _, _, pytestArgsString, _ string) (strin
 }
 
 // Parse validates DAGs by running the default integrity test.
-func (s *Standalone) Parse(_, _, _ string) error {
+func (s *Standalone) Parse(_, _ string, _ []string) error {
 	path := filepath.Join(s.airflowHome, DefaultTestPath)
 
 	fileExist, err := fileutil.Exists(path, nil)
@@ -1237,7 +1237,7 @@ func (s *Standalone) Parse(_, _, _ string) error {
 
 	fmt.Println("Checking your DAGs for errors…")
 
-	exitCode, err := s.Pytest(DefaultTestPath, "", "", "", "")
+	exitCode, err := s.Pytest(DefaultTestPath, "", "", "", nil)
 	if err != nil {
 		if code, convErr := strconv.Atoi(exitCode); convErr == nil && code == 1 { // exit code 1 means tests failed
 			return errors.New("See above for errors detected in your DAGs")
@@ -1248,7 +1248,7 @@ func (s *Standalone) Parse(_, _, _ string) error {
 	return nil
 }
 
-func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astrov1.ClientWithResponsesInterface) error {
+func (s *Standalone) UpgradeTest(_, _, _ string, _ []string, _, _, _, _, _ bool, _ string, _ astrov1.ClientWithResponsesInterface) error {
 	return errors.New("astro dev upgrade-test is not available in standalone mode")
 }
 

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -287,7 +287,7 @@ func (s *Suite) TestStandaloneUnsupportedCommands() {
 
 	s.Equal(errStandaloneNotSupported, handler.RunDAG("", "", "", "", false, false))
 
-	buildErr := handler.Build("", "", false)
+	buildErr := handler.Build("", nil, false)
 	s.Error(buildErr)
 	s.Contains(buildErr.Error(), "not available in standalone mode")
 
@@ -295,7 +295,7 @@ func (s *Suite) TestStandaloneUnsupportedCommands() {
 	s.Error(composeErr)
 	s.Contains(composeErr.Error(), "not available in standalone mode")
 
-	upgradeErr := handler.UpgradeTest("", "", "", "", false, false, false, false, false, "", nil)
+	upgradeErr := handler.UpgradeTest("", "", "", nil, false, false, false, false, false, "", nil)
 	s.Error(upgradeErr)
 	s.Contains(upgradeErr.Error(), "not available in standalone mode")
 }
@@ -1758,7 +1758,7 @@ func (s *Suite) TestStandalonePytest_NoVenv() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	_, err = handler.Pytest("", "", "", "", "")
+	_, err = handler.Pytest("", "", "", "", nil)
 	s.Error(err)
 	s.Contains(err.Error(), "no virtual environment found")
 }
@@ -1785,7 +1785,7 @@ func (s *Suite) TestStandalonePytest_Success() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	exitCode, err := handler.Pytest("", "", "", "", "")
+	exitCode, err := handler.Pytest("", "", "", "", nil)
 	s.NoError(err)
 	s.Equal("", exitCode)
 	s.Equal([]string{"pytest", "tests/"}, capturedArgs)
@@ -1824,7 +1824,7 @@ func (s *Suite) TestStandalonePytest_WithFileAndArgs() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	exitCode, err := handler.Pytest("test_dag.py", "", "", "-v --tb=short", "")
+	exitCode, err := handler.Pytest("test_dag.py", "", "", "-v --tb=short", nil)
 	s.NoError(err)
 	s.Equal("", exitCode)
 	s.Equal([]string{"pytest", "tests/test_dag.py", "-v", "--tb=short"}, capturedArgs)
@@ -1850,7 +1850,7 @@ func (s *Suite) TestStandalonePytest_DefaultTestPath() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	exitCode, err := handler.Pytest(DefaultTestPath, "", "", "", "")
+	exitCode, err := handler.Pytest(DefaultTestPath, "", "", "", nil)
 	s.NoError(err)
 	s.Equal("", exitCode)
 	// DefaultTestPath should NOT be prepended with tests/
@@ -1877,7 +1877,7 @@ func (s *Suite) TestStandalonePytest_FileInTestsDir() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	exitCode, err := handler.Pytest("tests/test_my_dag.py", "", "", "", "")
+	exitCode, err := handler.Pytest("tests/test_my_dag.py", "", "", "", nil)
 	s.NoError(err)
 	s.Equal("", exitCode)
 	// Already contains "tests", should not be prepended
@@ -1904,7 +1904,7 @@ func (s *Suite) TestStandalonePytest_Failure() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	exitCode, err := handler.Pytest("", "", "", "", "")
+	exitCode, err := handler.Pytest("", "", "", "", nil)
 	s.Error(err)
 	s.Equal("1", exitCode)
 	s.Contains(err.Error(), "something went wrong while Pytesting your DAGs")
@@ -1921,7 +1921,7 @@ func (s *Suite) TestStandaloneParse_FileNotFound() {
 	s.NoError(err)
 
 	// No DefaultTestPath file exists — should return nil with a message
-	err = handler.Parse("", "", "")
+	err = handler.Parse("", "", nil)
 	s.NoError(err)
 }
 
@@ -1950,7 +1950,7 @@ func (s *Suite) TestStandaloneParse_Success() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	err = handler.Parse("", "", "")
+	err = handler.Parse("", "", nil)
 	s.NoError(err)
 }
 
@@ -1978,7 +1978,7 @@ func (s *Suite) TestStandaloneParse_DagErrors() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	err = handler.Parse("", "", "")
+	err = handler.Parse("", "", nil)
 	s.Error(err)
 	s.Contains(err.Error(), "errors detected in your DAGs")
 }

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -2008,7 +2008,7 @@ func (s *Suite) TestStandaloneParse_Interrupted() {
 	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
 	s.NoError(err)
 
-	err = handler.Parse("", "", "")
+	err = handler.Parse("", "", nil)
 	s.Error(err)
 	s.Contains(err.Error(), "something went wrong while parsing your DAGs")
 }

--- a/airflow/standalone_windows.go
+++ b/airflow/standalone_windows.go
@@ -31,14 +31,14 @@ func StandaloneInit(airflowHome, envFile, dockerfile string) (*Standalone, error
 	return nil, errStandaloneWindows
 }
 
-func (s *Standalone) Start(_ *types.StartOptions) error { return errStandaloneWindows }
-func (s *Standalone) Stop(_ bool) error                 { return errStandaloneWindows }
-func (s *Standalone) PS() (*types.PSStatus, error)      { return nil, errStandaloneWindows }
-func (s *Standalone) Kill() error                       { return errStandaloneWindows }
-func (s *Standalone) Logs(_ bool, _ ...string) error    { return errStandaloneWindows }
-func (s *Standalone) Run(_ []string, _ string) error    { return errStandaloneWindows }
-func (s *Standalone) Bash(_ string) error               { return errStandaloneWindows }
-func (s *Standalone) Build(_, _ string, _ bool) error   { return errStandaloneWindows }
+func (s *Standalone) Start(_ *types.StartOptions) error        { return errStandaloneWindows }
+func (s *Standalone) Stop(_ bool) error                        { return errStandaloneWindows }
+func (s *Standalone) PS() (*types.PSStatus, error)             { return nil, errStandaloneWindows }
+func (s *Standalone) Kill() error                              { return errStandaloneWindows }
+func (s *Standalone) Logs(_ bool, _ ...string) error           { return errStandaloneWindows }
+func (s *Standalone) Run(_ []string, _ string) error           { return errStandaloneWindows }
+func (s *Standalone) Bash(_ string) error                      { return errStandaloneWindows }
+func (s *Standalone) Build(_ string, _ []string, _ bool) error { return errStandaloneWindows }
 func (s *Standalone) RunDAG(_, _, _, _ string, _, _ bool) error {
 	return errStandaloneWindows
 }
@@ -47,10 +47,10 @@ func (s *Standalone) ExportSettings(_, _ string, _, _, _, _ bool) error {
 	return errStandaloneWindows
 }
 func (s *Standalone) ComposeExport(_, _ string) error { return errStandaloneWindows }
-func (s *Standalone) Pytest(_, _, _, _, _ string) (string, error) {
+func (s *Standalone) Pytest(_, _, _, _ string, _ []string) (string, error) {
 	return "", errStandaloneWindows
 }
-func (s *Standalone) Parse(_, _, _ string) error { return errStandaloneWindows }
-func (s *Standalone) UpgradeTest(_, _, _, _ string, _, _, _, _, _ bool, _ string, _ astrov1.ClientWithResponsesInterface) error {
+func (s *Standalone) Parse(_, _ string, _ []string) error { return errStandaloneWindows }
+func (s *Standalone) UpgradeTest(_, _, _ string, _ []string, _, _, _, _, _ bool, _ string, _ astrov1.ClientWithResponsesInterface) error {
 	return errStandaloneWindows
 }

--- a/airflow/types/types.go
+++ b/airflow/types/types.go
@@ -18,14 +18,14 @@ type ImageBuildConfig struct {
 // Fields that don't apply to a given handler are silently ignored.
 type StartOptions struct {
 	// Common options (used by both Docker and Standalone)
-	ImageName         string
-	SettingsFile      string
-	ComposeFile       string
-	BuildSecretString string
-	NoCache           bool
-	NoBrowser         bool
-	WaitTime          time.Duration
-	EnvConns          map[string]astrov1.EnvironmentObjectConnection
+	ImageName    string
+	SettingsFile string
+	ComposeFile  string
+	BuildSecrets []string
+	NoCache      bool
+	NoBrowser    bool
+	WaitTime     time.Duration
+	EnvConns     map[string]astrov1.EnvironmentObjectConnection
 
 	// Proxy options
 	NoProxy bool // disable the reverse proxy (use fixed ports instead)

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -98,33 +98,33 @@ type deploymentInfo struct {
 }
 
 type InputDeploy struct {
-	Path              string
-	RuntimeID         string
-	WsID              string
-	Pytest            string
-	EnvFile           string
-	ImageName         string
-	DeploymentName    string
-	Prompt            bool
-	Dags              bool
-	NoDagsBaseDir     bool
-	Image             bool
-	WaitForStatus     bool
-	WaitTime          time.Duration
-	DagsPath          string
-	Description       string
-	BuildSecretString string
-	Force             bool
-	DagBundleName     string
+	Path           string
+	RuntimeID      string
+	WsID           string
+	Pytest         string
+	EnvFile        string
+	ImageName      string
+	DeploymentName string
+	Prompt         bool
+	Dags           bool
+	NoDagsBaseDir  bool
+	Image          bool
+	WaitForStatus  bool
+	WaitTime       time.Duration
+	DagsPath       string
+	Description    string
+	BuildSecrets   []string
+	Force          bool
+	DagBundleName  string
 }
 
 // InputClientDeploy contains inputs for client image deployments
 type InputClientDeploy struct {
-	Path              string
-	ImageName         string
-	Platform          string
-	BuildSecretString string
-	DeploymentID      string
+	Path         string
+	ImageName    string
+	Platform     string
+	BuildSecrets []string
+	DeploymentID string
 }
 
 const accessYourDeploymentFmt = `
@@ -342,12 +342,12 @@ func Deploy(deployInput InputDeploy, astroV1Client astrov1.APIClient, astroV1Alp
 			}
 		}
 		if deployInput.Pytest != "" {
-			runtimeVersion, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.organizationID, deployInput.BuildSecretString, deployInfo.dagDeployEnabled, deployInfo.isRemoteExecutionEnabled, astroV1Client)
+			runtimeVersion, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.organizationID, deployInput.BuildSecrets, deployInfo.dagDeployEnabled, deployInfo.isRemoteExecutionEnabled, astroV1Client)
 			if err != nil {
 				return err
 			}
 
-			err = parseOrPytestDAG(deployInput.Pytest, runtimeVersion, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace, deployInput.BuildSecretString)
+			err = parseOrPytestDAG(deployInput.Pytest, runtimeVersion, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace, deployInput.BuildSecrets)
 			if err != nil {
 				return err
 			}
@@ -422,13 +422,13 @@ func Deploy(deployInput InputDeploy, astroV1Client astrov1.APIClient, astroV1Alp
 		}
 
 		// Build our image
-		runtimeVersion, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.organizationID, deployInput.BuildSecretString, deployInfo.dagDeployEnabled, deployInfo.isRemoteExecutionEnabled, astroV1Client)
+		runtimeVersion, err := buildImage(deployInput.Path, deployInfo.currentVersion, deployInfo.deployImage, deployInput.ImageName, deployInfo.organizationID, deployInput.BuildSecrets, deployInfo.dagDeployEnabled, deployInfo.isRemoteExecutionEnabled, astroV1Client)
 		if err != nil {
 			return err
 		}
 
 		if len(dagFiles) > 0 {
-			err = parseOrPytestDAG(deployInput.Pytest, runtimeVersion, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace, deployInput.BuildSecretString)
+			err = parseOrPytestDAG(deployInput.Pytest, runtimeVersion, deployInput.EnvFile, deployInfo.deployImage, deployInfo.namespace, deployInput.BuildSecrets)
 			if err != nil {
 				return err
 			}
@@ -539,7 +539,7 @@ func getDeploymentInfo(
 	return deployInfo, nil
 }
 
-func parseOrPytestDAG(pytest, runtimeVersion, envFile, deployImage, namespace, buildSecretString string) error {
+func parseOrPytestDAG(pytest, runtimeVersion, envFile, deployImage, namespace string, buildSecrets []string) error {
 	validDAGParseVersion := airflowversions.CompareRuntimeVersions(runtimeVersion, dagParseAllowedVersion) >= 0
 	if !validDAGParseVersion {
 		fmt.Println("\nruntime image is earlier than 4.1.0, this deploy will skip DAG parse...")
@@ -554,26 +554,26 @@ func parseOrPytestDAG(pytest, runtimeVersion, envFile, deployImage, namespace, b
 	case pytest == parse && validDAGParseVersion:
 		// parse dags
 		fmt.Println("Testing image...")
-		err := parseDAGs(deployImage, buildSecretString, containerHandler)
+		err := parseDAGs(deployImage, buildSecrets, containerHandler)
 		if err != nil {
 			return err
 		}
 	case pytest != "" && pytest != parse && pytest != parseAndPytest:
 		// check pytests
 		fmt.Println("Testing image...")
-		err := checkPytest(pytest, deployImage, buildSecretString, containerHandler)
+		err := checkPytest(pytest, deployImage, buildSecrets, containerHandler)
 		if err != nil {
 			return err
 		}
 	case pytest == parseAndPytest:
 		// parse dags and check pytests
 		fmt.Println("Testing image...")
-		err := parseDAGs(deployImage, buildSecretString, containerHandler)
+		err := parseDAGs(deployImage, buildSecrets, containerHandler)
 		if err != nil {
 			return err
 		}
 
-		err = checkPytest(pytest, deployImage, buildSecretString, containerHandler)
+		err = checkPytest(pytest, deployImage, buildSecrets, containerHandler)
 		if err != nil {
 			return err
 		}
@@ -581,9 +581,9 @@ func parseOrPytestDAG(pytest, runtimeVersion, envFile, deployImage, namespace, b
 	return nil
 }
 
-func parseDAGs(deployImage, buildSecretString string, containerHandler airflow.ContainerHandler) error {
+func parseDAGs(deployImage string, buildSecrets []string, containerHandler airflow.ContainerHandler) error {
 	if !config.CFG.SkipParse.GetBool() && !util.CheckEnvBool(os.Getenv("ASTRONOMER_SKIP_PARSE")) {
-		err := containerHandler.Parse("", deployImage, buildSecretString)
+		err := containerHandler.Parse("", deployImage, buildSecrets)
 		if err != nil {
 			fmt.Println(err)
 			return errDagsParseFailed
@@ -596,12 +596,12 @@ func parseDAGs(deployImage, buildSecretString string, containerHandler airflow.C
 }
 
 // Validate code with pytest
-func checkPytest(pytest, deployImage, buildSecretString string, containerHandler airflow.ContainerHandler) error {
+func checkPytest(pytest, deployImage string, buildSecrets []string, containerHandler airflow.ContainerHandler) error {
 	if pytest != allTests && pytest != parseAndPytest {
 		pytestFile = pytest
 	}
 
-	exitCode, err := containerHandler.Pytest(pytestFile, "", deployImage, "", buildSecretString)
+	exitCode, err := containerHandler.Pytest(pytestFile, "", deployImage, "", buildSecrets)
 	if err != nil {
 		if strings.Contains(exitCode, "1") { // exit code is 1 meaning tests failed
 			return errors.New("at least 1 pytest in your tests directory failed. Fix the issues listed or rerun the command without the '--pytest' flag to deploy")
@@ -655,7 +655,7 @@ func fetchDeploymentDetails(deploymentID, organizationID string, astroV1Client a
 	}, nil
 }
 
-func buildImageWithoutDags(path, buildSecretString string, imageHandler airflow.ImageHandler) error {
+func buildImageWithoutDags(path string, buildSecrets []string, imageHandler airflow.ImageHandler) error {
 	fullpath := filepath.Join(path, ".dockerignore")
 
 	// Snapshot the original bytes so we can restore byte-for-byte after the build
@@ -690,7 +690,7 @@ func buildImageWithoutDags(path, buildSecretString string, imageHandler airflow.
 		}
 	}
 
-	return imageHandler.Build("", buildSecretString, types.ImageBuildConfig{Path: path, TargetPlatforms: deployImagePlatformSupport})
+	return imageHandler.Build("", buildSecrets, types.ImageBuildConfig{Path: path, TargetPlatforms: deployImagePlatformSupport})
 }
 
 // dockerignoreContainsDags reports whether content has a line equal to "dags/".
@@ -705,7 +705,7 @@ func dockerignoreContainsDags(content []byte) bool {
 	return false
 }
 
-func buildImage(path, currentVersion, deployImage, imageName, organizationID, buildSecretString string, dagDeployEnabled, isRemoteExecutionEnabled bool, astroV1Client astrov1.APIClient) (version string, err error) {
+func buildImage(path, currentVersion, deployImage, imageName, organizationID string, buildSecrets []string, dagDeployEnabled, isRemoteExecutionEnabled bool, astroV1Client astrov1.APIClient) (version string, err error) {
 	imageHandler := airflowImageHandler(deployImage)
 
 	if imageName == "" {
@@ -713,12 +713,12 @@ func buildImage(path, currentVersion, deployImage, imageName, organizationID, bu
 		fmt.Println(composeImageBuildingPromptMsg)
 
 		if dagDeployEnabled || isRemoteExecutionEnabled {
-			err := buildImageWithoutDags(path, buildSecretString, imageHandler)
+			err := buildImageWithoutDags(path, buildSecrets, imageHandler)
 			if err != nil {
 				return "", err
 			}
 		} else {
-			err := imageHandler.Build("", buildSecretString, types.ImageBuildConfig{Path: path, TargetPlatforms: deployImagePlatformSupport})
+			err := imageHandler.Build("", buildSecrets, types.ImageBuildConfig{Path: path, TargetPlatforms: deployImagePlatformSupport})
 			if err != nil {
 				return "", err
 			}
@@ -1139,7 +1139,7 @@ func DeployClientImage(deployInput InputClientDeploy, astroV1Client astrov1.APIC
 			TargetPlatforms: targetPlatforms,
 		}
 
-		err = imageHandler.Build("Dockerfile.client", deployInput.BuildSecretString, buildConfig)
+		err = imageHandler.Build("Dockerfile.client", deployInput.BuildSecrets, buildConfig)
 		if err != nil {
 			return fmt.Errorf("failed to build client image: %w", err)
 		}

--- a/cloud/deploy/deploy_test.go
+++ b/cloud/deploy/deploy_test.go
@@ -1143,7 +1143,7 @@ func TestBuildImageFailure(t *testing.T) {
 		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(errMock).Once()
 		return mockImageHandler
 	}
-	_, err := buildImage("./testfiles/", "4.2.5", "", "", "", "", false, false, mockV1Client)
+	_, err := buildImage("./testfiles/", "4.2.5", "", "", "", nil, false, false, mockV1Client)
 	assert.ErrorIs(t, err, errMock)
 
 	// dockerfile parsing error: no imageName, version label empty → enters parse branch
@@ -1153,7 +1153,7 @@ func TestBuildImageFailure(t *testing.T) {
 		return mockImageHandler
 	}
 	dockerfile = "Dockerfile.invalid"
-	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, false, mockV1Client)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", nil, false, false, mockV1Client)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse dockerfile")
 
@@ -1166,7 +1166,7 @@ func TestBuildImageFailure(t *testing.T) {
 	}
 	mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentOptionsResponse, nil).Once()
 	dockerfile = "Dockerfile.invalid" // would normally cause a parse error
-	_, err = buildImage("./testfiles/", "4.2.5", "", "my-registry/my-image:tag", "", "", false, false, mockV1Client)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "my-registry/my-image:tag", "", nil, false, false, mockV1Client)
 	assert.NoError(t, err, "Dockerfile should not be parsed when --image-name is provided")
 
 	// failed to get runtime releases
@@ -1177,7 +1177,7 @@ func TestBuildImageFailure(t *testing.T) {
 	}
 	dockerfile = "Dockerfile"
 	mockV1Client.On("GetDeploymentOptionsWithResponse", mock.Anything, mock.Anything, mock.Anything).Return(&getDeploymentOptionsResponse, errMock).Once()
-	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", "", false, false, mockV1Client)
+	_, err = buildImage("./testfiles/", "4.2.5", "", "", "", nil, false, false, mockV1Client)
 	assert.ErrorIs(t, err, errMock)
 	mockV1Client.AssertExpectations(t)
 	mockV1Client.AssertExpectations(t)
@@ -1402,16 +1402,16 @@ func TestCheckPyTest(t *testing.T) {
 	mockDeployImage := "test-image"
 
 	mockContainerHandler := new(mocks.ContainerHandler)
-	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "", "").Return("", errMock).Once()
+	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "", mock.Anything).Return("", errMock).Once()
 
 	// random error on running airflow pytest
-	err := checkPytest("", mockDeployImage, "", mockContainerHandler)
+	err := checkPytest("", mockDeployImage, nil, mockContainerHandler)
 	assert.ErrorIs(t, err, errMock)
 	mockContainerHandler.AssertExpectations(t)
 
 	// airflow pytest exited with status code 1
-	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "", "").Return("exit code 1", errMock).Once()
-	err = checkPytest("", mockDeployImage, "", mockContainerHandler)
+	mockContainerHandler.On("Pytest", "", "", mockDeployImage, "", mock.Anything).Return("exit code 1", errMock).Once()
+	err = checkPytest("", mockDeployImage, nil, mockContainerHandler)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least 1 pytest in your tests directory failed. Fix the issues listed or rerun the command without the '--pytest' flag to deploy")
 	mockContainerHandler.AssertExpectations(t)
@@ -1461,7 +1461,7 @@ func TestDeployClientImage(t *testing.T) {
 
 		// Mock image handler
 		mockImageHandler := new(mocks.ImageHandler)
-		mockImageHandler.On("Build", "Dockerfile.client", "", mock.AnythingOfType("types.ImageBuildConfig")).Return(nil).Once()
+		mockImageHandler.On("Build", "Dockerfile.client", mock.Anything, mock.AnythingOfType("types.ImageBuildConfig")).Return(nil).Once()
 		mockImageHandler.On("Push", mock.AnythingOfType("string"), "", "", false).Return("", nil).Once()
 
 		// Override airflowImageHandler
@@ -1477,8 +1477,8 @@ func TestDeployClientImage(t *testing.T) {
 		config.CFG.RemoteClientRegistry.SetHomeString("test-registry:latest")
 
 		deployInput := InputClientDeploy{
-			Path:              tempDir,
-			BuildSecretString: "",
+			Path:         tempDir,
+			BuildSecrets: nil,
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1507,8 +1507,8 @@ func TestDeployClientImage(t *testing.T) {
 		config.CFG.RemoteClientRegistry.SetHomeString("test-registry:latest")
 
 		deployInput := InputClientDeploy{
-			Path:              "/test/path",
-			BuildSecretString: "",
+			Path:         "/test/path",
+			BuildSecrets: nil,
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1535,8 +1535,8 @@ func TestDeployClientImage(t *testing.T) {
 		config.CFG.RemoteClientRegistry.SetHomeString("") // Empty registry
 
 		deployInput := InputClientDeploy{
-			Path:              "/test/path",
-			BuildSecretString: "",
+			Path:         "/test/path",
+			BuildSecrets: nil,
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1577,7 +1577,7 @@ func TestDeployClientImage(t *testing.T) {
 
 		// Mock image handler with build failure
 		mockImageHandler := new(mocks.ImageHandler)
-		mockImageHandler.On("Build", "Dockerfile.client", "", mock.AnythingOfType("types.ImageBuildConfig")).Return(errors.New("build failed")).Once()
+		mockImageHandler.On("Build", "Dockerfile.client", mock.Anything, mock.AnythingOfType("types.ImageBuildConfig")).Return(errors.New("build failed")).Once()
 
 		// Override airflowImageHandler
 		originalAirflowImageHandler := airflowImageHandler
@@ -1591,8 +1591,8 @@ func TestDeployClientImage(t *testing.T) {
 		config.CFG.RemoteClientRegistry.SetHomeString("test-registry:latest")
 
 		deployInput := InputClientDeploy{
-			Path:              tempDir,
-			BuildSecretString: "",
+			Path:         tempDir,
+			BuildSecrets: nil,
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1633,7 +1633,7 @@ func TestDeployClientImage(t *testing.T) {
 
 		// Mock image handler with push failure
 		mockImageHandler := new(mocks.ImageHandler)
-		mockImageHandler.On("Build", "Dockerfile.client", "", mock.AnythingOfType("types.ImageBuildConfig")).Return(nil).Once()
+		mockImageHandler.On("Build", "Dockerfile.client", mock.Anything, mock.AnythingOfType("types.ImageBuildConfig")).Return(nil).Once()
 		mockImageHandler.On("Push", mock.AnythingOfType("string"), "", "", false).Return("", errors.New("push failed")).Once()
 
 		// Override airflowImageHandler
@@ -1648,8 +1648,8 @@ func TestDeployClientImage(t *testing.T) {
 		config.CFG.RemoteClientRegistry.SetHomeString("test-registry:latest")
 
 		deployInput := InputClientDeploy{
-			Path:              tempDir,
-			BuildSecretString: "",
+			Path:         tempDir,
+			BuildSecrets: nil,
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -1694,9 +1694,9 @@ func TestDeployClientImage(t *testing.T) {
 		defer os.RemoveAll(tempDir)
 
 		deployInput := InputClientDeploy{
-			Path:              tempDir,
-			ImageName:         "custom-image:tag",
-			BuildSecretString: "",
+			Path:         tempDir,
+			ImageName:    "custom-image:tag",
+			BuildSecrets: nil,
 		}
 
 		err = DeployClientImage(deployInput, nil)
@@ -2500,7 +2500,7 @@ func TestBuildImageWithoutDagsPreservesDockerignore(t *testing.T) {
 			mockImageHandler := new(mocks.ImageHandler)
 			mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-			err = buildImageWithoutDags(dir, "", mockImageHandler)
+			err = buildImageWithoutDags(dir, nil, mockImageHandler)
 			assert.NoError(t, err)
 
 			got, err := os.ReadFile(dockerignorePath)
@@ -2519,7 +2519,7 @@ func TestBuildImageWithoutDagsCleansUpCreatedDockerignore(t *testing.T) {
 	mockImageHandler := new(mocks.ImageHandler)
 	mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	err := buildImageWithoutDags(dir, "", mockImageHandler)
+	err := buildImageWithoutDags(dir, nil, mockImageHandler)
 	assert.NoError(t, err)
 
 	_, statErr := os.Stat(dockerignorePath)
@@ -2565,7 +2565,7 @@ func TestBuildImageWithoutDagsAppendsDagsDuringBuild(t *testing.T) {
 				assert.Equal(t, tc.expectedDuringBuild, string(got))
 			}).Return(nil)
 
-			err = buildImageWithoutDags(dir, "", mockImageHandler)
+			err = buildImageWithoutDags(dir, nil, mockImageHandler)
 			assert.NoError(t, err)
 
 			mockImageHandler.AssertExpectations(t)

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -52,7 +52,6 @@ var (
 	pytestFile             string
 	workspaceID            string
 	deploymentID           string
-	buildSecretString      string
 	followLogs             bool
 	schedulerLogs          bool
 	webserverLogs          bool
@@ -287,7 +286,9 @@ func newAirflowUpgradeTestCmd(astroV1Client astrov1.APIClient) *cobra.Command {
 	cmd.Flags().StringVarP(&lintConfigFile, "lint-config-file", "", "", "Relative path within project to a custom ruff config file. If not specified, a default config will be used.")
 	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "i", "", "ID of the Deployment you want run dependency tests against.")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "n", "", "Name of the upgraded image. Updates the FROM line in your Dockerfile to pull this image for the upgrade.")
-	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Expose a secret to containers. Equivalent to 'docker build --secret'. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Expose a secret to containers. Equivalent to 'docker build --secret'. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
+	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
 	var err error
 	var avoidACFlag bool
 
@@ -335,12 +336,14 @@ func newAirflowStartCmd(astroV1Client astrov1.APIClient) *cobra.Command {
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to start airflow with")
 	cmd.Flags().BoolVarP(&noBrowser, "no-browser", "n", false, "Don't bring up the browser once the Webserver is healthy")
 	cmd.Flags().StringVarP(&composeFile, "compose-file", "", "", "Location of a custom compose file to use for starting Airflow")
-	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
+	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
 	annotateFlag(cmd, "no-cache", "docker")
 	annotateFlag(cmd, "image-name", "docker")
 	annotateFlag(cmd, "no-browser", "docker")
 	annotateFlag(cmd, "compose-file", "docker")
-	annotateFlag(cmd, "build-secrets", "docker")
+	annotateFlag(cmd, "build-secret", "docker")
 
 	// Standalone mode flags
 	cmd.Flags().BoolVarP(&localForeground, "foreground", "f", false, "Run in the foreground")
@@ -442,10 +445,12 @@ func newAirflowRestartCmd(astroV1Client astrov1.APIClient) *cobra.Command {
 	// Docker mode flags
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "Do not use cache when building container image")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to restart airflow with")
-	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
+	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
 	annotateFlag(cmd, "no-cache", "docker")
 	annotateFlag(cmd, "image-name", "docker")
-	annotateFlag(cmd, "build-secrets", "docker")
+	annotateFlag(cmd, "build-secret", "docker")
 
 	// Standalone mode flags
 	cmd.Flags().BoolVarP(&localForeground, "foreground", "f", false, "Run in the foreground")
@@ -471,7 +476,9 @@ func newAirflowPytestCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&pytestArgs, "args", "a", "", "pytest arguments you'd like passed to the pytest command. Surround the args in quotes. For example 'astro dev pytest --args \"--cov-config path\"'")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to run pytest with")
-	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
+	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
 
 	return cmd
 }
@@ -487,7 +494,9 @@ func newAirflowParseCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to run parse with")
-	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
+	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
 
 	return cmd
 }
@@ -502,7 +511,9 @@ func newAirflowBuildCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "Do not use cache when building container image")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to tag as the project image")
-	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
+	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
 
 	return cmd
 }
@@ -810,9 +821,9 @@ func airflowUpgradeTest(cmd *cobra.Command, astroV1Client astrov1.APIClient) err
 		fmt.Printf("failed to add 'upgrade-test*' to .gitignore: %s", err.Error())
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
-	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, buildSecretString, versionTest, dagTest, lintTest, lintDeprecations, lintFix, lintConfigFile, astroV1Client)
+	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, resolvedBuildSecrets, versionTest, dagTest, lintTest, lintDeprecations, lintFix, lintConfigFile, astroV1Client)
 	if err != nil {
 		return err
 	}
@@ -845,20 +856,20 @@ func airflowStart(cmd *cobra.Command, args []string, astroV1Client astrov1.APICl
 		return err
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
 	return containerHandler.Start(&airflow.StartOptions{
-		ImageName:         customImageName,
-		SettingsFile:      settingsFile,
-		ComposeFile:       composeFile,
-		BuildSecretString: buildSecretString,
-		NoCache:           noCache,
-		NoBrowser:         noBrowser,
-		WaitTime:          waitTime,
-		EnvConns:          envConns,
-		NoProxy:           noProxyFlag,
-		Foreground:        localForeground,
-		Port:              localPort,
+		ImageName:    customImageName,
+		SettingsFile: settingsFile,
+		ComposeFile:  composeFile,
+		BuildSecrets: resolvedBuildSecrets,
+		NoCache:      noCache,
+		NoBrowser:    noBrowser,
+		WaitTime:     waitTime,
+		EnvConns:     envConns,
+		NoProxy:      noProxyFlag,
+		Foreground:   localForeground,
+		Port:         localPort,
 	})
 }
 
@@ -1051,20 +1062,20 @@ func airflowRestart(cmd *cobra.Command, args []string, astroV1Client astrov1.API
 		}
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
 	return containerHandler.Start(&airflow.StartOptions{
-		ImageName:         customImageName,
-		SettingsFile:      settingsFile,
-		ComposeFile:       composeFile,
-		BuildSecretString: buildSecretString,
-		NoCache:           noCache,
-		NoBrowser:         noBrowser,
-		WaitTime:          waitTime,
-		EnvConns:          envConns,
-		NoProxy:           noProxyFlag,
-		Foreground:        localForeground,
-		Port:              localPort,
+		ImageName:    customImageName,
+		SettingsFile: settingsFile,
+		ComposeFile:  composeFile,
+		BuildSecrets: resolvedBuildSecrets,
+		NoCache:      noCache,
+		NoBrowser:    noBrowser,
+		WaitTime:     waitTime,
+		EnvConns:     envConns,
+		NoProxy:      noProxyFlag,
+		Foreground:   localForeground,
+		Port:         localPort,
 	})
 }
 
@@ -1105,9 +1116,9 @@ func airflowPytest(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
-	exitCode, err := containerHandler.Pytest(pytestFile, customImageName, "", pytestArgs, buildSecretString)
+	exitCode, err := containerHandler.Pytest(pytestFile, customImageName, "", pytestArgs, resolvedBuildSecrets)
 	if err != nil {
 		if strings.Contains(exitCode, "1") { // exit code is 1 meaning tests failed
 			return errors.New("pytest failed")
@@ -1134,9 +1145,9 @@ func airflowParse(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
-	return containerHandler.Parse(customImageName, "", buildSecretString)
+	return containerHandler.Parse(customImageName, "", resolvedBuildSecrets)
 }
 
 // Build the Airflow project image
@@ -1155,9 +1166,9 @@ func airflowBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	buildSecretString = util.GetbuildSecretString(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
 
-	return containerHandler.Build(customImageName, buildSecretString, noCache)
+	return containerHandler.Build(customImageName, resolvedBuildSecrets, noCache)
 }
 
 // Exec into an airflow container

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -286,9 +286,7 @@ func newAirflowUpgradeTestCmd(astroV1Client astrov1.APIClient) *cobra.Command {
 	cmd.Flags().StringVarP(&lintConfigFile, "lint-config-file", "", "", "Relative path within project to a custom ruff config file. If not specified, a default config will be used.")
 	cmd.Flags().StringVarP(&deploymentID, "deployment-id", "i", "", "ID of the Deployment you want run dependency tests against.")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "n", "", "Name of the upgraded image. Updates the FROM line in your Dockerfile to pull this image for the upgrade.")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Expose a secret to containers. Equivalent to 'docker build --secret'. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
-	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
+	utils.AddBuildSecretFlags(cmd.Flags(), &buildSecrets)
 	var err error
 	var avoidACFlag bool
 
@@ -336,9 +334,7 @@ func newAirflowStartCmd(astroV1Client astrov1.APIClient) *cobra.Command {
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to start airflow with")
 	cmd.Flags().BoolVarP(&noBrowser, "no-browser", "n", false, "Don't bring up the browser once the Webserver is healthy")
 	cmd.Flags().StringVarP(&composeFile, "compose-file", "", "", "Location of a custom compose file to use for starting Airflow")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
-	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
+	utils.AddBuildSecretFlags(cmd.Flags(), &buildSecrets)
 	annotateFlag(cmd, "no-cache", "docker")
 	annotateFlag(cmd, "image-name", "docker")
 	annotateFlag(cmd, "no-browser", "docker")
@@ -445,9 +441,7 @@ func newAirflowRestartCmd(astroV1Client astrov1.APIClient) *cobra.Command {
 	// Docker mode flags
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "Do not use cache when building container image")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to restart airflow with")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
-	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
+	utils.AddBuildSecretFlags(cmd.Flags(), &buildSecrets)
 	annotateFlag(cmd, "no-cache", "docker")
 	annotateFlag(cmd, "image-name", "docker")
 	annotateFlag(cmd, "build-secret", "docker")
@@ -476,9 +470,7 @@ func newAirflowPytestCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&pytestArgs, "args", "a", "", "pytest arguments you'd like passed to the pytest command. Surround the args in quotes. For example 'astro dev pytest --args \"--cov-config path\"'")
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to run pytest with")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
-	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
+	utils.AddBuildSecretFlags(cmd.Flags(), &buildSecrets)
 
 	return cmd
 }
@@ -494,9 +486,7 @@ func newAirflowParseCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&envFile, "env", "e", ".env", "Location of file containing environment variables")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to run parse with")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
-	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
+	utils.AddBuildSecretFlags(cmd.Flags(), &buildSecrets)
 
 	return cmd
 }
@@ -511,9 +501,7 @@ func newAirflowBuildCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "Do not use cache when building container image")
 	cmd.Flags().StringVarP(&customImageName, "image-name", "i", "", "Name of a custom built image to tag as the project image")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
-	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
+	utils.AddBuildSecretFlags(cmd.Flags(), &buildSecrets)
 
 	return cmd
 }
@@ -821,7 +809,7 @@ func airflowUpgradeTest(cmd *cobra.Command, astroV1Client astrov1.APIClient) err
 		fmt.Printf("failed to add 'upgrade-test*' to .gitignore: %s", err.Error())
 	}
 
-	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString(), os.Getenv("BUILD_SECRET_INPUT"))
 
 	err = containerHandler.UpgradeTest(runtimeVersion, deploymentID, customImageName, resolvedBuildSecrets, versionTest, dagTest, lintTest, lintDeprecations, lintFix, lintConfigFile, astroV1Client)
 	if err != nil {
@@ -856,7 +844,7 @@ func airflowStart(cmd *cobra.Command, args []string, astroV1Client astrov1.APICl
 		return err
 	}
 
-	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString(), os.Getenv("BUILD_SECRET_INPUT"))
 
 	return containerHandler.Start(&airflow.StartOptions{
 		ImageName:    customImageName,
@@ -1062,7 +1050,7 @@ func airflowRestart(cmd *cobra.Command, args []string, astroV1Client astrov1.API
 		}
 	}
 
-	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString(), os.Getenv("BUILD_SECRET_INPUT"))
 
 	return containerHandler.Start(&airflow.StartOptions{
 		ImageName:    customImageName,
@@ -1116,7 +1104,7 @@ func airflowPytest(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString(), os.Getenv("BUILD_SECRET_INPUT"))
 
 	exitCode, err := containerHandler.Pytest(pytestFile, customImageName, "", pytestArgs, resolvedBuildSecrets)
 	if err != nil {
@@ -1145,7 +1133,7 @@ func airflowParse(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString(), os.Getenv("BUILD_SECRET_INPUT"))
 
 	return containerHandler.Parse(customImageName, "", resolvedBuildSecrets)
 }
@@ -1166,7 +1154,7 @@ func airflowBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString())
+	resolvedBuildSecrets := util.ResolveBuildSecrets(buildSecrets, config.CFG.DevBuildSecrets.GetString(), os.Getenv("BUILD_SECRET_INPUT"))
 
 	return containerHandler.Build(customImageName, resolvedBuildSecrets, noCache)
 }

--- a/cmd/airflow_test.go
+++ b/cmd/airflow_test.go
@@ -1366,14 +1366,14 @@ func (s *AirflowSuite) TestAirflowPytest() {
 	s.Run("success", func() {
 		cmd := newAirflowPytestCmd()
 		cmd.Flag("args").Value.Set("args-string")
-		cmd.Flag("build-secrets").Value.Set("id=mysecret,src=secrets.txt")
+		cmd.Flag("build-secret").Value.Set("id=mysecret,src=secrets.txt")
 		cmd.Flag("image-name").Value.Set("custom-image")
 		args := []string{"test-pytest-file"}
 		pytestDir = ""
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "custom-image", "", "args-string", "id=mysecret,src=secrets.txt").Return("0", nil).Once()
+			mockContainerHandler.On("Pytest", "test-pytest-file", "custom-image", "", "args-string", []string{"id=mysecret,src=secrets.txt"}).Return("0", nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1389,7 +1389,7 @@ func (s *AirflowSuite) TestAirflowPytest() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", "").Return("exit code 1", errMock).Once()
+			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", mock.Anything).Return("exit code 1", errMock).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1405,7 +1405,7 @@ func (s *AirflowSuite) TestAirflowPytest() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", "").Return("0", nil).Once()
+			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", mock.Anything).Return("0", nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1421,7 +1421,7 @@ func (s *AirflowSuite) TestAirflowPytest() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", "").Return("0", errMock).Once()
+			mockContainerHandler.On("Pytest", "test-pytest-file", "", "", "", mock.Anything).Return("0", errMock).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1473,7 +1473,7 @@ func (s *AirflowSuite) TestAirflowParse() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Parse", "", "", "").Return(nil).Once()
+			mockContainerHandler.On("Parse", "", "", mock.Anything).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1488,7 +1488,7 @@ func (s *AirflowSuite) TestAirflowParse() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Parse", "", "", "").Return(errMock).Once()
+			mockContainerHandler.On("Parse", "", "", mock.Anything).Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1976,7 +1976,7 @@ func (s *AirflowSuite) TestAirflowBuild() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Build", "", "", false).Return(nil).Once()
+			mockContainerHandler.On("Build", "", mock.Anything, false).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -1992,7 +1992,7 @@ func (s *AirflowSuite) TestAirflowBuild() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Build", "", "", true).Return(nil).Once()
+			mockContainerHandler.On("Build", "", mock.Anything, true).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -2009,7 +2009,7 @@ func (s *AirflowSuite) TestAirflowBuild() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Build", "my-custom-image:latest", "", false).Return(nil).Once()
+			mockContainerHandler.On("Build", "my-custom-image:latest", mock.Anything, false).Return(nil).Once()
 			return mockContainerHandler, nil
 		}
 
@@ -2025,7 +2025,7 @@ func (s *AirflowSuite) TestAirflowBuild() {
 
 		mockContainerHandler := new(mocks.ContainerHandler)
 		containerHandlerInit = func(airflowHome, envFile, dockerfile, imageName string) (airflow.ContainerHandler, error) {
-			mockContainerHandler.On("Build", "", "", false).Return(errMock).Once()
+			mockContainerHandler.On("Build", "", mock.Anything, false).Return(errMock).Once()
 			return mockContainerHandler, nil
 		}
 

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -96,9 +96,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().DurationVar(&waitTime, "wait-time", deployWaitTime, "Wait time for the Deployment to become healthy before ending the command. Can only be used with --wait=true")
 	cmd.Flags().MarkHidden("dags-path") //nolint:errcheck
 	cmd.Flags().StringVarP(&deployDescription, "description", "", "", "Add a description for more context on this deploy")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
-	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
-	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
+	utils.AddBuildSecretFlags(cmd.Flags(), &buildSecrets)
 	cmd.Flags().Bool("force-upgrade-to-af3", false, "This flag is no longer required for Airflow 2 to Airflow 3 upgrades. Support will be removed in a future release.")
 	cmd.Flags().MarkDeprecated("force-upgrade-to-af3", "this flag is no longer required for Airflow 2 to Airflow 3 upgrades. Support will be removed in a future release.") //nolint:errcheck
 	cmd.Flags().BoolVar(&nonDags, nonDagsFlag, false, "Deploy a non-DAG bundle from a separate directory, instead of your Astro project. Requires --non-dags-mount-path")
@@ -224,7 +222,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		WaitTime:       waitTime,
 		DagsPath:       dagsPath,
 		Description:    deployDescription,
-		BuildSecrets:   util.ResolveBuildSecrets(buildSecrets),
+		BuildSecrets:   util.ResolveBuildSecrets(buildSecrets, os.Getenv("BUILD_SECRET_INPUT")),
 		Force:          forceDeploy,
 		DagBundleName:  dagBundleName,
 	}

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -96,7 +96,9 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().DurationVar(&waitTime, "wait-time", deployWaitTime, "Wait time for the Deployment to become healthy before ending the command. Can only be used with --wait=true")
 	cmd.Flags().MarkHidden("dags-path") //nolint:errcheck
 	cmd.Flags().StringVarP(&deployDescription, "description", "", "", "Add a description for more context on this deploy")
-	cmd.Flags().StringSliceVar(&buildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
+	cmd.Flags().StringArrayVar(&buildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
+	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
 	cmd.Flags().Bool("force-upgrade-to-af3", false, "This flag is no longer required for Airflow 2 to Airflow 3 upgrades. Support will be removed in a future release.")
 	cmd.Flags().MarkDeprecated("force-upgrade-to-af3", "this flag is no longer required for Airflow 2 to Airflow 3 upgrades. Support will be removed in a future release.") //nolint:errcheck
 	cmd.Flags().BoolVar(&nonDags, nonDagsFlag, false, "Deploy a non-DAG bundle from a separate directory, instead of your Astro project. Requires --non-dags-mount-path")
@@ -110,7 +112,7 @@ func NewDeployCmd() *cobra.Command {
 
 	annotateDeployFlag(cmd, "image", "image")
 	annotateDeployFlag(cmd, imageNameFlag, "image")
-	annotateDeployFlag(cmd, "build-secrets", "image")
+	annotateDeployFlag(cmd, "build-secret", "image")
 	annotateDeployFlag(cmd, "dags", "dag")
 	annotateDeployFlag(cmd, "no-dags-base-dir", "dag")
 	annotateDeployFlag(cmd, "dag-bundle-name", "dag")
@@ -172,7 +174,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flags().Changed(imageNameFlag) {
-		for _, f := range []string{"dags", "dags-path", "no-dags-base-dir", "pytest", "parse", "build-secrets", "dag-bundle-name"} {
+		for _, f := range []string{"dags", "dags-path", "no-dags-base-dir", "pytest", "parse", "build-secret", "build-secrets", "dag-bundle-name"} {
 			if cmd.Flags().Changed(f) {
 				return fmt.Errorf("cannot use --%s with --image-name; --image-name implies an image-only deploy", f)
 			}
@@ -206,34 +208,32 @@ func deploy(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	BuildSecretString := util.GetbuildSecretString(buildSecrets)
-
 	deployInput := cloud.InputDeploy{
-		Path:              config.WorkingPath,
-		RuntimeID:         deploymentID,
-		WsID:              workspaceID,
-		Pytest:            pytestFile,
-		EnvFile:           envFile,
-		ImageName:         imageName,
-		DeploymentName:    deploymentName,
-		Prompt:            forcePrompt,
-		Dags:              dags,
-		NoDagsBaseDir:     noDagsBaseDir,
-		Image:             image,
-		WaitForStatus:     waitForDeploy,
-		WaitTime:          waitTime,
-		DagsPath:          dagsPath,
-		Description:       deployDescription,
-		BuildSecretString: BuildSecretString,
-		Force:             forceDeploy,
-		DagBundleName:     dagBundleName,
+		Path:           config.WorkingPath,
+		RuntimeID:      deploymentID,
+		WsID:           workspaceID,
+		Pytest:         pytestFile,
+		EnvFile:        envFile,
+		ImageName:      imageName,
+		DeploymentName: deploymentName,
+		Prompt:         forcePrompt,
+		Dags:           dags,
+		NoDagsBaseDir:  noDagsBaseDir,
+		Image:          image,
+		WaitForStatus:  waitForDeploy,
+		WaitTime:       waitTime,
+		DagsPath:       dagsPath,
+		Description:    deployDescription,
+		BuildSecrets:   util.ResolveBuildSecrets(buildSecrets),
+		Force:          forceDeploy,
+		DagBundleName:  dagBundleName,
 	}
 
 	return DeployImage(deployInput, astroV1Client, astroV1Alpha1Client)
 }
 
 func deployNonDagsBundle(cmd *cobra.Command, args []string) error {
-	for _, f := range []string{"dags", "image", imageNameFlag, "dag-bundle-name", "pytest", "parse", "build-secrets", "dags-path", "no-dags-base-dir"} {
+	for _, f := range []string{"dags", "image", imageNameFlag, "dag-bundle-name", "pytest", "parse", "build-secret", "build-secrets", "dags-path", "no-dags-base-dir"} {
 		if cmd.Flags().Changed(f) {
 			return fmt.Errorf("cannot use --%s with --non-dags; --non-dags performs a non-DAG bundle deploy", f)
 		}

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -170,7 +170,8 @@ func TestDeployImageNameRejectsIncompatibleFlags(t *testing.T) {
 		{"no-dags-base-dir", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--no-dags-base-dir"}},
 		{"pytest", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--pytest"}},
 		{"parse", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--parse"}},
-		{"build-secrets", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--build-secrets", "id=mysecret,src=secrets.txt"}},
+		{"build-secret", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--build-secret", "id=mysecret,src=secrets.txt"}},
+		{"multiple build-secret", []string{"-f", "test-deployment-id", "--image-name", "img:1", "--build-secret", "id=mysecret,src=secrets.txt", "--build-secret", "id=aws,src=credentials"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/cloud/remote.go
+++ b/cmd/cloud/remote.go
@@ -65,7 +65,9 @@ func newRemoteDeployCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&remotePlatform, "platform", "", "Target platform for client image build (e.g., linux/amd64,linux/arm64). Defaults to host machine platform")
 	cmd.Flags().StringVarP(&remoteImageName, "image-name", "i", "", "Name of a custom image to deploy, or image name with custom tag. The image should be present on the local machine.")
-	cmd.Flags().StringArrayVar(&remoteBuildSecrets, "build-secrets", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt")
+	cmd.Flags().StringArrayVar(&remoteBuildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
+	cmd.Flags().StringArrayVar(&remoteBuildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
+	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
 	cmd.Flags().StringVar(&remoteDeploymentID, "deployment-id", "", "Deployment ID to validate client image runtime version against deployment runtime version")
 
 	return cmd
@@ -76,14 +78,12 @@ func remoteDeploy(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
 
-	buildSecretString := util.GetbuildSecretString(remoteBuildSecrets)
-
 	deployInput := cloud.InputClientDeploy{
-		Path:              config.WorkingPath,
-		ImageName:         remoteImageName,
-		Platform:          remotePlatform,
-		BuildSecretString: buildSecretString,
-		DeploymentID:      remoteDeploymentID,
+		Path:         config.WorkingPath,
+		ImageName:    remoteImageName,
+		Platform:     remotePlatform,
+		BuildSecrets: util.ResolveBuildSecrets(remoteBuildSecrets),
+		DeploymentID: remoteDeploymentID,
 	}
 
 	return cloud.DeployClientImage(deployInput, astroV1Client)

--- a/cmd/cloud/remote.go
+++ b/cmd/cloud/remote.go
@@ -1,6 +1,8 @@
 package cloud
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	cloud "github.com/astronomer/astro-cli/cloud/deploy"
@@ -65,9 +67,7 @@ func newRemoteDeployCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&remotePlatform, "platform", "", "Target platform for client image build (e.g., linux/amd64,linux/arm64). Defaults to host machine platform")
 	cmd.Flags().StringVarP(&remoteImageName, "image-name", "i", "", "Name of a custom image to deploy, or image name with custom tag. The image should be present on the local machine.")
-	cmd.Flags().StringArrayVar(&remoteBuildSecrets, "build-secret", []string{}, "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input id=mysecret,src=secrets.txt. Can be used multiple times to expose multiple secrets")
-	cmd.Flags().StringArrayVar(&remoteBuildSecrets, "build-secrets", []string{}, "Deprecated: use --build-secret instead")
-	cmd.Flags().MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
+	utils.AddBuildSecretFlags(cmd.Flags(), &remoteBuildSecrets)
 	cmd.Flags().StringVar(&remoteDeploymentID, "deployment-id", "", "Deployment ID to validate client image runtime version against deployment runtime version")
 
 	return cmd
@@ -82,7 +82,7 @@ func remoteDeploy(cmd *cobra.Command, args []string) error {
 		Path:         config.WorkingPath,
 		ImageName:    remoteImageName,
 		Platform:     remotePlatform,
-		BuildSecrets: util.ResolveBuildSecrets(remoteBuildSecrets),
+		BuildSecrets: util.ResolveBuildSecrets(remoteBuildSecrets, os.Getenv("BUILD_SECRET_INPUT")),
 		DeploymentID: remoteDeploymentID,
 	}
 

--- a/cmd/cloud/remote_test.go
+++ b/cmd/cloud/remote_test.go
@@ -98,31 +98,43 @@ func TestRemoteDeployCommandFlags(t *testing.T) {
 		assert.Equal(t, "short-flag-image:tag", imageNameValue)
 	})
 
-	t.Run("command accepts build-secrets flag", func(t *testing.T) {
+	t.Run("command accepts build-secret flag", func(t *testing.T) {
 		cmd := newRemoteDeployCmd()
 
-		err := cmd.ParseFlags([]string{"--build-secrets", "id=mysecret,src=secrets.txt"})
+		err := cmd.ParseFlags([]string{"--build-secret", "id=mysecret,src=secrets.txt"})
 		assert.NoError(t, err)
 
-		buildSecretsValue, err := cmd.Flags().GetStringArray("build-secrets")
+		buildSecretsValue, err := cmd.Flags().GetStringArray("build-secret")
 		assert.NoError(t, err)
 		// StringArrayVar preserves the full secret string without comma splitting
 		assert.Equal(t, []string{"id=mysecret,src=secrets.txt"}, buildSecretsValue)
 	})
 
-	t.Run("command accepts multiple build-secrets properly", func(t *testing.T) {
+	t.Run("command accepts multiple build-secret flags properly", func(t *testing.T) {
 		cmd := newRemoteDeployCmd()
 
 		// Proper way to pass multiple secrets (each as a separate flag)
 		err := cmd.ParseFlags([]string{
-			"--build-secrets", "id=secret1,src=file1.txt",
-			"--build-secrets", "id=secret2,src=file2.txt",
+			"--build-secret", "id=secret1,src=file1.txt",
+			"--build-secret", "id=secret2,src=file2.txt",
 		})
 		assert.NoError(t, err)
 
-		buildSecretsValue, err := cmd.Flags().GetStringArray("build-secrets")
+		buildSecretsValue, err := cmd.Flags().GetStringArray("build-secret")
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"id=secret1,src=file1.txt", "id=secret2,src=file2.txt"}, buildSecretsValue)
+	})
+
+	t.Run("command accepts deprecated build-secrets flag", func(t *testing.T) {
+		cmd := newRemoteDeployCmd()
+
+		err := cmd.ParseFlags([]string{"--build-secrets", "id=mysecret,src=secrets.txt"})
+		assert.NoError(t, err)
+
+		// The deprecated alias is bound to the same variable as --build-secret
+		buildSecretsValue, err := cmd.Flags().GetStringArray("build-secret")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"id=mysecret,src=secrets.txt"}, buildSecretsValue)
 	})
 
 	t.Run("command accepts deployment-id flag", func(t *testing.T) {
@@ -178,12 +190,19 @@ func TestRemoteDeployFlags(t *testing.T) {
 		assert.Equal(t, "i", imageNameFlag.Shorthand)
 	})
 
-	t.Run("build-secrets flag configuration", func(t *testing.T) {
+	t.Run("build-secret flag configuration", func(t *testing.T) {
+		buildSecretFlag := cmd.Flags().Lookup("build-secret")
+		assert.NotNil(t, buildSecretFlag)
+		assert.Equal(t, "stringArray", buildSecretFlag.Value.Type())
+		assert.Equal(t, "[]", buildSecretFlag.DefValue)
+		assert.Contains(t, buildSecretFlag.Usage, "docker build --secret")
+	})
+
+	t.Run("deprecated build-secrets flag configuration", func(t *testing.T) {
 		buildSecretsFlag := cmd.Flags().Lookup("build-secrets")
 		assert.NotNil(t, buildSecretsFlag)
 		assert.Equal(t, "stringArray", buildSecretsFlag.Value.Type())
-		assert.Equal(t, "[]", buildSecretsFlag.DefValue)
-		assert.Contains(t, buildSecretsFlag.Usage, "docker build --secret")
+		assert.Equal(t, "use --build-secret instead", buildSecretsFlag.Deprecated)
 	})
 
 	t.Run("deployment-id flag configuration", func(t *testing.T) {
@@ -236,7 +255,7 @@ func TestRemoteDeployDeploymentValidation(t *testing.T) {
 			"--deployment-id", "full-test-deployment",
 			"--platform", "linux/amd64,linux/arm64",
 			"--image-name", "test-image:v1.0",
-			"--build-secrets", "id=secret1,src=file1.txt",
+			"--build-secret", "id=secret1,src=file1.txt",
 		})
 		assert.NoError(t, err)
 

--- a/cmd/cloud/remote_test.go
+++ b/cmd/cloud/remote_test.go
@@ -137,6 +137,20 @@ func TestRemoteDeployCommandFlags(t *testing.T) {
 		assert.Equal(t, []string{"id=mysecret,src=secrets.txt"}, buildSecretsValue)
 	})
 
+	t.Run("command merges mixed build-secret and build-secrets flags", func(t *testing.T) {
+		cmd := newRemoteDeployCmd()
+
+		err := cmd.ParseFlags([]string{
+			"--build-secret", "id=secret1,src=file1.txt",
+			"--build-secrets", "id=secret2,src=file2.txt",
+		})
+		assert.NoError(t, err)
+
+		buildSecretsValue, err := cmd.Flags().GetStringArray("build-secret")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"id=secret1,src=file1.txt", "id=secret2,src=file2.txt"}, buildSecretsValue)
+	})
+
 	t.Run("command accepts deployment-id flag", func(t *testing.T) {
 		cmd := newRemoteDeployCmd()
 
@@ -195,7 +209,7 @@ func TestRemoteDeployFlags(t *testing.T) {
 		assert.NotNil(t, buildSecretFlag)
 		assert.Equal(t, "stringArray", buildSecretFlag.Value.Type())
 		assert.Equal(t, "[]", buildSecretFlag.DefValue)
-		assert.Contains(t, buildSecretFlag.Usage, "docker build --secret")
+		assert.Contains(t, buildSecretFlag.Usage, "Secret to expose to the build")
 	})
 
 	t.Run("deprecated build-secrets flag configuration", func(t *testing.T) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// AddBuildSecretFlags registers --build-secret together and its deprecated
+// alias --build-secrets. Both register args to the same target slice.
+func AddBuildSecretFlags(flags *pflag.FlagSet, target *[]string) {
+	flags.StringArrayVar(target, "build-secret", []string{}, "Secret to expose to the build. See https://docs.docker.com/build/building/secrets/. Repeat to specify multiple secrets. (format: \"id=mysecret[,src=/local/secret]\")")
+	flags.Var(flags.Lookup("build-secret").Value, "build-secrets", "Deprecated: use --build-secret instead")
+	flags.MarkDeprecated("build-secrets", "use --build-secret instead") //nolint:errcheck
+}

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddBuildSecretFlags(t *testing.T) {
+	newFlagSet := func() (*pflag.FlagSet, *[]string) {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		target := []string{}
+		AddBuildSecretFlags(flags, &target)
+		return flags, &target
+	}
+
+	t.Run("collects repeated --build-secret values", func(t *testing.T) {
+		flags, target := newFlagSet()
+		err := flags.Parse([]string{"--build-secret", "id=one,src=one.txt", "--build-secret", "id=two,src=two.txt"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"id=one,src=one.txt", "id=two,src=two.txt"}, *target)
+	})
+
+	t.Run("deprecated --build-secrets feeds the same value", func(t *testing.T) {
+		flags, target := newFlagSet()
+		err := flags.Parse([]string{"--build-secrets", "id=one,src=one.txt"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"id=one,src=one.txt"}, *target)
+	})
+
+	t.Run("mixing both flags merges values in command-line order", func(t *testing.T) {
+		flags, target := newFlagSet()
+		err := flags.Parse([]string{
+			"--build-secret", "id=one,src=one.txt",
+			"--build-secrets", "id=two,src=two.txt",
+			"--build-secret", "id=three,src=three.txt",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"id=one,src=one.txt", "id=two,src=two.txt", "id=three,src=three.txt"}, *target)
+	})
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -103,22 +103,30 @@ func ParseAPIToken(astroAPIToken string) (*CustomClaims, error) {
 	return claims, nil
 }
 
-// ResolveBuildSecrets returns the Docker build secrets to use, preferring
-// secrets given on the command line over the configured fallbacks. Each
-// element is one complete `docker build --secret` specification.
+// ResolveBuildSecrets returns the Docker build secrets to use: the secrets
+// given on the command line if there are any, otherwise the first fallback
+// that provides any. Each element is one complete `docker build --secret`
+// specification; fallbacks may be newline-delimited to provide multiple
+// secrets.
 func ResolveBuildSecrets(flagSecrets []string, fallbacks ...string) []string {
 	if len(flagSecrets) > 0 {
 		return flagSecrets
 	}
 	for _, fb := range fallbacks {
-		if fb != "" {
-			return []string{fb}
+		if secrets := splitBuildSecretLines(fb); len(secrets) > 0 {
+			return secrets
 		}
 	}
-	if env := os.Getenv("BUILD_SECRET_INPUT"); env != "" {
-		return []string{env}
-	}
 	return nil
+}
+
+func splitBuildSecretLines(value string) (secrets []string) {
+	for _, line := range strings.Split(value, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			secrets = append(secrets, line)
+		}
+	}
+	return secrets
 }
 
 func StripOutKeysFromJSONByteArray(jsonData []byte, keys []string) ([]byte, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -103,27 +103,22 @@ func ParseAPIToken(astroAPIToken string) (*CustomClaims, error) {
 	return claims, nil
 }
 
-func GetbuildSecretString(buildSecret []string, fallbacks ...string) (buildSecretString string) {
-	for i, secret := range buildSecret {
-		if i == 0 {
-			buildSecretString = secret
-		} else {
-			buildSecretString = buildSecretString + "," + secret
+// ResolveBuildSecrets returns the Docker build secrets to use, preferring
+// secrets given on the command line over the configured fallbacks. Each
+// element is one complete `docker build --secret` specification.
+func ResolveBuildSecrets(flagSecrets []string, fallbacks ...string) []string {
+	if len(flagSecrets) > 0 {
+		return flagSecrets
+	}
+	for _, fb := range fallbacks {
+		if fb != "" {
+			return []string{fb}
 		}
 	}
-	if buildSecretString == "" {
-		for _, fb := range fallbacks {
-			if fb != "" {
-				buildSecretString = fb
-				break
-			}
-		}
+	if env := os.Getenv("BUILD_SECRET_INPUT"); env != "" {
+		return []string{env}
 	}
-	if os.Getenv("BUILD_SECRET_INPUT") != "" && buildSecretString == "" {
-		buildSecretString = os.Getenv("BUILD_SECRET_INPUT")
-	}
-
-	return buildSecretString
+	return nil
 }
 
 func StripOutKeysFromJSONByteArray(jsonData []byte, keys []string) ([]byte, error) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -228,25 +228,25 @@ func (s *Suite) TestParseAPIToken() {
 	})
 }
 
-func (s *Suite) TestGetbuildSecretString() {
-	s.Run("returns empty string if buildSecret is empty", func() {
-		s.Equal("", GetbuildSecretString([]string{}))
+func (s *Suite) TestResolveBuildSecrets() {
+	s.Run("returns nil if no secrets are given", func() {
+		s.Nil(ResolveBuildSecrets([]string{}))
 	})
 
-	s.Run("returns the only secret if buildSecret has only one element", func() {
-		s.Equal("secret1", GetbuildSecretString([]string{"secret1"}))
+	s.Run("returns flag values as-is", func() {
+		s.Equal([]string{"secret1"}, ResolveBuildSecrets([]string{"secret1"}))
+		s.Equal(
+			[]string{"secret1", "secret2", "secret3"},
+			ResolveBuildSecrets([]string{"secret1", "secret2", "secret3"}),
+		)
 	})
 
-	s.Run("returns comma-separated string for multiple secrets in buildSecret", func() {
-		s.Equal("secret1,secret2,secret3", GetbuildSecretString([]string{"secret1", "secret2", "secret3"}))
-	})
-
-	s.Run("uses fallback when buildSecret is empty and fallback is provided", func() {
-		s.Equal("fallback-secret", GetbuildSecretString([]string{}, "fallback-secret"))
+	s.Run("uses fallback when flag is empty", func() {
+		s.Equal([]string{"fallback-secret"}, ResolveBuildSecrets([]string{}, "fallback-secret"))
 	})
 
 	s.Run("flag takes priority over fallback", func() {
-		s.Equal("flag-secret", GetbuildSecretString([]string{"flag-secret"}, "fallback-secret"))
+		s.Equal([]string{"flag-secret"}, ResolveBuildSecrets([]string{"flag-secret"}, "fallback-secret"))
 	})
 
 	s.Run("fallback takes priority over BUILD_SECRET_INPUT", func() {
@@ -254,25 +254,16 @@ func (s *Suite) TestGetbuildSecretString() {
 		defer os.Setenv("BUILD_SECRET_INPUT", originalBuildSecretInput)
 		os.Setenv("BUILD_SECRET_INPUT", "env-secret")
 
-		s.Equal("fallback-secret", GetbuildSecretString([]string{}, "fallback-secret"))
+		s.Equal([]string{"fallback-secret"}, ResolveBuildSecrets([]string{}, "fallback-secret"))
 	})
 
-	s.Run("overrides buildSecretString with BUILD_SECRET_INPUT if set", func() {
-		// Save the original value of BUILD_SECRET_INPUT
+	s.Run("uses BUILD_SECRET_INPUT when flag and fallbacks are empty", func() {
 		originalBuildSecretInput := os.Getenv("BUILD_SECRET_INPUT")
-		defer func() {
-			// Reset BUILD_SECRET_INPUT to its original value after the test
-			os.Setenv("BUILD_SECRET_INPUT", originalBuildSecretInput)
-		}()
+		defer os.Setenv("BUILD_SECRET_INPUT", originalBuildSecretInput)
+		os.Setenv("BUILD_SECRET_INPUT", "env-secret")
 
-		// Set BUILD_SECRET_INPUT to a different value
-		os.Setenv("BUILD_SECRET_INPUT", "override_secret")
-
-		// Test with a non-empty buildSecret
-		s.Equal("secret1,secret2", GetbuildSecretString([]string{"secret1", "secret2"}))
-
-		// Test with an empty buildSecret
-		s.Equal("override_secret", GetbuildSecretString([]string{}))
+		s.Equal([]string{"flag-secret"}, ResolveBuildSecrets([]string{"flag-secret"}))
+		s.Equal([]string{"env-secret"}, ResolveBuildSecrets([]string{}))
 	})
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -230,14 +229,14 @@ func (s *Suite) TestParseAPIToken() {
 
 func (s *Suite) TestResolveBuildSecrets() {
 	s.Run("returns nil if no secrets are given", func() {
-		s.Nil(ResolveBuildSecrets([]string{}))
+		s.Nil(ResolveBuildSecrets([]string{}, ""))
 	})
 
 	s.Run("returns flag values as-is", func() {
-		s.Equal([]string{"secret1"}, ResolveBuildSecrets([]string{"secret1"}))
+		s.Equal([]string{"secret1"}, ResolveBuildSecrets([]string{"secret1"}, ""))
 		s.Equal(
 			[]string{"secret1", "secret2", "secret3"},
-			ResolveBuildSecrets([]string{"secret1", "secret2", "secret3"}),
+			ResolveBuildSecrets([]string{"secret1", "secret2", "secret3"}, ""),
 		)
 	})
 
@@ -249,21 +248,30 @@ func (s *Suite) TestResolveBuildSecrets() {
 		s.Equal([]string{"flag-secret"}, ResolveBuildSecrets([]string{"flag-secret"}, "fallback-secret"))
 	})
 
-	s.Run("fallback takes priority over BUILD_SECRET_INPUT", func() {
-		originalBuildSecretInput := os.Getenv("BUILD_SECRET_INPUT")
-		defer os.Setenv("BUILD_SECRET_INPUT", originalBuildSecretInput)
-		os.Setenv("BUILD_SECRET_INPUT", "env-secret")
-
-		s.Equal([]string{"fallback-secret"}, ResolveBuildSecrets([]string{}, "fallback-secret"))
+	s.Run("earlier fallback takes priority over later ones", func() {
+		s.Equal([]string{"first"}, ResolveBuildSecrets([]string{}, "first", "second"))
 	})
 
-	s.Run("uses BUILD_SECRET_INPUT when flag and fallbacks are empty", func() {
-		originalBuildSecretInput := os.Getenv("BUILD_SECRET_INPUT")
-		defer os.Setenv("BUILD_SECRET_INPUT", originalBuildSecretInput)
-		os.Setenv("BUILD_SECRET_INPUT", "env-secret")
+	s.Run("uses later fallback when earlier ones are empty", func() {
+		s.Equal([]string{"second"}, ResolveBuildSecrets([]string{}, "", "second"))
+	})
 
-		s.Equal([]string{"flag-secret"}, ResolveBuildSecrets([]string{"flag-secret"}))
-		s.Equal([]string{"env-secret"}, ResolveBuildSecrets([]string{}))
+	s.Run("splits newline-delimited fallbacks", func() {
+		s.Equal(
+			[]string{"id=aws,src=credentials", "id=PLATFORM_PASSWORD,env=PLATFORM_PASSWORD"},
+			ResolveBuildSecrets([]string{}, "id=aws,src=credentials\nid=PLATFORM_PASSWORD,env=PLATFORM_PASSWORD"),
+		)
+	})
+
+	s.Run("drops blank lines and surrounding whitespace", func() {
+		s.Equal(
+			[]string{"id=one,src=one.txt", "id=two,env=TWO"},
+			ResolveBuildSecrets([]string{}, "\n  id=one,src=one.txt\r\n\nid=two,env=TWO\n"),
+		)
+	})
+
+	s.Run("whitespace-only fallback is skipped in favor of later ones", func() {
+		s.Equal([]string{"second"}, ResolveBuildSecrets([]string{}, " \n ", "second"))
 	})
 }
 

--- a/software/deploy/deploy.go
+++ b/software/deploy/deploy.go
@@ -325,7 +325,7 @@ func buildDockerImageFromWorkingDir(path string, imageHandler airflow.ImageHandl
 		Labels:          deployLabels,
 	}
 
-	err = imageHandler.Build("", "", buildConfig)
+	err = imageHandler.Build("", nil, buildConfig)
 	return err
 }
 


### PR DESCRIPTION
## Description

Allow specifying multiple build secrets, using the CLI (`--build-secret`), dev config, or the `BUILD_SECRET_INPUT` env var.

The existing `--build-secrets` flag, despite its name, didn't actually allow passing multiple build secrets to Docker. It was parsed with `StringSliceVar`, meaning that literal build secret strings such as `id=aws,env=AWS_SECRET_ACCESS_KEY` would be split into two strings (`id=aws`, `env=AWS_SECRET_ACCESS_KEY`) and then rejoined into a single string that was ultimately passed as one `docker build --secret` argument.

Docker parses that as a single secret spec in which later fields override earlier ones, so providing more than one secret silently mounted only the last one.

As it was presumably originally intended that you could provide multiple secrets, this commit makes the following changes:

- Mark `--build-secrets` as deprecated. It can still be provided but will warn on use.
- Add `--build-secret`, which allows specifying a single secret, e.g. `id=aws,env=AWS_SECRET_ACCESS_KEY`, but can be provided multiple times.
- Pass all provided `--build-secret` values through to Docker.
- Dev config overrides as well as the `BUILD_SECRET_INPUT` env var can now contain newline-delimited strings to carry multiple build secrets. This is backwards compatible: a newline can't occur inside a valid secret specification, and a multiline value previously produced a single `--secret` argument that docker rejected, so no working configuration changes meaning.

Note: Comma-delimiting multiple secrets inside a single flag value (e.g. `id=a,src=x,id=b,env=Y`) is intentionally not supported: the comma already separates fields within one docker secret spec, so it cannot unambiguously separate specs too.

## 🎟 Issue(s)

Fixes #1720.

## 🧪 Functional Testing

- [x] Run `astro dev build` locally with multiple `--build-secret` args and verify all are passed to Docker.

## 📸 Screenshots

<img width="1158" height="212" alt="image" src="https://github.com/user-attachments/assets/86a69985-71ff-4cc8-947b-0baee9baa250" />

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- ~[ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary)~.
- ~[ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary)~.
- [x] ~Communicated to/tagged owners of respective clients potentially impacted by these changes.~ (N/A: backwards-compatible change.)
- [x] Updated any related [documentation](https://github.com/astronomer/docs/): https://github.com/astronomer/docs/pull/7000 (to merge after this is released)
