### PR TITLE
Detect Otto and GitHub Copilot as calling agents

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -60,6 +60,45 @@ var agentEnvVars = []envMapping{
 	{"GEMINI_CLI", "gemini-cli"},
 	{"OPENCODE", "opencode"},
 	{"CODEX_API_KEY", "codex"},
+	// GitHub Copilot. COPILOT_CLI is set by the Copilot CLI, which is also the
+	// harness behind the cloud coding agent and, as of 2026, Copilot for
+	// JetBrains; github's own gh keys on it (cli/cli internal/agents/detect.go).
+	// COPILOT_AGENT is set on terminals VS Code creates for agent mode
+	// (microsoft/vscode toolTerminalCreator.ts), where it is described as
+	// backward compatibility for exactly this kind of detection.
+	{"COPILOT_CLI", "github-copilot"},
+	{"COPILOT_AGENT", "github-copilot"},
+}
+
+// aiAgentEnvVar is a cross-vendor convention where the value names the agent
+// rather than the variable: VS Code sets AI_AGENT=github_copilot_vscode_agent
+// for agent sessions and the Copilot desktop app sets github_copilot_app_agent
+// (microsoft/vscode aiAgentEnv.ts). gh reads it too.
+//
+// It is checked after agentEnvVars so a specific marker still wins, and only
+// prefixes we recognise are mapped. Values are not passed through: some vendors
+// put a version in theirs (claude-code_2-1-156_agent), which would spray one
+// agent across dozens of distinct values in the telemetry. A new vendor adopting
+// the convention is a one-line addition here.
+const aiAgentEnvVar = "AI_AGENT"
+
+var aiAgentPrefixes = []envMapping{
+	{"github_copilot", "github-copilot"},
+}
+
+// detectAIAgent maps the AI_AGENT convention to an agent name, or "" if the
+// value is empty or not one we recognise.
+func detectAIAgent() string {
+	value := strings.ToLower(os.Getenv(aiAgentEnvVar))
+	if value == "" {
+		return ""
+	}
+	for _, m := range aiAgentPrefixes {
+		if strings.HasPrefix(value, m.envVar) {
+			return m.name
+		}
+	}
+	return ""
 }
 
 // ciEnvVars is an ordered list of environment variables to detect CI contexts.
@@ -106,7 +145,7 @@ func DetectAgent() string {
 			return m.name
 		}
 	}
-	return ""
+	return detectAIAgent()
 }
 
 // DetectCISystem returns the name of the detected CI system (e.g. "github-actions"), or "" if none.

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -43,8 +43,13 @@ type envMapping struct {
 	name   string
 }
 
