### PR TITLE
Reject embedded image tags in remote.client_registry

### DIFF
--- a/config/validators.go
+++ b/config/validators.go
@@ -47,5 +47,15 @@ func ValidateRegistryEndpoint(endpoint string) error {
 		return fmt.Errorf("registry endpoint cannot start or end with slashes")
 	}
 
+	// The repository path (everything after the first slash) must not contain
+	// an embedded image tag. A colon before the first slash is a valid registry
+	// port (e.g. "localhost:5000/repo"), but a colon after it means the user
+	// included a ":tag" on the repository path, which the CLI will double up
+	// with its own "deploy-<timestamp>" tag and produce an invalid reference.
+	repoPath := endpoint[strings.Index(endpoint, "/")+1:]
+	if strings.Contains(repoPath, ":") {
+		return fmt.Errorf("registry endpoint must not include an image tag -- got %q, use 'registry[:port]/repository/path' without a trailing ':tag' (the CLI appends its own deploy tag automatically)", endpoint)
+	}
+
 	return nil
 }

--- a/config/validators_test.go
+++ b/config/validators_test.go
@@ -22,6 +22,7 @@ func (s *Suite) Test_validateRegistryEndpoint() {
 			"registry with spaces/repo", // contains spaces
 			"/registry/repo",            // starts with slash
 			"registry/repo/",            // ends with slash
+			"myregistry.example.com:7990/repository/path/my-image:1.0", // embedded tag on repository path
 		}
 
 		for _, endpoint := range invalidEndpoints {


### PR DESCRIPTION
## Summary

Fixes #2223.

`astro remote deploy` builds its remote push tag as `registryEndpoint + ":deploy-" + <timestamp>`, where `registryEndpoint` is the raw `remote.client_registry` config value. If a user sets that config to a value that already contains a `:tag` (e.g. pasted from a Dockerfile `FROM` line), the CLI double-tags the reference (`.../my-image:1.0:deploy-2026-07-22T16:23`), and Docker fails the build with an opaque `invalid reference format` error instead of a clear CLI-level message. This hit a customer live mid-PoV.

`ValidateRegistryEndpoint` in `config/validators.go` is the single shared validator for `remote.client_registry`, used by both `astro dev init --remote-execution-enabled` (`getRegistryEndpoint()` in `cmd/airflow.go`) and `astro config set remote.client_registry <value>` (`cmd/config.go`). It previously only checked for non-empty, presence of `/`, no spaces, and no leading/trailing `/` -- it never rejected an embedded tag.

## Fix

`ValidateRegistryEndpoint` now rejects any value where the repository-path portion (everything after the *first* `/`) contains a `:`. A `:port` on the registry host itself (before the first `/`, e.g. `localhost:5000/repo`) remains valid, since the colon there is not a tag.

New error:

```
registry endpoint must not include an image tag -- got %q, use 'registry[:port]/repository/path' without a trailing ':tag' (the CLI appends its own deploy tag automatically)
```

## Test plan

- [x] Added a new invalid-case fixture to `Test_validateRegistryEndpoint` in `config/validators_test.go`: `myregistry.example.com:7990/repository/path/my-image:1.0` (embedded tag on repo path) now fails validation.
- [x] Existing valid cases still pass, including `localhost:5000/test/repo` (registry port, not a tag).
- [x] Existing invalid cases (empty, no slash, spaces, leading/trailing slash) still pass.
- [x] `go test ./config/...` passes.
- [x] `gofmt -l` and `go vet ./config/...` clean on changed files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Sonnet 5
