### PR TITLE
[chore] Backport 1.44 release PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 !airflow/include/*/requirements.txt
 *.ndjson.gz
 *.test
+*.yaml.lock
 .astro/
 .DS_Store
 .env

--- a/cloud/deploy/bundle.go
+++ b/cloud/deploy/bundle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/astronomer/astro-cli/astro-client-v1"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/cosmosboost"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/git"
 	"github.com/astronomer/astro-cli/pkg/logger"
@@ -215,6 +216,19 @@ func UploadBundle(tarDirPath, bundlePath, uploadURL string, prependBaseDir bool,
 			}
 		}
 	}()
+
+	// Cosmos Boost pre-deploy step, opt-in via cosmos_boost.pre_deploy; with
+	// the setting off the deploy does not touch the tree at all. Cleanup runs
+	// first and is fatal on failure (a stale artifact must not ship inside the
+	// bundle), while stamping is best-effort (a missing artifact is safe).
+	// Artifacts left by earlier enabled deploys are removed with
+	// `astro dbt cleanup`.
+	if config.CFG.CosmosBoostPreDeploy.GetBool() {
+		if err := cosmosboost.EnsureClean(bundlePath); err != nil {
+			return "", err
+		}
+		cosmosboost.BestEffortPreDeploy(bundlePath)
+	}
 
 	// Generate the bundle tar
 	err := fileutil.Tar(bundlePath, tarFilePath, prependBaseDir, []string{".git/"})

--- a/cloud/deploy/cosmosboost_hook_test.go
+++ b/cloud/deploy/cosmosboost_hook_test.go
@@ -1,0 +1,236 @@
+package deploy
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/astronomer/astro-cli/airflow"
+	"github.com/astronomer/astro-cli/airflow/mocks"
+	astrov1_mocks "github.com/astronomer/astro-cli/astro-client-v1/mocks"
+	"github.com/astronomer/astro-cli/config"
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+)
+
+// cosmosBoostArtifact is the sidecar the pre-deploy step writes next to a dbt
+// project; these tests assert it is produced (or removed) at the right moment
+// in each deploy path.
+const cosmosBoostArtifact = ".astro/dbt_metadata.json"
+
+// setupCosmosBoostEnv isolates ~/.astro for the test.
+func setupCosmosBoostEnv(t *testing.T) {
+	t.Helper()
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+	origHome := config.HomeConfigPath
+	config.HomeConfigPath = t.TempDir()
+	t.Cleanup(func() { config.HomeConfigPath = origHome })
+}
+
+func writeDbtBundle(t *testing.T) string {
+	t.Helper()
+	bundleDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "dbt_project.yml"), []byte("name: shop\n"), 0o644))
+	return bundleDir
+}
+
+func TestUploadBundleRunsPreDeployWhenEnabled(t *testing.T) {
+	setupCosmosBoostEnv(t)
+	require.NoError(t, config.CFG.CosmosBoostPreDeploy.SetHomeString("true"))
+
+	bundleDir := writeDbtBundle(t)
+
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	_, err := UploadBundle(t.TempDir(), bundleDir, "http://upload-url", false, "0.0.0")
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(bundleDir, cosmosBoostArtifact),
+		"the pre-deploy step must stamp the bundle before it is tarred")
+}
+
+func TestUploadBundleSkipsPreDeployByDefault(t *testing.T) {
+	setupCosmosBoostEnv(t)
+	// cosmos_boost.pre_deploy defaults to false, so nothing may be produced.
+
+	bundleDir := writeDbtBundle(t)
+
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	_, err := UploadBundle(t.TempDir(), bundleDir, "http://upload-url", false, "0.0.0")
+	require.NoError(t, err)
+
+	assert.NoFileExists(t, filepath.Join(bundleDir, cosmosBoostArtifact),
+		"opt-in gate is off by default; nothing may be written")
+}
+
+// TestDeployBundleDbtPathRunsPreDeployWhenEnabled drives the full
+// `astro dbt deploy` bundle path (DeployBundle into UploadBundle) to pin that
+// moving the hook out of cmd/cloud/dbt.go did not lose dbt-deploy coverage.
+func TestDeployBundleDbtPathRunsPreDeployWhenEnabled(t *testing.T) {
+	setupCosmosBoostEnv(t)
+	require.NoError(t, config.CFG.CosmosBoostPreDeploy.SetHomeString("true"))
+
+	canCiCdDeploy = func(token string) bool { return true }
+
+	bundleDir := writeDbtBundle(t)
+
+	mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
+	mockGetDeployment(mockV1Client, true, false)
+	mockCreateDeploy(mockV1Client, "http://bundle-upload-url", nil)
+	mockUpdateDeploy(mockV1Client, "version-id")
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	err := DeployBundle(&DeployBundleInput{
+		BundlePath:    bundleDir,
+		MountPath:     "dbt/shop",
+		DeploymentID:  "test-deployment-id",
+		BundleType:    "dbt",
+		AstroV1Client: mockV1Client,
+	})
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(bundleDir, cosmosBoostArtifact),
+		"astro dbt deploy must still run the pre-deploy step after the hook moved into UploadBundle")
+}
+
+func TestBuildImageRunsPreDeployOnBuildContextWhenEnabled(t *testing.T) {
+	setupCosmosBoostEnv(t)
+	require.NoError(t, config.CFG.CosmosBoostPreDeploy.SetHomeString("true"))
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "dbt_project.yml"), []byte("name: shop\n"), 0o644))
+
+	// Fail the build immediately: the assertion below then proves the step ran
+	// against the build context BEFORE docker build.
+	mockImageHandler := new(mocks.ImageHandler)
+	airflowImageHandler = func(image string) airflow.ImageHandler {
+		mockImageHandler.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(errMock).Once()
+		return mockImageHandler
+	}
+	mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
+
+	_, err := buildImage(projectDir, "4.2.5", "", "", "", nil, false, false, mockV1Client)
+	assert.ErrorIs(t, err, errMock)
+
+	assert.FileExists(t, filepath.Join(projectDir, cosmosBoostArtifact),
+		"the pre-deploy step must run against the build context before docker build")
+	mockImageHandler.AssertExpectations(t)
+}
+
+// TestUploadBundleFailsWhenStaleArtifactUnremovable pins the safety property
+// of ENABLED deploys: a deploy that cannot guarantee the payload is free of
+// stale artifacts must fail rather than ship one, because consumers cannot
+// tell fresh from stale.
+func TestUploadBundleFailsWhenStaleArtifactUnremovable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory write-permission semantics differ on windows")
+	}
+	setupCosmosBoostEnv(t)
+	require.NoError(t, config.CFG.CosmosBoostPreDeploy.SetHomeString("true"))
+
+	bundleDir := writeDbtBundle(t)
+	stale := filepath.Join(bundleDir, cosmosBoostArtifact)
+	require.NoError(t, os.MkdirAll(filepath.Dir(stale), 0o755))
+	require.NoError(t, os.WriteFile(stale, []byte(`{"generated_by": {"application": "astro"}}`), 0o644))
+	require.NoError(t, os.Chmod(filepath.Dir(stale), 0o555)) // file cannot be unlinked
+	t.Cleanup(func() { _ = os.Chmod(filepath.Dir(stale), 0o755) })
+
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	_, err := UploadBundle(t.TempDir(), bundleDir, "http://upload-url", false, "0.0.0")
+
+	require.Error(t, err, "the deploy must not proceed with a stale artifact it could not remove")
+	assert.ErrorContains(t, err, "Cosmos Boost")
+}
+
+// TestUploadBundleIsANoOpWhenDisabled pins the opt-out contract (review ask on
+// astronomer/astro-cli#2236): with the gate off the deploy neither walks nor
+// mutates the tree - even an artifact left by an earlier enabled deploy stays
+// in place, and removing it is `astro dbt cleanup`'s job.
+func TestUploadBundleIsANoOpWhenDisabled(t *testing.T) {
+	setupCosmosBoostEnv(t)
+
+	bundleDir := writeDbtBundle(t)
+	leftover := filepath.Join(bundleDir, cosmosBoostArtifact)
+	require.NoError(t, os.MkdirAll(filepath.Dir(leftover), 0o755))
+	require.NoError(t, os.WriteFile(leftover, []byte(`{"generated_by": {"application": "astro"}}`), 0o644))
+
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	_, err := UploadBundle(t.TempDir(), bundleDir, "http://upload-url", false, "0.0.0")
+	require.NoError(t, err)
+
+	assert.FileExists(t, leftover,
+		"a disabled deploy must not touch the tree; leftovers are cleaned by astro dbt cleanup")
+}
+
+// TestBuildImageFailsWhenStaleArtifactUnremovable mirrors the bundle-path
+// safety test for the image path: an enabled build that cannot guarantee the
+// context is free of stale artifacts must fail before docker build runs.
+func TestBuildImageFailsWhenStaleArtifactUnremovable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory write-permission semantics differ on windows")
+	}
+	setupCosmosBoostEnv(t)
+	require.NoError(t, config.CFG.CosmosBoostPreDeploy.SetHomeString("true"))
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "dbt_project.yml"), []byte("name: shop\n"), 0o644))
+	stale := filepath.Join(projectDir, cosmosBoostArtifact)
+	require.NoError(t, os.MkdirAll(filepath.Dir(stale), 0o755))
+	require.NoError(t, os.WriteFile(stale, []byte(`{"generated_by": {"application": "astro"}}`), 0o644))
+	require.NoError(t, os.Chmod(filepath.Dir(stale), 0o555))
+	t.Cleanup(func() { _ = os.Chmod(filepath.Dir(stale), 0o755) })
+
+	// No Build expectation: the failure must happen before docker build.
+	mockImageHandler := new(mocks.ImageHandler)
+	airflowImageHandler = func(image string) airflow.ImageHandler {
+		return mockImageHandler
+	}
+	mockV1Client := new(astrov1_mocks.ClientWithResponsesInterface)
+
+	_, err := buildImage(projectDir, "4.2.5", "", "", "", nil, false, false, mockV1Client)
+
+	require.Error(t, err, "the build must not proceed with a stale artifact it could not remove")
+	assert.ErrorContains(t, err, "Cosmos Boost")
+	mockImageHandler.AssertExpectations(t)
+}
+
+// TestUploadBundleFailsOnForeignSidecar: an enabled deploy must not ship a
+// sidecar from an unrecognized producer - cleanup will not delete it, the
+// plugin would consume it, so the deploy stops and asks for manual removal.
+func TestUploadBundleFailsOnForeignSidecar(t *testing.T) {
+	setupCosmosBoostEnv(t)
+	require.NoError(t, config.CFG.CosmosBoostPreDeploy.SetHomeString("true"))
+
+	bundleDir := writeDbtBundle(t)
+	foreign := filepath.Join(bundleDir, cosmosBoostArtifact)
+	require.NoError(t, os.MkdirAll(filepath.Dir(foreign), 0o755))
+	require.NoError(t, os.WriteFile(foreign, []byte(`{"schema": 1, "version": {"hash": "abc"}, "generated_by": {"application": "someone-else"}}`), 0o644))
+
+	azureUploader = func(sasLink string, file io.Reader) (string, error) {
+		return "version-id", nil
+	}
+
+	_, err := UploadBundle(t.TempDir(), bundleDir, "http://upload-url", false, "0.0.0")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unrecognized producer")
+	assert.FileExists(t, foreign, "the foreign file must be preserved")
+}

--- a/cloud/deploy/deploy.go
+++ b/cloud/deploy/deploy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/astronomer/astro-cli/docker"
 	"github.com/astronomer/astro-cli/pkg/ansi"
 	"github.com/astronomer/astro-cli/pkg/azure"
+	"github.com/astronomer/astro-cli/pkg/cosmosboost"
 	"github.com/astronomer/astro-cli/pkg/fileutil"
 	"github.com/astronomer/astro-cli/pkg/httputil"
 	"github.com/astronomer/astro-cli/pkg/input"
@@ -711,6 +712,19 @@ func buildImage(path, currentVersion, deployImage, imageName, organizationID str
 	if imageName == "" {
 		// Build our image
 		fmt.Println(composeImageBuildingPromptMsg)
+
+		// Cosmos Boost pre-deploy step, opt-in via cosmos_boost.pre_deploy;
+		// with the setting off the build does not touch the tree at all.
+		// Cleanup runs first and is fatal on failure (a stale artifact must
+		// not ship inside the image), while stamping is best-effort (a
+		// missing artifact is safe). Artifacts left by earlier enabled
+		// deploys are removed with `astro dbt cleanup`.
+		if config.CFG.CosmosBoostPreDeploy.GetBool() {
+			if err := cosmosboost.EnsureClean(path); err != nil {
+				return "", err
+			}
+			cosmosboost.BestEffortPreDeploy(path)
+		}
 
 		if dagDeployEnabled || isRemoteExecutionEnabled {
 			err := buildImageWithoutDags(path, buildSecrets, imageHandler)

--- a/cmd/cloud/dbt.go
+++ b/cmd/cloud/dbt.go
@@ -13,6 +13,7 @@ import (
 	cloud "github.com/astronomer/astro-cli/cloud/deploy"
 	"github.com/astronomer/astro-cli/cloud/deployment"
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/cosmosboost"
 )
 
 var (
@@ -38,8 +39,25 @@ func newDbtCmd() *cobra.Command {
 	cmd.AddCommand(
 		newDbtDeployCmd(),
 		newDbtDeleteCmd(),
+		newDbtCleanupCmd(),
 	)
 	return cmd
+}
+
+func newDbtCleanupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cleanup [path ...]",
+		Args:  cobra.ArbitraryArgs,
+		Short: "Remove the Cosmos Boost artifacts under each path",
+		Long:  "Remove the artifacts the Cosmos Boost pre-deploy step wrote under each path (default: the current directory). Run it after disabling cosmos_boost.pre_deploy, because a disabled deploy leaves earlier deploys' artifacts in place.",
+		RunE:  cleanupDbt,
+	}
+	return cmd
+}
+
+func cleanupDbt(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	return cosmosboost.Cleanup(args...)
 }
 
 //nolint:dupl

--- a/cmd/cloud/dbt_test.go
+++ b/cmd/cloud/dbt_test.go
@@ -278,3 +278,19 @@ func (s *DbtSuite) mockGetTestDeployment() {
 		},
 	}, nil)
 }
+
+func (s *DbtSuite) TestDbtCleanup_RemovesArtifacts() {
+	dir := s.T().TempDir()
+	artifact := filepath.Join(dir, ".astro", "dbt_metadata.json")
+	assert.NoError(s.T(), os.MkdirAll(filepath.Dir(artifact), 0o755))
+	assert.NoError(s.T(), os.WriteFile(artifact, []byte(`{"generated_by": {"application": "astro"}}`), 0o644))
+
+	err := testExecCmd(newDbtCleanupCmd(), dir)
+	assert.NoError(s.T(), err)
+	assert.NoFileExists(s.T(), artifact)
+}
+
+func (s *DbtSuite) TestDbtCleanup_NonexistentPath() {
+	err := testExecCmd(newDbtCleanupCmd(), filepath.Join(s.T().TempDir(), "does-not-exist"))
+	assert.Error(s.T(), err)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -101,6 +101,7 @@ var (
 		TelemetryNoticeShown:    newCfg("telemetry.notice_shown", ""),
 		ProxyPort:               newCfg("proxy.port", "6563"),
 		OttoAutoUpdate:          newCfg("otto.auto_update", "true"),
+		CosmosBoostPreDeploy:    newCfg("cosmos_boost.pre_deploy", "false"),
 	}
 
 	// viperHome is the viper object in the users home directory

--- a/config/types.go
+++ b/config/types.go
@@ -63,6 +63,7 @@ type cfgs struct {
 	TelemetryNoticeShown    cfg
 	ProxyPort               cfg
 	OttoAutoUpdate          cfg
+	CosmosBoostPreDeploy    cfg
 }
 
 // Creates a new cfg struct

--- a/pkg/airflowrt/include/gitignore
+++ b/pkg/airflowrt/include/gitignore
@@ -13,3 +13,5 @@ airflow.cfg
 airflow.db
 .astro/*.local.yml
 .astro/*.local.yaml
+
+**/.astro/dbt_metadata.json

