### PR TITLE
Add --mode flag to APC deployment create

### DIFF
--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -58,6 +58,7 @@ var (
 	runtimeVersion          string
 	desiredRuntimeVersion   string
 	clusterID               string
+	deploymentMode          string
 
 	adoptName                    string
 	adoptNamespace               string
@@ -98,6 +99,9 @@ $ astro deployment create --label=new-deployment-name-k8s --executor=k8s --airfl
 
 # Create new deployment with Astronomer Runtime.
 $ astro deployment create --label=my-new-deployment --executor=k8s --runtime-version=6.0.1 --cluster-id=123
+
+# Create Operator deployment (Houston 2.1.0+).
+$ astro deployment create --label=my-operator-deployment --executor=k8s --cluster-id=123 --mode=operator
 `
 
 	createExampleDagDeployment = `
@@ -226,6 +230,10 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	if localHoustonVersion >= "1.0.0" {
 		cmd.Flags().StringVarP(&clusterID, "cluster-id", "", "", "Set cluster ID to create deployment in ")
 		_ = cmd.MarkFlagRequired("cluster-id")
+	}
+
+	if localHoustonVersion >= "2.1.0" {
+		cmd.Flags().StringVarP(&deploymentMode, "mode", "", "", "Deployment mode, one of: helm (default), operator")
 	}
 	_ = cmd.MarkFlagRequired("label")
 	return cmd
@@ -490,6 +498,10 @@ func deploymentCreate(cmd *cobra.Command, out io.Writer) error {
 		return err
 	}
 
+	if err := validateDeploymentModeArg(deploymentMode); err != nil {
+		return err
+	}
+
 	var nfsMountDAGDeploymentEnabled, gitSyncDAGDeploymentEnabled, dagOnlyDeployEnabled bool
 	if appConfig != nil {
 		nfsMountDAGDeploymentEnabled = appConfig.Flags.NfsMountDagDeployment
@@ -536,6 +548,7 @@ func deploymentCreate(cmd *cobra.Command, out io.Writer) error {
 		GitSyncInterval:   gitSyncInterval,
 		TriggererReplicas: createTriggererReplicas,
 		ClusterID:         clusterID,
+		Mode:              deploymentMode,
 	}
 	return deployment.Create(req, houstonClient, out, appConfig)
 }

--- a/cmd/software/deployment.go
+++ b/cmd/software/deployment.go
@@ -100,7 +100,7 @@ $ astro deployment create --label=new-deployment-name-k8s --executor=k8s --airfl
 # Create new deployment with Astronomer Runtime.
 $ astro deployment create --label=my-new-deployment --executor=k8s --runtime-version=6.0.1 --cluster-id=123
 
-# Create Operator deployment (Houston 2.1.0+).
+# Create Operator deployment (APC 2.1.0+).
 $ astro deployment create --label=my-operator-deployment --executor=k8s --cluster-id=123 --mode=operator
 `
 
@@ -170,7 +170,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	}
 
 	example := deploymentCreateExample
-	if localHoustonVersion >= "1.0.0" {
+	if houston.VerifyVersionMatch(localHoustonVersion, houston.VersionRestrictions{GTE: "1.0.0"}) {
 		example = deploymentCreateExampleSoftwareV1
 	}
 	cmd := &cobra.Command{
@@ -201,7 +201,7 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	}
 
 	if nfsMountDAGDeploymentEnabled {
-		if localHoustonVersion >= "1.0.0" {
+		if houston.VerifyVersionMatch(localHoustonVersion, houston.VersionRestrictions{GTE: "1.0.0"}) {
 			cmd.Example += createExampleDagDeploymentSoftwareV1
 		} else {
 			cmd.Example += createExampleDagDeployment
@@ -227,12 +227,12 @@ func newDeploymentCreateCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&releaseName, "release-name", "r", "", "Set custom release-name if possible")
 	cmd.Flags().StringVarP(&cloudRole, "cloud-role", "c", "", "Set cloud role to annotate service accounts in deployment")
 
-	if localHoustonVersion >= "1.0.0" {
+	if houston.VerifyVersionMatch(localHoustonVersion, houston.VersionRestrictions{GTE: "1.0.0"}) {
 		cmd.Flags().StringVarP(&clusterID, "cluster-id", "", "", "Set cluster ID to create deployment in ")
 		_ = cmd.MarkFlagRequired("cluster-id")
 	}
 
-	if localHoustonVersion >= "2.1.0" {
+	if houston.VerifyVersionMatch(localHoustonVersion, houston.VersionRestrictions{GTE: "2.1.0"}) {
 		cmd.Flags().StringVarP(&deploymentMode, "mode", "", "", "Deployment mode, one of: helm (default), operator")
 	}
 	_ = cmd.MarkFlagRequired("label")
@@ -315,7 +315,7 @@ func newDeploymentListCmd(out io.Writer) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&allDeployments, "all", "a", false, "Show Deployments across all Workspaces")
-	if localHoustonVersion >= "1.0.0" {
+	if houston.VerifyVersionMatch(localHoustonVersion, houston.VersionRestrictions{GTE: "1.0.0"}) {
 		cmd.Flags().StringVarP(&clusterID, "cluster-id", "", "", "Show Deployments from the specified cluster")
 	}
 	return cmd

--- a/cmd/software/validation.go
+++ b/cmd/software/validation.go
@@ -18,6 +18,7 @@ var (
 	errGitRepoNotFound          = errors.New("please specify a valid git repository URL via --git-repository-url")
 	errInvalidExecutorType      = errors.New("please specify correct executor, one of: local, celery, kubernetes, k8s")
 	errNoWorkspaceFound         = errors.New("no valid workspace source found")
+	errInvalidDeploymentMode    = errors.New("please specify a valid deployment mode, one of: helm, operator")
 )
 
 var validGitScheme = map[string]struct{}{
@@ -98,6 +99,15 @@ func validateDagDeploymentArgs(dagDeploymentType, nfsLocation, gitRepoURL string
 		return errGitRepoNotFound
 	}
 	return nil
+}
+
+func validateDeploymentModeArg(mode string) error {
+	switch mode {
+	case "", houston.HelmDeploymentMode, houston.OperatorDeploymentMode:
+		return nil
+	default:
+		return errInvalidDeploymentMode
+	}
 }
 
 func validateExecutorArg(executor string) (string, error) {

--- a/cmd/software/validation_test.go
+++ b/cmd/software/validation_test.go
@@ -218,3 +218,43 @@ func (s *Suite) TestValidateExecutorArg() {
 		})
 	}
 }
+
+func (s *Suite) TestValidateDeploymentModeArg() {
+	tests := []struct {
+		name        string
+		mode        string
+		expectedErr string
+	}{
+		{
+			name:        "empty mode is allowed (Houston defaults to helm)",
+			mode:        "",
+			expectedErr: "",
+		},
+		{
+			name:        "valid helm mode",
+			mode:        houston.HelmDeploymentMode,
+			expectedErr: "",
+		},
+		{
+			name:        "valid operator mode",
+			mode:        houston.OperatorDeploymentMode,
+			expectedErr: "",
+		},
+		{
+			name:        "invalid mode",
+			mode:        "invalid",
+			expectedErr: "please specify a valid deployment mode, one of: helm, operator",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			err := validateDeploymentModeArg(tt.mode)
+			if tt.expectedErr != "" {
+				s.EqualError(err, tt.expectedErr)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}

--- a/houston/constants.go
+++ b/houston/constants.go
@@ -29,6 +29,10 @@ const (
 	ImageDeploymentType   = "image"
 	DagOnlyDeploymentType = "dag_deploy"
 
+	// Available on Houston >= 2.1.0.
+	HelmDeploymentMode     = "helm"
+	OperatorDeploymentMode = "operator"
+
 	DagDeployDocsLink    = "https://www.astronomer.io/docs/software/deploy-dags/"
 	DeployViaCLIDocsLink = "https://www.astronomer.io/docs/software/deploy-cli/"
 )

--- a/houston/deployment.go
+++ b/houston/deployment.go
@@ -283,6 +283,52 @@ var (
 			      }
 			    }`,
 		},
