### PR TITLE
Parse pytest container exit codes as integers

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -698,7 +698,7 @@ func (d *DockerCompose) Pytest(pytestFile, customImageName, deployImageName, pyt
 	if err != nil {
 		return exitCode, err
 	}
-	if strings.Contains(exitCode, "0") { // if the error code is 0 the pytests passed
+	if code, convErr := strconv.Atoi(exitCode); convErr == nil && code == 0 { // exit code 0 means the pytests passed
 		return "", nil
 	}
 	return exitCode, errors.New("something went wrong while Pytesting your DAGs")
@@ -912,7 +912,7 @@ func (d *DockerCompose) dagTest(testHomeDirectory, newVersion, newDockerFile, cu
 	fmt.Println("\nRunning DAG parse test with the new Airflow version")
 	exitCode, err := d.imageHandler.Pytest(pytestFile, d.airflowHome, d.envFile, testHomeDirectory, strings.Fields(htmlReportArgs), true, airflowTypes.ImageBuildConfig{Path: d.airflowHome})
 	if err != nil {
-		if strings.Contains(exitCode, "1") { // exit code is 1 meaning tests failed
+		if code, convErr := strconv.Atoi(exitCode); convErr == nil && code == 1 { // exit code 1 means tests failed
 			fmt.Println("See above for errors detected in your DAGs")
 			return false, nil
 		} else {
@@ -1333,7 +1333,7 @@ func (d *DockerCompose) Parse(customImageName, deployImageName, buildSecretStrin
 	pytestFile := DefaultTestPath
 	exitCode, err := d.Pytest(pytestFile, customImageName, deployImageName, "", buildSecretString)
 	if err != nil {
-		if strings.Contains(exitCode, "1") { // exit code is 1 meaning tests failed
+		if code, convErr := strconv.Atoi(exitCode); convErr == nil && code == 1 { // exit code 1 means tests failed
 			return errors.New("See above for errors detected in your DAGs")
 		}
 		return errors.Wrap(err, "something went wrong while parsing your DAGs")

--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -238,7 +238,7 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 	args = []string{
 		"inspect",
 		"astro-pytest",
-		"--format='{{.State.ExitCode}}'",
+		"--format={{.State.ExitCode}}",
 	}
 	var outb bytes.Buffer
 	inspectErr := cmdExec(containerRuntime, &outb, stderr, args...)
@@ -260,7 +260,8 @@ func (d *DockerImage) Pytest(pytestFile, airflowHome, envFile, testHomeDirectory
 		logger.Debugf("Error removing the astro-pytest container: %s", rmErr.Error())
 	}
 
-	return outb.String(), err
+	// trim the trailing newline so consumers get a clean integer string to parse
+	return strings.TrimSpace(outb.String()), err
 }
 
 func (d *DockerImage) CreatePipFreeze(altImageName, pipFreezeFile string) error {

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -186,6 +186,23 @@ func (s *Suite) TestDockerImagePytest() {
 		s.Equal(out, "exit code 1")
 	})
 
+	s.Run("exit code trimmed to clean integer", func() {
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			switch {
+			case args[0] == "start":
+				return errMock
+			case args[0] == "inspect":
+				stdout.Write([]byte("10\n")) // docker inspect prints the code with a trailing newline
+				return nil
+			default:
+				return nil
+			}
+		}
+		out, err := handler.Pytest("", "", "", "", []string{}, true, options)
+		s.Error(err)
+		s.Equal("10", out)
+	})
+
 	s.Run("copy error", func() {
 		// Create a directory so the docker cp loop has something to copy
 		dagsDir := cwd + "/dags"

--- a/airflow/docker_test.go
+++ b/airflow/docker_test.go
@@ -1204,6 +1204,33 @@ func (s *Suite) TestDockerComposePytest() {
 		imageHandler.AssertExpectations(s.T())
 	})
 
+	s.Run("internal error exit code 10 reported as failure", func() {
+		// exit code 10 substring-contains "0"; the old check reported it as a pass
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("10", nil).Once()
+
+		mockDockerCompose.imageHandler = imageHandler
+
+		resp, err := mockDockerCompose.Pytest("", "", "", "", "")
+		s.Contains(err.Error(), "something went wrong while Pytesting your DAGs")
+		s.Equal("10", resp)
+		imageHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("interrupt exit code 130 reported as failure", func() {
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(nil).Once()
+		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("130", nil).Once()
+
+		mockDockerCompose.imageHandler = imageHandler
+
+		resp, err := mockDockerCompose.Pytest("", "", "", "", "")
+		s.Contains(err.Error(), "something went wrong while Pytesting your DAGs")
+		s.Equal("130", resp)
+		imageHandler.AssertExpectations(s.T())
+	})
+
 	s.Run("image build failure", func() {
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("Build", "", "", airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return(errMockDocker).Once()
@@ -1585,6 +1612,40 @@ func (s *Suite) TestDockerComposeParse() {
 
 		imageHandler := new(mocks.ImageHandler)
 		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("2", nil).Once()
+
+		composeMock := new(mocks.DockerComposeAPI)
+		mockDockerCompose.composeService = composeMock
+		mockDockerCompose.imageHandler = imageHandler
+
+		err := mockDockerCompose.Parse("", "test", "")
+		s.Contains(err.Error(), "something went wrong while parsing your DAGs")
+		composeMock.AssertExpectations(s.T())
+		imageHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("internal error exit code 10", func() {
+		// exit code 10 substring-contains "1"; the old check reported it as a clean DAG error
+		DefaultTestPath = "test_dag_integrity_file.py"
+
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("10", nil).Once()
+
+		composeMock := new(mocks.DockerComposeAPI)
+		mockDockerCompose.composeService = composeMock
+		mockDockerCompose.imageHandler = imageHandler
+
+		err := mockDockerCompose.Parse("", "test", "")
+		s.Contains(err.Error(), "something went wrong while parsing your DAGs")
+		composeMock.AssertExpectations(s.T())
+		imageHandler.AssertExpectations(s.T())
+	})
+
+	s.Run("interrupt exit code 130", func() {
+		// exit code 130 (Ctrl-C) substring-contains "1"; the old check reported it as a clean DAG error
+		DefaultTestPath = "test_dag_integrity_file.py"
+
+		imageHandler := new(mocks.ImageHandler)
+		imageHandler.On("Pytest", mock.Anything, mock.Anything, mock.Anything, mock.Anything, []string{}, mock.Anything, airflowTypes.ImageBuildConfig{Path: mockDockerCompose.airflowHome, NoCache: false}).Return("130", nil).Once()
 
 		composeMock := new(mocks.DockerComposeAPI)
 		mockDockerCompose.composeService = composeMock

--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -1238,7 +1239,7 @@ func (s *Standalone) Parse(_, _, _ string) error {
 
 	exitCode, err := s.Pytest(DefaultTestPath, "", "", "", "")
 	if err != nil {
-		if strings.Contains(exitCode, "1") {
+		if code, convErr := strconv.Atoi(exitCode); convErr == nil && code == 1 { // exit code 1 means tests failed
 			return errors.New("See above for errors detected in your DAGs")
 		}
 		return errors.Wrap(err, "something went wrong while parsing your DAGs")

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -1983,6 +1983,36 @@ func (s *Suite) TestStandaloneParse_DagErrors() {
 	s.Contains(err.Error(), "errors detected in your DAGs")
 }
 
+func (s *Suite) TestStandaloneParse_Interrupted() {
+	// exit code 130 (Ctrl-C) substring-contains "1"; the old check reported it as a clean DAG error
+	tmpDir, err := os.MkdirTemp("", "standalone-parse")
+	s.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	err = os.MkdirAll(filepath.Join(tmpDir, ".astro"), 0o755)
+	s.NoError(err)
+	err = os.WriteFile(filepath.Join(tmpDir, DefaultTestPath), []byte("test"), 0o644)
+	s.NoError(err)
+
+	err = os.MkdirAll(filepath.Join(tmpDir, ".venv", "bin"), 0o755)
+	s.NoError(err)
+
+	origExec := standaloneExec
+	defer func() { standaloneExec = origExec }()
+
+	standaloneExec = func(dir string, env, args []string, _ io.Reader, _, _ io.Writer) error {
+		cmd := exec.Command("sh", "-c", "exit 130") //nolint:gosec
+		return cmd.Run()
+	}
+
+	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
+	s.NoError(err)
+
+	err = handler.Parse("", "", "")
+	s.Error(err)
+	s.Contains(err.Error(), "something went wrong while parsing your DAGs")
+}
+
 // --- resolveInEnvPath tests ---
 
 func TestResolveInEnvPath(t *testing.T) {


### PR DESCRIPTION
## Description

`astro dev pytest` and `astro dev parse` compared container exit codes with `strings.Contains`, so exit 10 (a pytest internal error) contained "0" and was reported as a pass, and exit 130 (Ctrl-C) contained "1" and was reported as a test failure. Anyone gating CI on these commands got a wrong signal, and the failure direction made broken runs look green.

The exit code also arrived as a quoted string (`'10'`) because the inspect format argument kept its shell quotes.

What changed:
- The producer drops the quotes (`--format={{.State.ExitCode}}`) and trims the trailing newline, so the value is a clean integer string.
- The four consumers (`DockerCompose.Pytest`, `dagTest`, `DockerCompose.Parse`, `Standalone.Parse`) parse with `strconv.Atoi` and compare integers: 0 passes, 1 is a test failure, anything else is a real error.

Behavior note: on the parse paths, exit 10 used to be misreported as clean "errors detected in your DAGs"; it now falls through to the generic failure message, since only exit 1 is a pytest test-failure code.

## Testing

New subtests cover exit 0, 1, 10, and 130 across the compose and standalone paths, plus the newline trimming. `go test ./airflow/...`, `go vet ./airflow/...`, and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6DEdUpFBFaAiPKEu81Wti