--- a/pkg/airflowrt/scaffold_test.go
+++ b/pkg/airflowrt/scaffold_test.go
@@ -48,6 +48,9 @@ func TestScaffold_Airflow3_Minimal(t *testing.T) {
 	// astro-desktop and the otto CLI write into per-project state).
 	assert.Contains(t, fileMap[".gitignore"], ".astro/standalone/")
 	assert.Contains(t, fileMap[".gitignore"], ".astro/worktrees/")
+	// The Cosmos Boost pre-deploy artifact is generated at deploy time and
+	// must not be committed; **/ because dbt projects can be nested.
+	assert.Contains(t, fileMap[".gitignore"], "**/.astro/dbt_metadata.json")
 }
 
 func TestScaffold_Airflow3_Full(t *testing.T) {

--- a/pkg/cosmosboost/cleanup.go
+++ b/pkg/cosmosboost/cleanup.go
@@ -1,0 +1,16 @@
+package cosmosboost
+
+import "fmt"
+
+// Cleanup removes the Cosmos Boost artifacts under the given roots (default
+// ".").
+func Cleanup(roots ...string) error {
+	if len(roots) == 0 {
+		roots = []string{"."}
+	}
+	if err := removeArtifacts(roots); err != nil {
+		return err
+	}
+	fmt.Println("Removed the Cosmos Boost artifacts")
+	return nil
+}

--- a/pkg/cosmosboost/cleanup_test.go
+++ b/pkg/cosmosboost/cleanup_test.go
@@ -1,0 +1,48 @@
+package cosmosboost
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupDefaultRootRemovesArtifact(t *testing.T) {
+	dir := t.TempDir()
+	writeDbtProject(t, dir)
+	require.NoError(t, PreDeploy(dir))
+	t.Chdir(dir)
+
+	require.NoError(t, Cleanup())
+
+	_, err := os.Stat(filepath.Join(dir, artifactRelPath))
+	require.True(t, os.IsNotExist(err), "artifact under the default root must be removed")
+}
+
+func TestCleanupNothingToRemove(t *testing.T) {
+	require.NoError(t, Cleanup(t.TempDir()), "an already-clean tree is not an error")
+}
+
+func TestCleanupNonexistentRoot(t *testing.T) {
+	require.Error(t, Cleanup(filepath.Join(t.TempDir(), "does-not-exist")))
+}
+
+// TestCleanupTouchesOnlyTheRequestedPaths pins the command's scope: cleanup
+// acts on the paths it was given and nothing else on the machine.
+func TestCleanupTouchesOnlyTheRequestedPaths(t *testing.T) {
+	requested := t.TempDir()
+	writeDbtProject(t, requested)
+	require.NoError(t, PreDeploy(requested))
+
+	elsewhere := t.TempDir()
+	writeDbtProject(t, elsewhere)
+	require.NoError(t, PreDeploy(elsewhere))
+
+	require.NoError(t, Cleanup(requested))
+
+	_, err := os.Stat(filepath.Join(requested, artifactRelPath))
+	require.True(t, os.IsNotExist(err))
+	require.FileExists(t, filepath.Join(elsewhere, artifactRelPath),
+		"a path that was not requested must not be touched")
+}

--- a/pkg/cosmosboost/precompute/cleanup.go
+++ b/pkg/cosmosboost/precompute/cleanup.go
@@ -1,0 +1,167 @@
+package precompute
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// cleanupSkipDirs are not traversed below the walked root. Discovery never
+// writes sidecars under them (both discovery walks skip these names at any
+// depth), and generated directories like a root-owned logs/ left by a
+// container bind mount may not even be readable - aborting a deploy over a
+// directory we never write to helps nobody. The root itself is exempt,
+// mirroring discovery: a project that happens to live in a directory named
+// logs or dbt_packages can be stamped, so it must be cleanable too. .git is
+// skipped unconditionally - VCS internals are never ours to mutate. target/
+// is deliberately absent: a compiled manifest's sidecar lives at
+// target/.astro/.
+var cleanupSkipDirs = map[string]bool{
+	"logs":             true,
+	defaultPackagesDir: true,
+}
+
+// CleanupResult records what happened to one sidecar found during Cleanup.
+type CleanupResult struct {
+	Path string // sidecar file path
+	Kept bool   // left in place: the file was not written by this tool
+	Err  error  // non-nil if removal failed
+}
+
+// CleanupSummary is the structured outcome of an cleanup run.
+type CleanupSummary struct {
+	Duration time.Duration
+	Results  []CleanupResult
+}
+
+// Cleanup removes every .astro/dbt_metadata.json sidecar under the given
+// roots that this tool wrote, pruning each containing .astro directory when
+// removal leaves it empty. A dbt_metadata.json whose generated_by.application
+// is not ours — or that isn't valid JSON — is left in place and reported as
+// kept, so cleanup never deletes a file some other tool owns.
+//
+// Per-file removal failures are recorded in their Result and do not stop the
+// others; like Run, a non-nil error is returned only for a top-level problem
+// such as a root that cannot be walked.
+func Cleanup(roots []string) (CleanupSummary, error) {
+	start := time.Now()
+
+	seen := map[string]bool{}
+	var results []CleanupResult
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if d.Name() == gitDir || (path != root && cleanupSkipDirs[d.Name()]) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if d.Name() != sidecarName || filepath.Base(filepath.Dir(path)) != sidecarDir {
+				return nil
+			}
+			// Key on the canonical path, not the walked one. Roots that name the
+			// same tree differently — a relative name and an absolute one, or a
+			// symlink and its target — yield different strings for one file, and
+			// a sidecar left in place (foreign, so not removed) would then be
+			// found and reported once per spelling.
+			key := canonicalPath(path)
+			if seen[key] { // overlapping roots: report each sidecar once
+				return nil
+			}
+			seen[key] = true
+			results = append(results, removeSidecar(path))
+			return nil
+		})
+		if err != nil {
+			return CleanupSummary{}, fmt.Errorf("scanning %q for sidecars: %w", root, err)
+		}
+	}
+
+	return CleanupSummary{Duration: time.Since(start), Results: results}, nil
+}
+
+// canonicalPath returns a path suitable for identifying one file across roots
+// that spell it differently: absolute first, then symlinks resolved. Both steps
+// are needed. Abs alone leaves a symlinked directory and its target looking like
+// different files, and EvalSymlinks alone preserves relativity, so a relative
+// root and an absolute one would still not compare equal. Each step is skipped
+// if it fails, leaving Clean as the floor.
+func canonicalPath(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
+}
+
+// removeSidecar deletes one sidecar after checking this tool wrote it, then
+// prunes the containing .astro directory if removal left it empty. Only the
+// sidecar file is ever removed — anything else under .astro (e.g. an Astro
+// project's config.yaml) is never touched.
+func removeSidecar(path string) CleanupResult {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return CleanupResult{Path: path, Err: err}
+	}
+	var meta Metadata
+	if json.Unmarshal(data, &meta) != nil || meta.GeneratedBy.Application != application {
+		return CleanupResult{Path: path, Kept: true}
+	}
+	if err := os.Remove(path); err != nil {
+		return CleanupResult{Path: path, Err: err}
+	}
+	_ = os.Remove(filepath.Dir(path)) // rmdir; succeeds only when empty
+	return CleanupResult{Path: path}
+}
+
+// CountKept returns the number of sidecars left in place because this tool
+// did not write them.
+func (s CleanupSummary) CountKept() int {
+	n := 0
+	for _, r := range s.Results {
+		if r.Kept {
+			n++
+		}
+	}
+	return n
+}
+
+// CountFailed returns the number of sidecars that could not be removed.
+func (s CleanupSummary) CountFailed() int {
+	n := 0
+	for _, r := range s.Results {
+		if r.Err != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// WriteReport prints a short, human-readable report of the run. It follows the
+// same shape as Summary.WriteReport (precompute.go): a counts line, then one
+// line per entry using the shared glyphs. The columns differ because the entries
+// do — a cleanup has nothing to say about hashes or bytes.
+func (s CleanupSummary) WriteReport(w io.Writer) {
+	removed := len(s.Results) - s.CountKept() - s.CountFailed()
+	fmt.Fprintf(w, "cosmos boost cleanup: %d removed, %d kept, %d failed in %s\n",
+		removed, s.CountKept(), s.CountFailed(), s.Duration.Round(time.Microsecond))
+	for _, r := range s.Results {
+		switch {
+		case r.Err != nil:
+			fmt.Fprintf(w, "  %s %s  (%v)\n", glyphFail, r.Path, r.Err)
+		case r.Kept:
+			fmt.Fprintf(w, "  %s %s  (unrecognized producer; left in place)\n", glyphLeft, r.Path)
+		default:
+			fmt.Fprintf(w, "  %s %s\n", glyphDone, r.Path)
+		}
+	}
+}

--- a/pkg/cosmosboost/precompute/cleanup_test.go
+++ b/pkg/cosmosboost/precompute/cleanup_test.go
@@ -1,0 +1,339 @@
+package precompute
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// stampProject creates a minimal dbt project under dir and runs the real
+// pre-deploy over it, so cleanup tests exercise sidecars exactly as the
+// producer writes them.
+func stampProject(t *testing.T, dir string) {
+	t.Helper()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml": "name: shop\n",
+		"models/a.sql":    "select 1",
+	})
+	summary, err := Run([]string{dir}, "test")
+	if err != nil || summary.CountFailed() > 0 {
+		t.Fatalf("stamping fixture project failed: err=%v failed=%d", err, summary.CountFailed())
+	}
+}
+
+func TestCleanupRemovesSidecarAndPrunesDir(t *testing.T) {
+	dir := t.TempDir()
+	stampProject(t, dir)
+
+	summary, err := Cleanup([]string{dir})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if got := len(summary.Results); got != 1 {
+		t.Fatalf("results = %d, want 1", got)
+	}
+	if summary.CountFailed() != 0 || summary.CountKept() != 0 {
+		t.Fatalf("failed=%d kept=%d, want 0/0", summary.CountFailed(), summary.CountKept())
+	}
+	if _, err := os.Stat(filepath.Join(dir, sidecarDir, sidecarName)); !os.IsNotExist(err) {
+		t.Fatalf("sidecar still present: %v", err)
+	}
+	// Removal emptied .astro, so the directory itself is pruned too.
+	if _, err := os.Stat(filepath.Join(dir, sidecarDir)); !os.IsNotExist(err) {
+		t.Fatalf(".astro dir not pruned: %v", err)
+	}
+}
+
+func TestCleanupLeavesNonEmptyAstroDir(t *testing.T) {
+	dir := t.TempDir()
+	stampProject(t, dir)
+	writeFiles(t, dir, map[string]string{".astro/config.yaml": "project:\n  name: shop\n"})
+
+	if _, err := Cleanup([]string{dir}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, sidecarDir, sidecarName)); !os.IsNotExist(err) {
+		t.Fatalf("sidecar still present: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, sidecarDir, "config.yaml")); err != nil {
+		t.Fatalf("unrelated .astro content was touched: %v", err)
+	}
+}
+
+// TestCleanupKeepsForeignSidecars pins the safety property: a
+// .astro/dbt_metadata.json this tool did not write — another producer's, or
+// one that isn't JSON at all — is never deleted.
+func TestCleanupKeepsForeignSidecars(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"other/.astro/dbt_metadata.json":   `{"generated_by": {"application": "someone-else"}}`,
+		"invalid/.astro/dbt_metadata.json": "not json",
+	})
+
+	summary, err := Cleanup([]string{dir})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if got := summary.CountKept(); got != 2 {
+		t.Fatalf("kept = %d, want 2", got)
+	}
+	for _, rel := range []string{"other", "invalid"} {
+		if _, err := os.Stat(filepath.Join(dir, rel, sidecarDir, sidecarName)); err != nil {
+			t.Fatalf("foreign sidecar under %s was removed: %v", rel, err)
+		}
+	}
+}
+
+// TestCleanupIgnoresLookalikes: only dbt_metadata.json directly inside a
+// .astro directory is a sidecar; same-named files elsewhere are untouched.
+func TestCleanupIgnoresLookalikes(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"data/dbt_metadata.json": `{"generated_by": {"application": "astro"}}`,
+	})
+
+	summary, err := Cleanup([]string{dir})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if got := len(summary.Results); got != 0 {
+		t.Fatalf("results = %d, want 0", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "data", sidecarName)); err != nil {
+		t.Fatalf("lookalike outside .astro was removed: %v", err)
+	}
+}
+
+func TestCleanupOverlappingRoots(t *testing.T) {
+	dir := t.TempDir()
+	stampProject(t, dir)
+
+	summary, err := Cleanup([]string{dir, dir})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if got := len(summary.Results); got != 1 {
+		t.Fatalf("overlapping roots reported %d results, want 1", got)
+	}
+}
+
+// TestCleanupRootsSpelledDifferently covers one tree named two ways: an
+// absolute path and a relative one. A sidecar we remove cannot be double-counted
+// (it is gone by the second walk), but a foreign one is deliberately left in
+// place, so keying the seen-set on the raw walked path finds it again under the
+// other spelling and reports it kept twice.
+func TestCleanupRootsSpelledDifferently(t *testing.T) {
+	parent := t.TempDir()
+	project := filepath.Join(parent, "shop")
+	writeFiles(t, project, map[string]string{
+		".astro/dbt_metadata.json": `{"generated_by": {"application": "someone-else"}}`,
+	})
+
+	t.Chdir(parent) // so "shop" and the absolute path name one tree
+
+	summary, err := Cleanup([]string{project, "shop"})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if got := len(summary.Results); got != 1 {
+		t.Fatalf("roots spelled differently reported %d results, want 1", got)
+	}
+	if got := summary.CountKept(); got != 1 {
+		t.Fatalf("kept = %d, want 1: one file must be reported once per run", got)
+	}
+}
+
+func TestCleanupNonexistentRoot(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := Cleanup([]string{missing}); err == nil {
+		t.Fatal("Cleanup on a nonexistent root: error = nil, want non-nil")
+	}
+}
+
+func TestCleanupWriteReport(t *testing.T) {
+	dir := t.TempDir()
+	stampProject(t, dir)
+	writeFiles(t, dir, map[string]string{"other/.astro/dbt_metadata.json": "not json"})
+
+	summary, err := Cleanup([]string{dir})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	var out bytes.Buffer
+	summary.WriteReport(&out)
+	got := out.String()
+	if !strings.Contains(got, "1 removed, 1 kept, 0 failed") {
+		t.Fatalf("report summary line missing: %q", got)
+	}
+	if !strings.Contains(got, "left in place") {
+		t.Fatalf("kept sidecar not explained in report: %q", got)
+	}
+}
+
+// TestCleanupSkipsGitInternals pins that cleanup never traverses .git: even a
+// sidecar this tool's own (buggy or interrupted) run left there is not touched,
+// because mutating VCS internals is worse than leaving an undeployed file.
+func TestCleanupSkipsGitInternals(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		".git/trap/.astro/dbt_metadata.json": `{"generated_by": {"application": "astro"}}`,
+	})
+
+	summary, err := Cleanup([]string{dir})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if got := len(summary.Results); got != 0 {
+		t.Fatalf("results = %d, want 0 (nothing under .git may be visited)", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git", "trap", ".astro", "dbt_metadata.json")); err != nil {
+		t.Fatalf("file under .git was touched: %v", err)
+	}
+}
+
+func TestCanonicalPathFallsBackOnMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if got := canonicalPath(missing); got != filepath.Clean(missing) {
+		t.Fatalf("canonicalPath(%q) = %q, want the cleaned path", missing, got)
+	}
+}
+
+// TestCleanupReportsUnreadableSidecar: a sidecar whose content cannot be read
+// cannot be provenance-checked, so it is a failure (not silently kept).
+func TestCleanupReportsUnreadableSidecar(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission semantics differ on windows")
+	}
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"proj/.astro/dbt_metadata.json": `{"generated_by": {"application": "astro"}}`})
+	sidecar := filepath.Join(dir, "proj", ".astro", "dbt_metadata.json")
+	if err := os.Chmod(sidecar, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sidecar, 0o644) })
+
+	summary, err := Cleanup([]string{dir})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if summary.CountFailed() != 1 {
+		t.Fatalf("failed = %d, want 1", summary.CountFailed())
+	}
+	var out bytes.Buffer
+	summary.WriteReport(&out)
+	if !strings.Contains(out.String(), "✗") {
+		t.Fatalf("failure missing from report: %q", out.String())
+	}
+}
+
+// TestCleanupReportsUnremovableSidecar: a sidecar that passes the provenance
+// check but cannot be unlinked is recorded as failed, not dropped.
+func TestCleanupReportsUnremovableSidecar(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory write-permission semantics differ on windows")
+	}
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"proj/.astro/dbt_metadata.json": `{"generated_by": {"application": "astro"}}`})
+	astroDir := filepath.Join(dir, "proj", ".astro")
+	if err := os.Chmod(astroDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(astroDir, 0o755) })
+
+	summary, err := Cleanup([]string{dir})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if summary.CountFailed() != 1 {
+		t.Fatalf("failed = %d, want 1", summary.CountFailed())
+	}
+}
+
+// TestCleanupSkipsUnreadableGeneratedDirs: logs/ and dbt_packages/ never hold
+// sidecars (discovery skips them by name), so cleanup must not fail over
+// them even when they are unreadable, e.g. a root-owned bind-mount leftover.
+func TestCleanupSkipsUnreadableGeneratedDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission semantics differ on windows")
+	}
+	dir := t.TempDir()
+	for _, name := range []string{"logs", "dbt_packages"} {
+		locked := filepath.Join(dir, "proj", name)
+		if err := os.MkdirAll(locked, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(locked, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+	}
+
+	summary, err := Cleanup([]string{dir})
+	if err != nil {
+		t.Fatalf("Cleanup must not fail over generated dirs it never writes to: %v", err)
+	}
+	if len(summary.Results) != 0 {
+		t.Fatalf("results = %d, want 0", len(summary.Results))
+	}
+}
+
+// TestCleanupStillVisitsTarget: target/ can legitimately hold a compiled
+// manifest's sidecar at target/.astro/, so it is NOT among the skipped names.
+func TestCleanupStillVisitsTarget(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"proj/target/.astro/dbt_metadata.json": `{"generated_by": {"application": "astro"}}`,
+	})
+
+	summary, err := Cleanup([]string{dir})
+	if err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if len(summary.Results) != 1 || summary.CountFailed() != 0 || summary.CountKept() != 0 {
+		t.Fatalf("results = %+v, want the target/.astro sidecar removed", summary.Results)
+	}
+}
+
+// TestCleanupCleansRootsNamedLikeSkipDirs mirrors discovery's root exemption:
+// a project living in a directory named logs or dbt_packages can be stamped,
+// so cleanup of that same root must not skip it - otherwise a sidecar could
+// survive EnsureClean and ship stale. .git stays skipped even as the root.
+func TestCleanupCleansRootsNamedLikeSkipDirs(t *testing.T) {
+	for _, name := range []string{"logs", "dbt_packages"} {
+		t.Run(name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), name)
+			writeFiles(t, root, map[string]string{
+				"proj/.astro/dbt_metadata.json": `{"generated_by": {"application": "astro"}}`,
+			})
+
+			summary, err := Cleanup([]string{root})
+			if err != nil {
+				t.Fatalf("Cleanup: %v", err)
+			}
+			if len(summary.Results) != 1 || summary.CountFailed() != 0 || summary.CountKept() != 0 {
+				t.Fatalf("results = %+v, want the sidecar under the %s root removed", summary.Results, name)
+			}
+		})
+	}
+
+	t.Run(".git stays protected", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), ".git")
+		writeFiles(t, root, map[string]string{
+			"trap/.astro/dbt_metadata.json": `{"generated_by": {"application": "astro"}}`,
+		})
+
+		summary, err := Cleanup([]string{root})
+		if err != nil {
+			t.Fatalf("Cleanup: %v", err)
+		}
+		if len(summary.Results) != 0 {
+			t.Fatalf("results = %+v, want nothing visited under a .git root", summary.Results)
+		}
+		if _, err := os.Stat(filepath.Join(root, "trap", ".astro", "dbt_metadata.json")); err != nil {
+			t.Fatalf("file under .git was touched: %v", err)
+		}
+	})
+}