-// agentEnvVars is an ordered list of environment variables to detect agent contexts
+// agentEnvVars is an ordered list of environment variables to detect agent
+// contexts. Order matters: the first match wins. Otto is first because it
+// passes its own environment through to every command it runs, so an Otto
+// session started from inside another agent still carries that agent's marker.
+// Otto is the proximate caller, so it takes precedence.
 var agentEnvVars = []envMapping{
+	{"OTTO", "otto"},
 	{"CLAUDECODE", "claude-code"},
 	{"CLAUDE_CODE_ENTRYPOINT", "claude-code"},
 	{"CURSOR_TRACE_ID", "cursor"},

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -65,6 +65,7 @@ func TestDetectAgent(t *testing.T) {
 		envValue string
 		expected string
 	}{
+		{"otto", "OTTO", "1", "otto"},
 		{"claude code", "CLAUDECODE", "1", "claude-code"},
 		{"claude code entrypoint", "CLAUDE_CODE_ENTRYPOINT", "cli", "claude-code"},
 		{"cursor", "CURSOR_TRACE_ID", "abc123", "cursor"},
@@ -88,6 +89,29 @@ func TestDetectAgent(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// Otto passes its own environment through to every command it runs, so an Otto
+// session started from inside another agent still carries that agent's marker.
+// Otto is the proximate caller and must win.
+func TestDetectAgentOttoWinsOverInheritedMarker(t *testing.T) {
+	for _, env := range envVarNames(agentEnvVars) {
+		saved := os.Getenv(env)
+		os.Unsetenv(env)
+		defer func(env, saved string) {
+			if saved != "" {
+				os.Setenv(env, saved)
+			}
+		}(env, saved)
+	}
+
+	os.Setenv("CLAUDECODE", "1")
+	defer os.Unsetenv("CLAUDECODE")
+	assert.Equal(t, "claude-code", DetectAgent())
+
+	os.Setenv("OTTO", "1")
+	defer os.Unsetenv("OTTO")
+	assert.Equal(t, "otto", DetectAgent())
 }
 
 func TestDetectCISystem(t *testing.T) {

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -43,7 +43,7 @@ func TestIsDisabledByEnv(t *testing.T) {
 }
 
 func TestDetectAgent(t *testing.T) {
-	agentVars := envVarNames(agentEnvVars)
+	agentVars := append(envVarNames(agentEnvVars), aiAgentEnvVar)
 	savedVals := make(map[string]string)
 	for _, env := range agentVars {
 		savedVals[env] = os.Getenv(env)
@@ -73,6 +73,11 @@ func TestDetectAgent(t *testing.T) {
 		{"gemini cli", "GEMINI_CLI", "1", "gemini-cli"},
 		{"opencode", "OPENCODE", "1", "opencode"},
 		{"codex", "CODEX_API_KEY", "sk-test", "codex"},
+		{"copilot cli", "COPILOT_CLI", "1", "github-copilot"},
+		{"copilot vscode agent mode", "COPILOT_AGENT", "1", "github-copilot"},
+		{"ai_agent copilot vscode", "AI_AGENT", "github_copilot_vscode_agent", "github-copilot"},
+		{"ai_agent copilot app", "AI_AGENT", "github_copilot_app_agent", "github-copilot"},
+		{"ai_agent unrecognised vendor", "AI_AGENT", "some_other_agent", ""},
 		{"no agent", "", "", ""},
 	}
 
@@ -95,7 +100,7 @@ func TestDetectAgent(t *testing.T) {
 // session started from inside another agent still carries that agent's marker.
 // Otto is the proximate caller and must win.
 func TestDetectAgentOttoWinsOverInheritedMarker(t *testing.T) {
-	for _, env := range envVarNames(agentEnvVars) {
+	for _, env := range append(envVarNames(agentEnvVars), aiAgentEnvVar) {
 		saved := os.Getenv(env)
 		os.Unsetenv(env)
 		defer func(env, saved string) {
@@ -108,6 +113,29 @@ func TestDetectAgentOttoWinsOverInheritedMarker(t *testing.T) {
 	os.Setenv("CLAUDECODE", "1")
 	defer os.Unsetenv("CLAUDECODE")
 	assert.Equal(t, "claude-code", DetectAgent())
+
+	os.Setenv("OTTO", "1")
+	defer os.Unsetenv("OTTO")
+	assert.Equal(t, "otto", DetectAgent())
+}
+
+// AI_AGENT is the fallback, so a specific marker still decides. VS Code sets
+// both AI_AGENT and COPILOT_AGENT, and Otto inside a VS Code agent terminal
+// carries both plus its own.
+func TestDetectAgentSpecificMarkerBeatsAIAgent(t *testing.T) {
+	for _, env := range append(envVarNames(agentEnvVars), aiAgentEnvVar) {
+		saved := os.Getenv(env)
+		os.Unsetenv(env)
+		defer func(env, saved string) {
+			if saved != "" {
+				os.Setenv(env, saved)
+			}
+		}(env, saved)
+	}
+
+	os.Setenv("AI_AGENT", "github_copilot_vscode_agent")
+	defer os.Unsetenv("AI_AGENT")
+	assert.Equal(t, "github-copilot", DetectAgent())
 
 	os.Setenv("OTTO", "1")
 	defer os.Unsetenv("OTTO")


### PR DESCRIPTION
`DetectAgent` reads a fixed list of env vars to record which coding agent ran a command. Two were missing.

**Otto** set no marker, so Otto-driven commands looked like a person typing. It also passes its environment to children untouched, so an Otto session started inside another agent got credited to that agent. `OTTO` goes **first** in the list — first match wins, so the position is what fixes that. astronomer/otto#379 sets the variable; until that ships this does nothing.

**GitHub Copilot** gets three entries: `COPILOT_CLI` (also the harness behind the cloud agent and JetBrains, and what `gh` itself reads), `COPILOT_AGENT` (VS Code agent terminals), and `AI_AGENT`, a newer convention where the value names the agent rather than the variable.

`AI_AGENT` is read after the list, so a specific marker still wins, and only known prefixes are mapped. Values are not passed through: some vendors put a version in theirs, which would spread one agent across a new telemetry value every release.

Tests cover both agents and both precedence rules. `go test ./...` in `pkg/telemetry` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKSW26NfBtfq8hVeeLdfLj