### PR TITLE
Stop creating files and directories world-writable

### DIFF
--- a/airflow/airflow.go
+++ b/airflow/airflow.go
@@ -15,7 +15,7 @@ import (
 	"github.com/astronomer/astro-cli/pkg/util"
 )
 
-var perm os.FileMode = 0o777
+var perm os.FileMode = 0o755
 
 var ExtractTemplate = InitFromTemplate
 

--- a/airflow/runtime_templates.go
+++ b/airflow/runtime_templates.go
@@ -173,7 +173,7 @@ func extractTarGz(r io.Reader, dest, templateDir string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(targetPath, os.ModePerm); err != nil {
+			if err := os.MkdirAll(targetPath, 0o755); err != nil { //nolint:mnd
 				return fmt.Errorf("failed to create directory: %w", err)
 			}
 		case tar.TypeReg:

--- a/cmd/airflow_hooks.go
+++ b/cmd/airflow_hooks.go
@@ -55,7 +55,7 @@ func EnsureRuntime(cmd *cobra.Command, args []string) error {
 	osChecker := runtimes.CreateOSChecker()
 	if osChecker.IsWindows() {
 		pluginsDir := filepath.Join(config.WorkingPath, "plugins")
-		if err := os.MkdirAll(pluginsDir, os.ModePerm); err != nil && !os.IsExist(err) {
+		if err := os.MkdirAll(pluginsDir, 0o755); err != nil && !os.IsExist(err) { //nolint:mnd
 			return fmt.Errorf(failedToCreatePluginsDir, err)
 		}
 	}

--- a/pkg/fileutil/files.go
+++ b/pkg/fileutil/files.go
@@ -24,10 +24,10 @@ import (
 	"github.com/astronomer/astro-cli/pkg/util"
 )
 
-const openPermissions = 0o777
+const openPermissions = 0o755
 
 var (
-	perm                  os.FileMode = 0o777
+	perm                  os.FileMode = 0o755
 	openFile                          = os.OpenFile
 	readFile                          = os.ReadFile
 	ioCopy                            = io.Copy
@@ -234,7 +234,7 @@ func GetFilesWithSpecificExtension(folderPath, ext string) []string {
 }
 
 func AddLineToFile(filePath, lineText, commentText string) error {
-	f, err := openFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm) //nolint:mnd
+	f, err := openFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:mnd
 	if err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func AddLineToFile(filePath, lineText, commentText string) error {
 
 // This function removes airflow db init from the Dockerfile. Needed by astro run command
 func RemoveLineFromFile(filePath, lineText, commentText string) error {
-	f, err := openFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm) //nolint:mnd
+	f, err := openFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:mnd
 	if err != nil {
 		return err
 	}

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -1021,9 +1021,9 @@ func (s *Suite) TestDefaultPermissions() {
 	s.Run("CreateFile makes parent dirs 0o755", func() {
 		root := s.T().TempDir()
 		target := filepath.Join(root, "nested", "child", "file.txt")
-		f, err := CreateFile(target)
+		file, err := CreateFile(target)
 		s.NoError(err)
-		f.Close()
+		file.Close()
 
 		info, err := os.Stat(filepath.Join(root, "nested"))
 		s.NoError(err)

--- a/pkg/fileutil/files_test.go
+++ b/pkg/fileutil/files_test.go
@@ -1011,3 +1011,22 @@ func (s *Suite) TestCopyDirectory() {
 		s.True(os.IsNotExist(err), "expected infra/ to be pruned")
 	})
 }
+
+func (s *Suite) TestDefaultPermissions() {
+	// Directories default to 0o755 and files to 0o644 so the CLI stops writing
+	// world-writable paths (LOCAL-7).
+	s.Equal(os.FileMode(0o755), perm)
+	s.Equal(0o755, openPermissions)
+
+	s.Run("CreateFile makes parent dirs 0o755", func() {
+		root := s.T().TempDir()
+		target := filepath.Join(root, "nested", "child", "file.txt")
+		f, err := CreateFile(target)
+		s.NoError(err)
+		f.Close()
+
+		info, err := os.Stat(filepath.Join(root, "nested"))
+		s.NoError(err)
+		s.Equal(os.FileMode(0o755), info.Mode().Perm())
+	})
+}

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -26,7 +26,7 @@ const (
 	ErrorReturningContext = "error"
 )
 
-var perm os.FileMode = 0o777
+var perm os.FileMode = 0o600
 
 // RoundTripFunc
 type RoundTripFunc func(req *http.Request) *http.Response

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -456,8 +456,8 @@ func EnvExportVariables(id, envFile string) error {
 		if err != nil {
 			fmt.Printf("variable json decode unsuccessful: %s", err.Error())
 		}
-		// add variables to the env file
-		f, err := os.OpenFile(envFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:mnd
+		// add variables to the env file; env file can hold secret values, so keep it owner-only
+		f, err := os.OpenFile(envFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:mnd
 		if err != nil {
 			return errors.Wrap(err, "Writing variables to file unsuccessful")
 		}
@@ -497,8 +497,8 @@ func EnvExportConnections(id, envFile string) error {
 		}
 
 		vars := strings.Split(out, "\n")
-		// add connections to the env file
-		f, err := os.OpenFile(envFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:mnd
+		// add connections to the env file; connection URIs contain passwords, so keep it owner-only
+		f, err := os.OpenFile(envFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:mnd
 		if err != nil {
 			return errors.Wrap(err, "Writing connections to file unsuccessful")
 		}


### PR DESCRIPTION
## Description

The shared file helpers in `pkg/fileutil` defaulted to 0o777, so nearly everything the CLI wrote — including every scaffolded project — was world-writable.

What changed:
- `pkg/fileutil` defaults: directories 0o755, files 0o644.
- Swept the remaining direct 0o777/`os.ModePerm` sites: project scaffold dirs, template extraction, the Windows plugins dir.
- Files that can hold credentials go to 0o600: the settings env exports and the test config helper, matching what production config writing already uses.

Container check: compose runs containers as the `astro` user and only reads the bind-mounted project paths; logs go to a named Docker volume. 0o755/0o644 keeps read access, so local dev is unaffected.

## Testing

Added a test asserting the new fileutil defaults; no existing test asserted the old ones. `go test ./pkg/fileutil/... ./airflow/... ./settings/...` and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6DEdUpFBFaAiPKEu81Wti