--- a/pkg/cosmosboost/precompute/dbtproject.go
+++ b/pkg/cosmosboost/precompute/dbtproject.go
@@ -1,0 +1,86 @@
+package precompute
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const defaultPackagesDir = "dbt_packages"
+
+// dbtConfig holds the dbt_project.yml settings that decide which directories hold
+// generated or installed output and must be excluded from a project's source hash.
+// All paths are project-root-relative and already cleaned; an empty string means
+// "unset" — the caller still excludes the dbt defaults (target/, logs/, dbt_packages/)
+// unconditionally, so an unset field simply adds no extra exclusion.
+type dbtConfig struct {
+	packagesInstallPath string   // packages-install-path override (default: dbt_packages/)
+	targetPath          string   // target-path override (default: target/)
+	logPath             string   // log-path override (default: logs/)
+	templatedSettings   []string // settings holding unresolved Jinja templates, in dbt_project.yml order
+}
+
+// readDbtConfig reads dbt_project.yml once and returns the directory settings that
+// affect the project hash. It is best-effort: a missing file, a parse error, or an
+// unset key yields the zero value for that field, because a project's hash must never
+// fail over an optional setting. Reading here once (rather than per-lookup) keeps the
+// single dbt_project.yml read on the caller's hot path.
+//
+// A Jinja value (e.g. "{{ env_var('DBT_PKG_DIR') }}") in any of the three settings is
+// NOT rendered — that would need a Jinja engine, and the referenced env vars are
+// typically only set where dbt runs (the Airflow runtime), not where this CLI runs
+// (the deploy machine), so any value computed here would likely be wrong. Such a value
+// is reported as unset and recorded in templatedSettings so the caller can warn; the
+// dbt default for that directory stays excluded, and the real one isn't (a noisier
+// version key / cache churn, not a correctness problem). Rendering templates is left
+// to a future PR if ever needed.
+func readDbtConfig(projectDir string) dbtConfig {
+	data, err := os.ReadFile(filepath.Join(projectDir, dbtProjectFile))
+	if err != nil {
+		return dbtConfig{}
+	}
+	var raw struct {
+		PackagesInstallPath string `yaml:"packages-install-path"`
+		TargetPath          string `yaml:"target-path"`
+		LogPath             string `yaml:"log-path"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return dbtConfig{}
+	}
+
+	cfg := dbtConfig{}
+	cfg.packagesInstallPath = cfg.relDirSetting("packages-install-path", raw.PackagesInstallPath)
+	cfg.targetPath = cfg.relDirSetting("target-path", raw.TargetPath)
+	cfg.logPath = cfg.relDirSetting("log-path", raw.LogPath)
+	return cfg
+}
+
+// relDirSetting normalises one dbt_project.yml directory setting. An unset value
+// yields "" (the caller excludes the dbt default unconditionally); a Jinja value is
+// recorded in templatedSettings and treated as unset (see readDbtConfig doc).
+func (c *dbtConfig) relDirSetting(name, value string) string {
+	if value == "" {
+		return ""
+	}
+	if strings.Contains(value, "{{") {
+		c.templatedSettings = append(c.templatedSettings, name)
+		return ""
+	}
+	return cleanRelDir(value)
+}
+
+// cleanRelDir normalises a dbt_project.yml directory setting to a slash-separated,
+// project-root-relative path, or "" if it is empty or escapes the project root
+// (absolute or "../…"). A value that escapes the root can't be excluded by relative
+// path, so we drop it rather than risk excluding something outside the project.
+func cleanRelDir(p string) string {
+	// Callers guard the empty case; Clean("") would yield "." and fall into
+	// the drop branch below regardless.
+	c := filepath.ToSlash(filepath.Clean(p))
+	if c == "." || c == ".." || strings.HasPrefix(c, "../") || filepath.IsAbs(c) {
+		return ""
+	}
+	return c
+}

--- a/pkg/cosmosboost/precompute/discover.go
+++ b/pkg/cosmosboost/precompute/discover.go
@@ -1,0 +1,90 @@
+package precompute
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// dbt requires the project file to be named exactly dbt_project.yml (the .yaml
+// extension is not accepted), so we match only this name.
+const dbtProjectFile = "dbt_project.yml"
+
+const manifestFile = "manifest.json"
+
+// findProjects walks root and returns every directory that contains a
+// dbt_project.yml.
+//
+// A dbt project is treated as a single unit: once one is found, discovery does
+// not descend into it (so a nested project is not split out, and a dependency's
+// own dbt_project.yml under dbt_packages/ is never mistaken for a project), and
+// excluded directories are skipped entirely.
+func findProjects(root string) ([]string, error) {
+	var projects []string
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path != root && excludedDirs[d.Name()] {
+			return filepath.SkipDir
+		}
+		if isFile(filepath.Join(path, dbtProjectFile)) {
+			projects = append(projects, path)
+			return filepath.SkipDir // a project is one unit; don't recurse into it
+		}
+		return nil
+	})
+	return projects, err
+}
+
+// manifestSkipDirs are skipped when looking for manifest.json. Unlike project
+// hashing we do NOT skip target/, because a compiled manifest normally lives in
+// target/manifest.json; but installed packages and our own output can't hold a
+// project's own manifest, so they're skipped.
+var manifestSkipDirs = map[string]bool{
+	"logs":         true,
+	"dbt_packages": true,
+	sidecarDir:     true, // .astro
+	gitDir:         true, // VCS internals can't hold a project's manifest
+}
+
+// findManifests walks root and returns manifest.json file paths.
+//
+// A manifest whose parent directory is itself a discovered project root is
+// omitted: that project's folder hash already covers a manifest sitting in its
+// root. Manifests elsewhere — most importantly a standalone one shipped for a
+// manifest-only (DBT_MANIFEST) deployment, or a project's target/manifest.json —
+// each get their own sidecar.
+func findManifests(root string, projectDirs map[string]bool) ([]string, error) {
+	var manifests []string
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path != root && manifestSkipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != manifestFile {
+			return nil
+		}
+		if projectDirs[filepath.Dir(path)] {
+			return nil // covered by the project's folder hash
+		}
+		manifests = append(manifests, path)
+		return nil
+	})
+	return manifests, err
+}
+
+func isFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/pkg/cosmosboost/precompute/hash.go
+++ b/pkg/cosmosboost/precompute/hash.go
@@ -1,0 +1,247 @@
+package precompute
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// excludedDirs are directory names skipped during *project* discovery
+// (findProjects in discover.go): generated/installed/secret content can't hold a
+// project's dbt_project.yml. This includes target/, which is intentional here —
+// manifest discovery (findManifests) uses its own manifestSkipDirs that keeps
+// target/, so a compiled target/manifest.json is still found. Project hashing uses
+// the more precise, root-relative excludedRelDirsFor instead.
+var excludedDirs = map[string]bool{
+	"target":           true,
+	"logs":             true,
+	defaultPackagesDir: true, // "dbt_packages"
+	sidecarDir:         true, // ".astro"
+	gitDir:             true, // VCS internals can't hold a real project
+}
+
+// excludedFiles are non-source files (matched at the project root only — see
+// hashProject) that dbt/Cosmos ignore for project identity.
+var excludedFiles = map[string]bool{
+	"package-lock.yml": true, // dbt package lockfile
+	"profiles.yml":     true, // dbt connection profiles (secret, env-specific)
+}
+
+// excludedRelDirsFor returns the project-root-relative directories to skip when
+// hashing a project, derived from the (already-read) dbt config. Exclusions are
+// root-relative (not name-based), so a custom packages-install-path like
+// "vendor/packages" excludes exactly that directory and never a same-named source
+// directory elsewhere (e.g. models/packages/). Mirrors cosmos/dbt/project.py::
+// create_symlinks (whose ignore list is likewise project-root-relative), plus our
+// own .astro/ output.
+//
+// The dbt defaults (target/, logs/, dbt_packages/) are always excluded; a custom
+// target-path / log-path / packages-install-path from dbt_project.yml is excluded in
+// addition, so generated output under a renamed output directory doesn't churn the
+// hash on every compile.
+func excludedRelDirsFor(cfg dbtConfig) map[string]bool {
+	out := map[string]bool{
+		"target":           true,
+		"logs":             true,
+		defaultPackagesDir: true,
+		sidecarDir:         true,
+	}
+	for _, d := range []string{cfg.packagesInstallPath, cfg.targetPath, cfg.logPath} {
+		if d != "" {
+			out[d] = true
+		}
+	}
+	return out
+}
+
+// gitDir is VCS metadata: never part of the deploy payload (bundle creation
+// excludes it too), so it must not affect project identity. In linked worktrees
+// and submodules .git is a pointer file rather than a directory, so both forms
+// are skipped.
+const gitDir = ".git"
+
+// relPath is filepath.Rel behind a variable so tests can exercise the guard
+// in hashProject's walk: WalkDir yields paths rooted at the walked directory,
+// so Rel cannot otherwise be made to fail.
+var relPath = filepath.Rel
+
+// hashProject computes the "sha256-tree-v2" hash of a dbt project directory: the
+// sha256 of the path-sorted list of "<relative-path>\x00<sha256(file)>\n" entries.
+// cfg carries the dbt_project.yml directory settings that widen the exclusion set.
+//
+// Because the entries are sorted by relative path, the result depends only on the
+// project's content, not on filesystem walk order — so it is stable across runs
+// and unaffected by any concurrency in the caller. The value need not match
+// Cosmos's own hash: the read-side treats it as an opaque version key.
+func hashProject(dir string, cfg dbtConfig) (hash string, files int, totalBytes int64, err error) {
+	excludedRel := excludedRelDirsFor(cfg)
+
+	type entry struct{ rel, digest string }
+	var entries []entry
+
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := relPath(dir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel) // stable across operating systems
+
+		if d.IsDir() {
+			// Our own sidecar directory must never affect the project hash, at ANY
+			// depth. A dbt manifest.json in a subdirectory (e.g. docs/manifest.json)
+			// gets its own sidecar written into the walked tree (docs/.astro/), and
+			// because manifest and project units run concurrently, hashing it would
+			// make the project hash depend on that sidecar and vary between runs.
+			// .astro is always our output, never dbt source, so skipping it by name
+			// everywhere is safe (unlike target/logs, which are matched root-relative
+			// to avoid over-excluding a same-named source dir).
+			if d.Name() == sidecarDir || d.Name() == gitDir {
+				return filepath.SkipDir
+			}
+			// Skip excluded directories by their root-relative path (never the root).
+			if rel != "." && excludedRel[rel] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == gitDir { // a worktree's or submodule's .git pointer file
+			return nil
+		}
+		if excludedFiles[rel] { // root-level files only (rel has no slash)
+			return nil
+		}
+
+		digest, n, err := hashFile(path)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, entry{rel, digest})
+		files++
+		totalBytes += n
+		return nil
+	})
+	if walkErr != nil {
+		return "", 0, 0, walkErr
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+
+	h := sha256.New()
+	for _, e := range entries {
+		// NUL separates path from digest so the encoding is unambiguous.
+		fmt.Fprintf(h, "%s\x00%s\n", e.rel, e.digest)
+	}
+	return hex.EncodeToString(h.Sum(nil)), files, totalBytes, nil
+}
+
+// volatileManifestKeys are dbt manifest metadata fields that change on every
+// invocation even when the source is unchanged. They must be ignored, or every
+// recompile would produce a new hash and defeat the cache.
+var volatileManifestKeys = []string{"generated_at", "invocation_id", "invocation_started_at", "run_started_at"}
+
+// stripEntityCreatedAt removes the dbt-owned created_at field from every
+// resource entry in every top-level manifest collection (nodes, sources,
+// macros, exposures, disabled, ...). dbt regenerates these timestamps on
+// every full parse, so a CI-built manifest would never hash-match a locally
+// built one. Only depth-2 entries are touched: a user-defined
+// meta.created_at inside a resource sits deeper and is preserved. The
+// disabled collection maps each name to a LIST of resources, so list
+// elements are handled as well.
+func stripEntityCreatedAt(doc map[string]any) {
+	for _, v := range doc {
+		collection, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, e := range collection {
+			switch entity := e.(type) {
+			case map[string]any:
+				delete(entity, "created_at")
+			case []any:
+				for _, item := range entity {
+					if m, ok := item.(map[string]any); ok {
+						delete(m, "created_at")
+					}
+				}
+			}
+		}
+	}
+}
+
+// isDbtManifest reports whether doc looks like a dbt manifest. dbt always writes
+// metadata.dbt_schema_version, which unrelated manifest.json files (web app/PWA,
+// tooling, etc.) do not have — so we only stamp files that carry it.
+func isDbtManifest(doc map[string]any) bool {
+	meta, ok := doc["metadata"].(map[string]any)
+	if !ok {
+		return false
+	}
+	v, ok := meta["dbt_schema_version"].(string)
+	return ok && v != ""
+}
+
+// hashManifest computes the "sha256-manifest-v2" hash of a dbt manifest.json: the
+// sha256 of its JSON content with the volatile metadata fields removed, so the
+// value is stable across recompiles of unchanged source.
+//
+// isDbt reports whether the file is actually a dbt manifest. A file that is not
+// valid JSON, or that lacks the dbt manifest shape, returns isDbt=false and is
+// not stamped (callers skip it) — so unrelated manifest.json files in the project
+// don't get a sidecar.
+func hashManifest(path string) (hash string, bytes int64, isDbt bool, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", 0, false, err
+	}
+	bytes = int64(len(data))
+
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		//nolint:nilerr // invalid JSON → not a dbt manifest: a skip, not an error (callers don't stamp it)
+		return "", bytes, false, nil
+	}
+	if !isDbtManifest(doc) {
+		return "", bytes, false, nil
+	}
+	if meta, ok := doc["metadata"].(map[string]any); ok {
+		for _, k := range volatileManifestKeys {
+			delete(meta, k)
+		}
+	}
+	stripEntityCreatedAt(doc)
+	// json.Marshal emits object keys in sorted order, so this is deterministic;
+	// doc came from json.Unmarshal, so it holds only JSON-native types and
+	// re-marshaling cannot fail.
+	canonical, _ := json.Marshal(doc)
+	return sha256Hex(canonical), bytes, true, nil
+}
+
+// hashFile returns the hex sha256 of a file's contents and its size in bytes.
+func hashFile(path string) (digest string, size int64, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	size, err = io.Copy(h, f)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(h.Sum(nil)), size, nil
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/cosmosboost/precompute/hash_test.go
+++ b/pkg/cosmosboost/precompute/hash_test.go
@@ -1,0 +1,493 @@
+package precompute
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// writeFiles creates files (relative path -> content) under dir.
+func writeFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestHashProjectDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml":  "name: shop\n",
+		"models/a.sql":     "select 1",
+		"models/sub/b.sql": "select 2",
+	})
+
+	h1, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 != h2 {
+		t.Fatalf("hash not deterministic: %s != %s", h1, h2)
+	}
+}
+
+func TestHashProjectExcludesGeneratedContent(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml": "name: shop\n",
+		"models/a.sql":    "select 1",
+	})
+	want, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Adding generated / installed / secret content must NOT change the hash.
+	writeFiles(t, dir, map[string]string{
+		"target/manifest.json":     `{"x":1}`,
+		"logs/dbt.log":             "noise",
+		"dbt_packages/dep/x.sql":   "select 9",
+		".astro/dbt_metadata.json": `{"hash":"stale"}`,
+		"package-lock.yml":         "sha: abc",
+		"profiles.yml":             "secret",
+	})
+	got, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("excluded content changed the hash:\n want %s\n got  %s", want, got)
+	}
+}
+
+// TestHashProjectExcludesGit pins that VCS metadata never affects project
+// identity: .git is not deployed, so commits, fetches, and gc must not change
+// the hash. Both the .git directory form and the pointer-file form (linked
+// worktrees, submodules) are covered.
+func TestHashProjectExcludesGit(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml": "name: shop\n",
+		"models/a.sql":    "select 1",
+	})
+	before := mustHashProject(t, dir)
+
+	writeFiles(t, dir, map[string]string{
+		".git/HEAD":              "ref: refs/heads/main\n",
+		".git/objects/ab/cdef01": "packed",
+		"vendored/.git":          "gitdir: ../../.git/modules/vendored\n",
+	})
+	if got := mustHashProject(t, dir); got != before {
+		t.Fatalf("git metadata changed the hash:\n want %s\n got  %s", before, got)
+	}
+}
+
+// mustHashProject hashes dir and fails the test on error, for tests that only
+// care about the hash value.
+func mustHashProject(t *testing.T, dir string) string {
+	t.Helper()
+	hash, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatalf("hashProject: %v", err)
+	}
+	return hash
+}
+
+func TestHashProjectSensitiveToModelChange(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml": "name: shop\n",
+		"models/a.sql":    "select 1",
+	})
+	before := mustHashProject(t, dir)
+
+	writeFiles(t, dir, map[string]string{"models/a.sql": "select 2"})
+	after := mustHashProject(t, dir)
+
+	if before == after {
+		t.Fatal("hash did not change after editing a model")
+	}
+}
+
+// TestHashProjectHonorsPackagesInstallPath verifies the dbt `packages-install-path`
+// override is excluded from the hash, not just the default dbt_packages/.
+func TestHashProjectHonorsPackagesInstallPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml": "name: shop\npackages-install-path: my_packages\n",
+		"models/a.sql":    "select 1",
+	})
+	want, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Installing packages into the custom dir must NOT change the hash.
+	writeFiles(t, dir, map[string]string{"my_packages/dep/x.sql": "select 999"})
+	got, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("custom packages-install-path content changed the hash:\n want %s\n got  %s", want, got)
+	}
+}
+
+// TestHashProjectGolden pins the exact algorithm output for a fixed input, so the
+// Cosmos Boost plugin's read-side can reproduce the same value. If this constant
+// has to change, the algorithm changed and `algoProjectTree` must be bumped.
+func TestHashProjectGolden(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml": "name: jaffle\n",
+		"models/x.sql":    "select 1\n",
+	})
+
+	got, files, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if files != 2 {
+		t.Fatalf("want 2 files hashed, got %d", files)
+	}
+
+	const want = "f8c7f8d2f8060e63e6ecbe5d2e817cdbb5c50bd4f020da28a6a1305f96be5d10"
+	if got != want {
+		t.Fatalf("golden hash mismatch (update the constant only if the algorithm intentionally changed):\n want %s\n got  %s", want, got)
+	}
+}
+
+// TestHashManifestIgnoresVolatileMetadata verifies a recompile that only changes
+// volatile metadata (generated_at, invocation_id) does NOT change the hash, while
+// a real node change does.
+func TestHashManifestIgnoresVolatileMetadata(t *testing.T) {
+	dir := t.TempDir()
+	const base = `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json","dbt_version":"1.8.0","generated_at":%q,"invocation_id":%q},"nodes":{"model.x":{"name":%q}}}`
+
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	hash := func(path string) string {
+		h, _, isDbt, err := hashManifest(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !isDbt {
+			t.Fatalf("expected %s to be recognized as a dbt manifest", path)
+		}
+		return h
+	}
+
+	a := hash(write("a.json", fmt.Sprintf(base, "2026-01-01T00:00:00Z", "aaaa", "x")))
+	// Same source, different volatile metadata only:
+	b := hash(write("b.json", fmt.Sprintf(base, "2026-06-30T12:34:56Z", "zzzz", "x")))
+	if a != b {
+		t.Fatalf("manifest hash changed when only volatile metadata differed:\n %s\n %s", a, b)
+	}
+	// A real content change (a node) must change the hash:
+	c := hash(write("c.json", fmt.Sprintf(base, "2026-01-01T00:00:00Z", "aaaa", "y")))
+	if a == c {
+		t.Fatal("manifest hash did not change when a node changed")
+	}
+}
+
+// TestHashManifestSkipsNonDBT verifies that a manifest.json lacking the dbt shape
+// (e.g. a web-app/PWA manifest) or invalid JSON is not treated as a dbt manifest,
+// so it won't be stamped.
+func TestHashManifestSkipsNonDBT(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string]string{
+		"webapp.json":  `{"name":"My App","short_name":"App","icons":[]}`, // no metadata.dbt_schema_version
+		"nometa.json":  `{"nodes":{"model.x":{}}}`,                        // nodes but no metadata
+		"invalid.json": `{not json`,                                       // not JSON at all
+	}
+	for name, content := range cases {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, _, isDbt, err := hashManifest(p)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", name, err)
+		}
+		if isDbt {
+			t.Fatalf("%s: should not be treated as a dbt manifest", name)
+		}
+	}
+}
+
+// TestHashProjectPackagesPathIsPathSpecific verifies the packages-install-path
+// override is excluded by its exact project-root-relative path, not by directory
+// basename — so a same-named source directory elsewhere is still hashed.
+func TestHashProjectPackagesPathIsPathSpecific(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml":         "name: shop\npackages-install-path: vendor/packages\n",
+		"vendor/packages/dep.sql": "select 9", // installed deps — excluded
+		"models/packages/m.sql":   "select 1", // real source, same basename "packages" — must be hashed
+	})
+	base, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Changing the installed-packages dir must NOT change the hash.
+	writeFiles(t, dir, map[string]string{"vendor/packages/dep.sql": "select 99"})
+	if got, _, _, _ := hashProject(dir, readDbtConfig(dir)); got != base {
+		t.Fatal("content under the packages-install-path changed the hash")
+	}
+
+	// Changing the same-basename source dir MUST change the hash (no over-exclusion).
+	writeFiles(t, dir, map[string]string{"models/packages/m.sql": "select 2"})
+	if got, _, _, _ := hashProject(dir, readDbtConfig(dir)); got == base {
+		t.Fatal("models/packages/ was wrongly excluded by basename")
+	}
+}
+
+// TestReadDbtConfig covers the dbt_project.yml settings the hasher relies on: an
+// unset key yields "" (the caller applies the dbt default), a plain packages/target/
+// log path is used verbatim, a Jinja-templated packages-install-path is reported as
+// unset + templated (NOT rendered), a path escaping the project root is dropped, and
+// a parse error degrades to the zero value.
+func TestReadDbtConfig(t *testing.T) {
+	cases := []struct {
+		name          string
+		yml           string
+		wantPackages  string
+		wantTarget    string
+		wantLog       string
+		wantTemplated bool
+	}{
+		{"unset", "name: shop\n", "", "", "", false},
+		{"plain packages", "name: shop\npackages-install-path: vendor/packages\n", "vendor/packages", "", "", false},
+		{"custom target and log", "name: shop\ntarget-path: build\nlog-path: mylogs\n", "", "build", "mylogs", false},
+		{"templated packages", "name: shop\npackages-install-path: \"{{ env_var('DBT_PKG_DIR') }}\"\n", "", "", "", true},
+		{"escaping path dropped", "name: shop\ntarget-path: ../outside\n", "", "", "", false},
+		{"invalid yaml", "- not\n- a mapping\n", "", "", "", false}, // best-effort: parse error → zero value
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFiles(t, dir, map[string]string{"dbt_project.yml": tc.yml})
+			cfg := readDbtConfig(dir)
+			if cfg.packagesInstallPath != tc.wantPackages || cfg.targetPath != tc.wantTarget ||
+				cfg.logPath != tc.wantLog || (len(cfg.templatedSettings) > 0) != tc.wantTemplated {
+				t.Fatalf("readDbtConfig = %+v, want packages=%q target=%q log=%q templated=%v",
+					cfg, tc.wantPackages, tc.wantTarget, tc.wantLog, tc.wantTemplated)
+			}
+		})
+	}
+}
+
+// TestHashProjectExcludesCustomTargetAndLogPaths verifies a custom target-path /
+// log-path from dbt_project.yml is excluded from the hash, so generated artifacts
+// under a renamed output dir don't churn the version key on every compile.
+func TestHashProjectExcludesCustomTargetAndLogPaths(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml": "name: shop\ntarget-path: build\nlog-path: mylogs\n",
+		"models/a.sql":    "select 1",
+	})
+	want, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generated artifacts under the custom target/log dirs must NOT change the hash.
+	writeFiles(t, dir, map[string]string{
+		"build/manifest.json": `{"x":1}`,
+		"mylogs/dbt.log":      "noise",
+	})
+	got, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("custom target-path/log-path content changed the hash:\n want %s\n got  %s", want, got)
+	}
+}
+
+// TestHashProjectTemplatedPackagesPathNotExcluded documents the cache-churn
+// trade-off: a templated packages-install-path is not resolved, so content under
+// the real packages dir is NOT excluded and does change the project hash. (We
+// can't know the real dir name without a Jinja engine; see packagesInstallPath.)
+func TestHashProjectTemplatedPackagesPathNotExcluded(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml": "name: shop\npackages-install-path: \"{{ env_var('DBT_PKG_DIR') }}\"\n",
+		"models/a.sql":    "select 1",
+	})
+	base, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Installing packages into the (unknown, templated) dir changes the hash,
+	// because we couldn't exclude it.
+	writeFiles(t, dir, map[string]string{"custom_pkgs/dep.sql": "select 9"})
+	if got, _, _, _ := hashProject(dir, readDbtConfig(dir)); got == base {
+		t.Fatal("expected templated packages dir to be included in the hash (cache churn), but it was excluded")
+	}
+}
+
+// TestHashProjectIgnoresNestedSidecarDir pins the stability fix: an .astro sidecar
+// directory anywhere in the tree (not just at the project root) must be excluded, so
+// writing a sidecar next to a nested manifest (docs/.astro/) never changes the
+// project hash. This is the deterministic complement to the concurrent Run-level
+// TestRunProjectHashStableWithNestedManifestSidecar.
+func TestHashProjectIgnoresNestedSidecarDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml":    "name: shop\n",
+		"models/a.sql":       "select 1",
+		"docs/manifest.json": `{"x":1}`,
+	})
+	want, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A sidecar written into a nested directory must NOT change the hash.
+	writeFiles(t, dir, map[string]string{
+		"docs/.astro/dbt_metadata.json": `{"hash":"nested"}`,
+		".astro/dbt_metadata.json":      `{"hash":"root"}`,
+	})
+	got, _, _, err := hashProject(dir, readDbtConfig(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("a nested .astro sidecar changed the project hash:\n want %s\n got  %s", want, got)
+	}
+}
+
+func TestHashFileError(t *testing.T) {
+	if _, _, err := hashFile(filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Fatal("hashFile on a missing file should return an error")
+	}
+}
+
+func TestHashManifestReadError(t *testing.T) {
+	_, _, isDbt, err := hashManifest(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err == nil {
+		t.Fatal("hashManifest on a missing file should return an error")
+	}
+	if isDbt {
+		t.Fatal("a missing file should not be reported as a dbt manifest")
+	}
+}
+
+// TestHashFileErrorsOnDirectory: opening succeeds but reading a directory
+// fails, exercising hashFile's read-error path.
+func TestHashFileErrorsOnDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("reading a directory handle behaves differently on windows")
+	}
+	if _, _, err := hashFile(t.TempDir()); err == nil {
+		t.Fatal("hashFile on a directory: error = nil, want non-nil")
+	}
+}
+
+// TestHashProjectSurfacesRelError drives the defensive guard on relative-path
+// computation through its test seam; the guard protects against silent hash
+// corruption if the walk's rooted-path invariant ever breaks.
+func TestHashProjectSurfacesRelError(t *testing.T) {
+	orig := relPath
+	relPath = func(basepath, targpath string) (string, error) {
+		return "", errors.New("rel exploded")
+	}
+	t.Cleanup(func() { relPath = orig })
+
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"dbt_project.yml": "name: shop\n"})
+
+	if _, _, _, err := hashProject(dir, dbtConfig{}); err == nil {
+		t.Fatal("hashProject: error = nil, want the rel error surfaced")
+	}
+}
+
+// TestHashManifestStableAcrossFullParses is the regression for cold-parse
+// stability: dbt regenerates created_at on every resource (and
+// metadata.run_started_at) whenever it fully parses, so two manifests built
+// from identical source in different environments must still hash-match.
+func TestHashManifestStableAcrossFullParses(t *testing.T) {
+	manifest := func(createdAt, runStartedAt, sql string) string {
+		return `{
+  "metadata": {"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+               "generated_at": "` + runStartedAt + `", "invocation_id": "` + runStartedAt + `",
+               "run_started_at": "` + runStartedAt + `"},
+  "nodes": {"model.shop.a": {"name": "a", "created_at": ` + createdAt + `, "raw_code": "` + sql + `",
+            "meta": {"created_at": "user-owned"}}},
+  "sources": {"source.shop.raw": {"name": "raw", "created_at": ` + createdAt + `}},
+  "macros": {"macro.shop.m": {"name": "m", "created_at": ` + createdAt + `}},
+  "disabled": {"model.shop.old": [{"name": "old", "created_at": ` + createdAt + `}]}
+}`
+	}
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"first/manifest.json":   manifest("1754300000.1", "2026-08-04T09:00:00Z", "select 1"),
+		"second/manifest.json":  manifest("1754399999.9", "2026-08-05T21:30:00Z", "select 1"),
+		"changed/manifest.json": manifest("1754300000.1", "2026-08-04T09:00:00Z", "select 2"),
+	})
+
+	h1, _, isDbt1, err := hashManifest(filepath.Join(dir, "first", "manifest.json"))
+	if err != nil || !isDbt1 {
+		t.Fatalf("first manifest: err=%v isDbt=%v", err, isDbt1)
+	}
+	h2, _, _, err := hashManifest(filepath.Join(dir, "second", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 != h2 {
+		t.Fatalf("full-parse timestamp churn changed the hash:\n want %s\n got  %s", h1, h2)
+	}
+	h3, _, _, err := hashManifest(filepath.Join(dir, "changed", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 == h3 {
+		t.Fatal("changed model content must change the hash")
+	}
+}
+
+// TestHashManifestKeepsUserMetaCreatedAt pins the depth guard: only dbt's own
+// resource-level created_at is stripped, never user content inside meta.
+func TestHashManifestKeepsUserMetaCreatedAt(t *testing.T) {
+	// The scalar top-level key pins that the created_at stripper tolerates
+	// non-collection values in the document root.
+	base := `{"metadata": {"dbt_schema_version": "v12"}, "unrelated_scalar": 7,
+  "nodes": {"model.shop.a": {"name": "a", "created_at": 1.0, "meta": {"created_at": "%s"}}}}`
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"one/manifest.json": fmt.Sprintf(base, "2001-01-01"),
+		"two/manifest.json": fmt.Sprintf(base, "2002-02-02"),
+	})
+	h1, _, _, err := hashManifest(filepath.Join(dir, "one", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, _, _, err := hashManifest(filepath.Join(dir, "two", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 == h2 {
+		t.Fatal("user-owned meta.created_at must still affect the hash")
+	}
+}

--- a/pkg/cosmosboost/precompute/metadata.go
+++ b/pkg/cosmosboost/precompute/metadata.go
@@ -1,0 +1,77 @@
+package precompute
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// application is the producer name recorded in the sidecar. (The version is owned
+// by the caller and passed in to Run.)
+const application = "astro"
+
+const (
+	// schemaVersion lets the read-side cope with future format changes.
+	schemaVersion = 1
+
+	// algoProjectTree hashes a whole dbt project directory (source files).
+	// v2 excludes .git, which never ships in a deploy payload, so VCS activity
+	// (commits, fetches, gc) cannot change the hash of unchanged content.
+	algoProjectTree = "sha256-tree-v2"
+	// algoManifestJSON hashes a dbt manifest.json by content, ignoring volatile
+	// metadata. Used for manifest-only deployments. v2 also strips the
+	// dbt-owned created_at stamped on every resource and
+	// metadata.run_started_at, which dbt regenerates on every full parse, so
+	// CI-built manifests hash-match locally built ones.
+	algoManifestJSON = "sha256-manifest-v2"
+
+	sidecarDir  = ".astro"
+	sidecarName = "dbt_metadata.json"
+
+	sidecarDirPerm = 0o755
+	// sidecarPerm is deliberately world-readable: the sidecar ships inside the
+	// deploy bundle or image and the Airflow runtime user must be able to read it.
+	sidecarPerm = 0o644
+)
+
+// Metadata is the content of the .astro/dbt_metadata.json sidecar. The Cosmos
+// Boost plugin reads the version.hash field and uses it as the cache version key;
+// it never recomputes the hash itself.
+type Metadata struct {
+	Schema      int            `json:"schema"`
+	Version     ProjectVersion `json:"version"`
+	GeneratedBy GeneratedBy    `json:"generated_by"`
+}
+
+// ProjectVersion identifies a dbt project's content. Hash is the version key;
+// Algo names how it was computed so the read-side knows how to interpret it.
+type ProjectVersion struct {
+	Algo string `json:"algo"`
+	Hash string `json:"hash"`
+}
+
+// GeneratedBy records which tool (and version) wrote the sidecar.
+type GeneratedBy struct {
+	Application string `json:"application"`
+	Version     string `json:"version"`
+}
+
+// writeSidecar writes .astro/dbt_metadata.json inside dir. version is the
+// producer's version, recorded in generated_by.
+func writeSidecar(dir, algo, hash, version string) error {
+	meta := Metadata{
+		Schema:      schemaVersion,
+		Version:     ProjectVersion{Algo: algo, Hash: hash},
+		GeneratedBy: GeneratedBy{Application: application, Version: version},
+	}
+
+	// Metadata holds only strings and ints, so marshaling cannot fail.
+	data, _ := json.MarshalIndent(meta, "", "  ")
+	data = append(data, '\n')
+
+	out := filepath.Join(dir, sidecarDir)
+	if err := os.MkdirAll(out, sidecarDirPerm); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(out, sidecarName), data, sidecarPerm) //nolint:gosec // see sidecarPerm
+}

--- a/pkg/cosmosboost/precompute/metadata_test.go
+++ b/pkg/cosmosboost/precompute/metadata_test.go
@@ -1,0 +1,21 @@
+package precompute
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteSidecarError covers the best-effort failure branch: when a plain file
+// already occupies the .astro path, MkdirAll can't create the sidecar directory, so
+// writeSidecar returns an error rather than panicking.
+func TestWriteSidecarError(t *testing.T) {
+	dir := t.TempDir()
+	// Block the ".astro" directory with a regular file of the same name.
+	if err := os.WriteFile(filepath.Join(dir, sidecarDir), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSidecar(dir, algoProjectTree, "deadbeef", "test"); err == nil {
+		t.Fatal("writeSidecar should fail when .astro is a file, not a directory")
+	}
+}

--- a/pkg/cosmosboost/precompute/precompute.go
+++ b/pkg/cosmosboost/precompute/precompute.go
@@ -1,0 +1,213 @@
+package precompute
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// The two kinds of unit a run processes.
+const (
+	kindProject  = "project"
+	kindManifest = "manifest"
+)
+
+// Result records what happened for one unit of work: either a dbt project
+// directory or a standalone manifest.json.
+type Result struct {
+	Kind     string        // "project" or "manifest"
+	Path     string        // project directory, or manifest.json path
+	Hash     string        // version hash (empty if Err != nil or Skipped)
+	Files    int           // files hashed (1 for a manifest)
+	Bytes    int64         // total bytes hashed
+	Duration time.Duration // time spent on this unit
+	Skipped  bool          // a manifest.json that isn't a dbt manifest (no sidecar written)
+	Warning  string        // non-fatal note (sidecar still written), e.g. an unresolved template
+	Err      error         // non-nil if hashing or writing the sidecar failed
+}
+
+// Summary is the structured outcome of a precompute run. It backs both the
+// human-readable report and the tracking of this step's deploy-time overhead.
+type Summary struct {
+	Duration time.Duration
+	Results  []Result
+}
+
+// Run finds every dbt project (a directory with dbt_project.yml) and standalone
+// dbt manifest.json under the given roots, and writes a .astro/dbt_metadata.json
+// hash sidecar next to each. Units are processed concurrently — one worker each,
+// bounded by GOMAXPROCS — and each is hashed over sorted input, so results are
+// deterministic with no cross-worker coordination.
+//
+// Per-unit failures are best-effort: a unit that fails is recorded in its Result
+// and does not stop the others. Run only returns a non-nil error for a top-level
+// problem, such as a root that cannot be walked. version is recorded in each
+// sidecar's generated_by.
+func Run(roots []string, version string) (Summary, error) {
+	start := time.Now()
+
+	projectDirs := map[string]bool{}
+	for _, root := range roots {
+		found, err := findProjects(root)
+		if err != nil {
+			return Summary{}, fmt.Errorf("scanning %q for dbt projects: %w", root, err)
+		}
+		for _, d := range found {
+			projectDirs[d] = true
+		}
+	}
+
+	manifests := map[string]bool{}
+	for _, root := range roots {
+		found, err := findManifests(root, projectDirs)
+		if err != nil {
+			return Summary{}, fmt.Errorf("scanning %q for manifests: %w", root, err)
+		}
+		for _, m := range found {
+			manifests[m] = true
+		}
+	}
+
+	type unit struct{ kind, path string }
+	var units []unit
+	for d := range projectDirs {
+		units = append(units, unit{kindProject, d})
+	}
+	for m := range manifests {
+		units = append(units, unit{kindManifest, m})
+	}
+	// Composite sort key: path first, kind as the tiebreaker. NUL sorts below
+	// every other byte, so prefix relationships between paths are preserved.
+	sort.Slice(units, func(i, j int) bool {
+		return units[i].path+"\x00"+units[i].kind < units[j].path+"\x00"+units[j].kind
+	})
+
+	results := make([]Result, len(units))
+	sem := make(chan struct{}, max(1, runtime.GOMAXPROCS(0)))
+	var wg sync.WaitGroup
+	for i, u := range units {
+		wg.Add(1)
+		sem <- struct{}{} // acquire a worker slot
+		go func(i int, u unit) {
+			defer wg.Done()
+			defer func() { <-sem }() // release the slot
+			if u.kind == kindProject {
+				results[i] = processProject(u.path, version)
+			} else {
+				results[i] = processManifest(u.path, version)
+			}
+		}(i, u)
+	}
+	wg.Wait()
+
+	return Summary{Duration: time.Since(start), Results: results}, nil
+}
+
+// processProject hashes one dbt project directory and writes its sidecar. It reads
+// dbt_project.yml once (readDbtConfig) and threads the result through hashing and the
+// templated-packages warning, so the file isn't parsed more than once per project.
+func processProject(dir, version string) Result {
+	start := time.Now()
+	cfg := readDbtConfig(dir)
+	hash, files, totalBytes, err := hashProject(dir, cfg)
+	r := Result{Kind: kindProject, Path: dir, Hash: hash, Files: files, Bytes: totalBytes, Duration: time.Since(start)}
+	if err != nil {
+		r.Err = err
+		return r
+	}
+	if len(cfg.templatedSettings) > 0 {
+		r.Warning = strings.Join(cfg.templatedSettings, ", ") +
+			" in dbt_project.yml hold unresolved Jinja templates; using the dbt default directories for exclusion (the real ones may add cache churn)"
+	}
+	r.Err = writeSidecar(dir, algoProjectTree, hash, version)
+	r.Duration = time.Since(start)
+	return r
+}
+
+// processManifest hashes one manifest.json and writes a sidecar next to it. A
+// file that isn't a dbt manifest is skipped (no sidecar) so unrelated
+// manifest.json files in the project aren't stamped.
+func processManifest(path, version string) Result {
+	start := time.Now()
+	hash, bytes, isDbt, err := hashManifest(path)
+	r := Result{Kind: kindManifest, Path: path, Hash: hash, Files: 1, Bytes: bytes, Duration: time.Since(start)}
+	switch {
+	case err != nil:
+		r.Err = err
+	case !isDbt:
+		r.Skipped = true
+	default:
+		r.Err = writeSidecar(filepath.Dir(path), algoManifestJSON, hash, version)
+	}
+	return r
+}
+
+// CountFailed returns the number of units that errored.
+func (s Summary) CountFailed() int {
+	n := 0
+	for _, r := range s.Results {
+		if r.Err != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// CountSkipped returns the number of units skipped (manifest.json files that aren't
+// dbt manifests).
+func (s Summary) CountSkipped() int {
+	n := 0
+	for _, r := range s.Results {
+		if r.Skipped {
+			n++
+		}
+	}
+	return n
+}
+
+// WriteReport prints a short, human-readable report of the run.
+// Per-entry glyphs, shared by every command's WriteReport (see also
+// CleanupSummary.WriteReport in cleanup.go) so the two reports keep one
+// convention: acted on, deliberately left alone, failed, and a note attached to
+// an entry that otherwise succeeded.
+const (
+	glyphDone = "✓"
+	glyphLeft = "⊘"
+	glyphFail = "✗"
+	glyphNote = "⚠"
+)
+
+func (s Summary) WriteReport(w io.Writer) {
+	stamped := len(s.Results) - s.CountFailed() - s.CountSkipped()
+	fmt.Fprintf(w, "cosmos boost pre-deploy: %d stamped, %d skipped, %d failed in %s total (incl. discovery)\n",
+		stamped, s.CountSkipped(), s.CountFailed(), s.Duration.Round(time.Microsecond))
+	for _, r := range s.Results {
+		switch {
+		case r.Err != nil:
+			fmt.Fprintf(w, "  %s %-8s %s  (%v)\n", glyphFail, r.Kind, r.Path, r.Err)
+		case r.Skipped:
+			fmt.Fprintf(w, "  %s %-8s %s  (not a dbt manifest)\n", glyphLeft, r.Kind, r.Path)
+		default:
+			fmt.Fprintf(w, "  %s %-8s %s  hash=%s files=%d bytes=%d %s\n",
+				glyphDone, r.Kind, r.Path, shortHash(r.Hash), r.Files, r.Bytes, r.Duration.Round(time.Microsecond))
+			if r.Warning != "" {
+				fmt.Fprintf(w, "    %s %s\n", glyphNote, r.Warning)
+			}
+		}
+	}
+}
+
+// shortHashLen is how much of the hash the human-readable report shows.
+const shortHashLen = 12
+
+func shortHash(hash string) string {
+	if len(hash) > shortHashLen {
+		return hash[:shortHashLen]
+	}
+	return hash
+}

--- a/pkg/cosmosboost/precompute/precompute_test.go
+++ b/pkg/cosmosboost/precompute/precompute_test.go
@@ -1,0 +1,475 @@
+package precompute
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunDiscoversProjectsAndWritesSidecars(t *testing.T) {
+	root := t.TempDir()
+	// Two dbt projects at different depths (one under dags/, one under include/),
+	// plus a non-project file that must be ignored.
+	writeFiles(t, root, map[string]string{
+		"dags/dbt/shop/dbt_project.yml":   "name: shop\n",
+		"dags/dbt/shop/models/a.sql":      "select 1",
+		"include/finance/dbt_project.yml": "name: finance\n",
+		"include/finance/models/f.sql":    "select 2",
+		"dags/plain_dag.py":               "print('hi')",
+	})
+
+	summary, err := Run([]string{root}, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summary.Results) != 2 {
+		t.Fatalf("want 2 results, got %d: %+v", len(summary.Results), summary.Results)
+	}
+	if summary.CountFailed() != 0 {
+		t.Fatalf("unexpected failures: %+v", summary.Results)
+	}
+
+	for _, r := range summary.Results {
+		if r.Kind != "project" {
+			t.Fatalf("want kind=project, got %q for %s", r.Kind, r.Path)
+		}
+		sidecar := filepath.Join(r.Path, sidecarDir, sidecarName)
+		var m Metadata
+		readJSON(t, sidecar, &m)
+		if m.Schema != schemaVersion || m.Version.Algo != algoProjectTree || m.Version.Hash != r.Hash {
+			t.Fatalf("sidecar mismatch for %s: %+v (result hash %s)", r.Path, m, r.Hash)
+		}
+		if m.GeneratedBy.Application != application || m.GeneratedBy.Version != "test" {
+			t.Fatalf("generated_by mismatch for %s: %+v", r.Path, m.GeneratedBy)
+		}
+	}
+}
+
+// TestRunManifestOnly covers a manifest-only deployment: a shipped manifest.json
+// with no surrounding dbt project still gets a sidecar (DBT_MANIFEST path).
+func TestRunManifestOnly(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"shipped/manifest.json": `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json","generated_at":"t"},"nodes":{"model.x":{"name":"x"}}}`,
+	})
+
+	summary, err := Run([]string{root}, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summary.Results) != 1 || summary.Results[0].Kind != "manifest" {
+		t.Fatalf("want 1 manifest result, got %+v", summary.Results)
+	}
+
+	var m Metadata
+	readJSON(t, filepath.Join(root, "shipped", sidecarDir, sidecarName), &m)
+	if m.Version.Algo != algoManifestJSON || m.Version.Hash == "" {
+		t.Fatalf("manifest sidecar mismatch: %+v", m)
+	}
+}
+
+// TestRunProjectWithTargetManifest covers the common full-project case: the
+// project gets a folder-hash sidecar, and its target/manifest.json gets its own
+// manifest sidecar (target/ is excluded from the folder hash).
+func TestRunProjectWithTargetManifest(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"proj/dbt_project.yml":      "name: p\n",
+		"proj/models/a.sql":         "select 1",
+		"proj/target/manifest.json": `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json","generated_at":"t"},"nodes":{}}`,
+	})
+
+	summary, err := Run([]string{root}, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kinds := map[string]int{}
+	for _, r := range summary.Results {
+		if r.Err != nil {
+			t.Fatalf("unexpected error for %s: %v", r.Path, r.Err)
+		}
+		kinds[r.Kind]++
+	}
+	if kinds["project"] != 1 || kinds["manifest"] != 1 {
+		t.Fatalf("want 1 project + 1 manifest, got %+v (%+v)", kinds, summary.Results)
+	}
+	mustExist(t, filepath.Join(root, "proj", sidecarDir, sidecarName))
+	mustExist(t, filepath.Join(root, "proj", "target", sidecarDir, sidecarName))
+}
+
+// TestRunSkipsNonDBTManifest verifies an unrelated manifest.json (no dbt shape)
+// is discovered but skipped — no sidecar is written beside it.
+func TestRunSkipsNonDBTManifest(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"webapp/manifest.json": `{"name":"My App","icons":[]}`,
+	})
+
+	summary, err := Run([]string{root}, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summary.Results) != 1 || !summary.Results[0].Skipped {
+		t.Fatalf("want 1 skipped manifest, got %+v", summary.Results)
+	}
+	if summary.CountSkipped() != 1 {
+		t.Fatalf("Skipped() = %d, want 1", summary.CountSkipped())
+	}
+	if _, err := os.Stat(filepath.Join(root, "webapp", sidecarDir, sidecarName)); !os.IsNotExist(err) {
+		t.Fatalf("a sidecar was written beside a non-dbt manifest (err=%v)", err)
+	}
+}
+
+// TestRunWarnsOnTemplatedPackagesPath verifies a project whose packages-install-path
+// is a Jinja template still gets stamped, but the Result carries a non-fatal warning.
+func TestRunWarnsOnTemplatedPackagesPath(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"proj/dbt_project.yml": "name: p\npackages-install-path: \"{{ env_var('DBT_PKG_DIR') }}\"\n",
+		"proj/models/a.sql":    "select 1",
+	})
+
+	summary, err := Run([]string{root}, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(summary.Results) != 1 {
+		t.Fatalf("want 1 result, got %+v", summary.Results)
+	}
+	r := summary.Results[0]
+	if r.Err != nil {
+		t.Fatalf("unexpected error: %v", r.Err)
+	}
+	if r.Warning == "" {
+		t.Fatal("expected a warning for a templated packages-install-path")
+	}
+	mustExist(t, filepath.Join(root, "proj", sidecarDir, sidecarName))
+}
+
+func TestRunIsDeterministicAcrossRuns(t *testing.T) {
+	root := t.TempDir()
+	// Several projects so the worker pool runs them concurrently.
+	for _, name := range []string{"a", "b", "c", "d"} {
+		writeFiles(t, root, map[string]string{
+			name + "/dbt_project.yml": "name: " + name + "\n",
+			name + "/models/m.sql":    "select '" + name + "'",
+		})
+	}
+
+	first := hashesByPath(t, root)
+	for i := 0; i < 5; i++ {
+		got := hashesByPath(t, root)
+		for path, h := range got {
+			if first[path] != h {
+				t.Fatalf("non-deterministic hash for %s: %s != %s", path, first[path], h)
+			}
+		}
+	}
+}
+
+// TestSummaryWrite exercises the human-readable report across all branches
+// (stamped, skipped, failed, and a warning line) without needing to trigger a
+// real failure on disk.
+func TestSummaryWrite(t *testing.T) {
+	s := Summary{
+		Duration: 1234 * time.Microsecond,
+		Results: []Result{
+			{Kind: "project", Path: "/p/ok", Hash: "0123456789abcdef0123", Files: 3, Bytes: 42, Duration: time.Microsecond},
+			{Kind: "project", Path: "/p/warn", Hash: "abcdef0123456789abcd", Files: 1, Bytes: 7, Duration: time.Microsecond, Warning: "packages-install-path is a Jinja template"},
+			{Kind: "manifest", Path: "/p/web/manifest.json", Skipped: true},
+			{Kind: "project", Path: "/p/bad", Err: errors.New("boom")},
+		},
+	}
+
+	var buf bytes.Buffer
+	s.WriteReport(&buf)
+	out := buf.String()
+
+	for _, want := range []string{
+		"2 stamped, 1 skipped, 1 failed", // 2 ok (incl. the warned one) + 1 skipped + 1 failed
+		"hash=0123456789ab",              // shortHash truncates to 12 chars
+		"not a dbt manifest",
+		"(boom)",
+		"⚠ packages-install-path is a Jinja template",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("report missing %q\n--- report ---\n%s", want, out)
+		}
+	}
+}
+
+func hashesByPath(t *testing.T, root string) map[string]string {
+	t.Helper()
+	s, err := Run([]string{root}, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := make(map[string]string, len(s.Results))
+	for _, r := range s.Results {
+		if r.Err != nil {
+			t.Fatalf("unexpected error for %s: %v", r.Path, r.Err)
+		}
+		m[r.Path] = r.Hash
+	}
+	return m
+}
+
+func readJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+}
+
+func mustExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file %s: %v", path, err)
+	}
+}
+
+// TestRunProjectHashStableWithNestedManifestSidecar guards the hash-stability
+// concern: a dbt manifest.json in a subdirectory (e.g. docs/) gets its own sidecar
+// written into the walked tree (docs/.astro/). Since manifest and project units run
+// concurrently, the enclosing project's hash must not depend on that sidecar — so it
+// must be identical before and after the sidecar exists on disk.
+func TestRunProjectHashStableWithNestedManifestSidecar(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"proj/dbt_project.yml":    "name: p\n",
+		"proj/models/a.sql":       "select 1",
+		"proj/docs/manifest.json": `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json","generated_at":"t"},"nodes":{}}`,
+	})
+
+	projectHash := func() string {
+		s, err := Run([]string{root}, "test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, r := range s.Results {
+			if r.Kind == "project" {
+				if r.Err != nil {
+					t.Fatalf("unexpected error: %v", r.Err)
+				}
+				return r.Hash
+			}
+		}
+		t.Fatal("no project result")
+		return ""
+	}
+
+	first := projectHash()  // writes proj/.astro and proj/docs/.astro
+	second := projectHash() // the nested sidecar now exists on disk
+	if first != second {
+		t.Fatalf("project hash changed once the nested docs/.astro sidecar existed:\n first  %s\n second %s", first, second)
+	}
+	// Sanity: the nested docs/manifest.json did get its own sidecar (so the walk
+	// really does encounter docs/.astro and correctly skips it).
+	mustExist(t, filepath.Join(root, "proj", "docs", sidecarDir, sidecarName))
+}
+
+func TestShortHash(t *testing.T) {
+	if got := shortHash("abcdef"); got != "abcdef" { // <= 12 chars: returned as-is
+		t.Fatalf("shortHash(short) = %q, want abcdef", got)
+	}
+	if got := shortHash("0123456789abcdef0123"); got != "0123456789ab" { // truncated to 12
+		t.Fatalf("shortHash(long) = %q, want 0123456789ab", got)
+	}
+}
+
+// TestRunSkipsGitInternals pins that discovery never descends into .git: a
+// dbt_project.yml or manifest.json inside VCS internals is not a deployable
+// unit, and stamping it would write into (and later delete from) .git.
+func TestRunSkipsGitInternals(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"proj/dbt_project.yml":      "name: shop\n",
+		"proj/models/a.sql":         "select 1",
+		".git/trap/dbt_project.yml": "name: trap\n",
+		".git/deep/manifest.json":   `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json"},"nodes":{}}`,
+	})
+
+	summary, err := Run([]string{dir}, "test")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(summary.Results); got != 1 {
+		t.Fatalf("results = %d, want 1 (only the real project)", got)
+	}
+	for _, rel := range []string{".git/trap/.astro", ".git/deep/.astro", ".git/.astro"} {
+		if _, err := os.Stat(filepath.Join(dir, filepath.FromSlash(rel))); !os.IsNotExist(err) {
+			t.Fatalf("wrote into VCS internals: %s exists (%v)", rel, err)
+		}
+	}
+}
+
+func TestReadDbtConfigMissingFile(t *testing.T) {
+	got := readDbtConfig(t.TempDir())
+	if got.packagesInstallPath != "" || got.targetPath != "" || got.logPath != "" || len(got.templatedSettings) != 0 {
+		t.Fatalf("readDbtConfig on a dir without dbt_project.yml = %+v, want zero value", got)
+	}
+}
+
+// TestRunWarnsOnAllTemplatedDirSettings: the Jinja guard covers target-path
+// and log-path the same way it covers packages-install-path, and the warning
+// names every templated setting.
+func TestRunWarnsOnAllTemplatedDirSettings(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"proj/dbt_project.yml": "name: shop\n" +
+			"packages-install-path: \"{{ env_var('P') }}\"\n" +
+			"target-path: \"{{ env_var('T') }}\"\n" +
+			"log-path: \"{{ env_var('L') }}\"\n",
+		"proj/models/a.sql": "select 1",
+	})
+
+	summary, err := Run([]string{dir}, "test")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(summary.Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(summary.Results))
+	}
+	w := summary.Results[0].Warning
+	for _, setting := range []string{"packages-install-path", "target-path", "log-path"} {
+		if !strings.Contains(w, setting) {
+			t.Fatalf("warning %q does not name templated setting %s", w, setting)
+		}
+	}
+}
+
+// TestReadDbtConfigTemplatedValuesFallBackToDefaults: a templated setting is
+// treated as unset, so the dbt default directory stays excluded rather than a
+// meaningless literal.
+func TestReadDbtConfigTemplatedValuesFallBackToDefaults(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"dbt_project.yml": "name: shop\ntarget-path: \"{{ var('t') }}\"\nlog-path: logs_custom\n",
+	})
+	cfg := readDbtConfig(dir)
+	if cfg.targetPath != "" {
+		t.Fatalf("templated target-path must resolve to unset, got %q", cfg.targetPath)
+	}
+	if cfg.logPath != "logs_custom" {
+		t.Fatalf("literal log-path must survive, got %q", cfg.logPath)
+	}
+	if len(cfg.templatedSettings) != 1 || cfg.templatedSettings[0] != "target-path" {
+		t.Fatalf("templatedSettings = %v, want [target-path]", cfg.templatedSettings)
+	}
+}
+
+func TestRunErrorsOnUnreadableDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission semantics differ on windows")
+	}
+	dir := t.TempDir()
+	locked := filepath.Join(dir, "locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	if _, err := Run([]string{dir}, "test"); err == nil {
+		t.Fatal("Run over a tree with an unreadable directory: error = nil, want non-nil")
+	}
+}
+
+// TestRunErrorsOnUnreadableTargetDir hits the manifest walk's error path:
+// project discovery skips target/ by name and never descends into a found
+// project, so only the manifest walk reaches the unreadable directory.
+func TestRunErrorsOnUnreadableTargetDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission semantics differ on windows")
+	}
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{"proj/dbt_project.yml": "name: shop\n"})
+	target := filepath.Join(dir, "proj", "target")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(target, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(target, 0o755) })
+
+	if _, err := Run([]string{dir}, "test"); err == nil {
+		t.Fatal("Run: error = nil, want manifest-scan error")
+	}
+}
+
+// TestRunSkipsManifestInProjectRoot: a manifest sitting in a discovered
+// project's root is covered by the project's tree hash and gets no unit of
+// its own.
+func TestRunSkipsManifestInProjectRoot(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"proj/dbt_project.yml": "name: shop\n",
+		"proj/manifest.json":   `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json"},"nodes":{}}`,
+	})
+
+	summary, err := Run([]string{dir}, "test")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(summary.Results) != 1 || summary.Results[0].Kind != kindProject {
+		t.Fatalf("results = %+v, want exactly one project unit", summary.Results)
+	}
+}
+
+// TestRunReportsFailedUnits: per-unit failures land in the unit's Result and
+// do not abort the run.
+func TestRunReportsFailedUnits(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission semantics differ on windows")
+	}
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"broken/dbt_project.yml":   "name: broken\n",
+		"broken/models/a.sql":      "select 1",
+		"lockdir/dbt_project.yml":  "name: lockdir\n",
+		"standalone/manifest.json": `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json"},"nodes":{}}`,
+	})
+	// An unreadable file fails hashing mid-walk.
+	if err := os.Chmod(filepath.Join(dir, "broken", "models", "a.sql"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "broken", "models", "a.sql"), 0o644) })
+	// An unreadable directory inside a project fails the hash walk itself.
+	// models/logs is skipped by BOTH discovery walks (name-based) but visited
+	// by the hash walk (whose logs exclusion is root-relative only), so the
+	// failure surfaces in the unit, not in discovery.
+	locked := filepath.Join(dir, "lockdir", "models", "logs")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+	// An unreadable manifest fails its unit.
+	if err := os.Chmod(filepath.Join(dir, "standalone", "manifest.json"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "standalone", "manifest.json"), 0o644) })
+
+	summary, err := Run([]string{dir}, "test")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := summary.CountFailed(); got != 3 {
+		t.Fatalf("failed = %d, want 3 (broken project, locked project, unreadable manifest)", got)
+	}
+}

