### PR TITLE
Return errors instead of nil when deploy config save or executor validation fails

### DIFF
--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -187,7 +187,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 	if deploymentID != "" && saveDeployConfig {
 		err := config.CFG.ProjectDeployment.SetProjectString(deploymentID)
 		if err != nil {
-			return nil
+			return errors.Wrap(err, "failed to save deployment id in config")
 		}
 	}
 

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -5,8 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/astronomer/astro-cli/astro-client-v1"
@@ -71,6 +73,37 @@ func TestDeployImage(t *testing.T) {
 
 	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--parse", "--pytest")
 	assert.NoError(t, err)
+}
+
+func TestDeployReturnsErrorWhenSaveConfigFails(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	EnsureProjectDir = func(cmd *cobra.Command, args []string) error {
+		return nil
+	}
+
+	DeployImage = func(deployInput cloud.InputDeploy, astroV1Client astrov1.APIClient, astroV1Alpha1Client astrov1alpha1.APIClient) error {
+		return nil
+	}
+
+	// Point the project config at a real directory, but make the config file itself
+	// a directory instead of a file, so the write that saves the deployment ID fails.
+	// This confirms that a save failure stops the deploy instead of returning nil.
+	tmpDir := t.TempDir()
+	astroDir := filepath.Join(tmpDir, config.ConfigDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(astroDir, config.ConfigFileNameWithExt), 0o755))
+
+	origWorkingPath := config.WorkingPath
+	config.WorkingPath = tmpDir
+	config.InitConfig(afero.NewOsFs())
+	defer func() {
+		config.WorkingPath = origWorkingPath
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+	}()
+
+	err := execDeployCmd("test-deployment-id", "--save")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save deployment id in config")
 }
 
 func TestDeploySkipsEnsureProjectDirWhenImageNameSet(t *testing.T) {

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -86,6 +86,24 @@ func TestDeployReturnsErrorWhenSaveConfigFails(t *testing.T) {
 		return nil
 	}
 
+	// config.InitConfig reads and writes real files on disk (via afero.NewOsFs()),
+	// including the home config that stores the current context. Point ASTRO_HOME at
+	// a throwaway directory with its own valid context, so the test does not depend on
+	// (or clobber) whatever real ~/.astro/config.yaml happens to exist on the machine
+	// running the test - on a fresh CI runner there is no such file, so without this
+	// the deploy fails earlier with "no context set" instead of exercising the save path.
+	//
+	// ASTRO_HOME is restored (and config's cached home-config path resynced) before
+	// testUtil.InitTestConfig runs in the deferred cleanup below, otherwise the fake
+	// config it writes for later tests lands at the wrong path and leaves them with no
+	// context set either.
+	origAstroHome, hadAstroHome := os.LookupEnv("ASTRO_HOME")
+	homeDir := t.TempDir()
+	require.NoError(t, os.Setenv("ASTRO_HOME", homeDir))
+	homeAstroDir := filepath.Join(homeDir, config.ConfigDir)
+	require.NoError(t, os.MkdirAll(homeAstroDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(homeAstroDir, config.ConfigFileNameWithExt), testUtil.NewTestConfig(testUtil.LocalPlatform), 0o600))
+
 	// Point the project config at a real directory, but make the config file itself
 	// a directory instead of a file, so the write that saves the deployment ID fails.
 	// This confirms that a save failure stops the deploy instead of returning nil.
@@ -97,7 +115,13 @@ func TestDeployReturnsErrorWhenSaveConfigFails(t *testing.T) {
 	config.WorkingPath = tmpDir
 	config.InitConfig(afero.NewOsFs())
 	defer func() {
+		if hadAstroHome {
+			os.Setenv("ASTRO_HOME", origAstroHome)
+		} else {
+			os.Unsetenv("ASTRO_HOME")
+		}
 		config.WorkingPath = origWorkingPath
+		config.InitConfig(afero.NewOsFs())
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 	}()
 

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -670,7 +670,7 @@ func deploymentUpdate(cmd *cobra.Command, args []string, dagDeploymentType, nfsL
 	if executorUpdate != "" {
 		executorType, err = validateExecutorArg(executorUpdate)
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 

--- a/cmd/software/deployment_test.go
+++ b/cmd/software/deployment_test.go
@@ -595,6 +595,30 @@ func (s *Suite) TestDeploymentUpdateWithTypeDagDeploy() {
 	})
 }
 
+func (s *Suite) TestDeploymentUpdateInvalidExecutor() {
+	s.Run("invalid executor stops the update and returns an error instead of silently doing nothing", func() {
+		appConfig = &houston.AppConfig{}
+
+		api := new(mocks.ClientInterface)
+		api.On("GetAppConfig", mock.Anything).Return(appConfig, nil)
+		api.On("GetPlatformVersion", nil).Return("0.25.0", nil)
+		dagDeployment := &houston.DagDeploymentConfig{
+			Type: houston.ImageDeploymentType,
+		}
+		deployment := &houston.Deployment{
+			DagDeployment: *dagDeployment,
+		}
+		api.On("GetDeployment", mock.Anything).Return(deployment, nil).Once()
+		houstonClient = api
+
+		cmdArgs := []string{"update", "cknrml96n02523xr97ygj95n5", "--executor=bogus"}
+		_, err := execDeploymentCmd(cmdArgs...)
+		s.EqualError(err, errInvalidExecutorType.Error())
+		// The update should never reach Houston when the executor flag is invalid.
+		api.AssertNotCalled(s.T(), "UpdateDeployment", mock.Anything)
+	})
+}
+
 func (s *Suite) TestDeploymentUpdateFromTypeDagDeployToNonDagDeploy() {
 	s.Run("user should be prompted if new deployment type is not dag_deploy but current type is dag_deploy. User rejects.", func() {
 		appConfig = &houston.AppConfig{


### PR DESCRIPTION
## Description

Two `return nil` sites turned failures into silent successes:

- `astro deploy`: a failure to save the deployment ID into project config aborted the whole deploy and exited 0. Nothing was built or pushed, CI saw green, stale code kept running. A read-only config file is enough to trigger it. Now returns the error, wrapped in the file's existing style.
- Software `astro deployment update`: an invalid `--executor` value returned nil, so the update silently did not happen. Now returns the validation error.

## Testing

Forcing the config write to fail (config path made a directory — deterministic, no permission games) asserts deploy errors instead of exiting clean. An invalid executor asserts the error and that Houston's `UpdateDeployment` is never called. `go test ./cmd/...` and `go vet ./cmd/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6DEdUpFBFaAiPKEu81Wti