+		{
+			version: "2.1.0",
+			query: `
+			mutation upsertDeployment(
+				$label: String,
+			    $workspaceId: Uuid,
+			    $clusterId: Uuid,
+			    $releaseName: String,
+				$executor: ExecutorType,
+				$runtimeVersion: String,
+			    $namespace: String,
+				$cloudRole: String,
+				$dagDeployment: DagDeployment,
+				$triggererReplicas: Int,
+				$mode: AllowedDeploymentModeValues,
+			  ) {
+			    upsertDeployment(
+			      workspaceUuid: $workspaceId,
+			      clusterId: $clusterId,
+			      label: $label,
+			      releaseName: $releaseName,
+			      namespace: $namespace,
+			      runtimeVersion: $runtimeVersion,
+			      executor: $executor,
+			      triggerer: {
+						replicas: $triggererReplicas
+					}
+			      dagDeployment: $dagDeployment,
+			      cloudRole: $cloudRole,
+			      mode: $mode,
+			    ) {
+			        id
+					type
+					label
+					releaseName
+					version
+					runtimeVersion
+					urls {
+						type
+						url
+					}
+					createdAt
+					updatedAt
+			      }
+			    }`,
+		},
 	}
 
 	DeploymentsGetRequest = queryList{

--- a/houston/deployment_test.go
+++ b/houston/deployment_test.go
@@ -108,6 +108,51 @@ func (s *Suite) TestCreateDeployment() {
 		_, err := api.CreateDeployment(map[string]interface{}{})
 		s.Contains(err.Error(), "Internal Server Error")
 	})