--- a/pkg/cosmosboost/predeploy.go
+++ b/pkg/cosmosboost/predeploy.go
@@ -1,0 +1,101 @@
+package cosmosboost
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/astronomer/astro-cli/pkg/cosmosboost/precompute"
+	"github.com/astronomer/astro-cli/pkg/logger"
+	"github.com/astronomer/astro-cli/version"
+)
+
+// PreDeploy runs the Cosmos Boost pre-deploy step over path: every dbt project
+// (dbt_project.yml) and standalone dbt manifest.json under it gets a
+// .astro/dbt_metadata.json sidecar carrying its content hash, which the Cosmos
+// Boost plugin uses as a cache version key at parse time instead of hashing
+// the project tree itself.
+func PreDeploy(path string) error {
+	summary, err := precompute.Run([]string{path}, version.CurrVersion)
+	if err != nil {
+		return fmt.Errorf("running the Cosmos Boost pre-deploy step: %w", err)
+	}
+	debugReport("pre-deploy", summary)
+	if failed := summary.CountFailed(); failed > 0 {
+		return fmt.Errorf("the Cosmos Boost pre-deploy step failed for %d unit(s) (re-run with --verbosity debug for details)", failed)
+	}
+	return nil
+}
+
+// cleanupRoots deletes the sidecars earlier pre-deploy runs wrote under
+// roots. Files this integration did not write are left in place; the summary
+// is returned so callers with stricter needs can inspect what was kept.
+func cleanupRoots(roots []string) (precompute.CleanupSummary, error) {
+	summary, err := precompute.Cleanup(roots)
+	if err != nil {
+		return summary, fmt.Errorf("removing the Cosmos Boost artifacts: %w", err)
+	}
+	debugReport("cleanup", summary)
+	if failed := summary.CountFailed(); failed > 0 {
+		return summary, fmt.Errorf("could not remove %d Cosmos Boost artifact(s) (re-run with --verbosity debug for details)", failed)
+	}
+	return summary, nil
+}
+
+// removeArtifacts is cleanupRoots for callers that only need the error.
+func removeArtifacts(roots []string) error {
+	_, err := cleanupRoots(roots)
+	return err
+}
+
+// EnsureClean removes the Cosmos Boost artifacts earlier deploys left under
+// path, and fails when their absence cannot be guaranteed. Consumers cannot
+// tell fresh output from stale, so a deploy must not proceed while a stale
+// artifact may still be in the payload.
+//
+// That includes sidecars from an unrecognized producer: cleanup deliberately
+// never deletes a file it does not own, but the plugin would consume its
+// version.hash all the same if the deploy shipped it - so an enabled deploy
+// stops and asks for manual removal instead. `astro dbt cleanup` keeps
+// preserving such files.
+func EnsureClean(path string) error {
+	summary, err := cleanupRoots([]string{path})
+	if err != nil {
+		return fmt.Errorf("%w; remove the reported files (or run 'astro dbt cleanup %s') and retry", err, path)
+	}
+	var kept []string
+	for _, r := range summary.Results {
+		if r.Kept {
+			kept = append(kept, r.Path)
+		}
+	}
+	if len(kept) > 0 {
+		return fmt.Errorf("found dbt_metadata.json files from an unrecognized producer: %s; the deploy cannot prove they are fresh, and cleanup will not delete files it does not own - remove them manually and retry", strings.Join(kept, ", "))
+	}
+	return nil
+}
+
+// BestEffortPreDeploy runs the Cosmos Boost pre-deploy step over path ahead of
+// a deploy. Stamping is best-effort — failures are warnings, never errors —
+// because without a sidecar the plugin simply falls back to hashing at parse
+// time. Callers must run EnsureClean first: writing nothing is safe, leaving
+// something stale is not.
+func BestEffortPreDeploy(path string) {
+	if err := PreDeploy(path); err != nil {
+		fmt.Printf("Warning: the Cosmos Boost pre-deploy step failed, continuing deploy: %s\n", err)
+		return
+	}
+	fmt.Println("Cosmos Boost pre-deploy step complete")
+}
+
+// reporter is the common shape of the precompute summaries.
+type reporter interface{ WriteReport(io.Writer) }
+
+// debugReport keeps the step's detailed report behind --verbosity debug; the
+// deploy output stays to one line either way.
+func debugReport(step string, r reporter) {
+	var buf bytes.Buffer
+	r.WriteReport(&buf)
+	logger.Debugf("cosmos boost %s report:\n%s", step, strings.TrimSpace(buf.String()))
+}

