### PR TITLE
Fix ASTRO_API_TOKEN context expiry set ~57 years out instead of ~1 year

### DIFF
--- a/cloud/auth/types.go
+++ b/cloud/auth/types.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"time"
+
 	"github.com/astronomer/astro-cli/config"
 	"github.com/astronomer/astro-cli/pkg/astroauth"
 )
@@ -55,7 +57,7 @@ func (res Result) writeToContext(c *config.Context) error {
 		return err
 	}
 
-	err = c.SetExpiresIn(res.ExpiresIn)
+	err = c.SetExpiresIn(time.Duration(res.ExpiresIn) * time.Second)
 	if err != nil {
 		return err
 	}

--- a/cmd/cloud/setup.go
+++ b/cmd/cloud/setup.go
@@ -167,7 +167,7 @@ func checkToken(astroV1Client astrov1.APIClient, out io.Writer) error {
 		if err != nil {
 			return err
 		}
-		err = c.SetExpiresIn(res.ExpiresIn)
+		err = c.SetExpiresIn(time.Duration(res.ExpiresIn) * time.Second)
 		if err != nil {
 			return err
 		}
@@ -322,7 +322,7 @@ func checkAPIKeys(astroV1Client astrov1.APIClient, isDeploymentFile bool) (bool,
 		return false, err
 	}
 
-	err = c.SetExpiresIn(tokenRes.ExpiresIn)
+	err = c.SetExpiresIn(time.Duration(tokenRes.ExpiresIn) * time.Second)
 	if err != nil {
 		return false, err
 	}
@@ -396,7 +396,7 @@ func checkAPIToken(isDeploymentFile bool, astroV1Client astrov1.APIClient) (bool
 		return false, err
 	}
 
-	err = c.SetExpiresIn(time.Now().AddDate(1, 0, 0).Unix())
+	err = c.SetExpiresIn(365 * 24 * time.Hour)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/cloud/setup_test.go
+++ b/cmd/cloud/setup_test.go
@@ -507,6 +507,37 @@ func TestCheckAPIToken(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("sets a one year expiry for an ASTRO_API_TOKEN, not a unix timestamp", func(t *testing.T) {
+		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
+			return nil
+		}
+
+		parseAPIToken = func(astroAPIToken string) (*util.CustomClaims, error) {
+			return &mockClaims, nil
+		}
+
+		mockV1Client.On("ListOrganizationsWithResponse", mock.Anything, mock.Anything).Return(&mockOrgsResponse, nil).Once()
+
+		t.Setenv("ASTRO_API_TOKEN", "token")
+
+		domain := "astronomer-dev.io"
+		err := context.Switch(domain)
+		assert.NoError(t, err)
+
+		_, err = checkAPIToken(true, mockV1Client)
+		assert.NoError(t, err)
+
+		c, err := context.GetContext(domain)
+		assert.NoError(t, err)
+		expiresAt, err := c.GetExpiresIn()
+		assert.NoError(t, err)
+
+		// The stored expiry should be about a year from now, not a Unix
+		// timestamp mistakenly treated as a duration in seconds (which would
+		// land roughly 57 years out).
+		assert.WithinDuration(t, time.Now().Add(365*24*time.Hour), expiresAt, time.Hour)
+	})
+
 	t.Run("failed to parse api token", func(t *testing.T) {
 		authLogin = func(domain, token string, astroV1Client astrov1.APIClient, out io.Writer, shouldDisplayLoginLink bool) error {
 			return nil

--- a/config/context.go
+++ b/config/context.go
@@ -217,12 +217,12 @@ func (c *Context) DeleteContext() error {
 	return nil
 }
 
-func (c *Context) SetExpiresIn(value int64) error {
+func (c *Context) SetExpiresIn(d time.Duration) error {
 	cKey, err := c.GetContextKey()
 	if err != nil {
 		return err
 	}
-	expiretime := time.Now().Add(time.Duration(value) * time.Second)
+	expiretime := time.Now().Add(d)
 	return setContextField(cKey, "ExpiresIn", expiretime)
 }
 

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -230,7 +230,7 @@ contexts:
 	ctx, err := GetCurrentContext()
 	s.Require().NoError(err)
 	s.Require().NoError(ctx.SetContextKey("token", "Bearer new"))
-	s.Require().NoError(ctx.SetExpiresIn(3600))
+	s.Require().NoError(ctx.SetExpiresIn(3600 * time.Second))
 
 	reread, err := GetCurrentContext()
 	s.Require().NoError(err)
@@ -264,7 +264,7 @@ func (s *Suite) TestSetOrganizationContext() {
 func (s *Suite) TestExpiresIn() {
 	initTestConfig()
 	ctx := Context{Domain: "localhost"}
-	err := ctx.SetExpiresIn(12)
+	err := ctx.SetExpiresIn(12 * time.Second)
 	s.NoError(err)
 
 	outCtx, err := ctx.GetContext()
@@ -279,7 +279,7 @@ func (s *Suite) TestExpiresIn() {
 func (s *Suite) TestExpiresInFailure() {
 	initTestConfig()
 	ctx := Context{}
-	err := ctx.SetExpiresIn(1)
+	err := ctx.SetExpiresIn(1 * time.Second)
 	s.ErrorIs(err, ErrCtxConfigErr)
 
 	val, err := ctx.GetExpiresIn()


### PR DESCRIPTION
## Description

`SetExpiresIn` adds its argument to `time.Now()` as a count of seconds, but the `ASTRO_API_TOKEN` path passed it a Unix timestamp (`time.Now().AddDate(1, 0, 0).Unix()`), landing the stored expiry around the year 2083. Once written to `~/.astro/config.yaml`, that context was never considered expired, so refresh and re-auth logic never fired for it.

What changed: `SetExpiresIn` now takes a `time.Duration`, so the unit lives in the type and this class of mistake stops being expressible. All four callers were converted; the buggy site now passes `365 * 24 * time.Hour`.

## Breaking changes

- Contexts written via `ASTRO_API_TOKEN` now actually expire about a year out. Day-to-day use is unaffected — the env-var path rewrites the expiry on every command.
- Already-written far-future expiries are not retroactively repaired; they get overwritten on the next run.
- `Context.SetExpiresIn` changed signature from `(int64)` to `(time.Duration)` — a Go API change for anyone importing `config` directly.

## Testing

New subtest runs the `ASTRO_API_TOKEN` path and asserts the stored expiry lands within an hour of one year out (it would have landed in 2083 before). `go build ./...`, `go test ./cmd/... ./config/... ./cloud/auth/...`, `go vet`, and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6DEdUpFBFaAiPKEu81Wti