+
+	s.Run("uses mode-aware query and passes mode for Houston >= 2.1.0", func() {
+		oldVersion := version
+		version = "2.1.0"
+		defer func() { version = oldVersion }()
+
+		var capturedBody string
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			b, _ := io.ReadAll(req.Body)
+			capturedBody = string(b)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.CreateDeployment(map[string]interface{}{"mode": OperatorDeploymentMode})
+		s.NoError(err)
+		s.Contains(capturedBody, "$mode: AllowedDeploymentModeValues")
+		s.Contains(capturedBody, OperatorDeploymentMode)
+	})
+
+	s.Run("omits mode variable from query for Houston < 2.1.0", func() {
+		oldVersion := version
+		version = "1.0.1"
+		defer func() { version = oldVersion }()
+
+		var capturedBody string
+		client := testUtil.NewTestClient(func(req *http.Request) *http.Response {
+			b, _ := io.ReadAll(req.Body)
+			capturedBody = string(b)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBuffer(jsonResponse)),
+				Header:     make(http.Header),
+			}
+		})
+		api := NewClient(client)
+
+		_, err := api.CreateDeployment(map[string]interface{}{})
+		s.NoError(err)
+		s.NotContains(capturedBody, "$mode: AllowedDeploymentModeValues")
+	})
 }
 
 func (s *Suite) TestDeleteDeployment() {

--- a/software/deployment/deployment.go
+++ b/software/deployment/deployment.go
@@ -97,6 +97,10 @@ func Create(req *CreateDeploymentRequest, client houston.ClientInterface, out io
 		vars["clusterId"] = req.ClusterID
 	}
 
+	if req.Mode != "" {
+		vars["mode"] = req.Mode
+	}
+
 	if appConfig.Flags.ManualNamespaceNames {
 		namespace, err := getDeploymentSelectionNamespaces(client, out, req.ClusterID)
 		if err != nil {

--- a/software/deployment/deployment_test.go
+++ b/software/deployment/deployment_test.go
@@ -188,7 +188,7 @@ func (s *Suite) TestCreate() {
 	nfsLocation := ""
 	triggerReplicas := 0
 	clusterID := "testClusterID"
-	req := &CreateDeploymentRequest{label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, clusterID}
+	req := &CreateDeploymentRequest{label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, clusterID, ""}
 
 	s.Run("create success. Cluster is not passed in the payload", func() {
 		req.ClusterID = ""
@@ -216,6 +216,34 @@ func (s *Suite) TestCreate() {
 		api.AssertExpectations(s.T())
 	})
 
+	s.Run("create success. Mode is passed in the payload when set", func() {
+		req.Mode = houston.OperatorDeploymentMode
+		api := new(mocks.ClientInterface)
+		api.On("CreateDeployment", mock.MatchedBy(func(vars map[string]interface{}) bool {
+			return vars["mode"] == houston.OperatorDeploymentMode
+		})).Return(mockDeployment, nil)
+
+		buf := new(bytes.Buffer)
+		err := Create(req, api, buf, mockAppConfig)
+		s.NoError(err)
+		api.AssertExpectations(s.T())
+		req.Mode = ""
+	})
+
+	s.Run("create success. Mode is omitted from the payload when empty", func() {
+		req.Mode = ""
+		api := new(mocks.ClientInterface)
+		api.On("CreateDeployment", mock.MatchedBy(func(vars map[string]interface{}) bool {
+			_, ok := vars["mode"]
+			return !ok
+		})).Return(mockDeployment, nil)
+
+		buf := new(bytes.Buffer)
+		err := Create(req, api, buf, mockAppConfig)
+		s.NoError(err)
+		api.AssertExpectations(s.T())
+	})
+
 	s.Run("create trigger enabled", func() {
 		mockAppConfig.TriggererEnabled = true
 
@@ -238,7 +266,7 @@ func (s *Suite) TestCreate() {
 
 		triggerReplicas = -1
 		buf := new(bytes.Buffer)
-		req = &CreateDeploymentRequest{label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, clusterID}
+		req = &CreateDeploymentRequest{label, ws, releaseName, role, executor, airflowVersion, "", dagDeploymentType, nfsLocation, "", "", "", "", "", "", 1, triggerReplicas, clusterID, ""}
 		err := Create(req, api, buf, mockAppConfig)
 		s.NoError(err)
 		s.Contains(buf.String(), "Successfully created deployment with Celery executor. Deployment can be accessed at the following URLs")
@@ -289,7 +317,7 @@ func (s *Suite) TestCreate() {
 
 		for _, tt := range myTests {
 			buf := new(bytes.Buffer)
-			createReq := &CreateDeploymentRequest{label, ws, releaseName, role, executor, "", runtimeVersion, dagDeploymentType, "", tt.repoURL, tt.revision, tt.branchName, tt.dagDirectoryLocation, tt.sshKey, tt.knownHosts, tt.syncInterval, triggerReplicas, clusterID}
+			createReq := &CreateDeploymentRequest{label, ws, releaseName, role, executor, "", runtimeVersion, dagDeploymentType, "", tt.repoURL, tt.revision, tt.branchName, tt.dagDirectoryLocation, tt.sshKey, tt.knownHosts, tt.syncInterval, triggerReplicas, clusterID, ""}
 			err := Create(createReq, api, buf, mockAppConfig)
 			if tt.expectedError != "" {
 				s.EqualError(err, tt.expectedError)

--- a/software/deployment/types.go
+++ b/software/deployment/types.go
@@ -19,4 +19,5 @@ type CreateDeploymentRequest struct {
 	GitSyncInterval   int
 	TriggererReplicas int
 	ClusterID         string
+	Mode              string
 }


### PR DESCRIPTION
## Description

Adds a --mode flag (helm/operator) to astro deployment create, gated behind Houston ≥ 2.1.0, enabling creation of Operator deployments. Passes mode through the upsertDeployment mutation; omitted for older Houston versions. Includes validation and tests.

## 🎟 Issue(s)

https://linear.app/astronomer/issue/PINF-1113/add-mode-support-in-astro-cli-api-call

## 🧪 Functional Testing

1. Created deployment with `--mode operator`
```
./astro deployment create --label=my-operator-deployment --executor=k8s --cluster-id=cms4gidt800002p9uz31dd7tc --mode=operator
 NAME                       DEPLOYMENT NAME           ASTRO     DEPLOYMENT ID                 TAG     IMAGE VERSION      
 my-operator-deployment     newtonian-proton-5623               cms5roq7q000ndr015loqmeew     -       Runtime-13.8.0     

 Successfully created deployment with Kubernetes executor. Deployment can be accessed at the following URLs 

 Airflow Dashboard: https://deployments.astro.airflow-operator.test.us-east-2.astro-qa-1.link/newtonian-proton-5623/airflow
```

2. Created deployment with no `--mode` -> Defaulted to helm
```
./astro deployment create --label=my-helm-deployment --executor=k8s --cluster-id=cms4gidt800002p9uz31dd7tc
 NAME                   DEPLOYMENT NAME             ASTRO     DEPLOYMENT ID                 TAG     IMAGE VERSION      
 my-helm-deployment     universal-aphelion-9816               cms5rd5wt000adr01qskgg8g2     -       Runtime-13.8.0     

 Successfully created deployment with Kubernetes executor. Deployment can be accessed at the following URLs 

 Airflow Dashboard: https://deployments.astro.airflow-operator.test.us-east-2.astro-qa-1.link/universal-aphelion-9816/airflow
```

3. Created deployment when operator mode was disabled in cluster
```
./astro deployment create --label=my-operator-deployment-2 --executor=k8s --cluster-id=cms4gidt800002p9uz31dd7tc --mode=operator
Error: Deployment with mode - operator cannot be created or updated. Reason: deployments.mode.operator.enabled is false
```

## 📸 Screenshots

1. 
<img width="723" height="556" alt="image" src="https://github.com/user-attachments/assets/62a0fb6f-b41a-4828-9cc1-8035e95676eb" />


2. 
<img width="716" height="614" alt="image" src="https://github.com/user-attachments/assets/3c669310-418a-4611-941b-b463776e1f2a" />


## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