--- a/pkg/cosmosboost/predeploy_test.go
+++ b/pkg/cosmosboost/predeploy_test.go
@@ -1,0 +1,169 @@
+package cosmosboost
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/astronomer/astro-cli/version"
+)
+
+const artifactRelPath = ".astro/dbt_metadata.json"
+
+func writeDbtProject(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "models"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dbt_project.yml"), []byte("name: shop\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "models", "a.sql"), []byte("select 1"), 0o644))
+}
+
+func TestPreDeployWritesArtifact(t *testing.T) {
+	origVersion := version.CurrVersion
+	version.CurrVersion = "1.2.3"
+	t.Cleanup(func() { version.CurrVersion = origVersion })
+
+	dir := t.TempDir()
+	writeDbtProject(t, dir)
+
+	require.NoError(t, PreDeploy(dir))
+
+	data, err := os.ReadFile(filepath.Join(dir, artifactRelPath))
+	require.NoError(t, err)
+	var meta struct {
+		Schema  int `json:"schema"`
+		Version struct {
+			Algo string `json:"algo"`
+			Hash string `json:"hash"`
+		} `json:"version"`
+		GeneratedBy struct {
+			Application string `json:"application"`
+			Version     string `json:"version"`
+		} `json:"generated_by"`
+	}
+	require.NoError(t, json.Unmarshal(data, &meta))
+	require.Equal(t, 1, meta.Schema, "schema is the plugin's compatibility gate and must stay 1")
+	require.NotEmpty(t, meta.Version.Hash, "version.hash is what the plugin consumes")
+	require.NotEmpty(t, meta.Version.Algo)
+	require.Equal(t, "astro", meta.GeneratedBy.Application)
+	require.Equal(t, "1.2.3", meta.GeneratedBy.Version, "provenance records the CLI version now that the step runs in-process")
+}
+
+func TestPreDeployNoDbtContentIsANoOp(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.py"), []byte("print('hi')"), 0o644))
+
+	require.NoError(t, PreDeploy(dir))
+
+	_, err := os.Stat(filepath.Join(dir, ".astro"))
+	require.True(t, os.IsNotExist(err), "nothing dbt-shaped means nothing written")
+}
+
+func TestPreDeployNonexistentPath(t *testing.T) {
+	require.Error(t, PreDeploy(filepath.Join(t.TempDir(), "does-not-exist")))
+}
+
+// TestEnsureCleanRemovesStaleArtifacts covers the sequence the deploy hooks
+// run: EnsureClean first, then (opt-in) BestEffortPreDeploy — so an artifact
+// from an earlier deploy, even one whose project no longer exists, cannot
+// survive into the payload.
+func TestEnsureCleanRemovesStaleArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	writeDbtProject(t, dir)
+
+	// A stale artifact from an earlier deploy, in a spot the current tree no
+	// longer produces one for (its project was deleted since).
+	stale := filepath.Join(dir, "removed-project", ".astro", "dbt_metadata.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stale), 0o755))
+	require.NoError(t, os.WriteFile(stale, []byte(`{"generated_by": {"application": "astro"}}`), 0o644))
+
+	require.NoError(t, EnsureClean(dir))
+	BestEffortPreDeploy(dir)
+
+	_, err := os.Stat(stale)
+	require.True(t, os.IsNotExist(err), "stale artifacts must not survive a pre-deploy run")
+	require.FileExists(t, filepath.Join(dir, artifactRelPath), "the current project must be stamped")
+}
+
+// TestEnsureCleanFailsOnForeignSidecar pins the strict-ownership contract for
+// deploys: cleanup never deletes a file it does not own, but the plugin would
+// consume its version.hash all the same - so an enabled deploy must stop and
+// ask for manual removal instead of shipping it.
+func TestEnsureCleanFailsOnForeignSidecar(t *testing.T) {
+	dir := t.TempDir()
+	writeDbtProject(t, dir)
+	require.NoError(t, PreDeploy(dir))
+
+	foreign := filepath.Join(dir, "other", ".astro", "dbt_metadata.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(foreign), 0o755))
+	require.NoError(t, os.WriteFile(foreign, []byte(`{"generated_by": {"application": "someone-else"}}`), 0o644))
+
+	err := EnsureClean(dir)
+
+	require.Error(t, err, "an unrecognized sidecar must fail the clean")
+	require.ErrorContains(t, err, foreign)
+	require.ErrorContains(t, err, "remove them manually")
+	_, statErr := os.Stat(filepath.Join(dir, artifactRelPath))
+	require.True(t, os.IsNotExist(statErr), "our artifact must still be removed")
+	require.FileExists(t, foreign, "a file another tool wrote must never be deleted")
+}
+
+// TestCleanupKeepsForeignSidecarWithoutError: the explicit command keeps
+// preserving unrecognized files and reports success, unlike EnsureClean.
+func TestCleanupKeepsForeignSidecarWithoutError(t *testing.T) {
+	dir := t.TempDir()
+	foreign := filepath.Join(dir, "other", ".astro", "dbt_metadata.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(foreign), 0o755))
+	require.NoError(t, os.WriteFile(foreign, []byte(`{"generated_by": {"application": "someone-else"}}`), 0o644))
+
+	require.NoError(t, Cleanup(dir))
+	require.FileExists(t, foreign)
+}
+
+// TestEnsureCleanFailsWhenArtifactUnremovable pins the safety property behind
+// the hooks: when a stale artifact's absence cannot be guaranteed, EnsureClean
+// errors so the deploy stops instead of shipping it.
+func TestEnsureCleanFailsWhenArtifactUnremovable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory write-permission semantics differ on windows")
+	}
+	dir := t.TempDir()
+	astroDir := filepath.Join(dir, "proj", ".astro")
+	require.NoError(t, os.MkdirAll(astroDir, 0o755))
+	artifact := filepath.Join(astroDir, "dbt_metadata.json")
+	require.NoError(t, os.WriteFile(artifact, []byte(`{"generated_by": {"application": "astro"}}`), 0o644))
+	require.NoError(t, os.Chmod(astroDir, 0o555)) // file cannot be unlinked
+	t.Cleanup(func() { _ = os.Chmod(astroDir, 0o755) })
+
+	err := EnsureClean(dir)
+
+	require.Error(t, err, "an artifact that cannot be removed must fail the clean")
+	require.ErrorContains(t, err, "astro dbt cleanup")
+	require.FileExists(t, artifact)
+}
+
+// TestPreDeployReportsFailedUnits: a unit that cannot be hashed turns into an
+// error naming the failure count, so the hook can warn with substance.
+func TestPreDeployReportsFailedUnits(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission semantics differ on windows")
+	}
+	dir := t.TempDir()
+	writeDbtProject(t, dir)
+	model := filepath.Join(dir, "models", "a.sql")
+	require.NoError(t, os.Chmod(model, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(model, 0o644) })
+
+	err := PreDeploy(dir)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed for 1 unit(s)")
+}
+
+// TestBestEffortPreDeployWarnsAndContinues: stamping failures never propagate.
+func TestBestEffortPreDeployWarnsAndContinues(t *testing.T) {
+	BestEffortPreDeploy(filepath.Join(t.TempDir(), "does-not-exist"))
+}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -43,8 +43,13 @@ type envMapping struct {
 	name   string
 }
 
