### PR TITLE
Clear the refresh token on logout and stop failing silently

### DIFF
--- a/cloud/auth/auth.go
+++ b/cloud/auth/auth.go
@@ -424,26 +424,36 @@ func Login(domain, token string, astroV1Client astrov1.APIClient, out io.Writer,
 }
 
 // Logout logs a user out of the docker registry. Will need to logout of Astro next.
-func Logout(domain string, out io.Writer) {
+// It clears every credential held in the context (access token, refresh token,
+// and email) so no live token is left behind in the config file.
+func Logout(domain string, out io.Writer) error {
 	c, _ := context.GetContext(domain)
 
 	err = c.SetContextKey("token", "")
 	if err != nil {
-		return
+		fmt.Fprintln(out, "Failed to clear access token: ", err.Error())
+		return err
+	}
+	err = c.SetContextKey("refreshtoken", "")
+	if err != nil {
+		fmt.Fprintln(out, "Failed to clear refresh token: ", err.Error())
+		return err
 	}
 	err = c.SetContextKey("user_email", "")
 	if err != nil {
-		return
+		fmt.Fprintln(out, "Failed to clear user email: ", err.Error())
+		return err
 	}
 
 	// remove the current context
 	err = config.ResetCurrentContext()
 	if err != nil {
 		fmt.Fprintln(out, "Failed to reset current context: ", err.Error())
-		return
+		return err
 	}
 
 	fmt.Fprintln(out, "Successfully logged out of Astronomer")
+	return nil
 }
 
 func FetchDomainAuthConfig(domain string) (Config, error) {

--- a/cloud/auth/auth_test.go
+++ b/cloud/auth/auth_test.go
@@ -921,12 +921,13 @@ func TestLogout(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 	t.Run("success", func(t *testing.T) {
 		buf := new(bytes.Buffer)
-		Logout("astronomer.io", buf)
+		err := Logout("astronomer.io", buf)
+		assert.NoError(t, err)
 		assert.Equal(t, "Successfully logged out of Astronomer\n", buf.String())
 	})
 
 	t.Run("success_with_email", func(t *testing.T) {
-		assertions := func(expUserEmail string, expToken string) {
+		assertions := func(expUserEmail, expToken, expRefreshToken string) {
 			contexts, err := config.GetContexts()
 			assert.NoError(t, err)
 			context := contexts.Contexts["localhost"]
@@ -934,6 +935,7 @@ func TestLogout(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, expUserEmail, context.UserEmail)
 			assert.Equal(t, expToken, context.Token)
+			assert.Equal(t, expRefreshToken, context.RefreshToken)
 		}
 		testUtil.InitTestConfig(testUtil.LocalPlatform)
 		c, err := config.GetCurrentContext()
@@ -942,16 +944,32 @@ func TestLogout(t *testing.T) {
 		assert.NoError(t, err)
 		err = c.SetContextKey("token", "Bearer some-token")
 		assert.NoError(t, err)
+		err = c.SetContextKey("refreshtoken", "some-refresh-token")
+		assert.NoError(t, err)
 		// test before
-		assertions("test.user@astronomer.io", "Bearer some-token")
+		assertions("test.user@astronomer.io", "Bearer some-token", "some-refresh-token")
 
 		// log out
 		c, err = config.GetCurrentContext()
 		assert.NoError(t, err)
-		Logout(c.Domain, os.Stdout)
+		buf := new(bytes.Buffer)
+		err = Logout(c.Domain, buf)
+		assert.NoError(t, err)
 
-		// test after logout
-		assertions("", "")
+		// test after logout: token, refresh token, and email are all cleared
+		assertions("", "", "")
+		assert.Equal(t, "Successfully logged out of Astronomer\n", buf.String())
+	})
+
+	t.Run("partial_failure_does_not_report_success", func(t *testing.T) {
+		testUtil.InitTestConfig(testUtil.LocalPlatform)
+		buf := new(bytes.Buffer)
+		// an empty domain makes every SetContextKey call fail (no domain configured),
+		// so Logout should bail out with an error instead of printing success.
+		err := Logout("", buf)
+		assert.Error(t, err)
+		assert.NotContains(t, buf.String(), "Successfully logged out of Astronomer")
+		assert.Contains(t, buf.String(), "Failed to clear access token")
 	})
 }
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -83,10 +83,9 @@ func logout(cmd *cobra.Command, args []string, out io.Writer) error {
 	cmd.SilenceUsage = true
 
 	if context.IsCloudDomain(domain) {
-		cloudLogout(domain, out)
-	} else {
-		softwareLogout(domain)
+		return cloudLogout(domain, out)
 	}
+	softwareLogout(domain)
 	return nil
 }
 

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -64,8 +64,9 @@ func (s *CmdSuite) TestLogout() {
 	localDomain := "localhost"
 	softwareDomain := "astronomer_dev.com"
 
-	cloudLogout = func(domain string, out io.Writer) {
+	cloudLogout = func(domain string, out io.Writer) error {
 		s.Equal(localDomain, domain)
+		return nil
 	}
 	softwareLogout = func(domain string) {
 		s.Equal(softwareDomain, domain)


### PR DESCRIPTION
## Description

`astro logout` cleared the access token and email but never the refresh token, leaving a live credential in `~/.astro/config.yaml` — it can be exchanged for a fresh access token — after telling the user they were logged out. Each field-clear failure also did a bare `return`, so a partial logout exited silently.

What changed: logout clears `refreshtoken` alongside the other fields; each clear failure prints a specific message and propagates an error; "Successfully logged out of Astronomer" only prints once every field is confirmed cleared. Field-by-field clearing was kept (rather than wiping the whole context) so the user's domain, org, and workspace selections survive to the next login.

## Breaking changes

- The refresh token no longer survives logout — anything that depended on credentials still working after `astro logout` stops working, which is the bug being fixed.
- `cloud/auth.Logout` now returns `error` (one caller, updated).
- `astro logout` exits non-zero when a clear fails, where it previously always exited 0.

## Testing

Extended the logout tests: refresh token asserted empty after success, and a forced partial failure asserts an error is returned, no success message prints, and a specific failure message does. `go test ./cloud/auth/... ./cmd/...`, `go vet`, and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6DEdUpFBFaAiPKEu81Wti