### PR TITLE
Don't clobber a successful re-login after a failed token refresh

### DIFF
--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -158,6 +158,9 @@ func checkToken(astroV1Client astrov1.APIClient, out io.Writer) error {
 			if err != nil {
 				return err
 			}
+			// authLogin already persisted the new context, so don't fall through
+			// and overwrite it with the failed refresh's zero-value token
+			return nil
 		}
 		// persist the updated context with the renewed access token
 		err = c.SetContextKey("token", "Bearer "+res.AccessToken)

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -423,6 +423,30 @@ func TestCheckToken(t *testing.T) {
 		err = checkToken(mockV1Client, nil)
 		assert.Contains(t, err.Error(), "failed to login")
 	})
+	t.Run("does not overwrite the token when refresh fails but relogin succeeds", func(t *testing.T) {
+		mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
+		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+			return nil
+		}
+
+		// the test config has no refresh token and an expired (zero-value) ExpiresIn,
+		// so checkToken will call refresh, which fails against the real auth endpoint
+		// with an empty refresh token, then falls back to authLogin above.
+		ctx, err := context.GetCurrentContext()
+		assert.NoError(t, err)
+		err = ctx.SetContextKey("token", "Bearer relogin-token")
+		assert.NoError(t, err)
+
+		// run checkToken
+		err = checkToken(mockV1Client, nil)
+		assert.NoError(t, err)
+
+		// the token set by the (mocked) successful relogin must survive: it should
+		// not be clobbered by the failed refresh's zero-value response
+		ctx, err = context.GetCurrentContext()
+		assert.NoError(t, err)
+		assert.Equal(t, "Bearer relogin-token", ctx.Token)
+	})
 }
 
 func TestCheckAPIToken(t *testing.T) {


### PR DESCRIPTION
## Description

In `checkToken`, when the access token is expired and the refresh fails, the code walks the user through an interactive login — then falls through and overwrites the token that login just saved with the failed refresh's zero value, persisting the literal string `"Bearer "` and an expiry of 0. The user does everything right and still lands logged out. This runs on the pre-run auth path before every cloud command.

What changed: return right after a successful `authLogin` inside the error branch, since `authLogin` already persisted its own context. The fall-through token write now only happens when the refresh succeeded.

## Testing

New subtest in `TestCheckToken` pre-sets a token, drives the refresh-fails/relogin-succeeds path, and asserts the token survives `checkToken`. It fails against the old code. `go test ./cmd/...` and `go vet ./cmd/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6DEdUpFBFaAiPKEu81Wti