-// agentEnvVars is an ordered list of environment variables to detect agent contexts
+// agentEnvVars is an ordered list of environment variables to detect agent
+// contexts. Order matters: the first match wins. Otto is first because it
+// passes its own environment through to every command it runs, so an Otto
+// session started from inside another agent still carries that agent's marker.
+// Otto is the proximate caller, so it takes precedence.
 var agentEnvVars = []envMapping{
+	{"OTTO", "otto"},
 	{"CLAUDECODE", "claude-code"},
 	{"CLAUDE_CODE_ENTRYPOINT", "claude-code"},
 	{"CURSOR_TRACE_ID", "cursor"},
@@ -55,6 +60,45 @@ var agentEnvVars = []envMapping{
 	{"GEMINI_CLI", "gemini-cli"},
 	{"OPENCODE", "opencode"},
 	{"CODEX_API_KEY", "codex"},
+	// GitHub Copilot. COPILOT_CLI is set by the Copilot CLI, which is also the
+	// harness behind the cloud coding agent and, as of 2026, Copilot for
+	// JetBrains; github's own gh keys on it (cli/cli internal/agents/detect.go).
+	// COPILOT_AGENT is set on terminals VS Code creates for agent mode
+	// (microsoft/vscode toolTerminalCreator.ts), where it is described as
+	// backward compatibility for exactly this kind of detection.
+	{"COPILOT_CLI", "github-copilot"},
+	{"COPILOT_AGENT", "github-copilot"},
+}
+
+// aiAgentEnvVar is a cross-vendor convention where the value names the agent
+// rather than the variable: VS Code sets AI_AGENT=github_copilot_vscode_agent
+// for agent sessions and the Copilot desktop app sets github_copilot_app_agent
+// (microsoft/vscode aiAgentEnv.ts). gh reads it too.
+//
+// It is checked after agentEnvVars so a specific marker still wins, and only
+// prefixes we recognise are mapped. Values are not passed through: some vendors
+// put a version in theirs (claude-code_2-1-156_agent), which would spray one
+// agent across dozens of distinct values in the telemetry. A new vendor adopting
+// the convention is a one-line addition here.
+const aiAgentEnvVar = "AI_AGENT"
+
+var aiAgentPrefixes = []envMapping{
+	{"github_copilot", "github-copilot"},
+}
+
+// detectAIAgent maps the AI_AGENT convention to an agent name, or "" if the
+// value is empty or not one we recognise.
+func detectAIAgent() string {
+	value := strings.ToLower(os.Getenv(aiAgentEnvVar))
+	if value == "" {
+		return ""
+	}
+	for _, m := range aiAgentPrefixes {
+		if strings.HasPrefix(value, m.envVar) {
+			return m.name
+		}
+	}
+	return ""
 }
 
 // ciEnvVars is an ordered list of environment variables to detect CI contexts.
@@ -101,7 +145,7 @@ func DetectAgent() string {
 			return m.name
 		}
 	}
