### PR TITLE
switch winget PR creation from Octo STS to PAT

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -184,7 +184,7 @@ jobs:
           version: ${{ needs.detect.outputs.version }}
           release-tag: ${{ needs.detect.outputs.tag }}
           installers-regex: '\.exe$'
-          token: ${{ steps.winget-token.outputs.token }}
+          token: ${{ secrets.WINGET_PAT }}
 
   cleanup-nightlies:
     needs: [detect, release]


### PR DESCRIPTION
## Description

The `update-winget` job was failing at PR creation with `Resource not accessible by integration`. Root cause: Octo STS mints GitHub App installation tokens, and a GitHub App can only open PRs where it is installed on the base repo. Since we can't install our App on `microsoft/winget-pkgs`, PR creation always fails.

Switching to a user-scoped PAT resolves issue where any authenticated user can open PRs to public upstream repos from a fork.

## 🎟 Issue(s)

Related #XXX

## 🧪 Functional Testing

> List the functional testing steps to confirm this feature or fix.

## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
