### PR TITLE
Bind standalone Airflow to loopback by default and stop the whole process group

### DIFF
--- a/airflow/standalone.go
+++ b/airflow/standalone.go
@@ -773,6 +773,11 @@ func (s *Standalone) buildEnv() []string {
 		overrides["AIRFLOW__WEBSERVER__EXPOSE_CONFIG"] = "True"
 	}
 
+	// Bind the api-server (AF3) / webserver (AF2) to loopback so the
+	// all-admins instance isn't reachable from the LAN. Unlike the settings
+	// above these are defaults: a user's .env or inherited env wins.
+	airflowrt.ApplyLoopbackDefaults(overrides)
+
 	// Layer 3: macOS fork-safety workarounds.
 	// a) Python's _scproxy calls SCDynamicStoreCopyProxies which is not fork-safe.
 	//    When Airflow forks, this can spin at 100% CPU indefinitely.
@@ -888,17 +893,20 @@ func (s *Standalone) Stop(_ bool) error {
 	fmt.Printf("Stopping Airflow standalone (PID %d)…\n", pid)
 	syscall.Kill(-pid, syscall.SIGTERM) //nolint:errcheck
 
-	// Poll for process exit
+	// Poll the process group — not just the master PID. airflow standalone
+	// spawns scheduler/api-server/triggerer into the same group (Setpgid at
+	// start), and the master often exits on SIGTERM before its children
+	// finish; returning then would leave them running.
 	deadline := time.Now().Add(stopTimeout)
 	for time.Now().Before(deadline) {
 		time.Sleep(stopPollInterval)
-		if _, stillAlive := s.readPID(); !stillAlive {
+		if !airflowrt.ProcessGroupAlive(pid) {
 			break
 		}
 	}
 
-	// If still alive, send SIGKILL
-	if _, stillAlive := s.readPID(); stillAlive {
+	// If any group member is still alive, send SIGKILL
+	if airflowrt.ProcessGroupAlive(pid) {
 		syscall.Kill(-pid, syscall.SIGKILL) //nolint:errcheck
 		time.Sleep(stopPollInterval)
 	}

--- a/airflow/standalone_test.go
+++ b/airflow/standalone_test.go
@@ -631,6 +631,72 @@ func (s *Suite) TestStandaloneBuildEnv_WithEnvFile() {
 	s.Equal("hello", envMap["MY_CUSTOM_VAR"])
 }
 
+func (s *Suite) TestStandaloneBuildEnv_LoopbackDefaults() {
+	handler, err := StandaloneInit("/tmp/test-project", "", "Dockerfile")
+	s.NoError(err)
+
+	env := handler.buildEnv()
+
+	envMap := make(map[string]string)
+	for _, e := range env {
+		if parts := splitEnvVar(e); parts != nil {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	// The api-server (AF3) and webserver (AF2) must default to loopback so a
+	// standalone instance with all-admins auth is not reachable from the LAN.
+	s.Equal("127.0.0.1", envMap["AIRFLOW__API__HOST"])
+	s.Equal("127.0.0.1", envMap["AIRFLOW__WEBSERVER__WEB_SERVER_HOST"])
+}
+
+func (s *Suite) TestStandaloneBuildEnv_LoopbackOverriddenByEnvFile() {
+	tmpDir, err := os.MkdirTemp("", "standalone-loopback-envfile")
+	s.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	envContent := "AIRFLOW__API__HOST=0.0.0.0\nAIRFLOW__WEBSERVER__WEB_SERVER_HOST=0.0.0.0\n"
+	err = os.WriteFile(filepath.Join(tmpDir, ".env"), []byte(envContent), 0o644)
+	s.NoError(err)
+
+	handler, err := StandaloneInit(tmpDir, "", "Dockerfile")
+	s.NoError(err)
+
+	env := handler.buildEnv()
+
+	envMap := make(map[string]string)
+	for _, e := range env {
+		if parts := splitEnvVar(e); parts != nil {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	// A user's explicit .env setting wins over the loopback default.
+	s.Equal("0.0.0.0", envMap["AIRFLOW__API__HOST"])
+	s.Equal("0.0.0.0", envMap["AIRFLOW__WEBSERVER__WEB_SERVER_HOST"])
+}
+
+func (s *Suite) TestStandaloneBuildEnv_LoopbackOverriddenByInheritedEnv() {
+	s.T().Setenv("AIRFLOW__API__HOST", "0.0.0.0")
+	s.T().Setenv("AIRFLOW__WEBSERVER__WEB_SERVER_HOST", "0.0.0.0")
+
+	handler, err := StandaloneInit("/tmp/test-project", "", "Dockerfile")
+	s.NoError(err)
+
+	env := handler.buildEnv()
+
+	envMap := make(map[string]string)
+	for _, e := range env {
+		if parts := splitEnvVar(e); parts != nil {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	// A user's setting in the inherited environment wins over the loopback default.
+	s.Equal("0.0.0.0", envMap["AIRFLOW__API__HOST"])
+	s.Equal("0.0.0.0", envMap["AIRFLOW__WEBSERVER__WEB_SERVER_HOST"])
+}
+
 func splitEnvVar(s string) []string {
 	idx := indexOf(s, '=')
 	if idx < 0 {
@@ -1115,6 +1181,51 @@ func (s *Suite) TestStandaloneStop_Running() {
 	s.NoError(err)
 
 	// PID file should be removed
+	_, err = os.Stat(filepath.Join(standaloneStateDir, "airflow.pid"))
+	s.True(os.IsNotExist(err))
+}
+
+func (s *Suite) TestStandaloneStop_WaitsForProcessGroup() {
+	tmpDir, err := os.MkdirTemp("", "standalone-stop-group")
+	s.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	standaloneStateDir := filepath.Join(tmpDir, ".astro", "standalone")
+	err = os.MkdirAll(standaloneStateDir, 0o755)
+	s.NoError(err)
+
+	// Reproduce airflow standalone's shutdown shape: the master exits on
+	// SIGTERM right away, but a child in the same process group (like the
+	// scheduler or triggerer) keeps running for a bit. The child inherits
+	// `trap '' TERM` so only the master dies on Stop's SIGTERM; the group
+	// must still be waited on. The ready file tells us the child exists, so
+	// Stop's SIGTERM can't land before the trap is set.
+	readyFile := filepath.Join(tmpDir, "ready")
+	script := fmt.Sprintf(`trap '' TERM; sleep 2 & touch %q; trap - TERM; wait $!`, readyFile)
+	cmd := exec.Command("bash", "-c", script)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	err = cmd.Start()
+	s.NoError(err)
+	go cmd.Wait() //nolint:errcheck
+	pid := cmd.Process.Pid
+	s.Eventually(func() bool {
+		_, statErr := os.Stat(readyFile)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond, "child process never came up")
+
+	err = os.WriteFile(filepath.Join(standaloneStateDir, "airflow.pid"), []byte(fmt.Sprintf("%d", pid)), 0o644)
+	s.NoError(err)
+
+	handler, err := StandaloneInit(tmpDir, ".env", "Dockerfile")
+	s.NoError(err)
+
+	err = handler.Stop(false)
+	s.NoError(err)
+
+	// Stop must not return while any group member is alive. Polling only the
+	// master PID would return here with the child still running.
+	s.Error(syscall.Kill(-pid, syscall.Signal(0)), "process group should be fully dead after Stop")
+
 	_, err = os.Stat(filepath.Join(standaloneStateDir, "airflow.pid"))
 	s.True(os.IsNotExist(err))
 }

--- a/pkg/airflowrt/env.go
+++ b/pkg/airflowrt/env.go
@@ -47,15 +47,8 @@ func BuildEnv(projectPath, port, envFilePath string) []string {
 	}
 	overrides["AIRFLOW__CORE__EXECUTION_API_SERVER_URL"] = "http://localhost:" + port + "/execution/"
 
-	// Pin the api-server (Airflow 3) and webserver (Airflow 2) to the IPv4
-	// loopback. Airflow's own default bind is 0.0.0.0, which — combined with
-	// SIMPLE_AUTH_MANAGER_ALL_ADMINS above — would expose the instance to every
-	// device on the LAN. Local dev only needs localhost. These are defaults, not
-	// forced values: a user's own setting, from the .env file or the inherited
-	// environment, wins. The inapplicable key for whichever Airflow major is
-	// running is simply ignored.
-	setDefault(overrides, "AIRFLOW__API__HOST", "127.0.0.1")
-	setDefault(overrides, "AIRFLOW__WEBSERVER__WEB_SERVER_HOST", "127.0.0.1")
+	// Bind to loopback by default so all-admins auth isn't exposed to the LAN.
+	ApplyLoopbackDefaults(overrides)
 
 	// Layer 3: macOS proxy workaround.
 	// Python's _scproxy calls SCDynamicStoreCopyProxies which is not fork-safe.
@@ -80,6 +73,17 @@ func BuildEnv(projectPath, port, envFilePath string) []string {
 		env = append(env, k+"="+v)
 	}
 	return env
+}
+
+// ApplyLoopbackDefaults pins the api-server (Airflow 3) and webserver
+// (Airflow 2) bind address to the IPv4 loopback. Airflow's own default is
+// 0.0.0.0, which would expose a SIMPLE_AUTH_MANAGER_ALL_ADMINS instance to
+// the whole network. These are defaults, not forced values: a user's own
+// setting, in overrides (the parsed .env file) or the inherited environment,
+// wins. Airflow ignores whichever key doesn't apply to the running major.
+func ApplyLoopbackDefaults(overrides map[string]string) {
+	setDefault(overrides, "AIRFLOW__API__HOST", "127.0.0.1")
+	setDefault(overrides, "AIRFLOW__WEBSERVER__WEB_SERVER_HOST", "127.0.0.1")
 }
 
 // setDefault sets key to value in overrides unless the user already supplied

--- a/pkg/airflowrt/env.go
+++ b/pkg/airflowrt/env.go
@@ -47,6 +47,16 @@ func BuildEnv(projectPath, port, envFilePath string) []string {
 	}
 	overrides["AIRFLOW__CORE__EXECUTION_API_SERVER_URL"] = "http://localhost:" + port + "/execution/"
 
+	// Pin the api-server (Airflow 3) and webserver (Airflow 2) to the IPv4
+	// loopback. Airflow's own default bind is 0.0.0.0, which — combined with
+	// SIMPLE_AUTH_MANAGER_ALL_ADMINS above — would expose the instance to every
+	// device on the LAN. Local dev only needs localhost. These are defaults, not
+	// forced values: a user's own setting, from the .env file or the inherited
+	// environment, wins. The inapplicable key for whichever Airflow major is
+	// running is simply ignored.
+	setDefault(overrides, "AIRFLOW__API__HOST", "127.0.0.1")
+	setDefault(overrides, "AIRFLOW__WEBSERVER__WEB_SERVER_HOST", "127.0.0.1")
+
 	// Layer 3: macOS proxy workaround.
 	// Python's _scproxy calls SCDynamicStoreCopyProxies which is not fork-safe.
 	// When Airflow's LocalExecutor forks, this can spin at 100% CPU indefinitely.
@@ -70,6 +80,19 @@ func BuildEnv(projectPath, port, envFilePath string) []string {
 		env = append(env, k+"="+v)
 	}
 	return env
+}
+
+// setDefault sets key to value in overrides unless the user already supplied
+// it — via the .env file (already merged into overrides) or the inherited
+// environment (which passes through to the final env untouched).
+func setDefault(overrides map[string]string, key, value string) {
+	if _, ok := overrides[key]; ok {
+		return
+	}
+	if _, ok := os.LookupEnv(key); ok {
+		return
+	}
+	overrides[key] = value
 }
 
 // LoadEnvFile reads a .env file and returns key=value pairs.

--- a/pkg/airflowrt/env_test.go
+++ b/pkg/airflowrt/env_test.go
@@ -60,6 +60,45 @@ func TestBuildEnv(t *testing.T) {
 	assert.True(t, strings.HasPrefix(envMap["PATH"], filepath.Join(dir, ".venv", "bin")))
 }
 
+func TestBuildEnv_LoopbackDefaults(t *testing.T) {
+	dir := t.TempDir()
+
+	env := BuildEnv(dir, "", "")
+
+	envMap := envToMap(env)
+	// The api-server (AF3) and webserver (AF2) must default to loopback so a
+	// standalone instance with all-admins auth is not reachable from the LAN.
+	assert.Equal(t, "127.0.0.1", envMap["AIRFLOW__API__HOST"])
+	assert.Equal(t, "127.0.0.1", envMap["AIRFLOW__WEBSERVER__WEB_SERVER_HOST"])
+}
+
+func TestBuildEnv_LoopbackOverriddenByEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	content := "AIRFLOW__API__HOST=0.0.0.0\nAIRFLOW__WEBSERVER__WEB_SERVER_HOST=0.0.0.0\n"
+	require.NoError(t, os.WriteFile(envFile, []byte(content), 0o644))
+
+	env := BuildEnv(dir, "", envFile)
+
+	envMap := envToMap(env)
+	// A user's explicit .env setting wins over the loopback default.
+	assert.Equal(t, "0.0.0.0", envMap["AIRFLOW__API__HOST"])
+	assert.Equal(t, "0.0.0.0", envMap["AIRFLOW__WEBSERVER__WEB_SERVER_HOST"])
+}
+
+func TestBuildEnv_LoopbackOverriddenByInheritedEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AIRFLOW__API__HOST", "0.0.0.0")
+	t.Setenv("AIRFLOW__WEBSERVER__WEB_SERVER_HOST", "0.0.0.0")
+
+	env := BuildEnv(dir, "", "")
+
+	envMap := envToMap(env)
+	// A user's setting in the inherited environment wins over the loopback default.
+	assert.Equal(t, "0.0.0.0", envMap["AIRFLOW__API__HOST"])
+	assert.Equal(t, "0.0.0.0", envMap["AIRFLOW__WEBSERVER__WEB_SERVER_HOST"])
+}
+
 func TestBuildEnv_DefaultPort(t *testing.T) {
 	dir := t.TempDir()
 

--- a/pkg/airflowrt/process.go
+++ b/pkg/airflowrt/process.go
@@ -90,6 +90,14 @@ func StopProcess(pidFilePath string) (bool, error) {
 	return true, nil
 }
 
+// ProcessGroupAlive reports whether any process in pid's group is still
+// running. The process must have been started with Setpgid so pid is the
+// group leader. On Windows, where Unix process groups don't apply, it checks
+// the single PID.
+func ProcessGroupAlive(pid int) bool {
+	return isProcessGroupAlive(pid)
+}
+
 // ResolveInEnvPath looks up a binary name in the PATH from the given env slice.
 // This is needed because exec.Command uses the parent process's PATH, not cmd.Env.
 func ResolveInEnvPath(binary string, env []string) string {

--- a/pkg/airflowrt/process.go
+++ b/pkg/airflowrt/process.go
@@ -19,6 +19,13 @@ const (
 	StopTimeout           = 10 * time.Second
 )
 
+// stopPollInterval and stopTimeout mirror the exported constants; tests
+// shorten them to exercise the stop path without real processes.
+var (
+	stopPollInterval = StopPollInterval
+	stopTimeout      = StopTimeout
+)
+
 // ReadPID reads a PID file and checks if the process is alive.
 // Returns the PID and true if the process is running, or 0 and false otherwise.
 func ReadPID(pidFilePath string) (int, bool) {
@@ -60,19 +67,23 @@ func StopProcess(pidFilePath string) (bool, error) {
 
 	terminateProcess(pid)
 
-	// Poll for process exit
-	deadline := time.Now().Add(StopTimeout)
+	// Poll the process group — not just the master PID. airflow standalone
+	// spawns scheduler/api-server/triggerer as subprocesses that inherit the
+	// group; the master often exits on SIGTERM well before its children finish
+	// graceful shutdown. Watching only the master would return early here and
+	// leave those subprocesses running.
+	deadline := time.Now().Add(stopTimeout)
 	for time.Now().Before(deadline) {
-		time.Sleep(StopPollInterval)
-		if _, stillAlive := ReadPID(pidFilePath); !stillAlive {
+		time.Sleep(stopPollInterval)
+		if !isProcessGroupAlive(pid) {
 			break
 		}
 	}
 
-	// If still alive, force kill
-	if _, stillAlive := ReadPID(pidFilePath); stillAlive {
+	// If any group member is still alive, force kill
+	if isProcessGroupAlive(pid) {
 		killProcess(pid)
-		time.Sleep(StopPollInterval)
+		time.Sleep(stopPollInterval)
 	}
 
 	os.Remove(pidFilePath)

--- a/pkg/airflowrt/process_test.go
+++ b/pkg/airflowrt/process_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,6 +80,75 @@ func TestStopProcess_NoPIDFile(t *testing.T) {
 	stopped, err := StopProcess("/nonexistent/airflow.pid")
 	assert.NoError(t, err)
 	assert.False(t, stopped)
+}
+
+// stubStopSeams replaces the process-signal seams and poll timing for the
+// duration of a test, restoring the real implementations afterward.
+func stubStopSeams(t *testing.T, groupAlive func(pid int) bool, terminated, killed *[]int) {
+	t.Helper()
+	origAlive, origGroupAlive := isProcessAlive, isProcessGroupAlive
+	origTerm, origKill := terminateProcess, killProcess
+	origPoll, origTimeout := stopPollInterval, stopTimeout
+	t.Cleanup(func() {
+		isProcessAlive, isProcessGroupAlive = origAlive, origGroupAlive
+		terminateProcess, killProcess = origTerm, origKill
+		stopPollInterval, stopTimeout = origPoll, origTimeout
+	})
+	isProcessAlive = func(int) bool { return true }
+	isProcessGroupAlive = groupAlive
+	terminateProcess = func(pid int) { *terminated = append(*terminated, pid) }
+	killProcess = func(pid int) { *killed = append(*killed, pid) }
+	stopPollInterval = time.Millisecond
+	stopTimeout = 50 * time.Millisecond
+}
+
+func TestStopProcess_WaitsForProcessGroup(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "airflow.pid")
+	require.NoError(t, WritePID(pidFile, 12345))
+
+	// Simulate airflow standalone's shutdown: the master exits immediately on
+	// SIGTERM, but scheduler/triggerer children in the process group take a few
+	// polls to finish. StopProcess must wait for the whole group, not just the
+	// master.
+	var terminated, killed []int
+	groupPolls := 0
+	stubStopSeams(t, func(int) bool {
+		groupPolls++
+		return groupPolls < 3
+	}, &terminated, &killed)
+
+	stopped, err := StopProcess(pidFile)
+	assert.NoError(t, err)
+	assert.True(t, stopped)
+
+	assert.Equal(t, []int{12345}, terminated)
+	assert.Empty(t, killed, "group exited gracefully; SIGKILL must not be sent")
+	assert.GreaterOrEqual(t, groupPolls, 3, "must poll until the whole group is gone")
+
+	_, statErr := os.Stat(pidFile)
+	assert.True(t, os.IsNotExist(statErr), "PID file should be cleaned up")
+}
+
+func TestStopProcess_ForceKillsSurvivingGroup(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "airflow.pid")
+	require.NoError(t, WritePID(pidFile, 12345))
+
+	// The group never exits within the timeout: StopProcess must escalate to
+	// SIGKILL and still clean up.
+	var terminated, killed []int
+	stubStopSeams(t, func(int) bool { return true }, &terminated, &killed)
+
+	stopped, err := StopProcess(pidFile)
+	assert.NoError(t, err)
+	assert.True(t, stopped)
+
+	assert.Equal(t, []int{12345}, terminated)
+	assert.Equal(t, []int{12345}, killed)
+
+	_, statErr := os.Stat(pidFile)
+	assert.True(t, os.IsNotExist(statErr), "PID file should be cleaned up")
 }
 
 func TestStopProcess_StalePIDFile(t *testing.T) {

--- a/pkg/airflowrt/process_unix.go
+++ b/pkg/airflowrt/process_unix.go
@@ -9,7 +9,8 @@ import (
 
 // isProcessAlive checks whether a process with the given PID is running.
 // On Unix, FindProcess always succeeds, so we probe with signal 0.
-func isProcessAlive(pid int) bool {
+// Declared as a var so tests can stub it.
+var isProcessAlive = func(pid int) bool {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return false
@@ -17,12 +18,22 @@ func isProcessAlive(pid int) bool {
 	return proc.Signal(syscall.Signal(0)) == nil
 }
 
+// isProcessGroupAlive reports whether any process in pid's group is still
+// reachable. kill(-pgid, 0) returns nil iff at least one member is alive, so
+// this stays true while scheduler/triggerer children outlive the master.
+// Declared as a var so tests can stub it.
+var isProcessGroupAlive = func(pid int) bool {
+	return syscall.Kill(-pid, syscall.Signal(0)) == nil
+}
+
 // terminateProcess sends SIGTERM to the process group.
-func terminateProcess(pid int) {
+// Declared as a var so tests can stub it.
+var terminateProcess = func(pid int) {
 	syscall.Kill(-pid, syscall.SIGTERM) //nolint:errcheck
 }
 
 // killProcess sends SIGKILL to the process group.
-func killProcess(pid int) {
+// Declared as a var so tests can stub it.
+var killProcess = func(pid int) {
 	syscall.Kill(-pid, syscall.SIGKILL) //nolint:errcheck
 }

--- a/pkg/airflowrt/process_unix.go
+++ b/pkg/airflowrt/process_unix.go
@@ -7,9 +7,10 @@ import (
 	"syscall"
 )
 
+// The helpers below are vars so tests can stub them.
+
 // isProcessAlive checks whether a process with the given PID is running.
 // On Unix, FindProcess always succeeds, so we probe with signal 0.
-// Declared as a var so tests can stub it.
 var isProcessAlive = func(pid int) bool {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
@@ -21,19 +22,16 @@ var isProcessAlive = func(pid int) bool {
 // isProcessGroupAlive reports whether any process in pid's group is still
 // reachable. kill(-pgid, 0) returns nil iff at least one member is alive, so
 // this stays true while scheduler/triggerer children outlive the master.
-// Declared as a var so tests can stub it.
 var isProcessGroupAlive = func(pid int) bool {
 	return syscall.Kill(-pid, syscall.Signal(0)) == nil
 }
 
 // terminateProcess sends SIGTERM to the process group.
-// Declared as a var so tests can stub it.
 var terminateProcess = func(pid int) {
 	syscall.Kill(-pid, syscall.SIGTERM) //nolint:errcheck
 }
 
 // killProcess sends SIGKILL to the process group.
-// Declared as a var so tests can stub it.
 var killProcess = func(pid int) {
 	syscall.Kill(-pid, syscall.SIGKILL) //nolint:errcheck
 }

--- a/pkg/airflowrt/process_windows.go
+++ b/pkg/airflowrt/process_windows.go
@@ -10,7 +10,8 @@ import (
 )
 
 // isProcessAlive checks whether a process with the given PID is running on Windows.
-func isProcessAlive(pid int) bool {
+// Declared as a var so tests can stub it.
+var isProcessAlive = func(pid int) bool {
 	cmd := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH") //nolint:gosec
 	output, err := cmd.Output()
 	if err != nil {
@@ -19,8 +20,16 @@ func isProcessAlive(pid int) bool {
 	return !strings.Contains(string(output), "No tasks")
 }
 
+// isProcessGroupAlive falls back to checking the single PID on Windows, where
+// Unix-style process groups don't apply and terminateProcess only targets the
+// master process. Declared as a var so tests can stub it.
+var isProcessGroupAlive = func(pid int) bool {
+	return isProcessAlive(pid)
+}
+
 // terminateProcess kills the process on Windows (no SIGTERM equivalent).
-func terminateProcess(pid int) {
+// Declared as a var so tests can stub it.
+var terminateProcess = func(pid int) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return
@@ -29,7 +38,8 @@ func terminateProcess(pid int) {
 }
 
 // killProcess force-kills the process on Windows.
-func killProcess(pid int) {
+// Declared as a var so tests can stub it.
+var killProcess = func(pid int) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return

--- a/pkg/airflowrt/process_windows.go
+++ b/pkg/airflowrt/process_windows.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 )
 
+// The helpers below are vars so tests can stub them.
+
 // isProcessAlive checks whether a process with the given PID is running on Windows.
-// Declared as a var so tests can stub it.
 var isProcessAlive = func(pid int) bool {
 	cmd := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH") //nolint:gosec
 	output, err := cmd.Output()
@@ -22,13 +23,12 @@ var isProcessAlive = func(pid int) bool {
 
 // isProcessGroupAlive falls back to checking the single PID on Windows, where
 // Unix-style process groups don't apply and terminateProcess only targets the
-// master process. Declared as a var so tests can stub it.
+// master process.
 var isProcessGroupAlive = func(pid int) bool {
 	return isProcessAlive(pid)
 }
 
 // terminateProcess kills the process on Windows (no SIGTERM equivalent).
-// Declared as a var so tests can stub it.
 var terminateProcess = func(pid int) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
@@ -38,7 +38,6 @@ var terminateProcess = func(pid int) {
 }
 
 // killProcess force-kills the process on Windows.
-// Declared as a var so tests can stub it.
 var killProcess = func(pid int) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {


### PR DESCRIPTION
## What changed

**Loopback binding.** Standalone mode runs Airflow with `SIMPLE_AUTH_MANAGER_ALL_ADMINS=True`, and Airflow's api-server (Airflow 3) and webserver (Airflow 2) default to binding `0.0.0.0`. That combination made a local dev instance reachable from other machines on the network. A new `airflowrt.ApplyLoopbackDefaults` defaults `AIRFLOW__API__HOST` and `AIRFLOW__WEBSERVER__WEB_SERVER_HOST` to `127.0.0.1`; both `airflowrt.BuildEnv` and the live path, `(*Standalone).buildEnv` in `airflow/standalone.go`, call it. Only the default changed: a user's own setting, from the `.env` file or the inherited environment, still wins. Airflow ignores whichever key doesn't apply to the running major.

**Stop the whole process group.** Both `airflowrt.StopProcess` and the live path, `(*Standalone).Stop`, polled the master PID, which often exits on SIGTERM before its scheduler/api-server/triggerer children, so those children outlive `astro dev stop`. Both now poll the process group (new `airflowrt.ProcessGroupAlive`) and return only once the whole group is gone, still escalating to SIGKILL on timeout. The master is the group leader — `Start` launches it with `Setpgid` — so `kill(-pid, 0)` is a valid group probe. On Windows, where Unix process groups don't apply, the airflowrt fallback checks the single PID — children a dead master leaves behind can still linger there. (v1's standalone mode is a stub on Windows, so its live path is unaffected.)

Review found that `airflowrt.BuildEnv` and `airflowrt.StopProcess` have no production callers in this repo — `astro dev` runs the `standalone.go` paths — so the fix lands in both places, keeping the shared module and the live path in agreement.

## Tests

- Env defaults include the loopback pins, and overrides from `.env` and from the inherited environment win — asserted for both `airflowrt.BuildEnv` and `(*Standalone).buildEnv`.
- `airflowrt.StopProcess` covered without real processes: the signal helpers are package vars the tests stub, so the graceful-wait and force-kill paths run in milliseconds.
- `(*Standalone).Stop` covered with a real process group whose master dies on SIGTERM while a TERM-ignoring child lives on ~2s; Stop must outwait the child and leave the group fully dead.
- `go build`/`go vet`/`go test` in `pkg/airflowrt` (including a `GOOS=windows` cross-compile), `go build ./...` and `go test ./airflow/...` at the root, `golangci-lint` on both (no new findings).

## Breaking changes

None. Defaults changed; explicit user overrides still win. The airflowrt additions (`ApplyLoopbackDefaults`, `ProcessGroupAlive`) are new exports, no signatures changed — the module stays backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6DEdUpFBFaAiPKEu81Wti