-	return ""
+	return detectAIAgent()
 }
 
 // DetectCISystem returns the name of the detected CI system (e.g. "github-actions"), or "" if none.

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -43,7 +43,7 @@ func TestIsDisabledByEnv(t *testing.T) {
 }
 
 func TestDetectAgent(t *testing.T) {
-	agentVars := envVarNames(agentEnvVars)
+	agentVars := append(envVarNames(agentEnvVars), aiAgentEnvVar)
 	savedVals := make(map[string]string)
 	for _, env := range agentVars {
 		savedVals[env] = os.Getenv(env)
@@ -65,6 +65,7 @@ func TestDetectAgent(t *testing.T) {
 		envValue string
 		expected string
 	}{
+		{"otto", "OTTO", "1", "otto"},
 		{"claude code", "CLAUDECODE", "1", "claude-code"},
 		{"claude code entrypoint", "CLAUDE_CODE_ENTRYPOINT", "cli", "claude-code"},
 		{"cursor", "CURSOR_TRACE_ID", "abc123", "cursor"},
@@ -72,6 +73,11 @@ func TestDetectAgent(t *testing.T) {
 		{"gemini cli", "GEMINI_CLI", "1", "gemini-cli"},
 		{"opencode", "OPENCODE", "1", "opencode"},
 		{"codex", "CODEX_API_KEY", "sk-test", "codex"},
+		{"copilot cli", "COPILOT_CLI", "1", "github-copilot"},
+		{"copilot vscode agent mode", "COPILOT_AGENT", "1", "github-copilot"},
+		{"ai_agent copilot vscode", "AI_AGENT", "github_copilot_vscode_agent", "github-copilot"},
+		{"ai_agent copilot app", "AI_AGENT", "github_copilot_app_agent", "github-copilot"},
+		{"ai_agent unrecognised vendor", "AI_AGENT", "some_other_agent", ""},
 		{"no agent", "", "", ""},
 	}
 
@@ -88,6 +94,52 @@ func TestDetectAgent(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// Otto passes its own environment through to every command it runs, so an Otto
+// session started from inside another agent still carries that agent's marker.
+// Otto is the proximate caller and must win.
+func TestDetectAgentOttoWinsOverInheritedMarker(t *testing.T) {
+	for _, env := range append(envVarNames(agentEnvVars), aiAgentEnvVar) {
+		saved := os.Getenv(env)
+		os.Unsetenv(env)
+		defer func(env, saved string) {
+			if saved != "" {
+				os.Setenv(env, saved)
+			}
+		}(env, saved)
+	}
+
+	os.Setenv("CLAUDECODE", "1")
+	defer os.Unsetenv("CLAUDECODE")
+	assert.Equal(t, "claude-code", DetectAgent())
+
+	os.Setenv("OTTO", "1")
+	defer os.Unsetenv("OTTO")
+	assert.Equal(t, "otto", DetectAgent())
+}
+
+// AI_AGENT is the fallback, so a specific marker still decides. VS Code sets
+// both AI_AGENT and COPILOT_AGENT, and Otto inside a VS Code agent terminal
+// carries both plus its own.
+func TestDetectAgentSpecificMarkerBeatsAIAgent(t *testing.T) {
+	for _, env := range append(envVarNames(agentEnvVars), aiAgentEnvVar) {
+		saved := os.Getenv(env)
+		os.Unsetenv(env)
+		defer func(env, saved string) {
+			if saved != "" {
+				os.Setenv(env, saved)
+			}
+		}(env, saved)
+	}
+
+	os.Setenv("AI_AGENT", "github_copilot_vscode_agent")
+	defer os.Unsetenv("AI_AGENT")
+	assert.Equal(t, "github-copilot", DetectAgent())
+
+	os.Setenv("OTTO", "1")
+	defer os.Unsetenv("OTTO")
+	assert.Equal(t, "otto", DetectAgent())
 }
 
 func TestDetectCISystem(t *testing.T) {


### PR DESCRIPTION
## Description

Backport two PRs merged to main targeted to the 1.44 release.

## 🎟 Issue(s)

N/A

## 🧪 Functional Testing

N/A

## 📸 Screenshots

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft
- [ ] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
