### PR TITLE
Pass registry passwords over stdin instead of through a shell string

### DIFF
--- a/airflow/docker_image.go
+++ b/airflow/docker_image.go
@@ -462,8 +462,7 @@ func (d *DockerImage) Pull(remoteImage, username, token string) error {
 		}
 		pass := token
 		pass = strings.TrimPrefix(pass, prefix)
-		cmd := "echo \"" + pass + "\"" + " | " + containerRuntime + " login " + registry + " -u " + username + " --password-stdin"
-		err = cmdExec("bash", os.Stdout, os.Stderr, "-c", cmd) // This command will only work on machines that have bash. If users have issues we will revist
+		err = cmdExecWithStdin(containerRuntime, pass, os.Stdout, os.Stderr, "login", registry, "-u", username, "--password-stdin")
 	}
 	if err != nil {
 		return err
@@ -707,7 +706,27 @@ var cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 	return nil
 }
 
-// When login and push do not work use bash to run docker commands, this function is for users using colima
+// cmdExecWithStdin runs cmd directly (no shell) and writes stdin to the process's stdin pipe.
+// Used for registry logins so a password is never parsed by a shell.
+var cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+	_, lookErr := exec.LookPath(cmd)
+	if lookErr != nil {
+		return fmt.Errorf("failed to find the %s command: %w", cmd, lookErr)
+	}
+
+	execCMD := exec.Command(cmd, args...)
+	execCMD.Stdin = strings.NewReader(stdin)
+	execCMD.Stdout = stdout
+	execCMD.Stderr = stderr
+
+	if cmdErr := execCMD.Run(); cmdErr != nil {
+		return fmt.Errorf("failed to execute cmd: %w", cmdErr)
+	}
+
+	return nil
+}
+
+// When login and push do not work via the go client, fall back to invoking the container runtime binary directly. This function is for users using colima
 func pushWithBash(authConfig *cliTypes.AuthConfig, imageName string) error {
 	containerRuntime, err := runtimes.GetContainerRuntimeBinary()
 	if err != nil {
@@ -717,9 +736,8 @@ func pushWithBash(authConfig *cliTypes.AuthConfig, imageName string) error {
 	if authConfig.Username != "" { // Case for cloud image push where we have both registry user & pass, for software login happens during `astro login` itself
 		pass := authConfig.Password
 		pass = strings.TrimPrefix(pass, prefix)
-		cmd := "echo \"" + pass + "\"" + " | " + containerRuntime + " login " + authConfig.ServerAddress + " -u " + authConfig.Username + " --password-stdin"
 		var stderr bytes.Buffer
-		err = cmdExec("bash", os.Stdout, &stderr, "-c", cmd) // This command will only work on machines that have bash. If users have issues we will revist
+		err = cmdExecWithStdin(containerRuntime, pass, os.Stdout, &stderr, "login", authConfig.ServerAddress, "-u", authConfig.Username, "--password-stdin")
 		if err != nil {
 			stderrOutput := stderr.String()
 			if stderrOutput != "" {

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -717,6 +717,29 @@ func (s *Suite) TestExecCmd() {
 	})
 }
 
+func (s *Suite) TestExecCmdWithStdin() {
+	s.Run("success", func() {
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		err := cmdExecWithStdin("cat", "s3cr3t", stdout, stderr)
+		s.NoError(err)
+		s.Equal("s3cr3t", stdout.String())
+		s.Empty(stderr.String())
+	})
+
+	s.Run("invalid cmd", func() {
+		err := cmdExecWithStdin("invalid-cmd", "", nil, nil)
+		s.Contains(err.Error(), "failed to find the invalid-cmd command")
+	})
+
+	s.Run("cmd failure", func() {
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		err := cmdExecWithStdin("test", "", stdout, stderr, "-f", "does-not-exist")
+		s.Contains(err.Error(), "failed to execute cmd")
+	})
+}
+
 func (s *Suite) TestUseBash() {
 	s.Run("success", func() {
 		var gotStdin string

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -843,6 +843,12 @@ func (s *Suite) TestDockerImagePush403Error() {
 			return nil
 		}
 
+		// the bash-less fallback logs in via cmdExecWithStdin; without this stub
+		// the test would invoke the real container runtime
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+			return nil
+		}
+
 		displayJSONMessagesToStream = func(_ io.ReadCloser, _ func(jsonmessage.JSONMessage)) error {
 			return fmt.Errorf("Error response from daemon: authentication required")
 		}

--- a/airflow/docker_image_test.go
+++ b/airflow/docker_image_test.go
@@ -294,8 +294,33 @@ func (s *Suite) TestDockerPull() {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
 			return nil
 		}
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+			return nil
+		}
 		err := handler.Pull("", "username", "")
 		s.NoError(err)
+	})
+
+	s.Run("pull login uses stdin, not a shell, for the password", func() {
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			return nil
+		}
+		const trickyPass = `p$(whoami)"'` + "`id`"
+		var gotCmd string
+		var gotStdin string
+		var gotArgs []string
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+			gotCmd = cmd
+			gotStdin = stdin
+			gotArgs = args
+			return nil
+		}
+		err := handler.Pull("", "username", trickyPass)
+		s.NoError(err)
+		s.NotEqual("bash", gotCmd)
+		s.Equal(trickyPass, gotStdin, "password must reach the login command unmodified, not interpolated into a shell string")
+		s.Contains(gotArgs, "--password-stdin")
+		s.NotContains(gotArgs, "-c")
 	})
 	s.Run("pull error", func() {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
@@ -306,6 +331,9 @@ func (s *Suite) TestDockerPull() {
 	})
 
 	s.Run("login error", func() {
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+			return errMock
+		}
 		err := handler.Pull("", "username", "")
 		s.Error(err)
 	})
@@ -327,20 +355,19 @@ func (s *Suite) TestDockerPull() {
 			pullSeen := false
 			loginSeen := false
 			cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
-				switch cmd {
-				case "bash":
-					// The _current_ way we log in.
-					s.Contains(args[1], tc.expectedLogin)
-					loginSeen = true
+				if cmd == "docker" && args[0] == "pull" {
+					s.Contains(args, tc.expected)
+					pullSeen = true
 					return nil
-				case "docker":
-					if args[0] == "pull" {
-						s.Contains(args, tc.expected)
-						pullSeen = true
-						return nil
-					}
 				}
 				return fmt.Errorf("unexpected command %q %q", cmd, args)
+			}
+			cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+				// Login must go straight to the container runtime, never through a shell.
+				s.Equal("docker", cmd)
+				s.Contains(args[1], tc.expectedLogin)
+				loginSeen = true
+				return nil
 			}
 			err := handler.Pull(tc.input, tc.username, "")
 			s.NoError(err)
@@ -367,6 +394,7 @@ func (s *Suite) TestDockerImagePush() {
 
 	// Set the default for the rest of the subtests -- run without error
 	cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error { return nil }
+	cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error { return nil }
 
 	s.Run("success", func() {
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error { return nil }
@@ -691,12 +719,38 @@ func (s *Suite) TestExecCmd() {
 
 func (s *Suite) TestUseBash() {
 	s.Run("success", func() {
+		var gotStdin string
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+			s.Equal("docker", cmd)
+			s.Contains(args, "login")
+			gotStdin = stdin
+			return nil
+		}
 		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
-			s.Contains([]string{"-c", "push", "rmi"}, args[0])
+			s.Contains([]string{"push", "rmi"}, args[0])
 			return nil
 		}
 		err := pushWithBash(&types.AuthConfig{Username: "testing", Password: "pass"}, "test")
 		s.NoError(err)
+		s.Equal("pass", gotStdin, "password must reach login via stdin, not a shell string")
+	})
+
+	s.Run("success with password containing shell metacharacters", func() {
+		const trickyPass = `p$(whoami)"'` + "`id`"
+		var gotStdin string
+		var gotArgs []string
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+			gotStdin = stdin
+			gotArgs = args
+			return nil
+		}
+		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+			return nil
+		}
+		err := pushWithBash(&types.AuthConfig{Username: "testing", Password: trickyPass}, "test")
+		s.NoError(err)
+		s.Equal(trickyPass, gotStdin, "password must reach the login command unmodified, not interpolated into a shell string")
+		s.NotContains(gotArgs, "-c")
 	})
 
 	s.Run("exec failure", func() {
@@ -709,8 +763,8 @@ func (s *Suite) TestUseBash() {
 	})
 
 	s.Run("login exec failure", func() {
-		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
-			s.Contains(cmd, "bash")
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+			s.Equal("docker", cmd)
 			return errMockDocker
 		}
 		err := pushWithBash(&types.AuthConfig{Username: "testing"}, "test")

--- a/airflow/docker_registry.go
+++ b/airflow/docker_registry.go
@@ -80,7 +80,7 @@ func (d *DockerRegistry) Login(username, token string) error {
 	return nil
 }
 
-// dockerLogin performs docker login using bash command instead of Docker API
+// dockerLogin performs docker login by invoking the container runtime binary directly, instead of the Docker API.
 // This is useful for OAuth-based registries that require special authentication flows
 func dockerLogin(registryName, username, token string) error {
 	containerRuntime, err := runtimes.GetContainerRuntimeBinary()
@@ -92,8 +92,7 @@ func dockerLogin(registryName, username, token string) error {
 		// Remove Bearer prefix if present (consistent with pushWithBash)
 		const prefix = "Bearer "
 		pass := strings.TrimPrefix(token, prefix)
-		cmd := "echo \"" + pass + "\"" + " | " + containerRuntime + " login " + registryName + " -u " + username + " --password-stdin"
-		err = cmdExec("bash", nil, os.Stderr, "-c", cmd)
+		err = cmdExecWithStdin(containerRuntime, pass, nil, os.Stderr, "login", registryName, "-u", username, "--password-stdin")
 		if err != nil {
 			return fmt.Errorf("docker login failed: %w", err)
 		}

--- a/airflow/docker_registry_test.go
+++ b/airflow/docker_registry_test.go
@@ -51,82 +51,104 @@ func (s *Suite) TestRegistryLogin() {
 }
 
 func (s *Suite) TestDockerLogin() {
-	// Store original cmdExec to restore after tests
-	originalCmdExec := cmdExec
+	// Store original cmdExecWithStdin to restore after tests
+	originalCmdExecWithStdin := cmdExecWithStdin
 	defer func() {
-		cmdExec = originalCmdExec
+		cmdExecWithStdin = originalCmdExecWithStdin
 	}()
 
 	s.Run("success with credentials", func() {
 		var capturedCmd string
+		var capturedStdin string
 		var capturedArgs []string
-		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
 			capturedCmd = cmd
+			capturedStdin = stdin
 			capturedArgs = args
 			return nil
 		}
 
 		err := DockerLogin("test.registry.com", "testuser", "testtoken")
 		s.NoError(err)
-		s.Equal("bash", capturedCmd)
-		s.Equal([]string{"-c", "echo \"testtoken\" | docker login test.registry.com -u testuser --password-stdin"}, capturedArgs)
+		s.Equal("docker", capturedCmd)
+		s.Equal("testtoken", capturedStdin, "password must be piped to stdin, not interpolated into a command string")
+		s.Equal([]string{"login", "test.registry.com", "-u", "testuser", "--password-stdin"}, capturedArgs)
 	})
 
 	s.Run("success with bearer token", func() {
 		var capturedCmd string
+		var capturedStdin string
 		var capturedArgs []string
-		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
 			capturedCmd = cmd
+			capturedStdin = stdin
 			capturedArgs = args
 			return nil
 		}
 
 		err := DockerLogin("test.registry.com", "testuser", "Bearer testtoken123")
 		s.NoError(err)
-		s.Equal("bash", capturedCmd)
+		s.Equal("docker", capturedCmd)
 		// Should strip Bearer prefix
-		s.Equal([]string{"-c", "echo \"testtoken123\" | docker login test.registry.com -u testuser --password-stdin"}, capturedArgs)
+		s.Equal("testtoken123", capturedStdin)
+		s.Equal([]string{"login", "test.registry.com", "-u", "testuser", "--password-stdin"}, capturedArgs)
+	})
+
+	s.Run("password with shell metacharacters reaches login intact", func() {
+		const trickyPass = `p$(whoami)"'` + "`id`"
+		var capturedStdin string
+		var capturedArgs []string
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
+			capturedStdin = stdin
+			capturedArgs = args
+			return nil
+		}
+
+		err := DockerLogin("test.registry.com", "testuser", trickyPass)
+		s.NoError(err)
+		s.Equal(trickyPass, capturedStdin, "password must reach the login command unmodified, not interpolated into a shell string")
+		s.NotContains(capturedArgs, "-c")
 	})
 
 	s.Run("no operation with empty credentials", func() {
 		cmdExecCalled := false
-		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
 			cmdExecCalled = true
 			return nil
 		}
 
 		err := DockerLogin("test.registry.com", "", "")
 		s.NoError(err)
-		s.False(cmdExecCalled, "cmdExec should not be called with empty credentials")
+		s.False(cmdExecCalled, "cmdExecWithStdin should not be called with empty credentials")
 	})
 
 	s.Run("no operation with empty username", func() {
 		cmdExecCalled := false
-		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
 			cmdExecCalled = true
 			return nil
 		}
 
 		err := DockerLogin("test.registry.com", "", "testtoken")
 		s.NoError(err)
-		s.False(cmdExecCalled, "cmdExec should not be called with empty username")
+		s.False(cmdExecCalled, "cmdExecWithStdin should not be called with empty username")
 	})
 
 	s.Run("no operation with empty token", func() {
 		cmdExecCalled := false
-		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
 			cmdExecCalled = true
 			return nil
 		}
 
 		err := DockerLogin("test.registry.com", "testuser", "")
 		s.NoError(err)
-		s.False(cmdExecCalled, "cmdExec should not be called with empty token")
+		s.False(cmdExecCalled, "cmdExecWithStdin should not be called with empty token")
 	})
 
 	s.Run("docker login command fails", func() {
 		expectedErr := errors.New("docker login failed")
-		cmdExec = func(cmd string, stdout, stderr io.Writer, args ...string) error {
+		cmdExecWithStdin = func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error {
 			return expectedErr
 		}
 

--- a/airflow/suite_test.go
+++ b/airflow/suite_test.go
@@ -16,6 +16,7 @@ import (
 type Suite struct {
 	suite.Suite
 	origCmdExec              func(cmd string, stdout, stderr io.Writer, args ...string) error
+	origCmdExecWithStdin     func(cmd, stdin string, stdout, stderr io.Writer, args ...string) error
 	origGetDockerClient      func() (client.APIClient, error)
 	origInitSettings         func(airflowURL, authHeader, settingsFile string, envConns map[string]astrov1.EnvironmentObjectConnection, connections, variables, pools bool) error
 	origCheckWebserverHealth func(url string, timeout time.Duration, component string) error
@@ -39,6 +40,7 @@ func TestAirflow(t *testing.T) {
 
 func (s *Suite) SetupSuite() {
 	s.origCmdExec = cmdExec
+	s.origCmdExecWithStdin = cmdExecWithStdin
 	s.origGetDockerClient = getDockerClient
 	s.origStdout = os.Stdout
 	s.origInitSettings = initSettings
@@ -57,6 +59,7 @@ func (s *Suite) SetupTest() {
 
 func (s *Suite) TearDownTest() {
 	cmdExec = s.origCmdExec
+	cmdExecWithStdin = s.origCmdExecWithStdin
 	getDockerClient = s.origGetDockerClient
 	initSettings = s.origInitSettings
 }


### PR DESCRIPTION
## Description

Three registry-login sites built a `bash -c` string of the form `echo "<password>" | docker login ... --password-stdin`, splicing the credential into shell text. A password containing a quote, `$`, or backticks either broke the login or got interpreted by the shell, and login required bash on the host for no reason.

What changed: a new `cmdExecWithStdin` helper (matching the existing `cmdExec`'s style) runs the runtime binary directly with the password written to the child's stdin pipe — no shell, no quoting rules, no bash dependency. All three sites converted; the rest of the tree was checked for the same pattern and none remain.

## Breaking changes

None for legitimate use — same login outcome, same error format. Bash is no longer required for login. One edge-case wording change: a missing runtime binary now errors as "failed to find the <runtime> command" rather than a bash "not found" error.

## Testing

Tests cover passwords containing `$(...)`, backticks, and quotes reaching the login command unchanged via stdin, plus mock updates across the touched files. `go test ./...`, `go vet ./airflow/...`, and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6DEdUpFBFaAiPKEu81Wti