### PR TITLE
Attach the Astro token to CLI telemetry so events can be attributed

### DIFF
--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -13,15 +13,18 @@ import (
 func newTelemetryCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "telemetry",
-		Short: "Manage anonymous telemetry settings",
-		Long: `Manage anonymous telemetry settings for the Astro CLI.
+		Short: "Manage telemetry settings",
+		Long: `Manage telemetry settings for the Astro CLI.
 
 Telemetry helps us understand how the CLI is used and improve it.
-We collect anonymous usage data including:
+We collect usage data including:
 - Commands used (not arguments or values)
 - CLI version
 - Operating system
 - Invocation context (CI, interactive, etc.)
+
+While you are logged in, events are linked to your Astro organization so we can
+see how the CLI is used across accounts. Logged-out usage stays anonymous.
 
 No personally identifiable information is collected.
 You can opt out at any time using 'astro telemetry disable' or by setting

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -55,6 +55,27 @@ func IsInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
+// currentToken returns the Astro bearer token for the active context, or "" when
+// the user has not logged in and no API token is configured.
+//
+// It reads local state only — no network call and no token refresh. The sender
+// runs in a detached subprocess alongside the main command, so refreshing here
+// would race the main process for ~/.astro/config.yaml. A stale token means the
+// server cannot attribute that one event, which is an acceptable loss for
+// telemetry and never blocks the user's actual command.
+//
+// An empty result is expected and fine: the event still sends, unattributed.
+func currentToken() string {
+	if t := os.Getenv("ASTRO_API_TOKEN"); t != "" {
+		return t
+	}
+	ctx, err := config.GetCurrentContext()
+	if err != nil {
+		return ""
+	}
+	return ctx.Token
+}
+
 // GetCommandPath extracts the command path from a cobra.Command
 // Returns the full command path (e.g., "deploy", "dev start")
 func GetCommandPath(cmd *cobra.Command) string {
@@ -66,16 +87,28 @@ func GetCommandPath(cmd *cobra.Command) string {
 	return ""
 }
 
-// showFirstRunNotice prints a one-time notice about telemetry on the first CLI invocation.
+// noticeVersion identifies the wording of the telemetry notice below. Bump it
+// whenever the notice makes a materially different claim about what is
+// collected, so users who accepted an earlier version are told about the change
+// instead of silently inheriting it.
+//
+// v1 (unversioned, stored as "true") promised fully anonymous collection.
+// v2 added organization attribution for logged-in users.
+const noticeVersion = "2"
+
+// showFirstRunNotice prints a notice about telemetry on the first CLI invocation,
+// and again whenever noticeVersion changes.
 func showFirstRunNotice() {
-	if config.CFG.TelemetryNoticeShown.GetHomeString() != "" {
+	if config.CFG.TelemetryNoticeShown.GetHomeString() == noticeVersion {
 		return
 	}
 	fmt.Fprintln(os.Stderr,
-		"The Astro CLI now collects anonymous usage data to help us prioritize and invest in CLI features.\n"+
-			"Only commands, OS, and CLI version are tracked — no personal information is collected.\n"+
+		"The Astro CLI collects usage data to help us prioritize and invest in CLI features.\n"+
+			"Commands, OS, and CLI version are tracked — never arguments or their values.\n"+
+			"While you are logged in, events are linked to your Astro organization.\n"+
+			"Logged-out usage stays anonymous.\n"+
 			"Opt out anytime: `astro telemetry disable` or ASTRO_TELEMETRY_DISABLED=1")
-	_ = config.CFG.TelemetryNoticeShown.SetHomeString("true")
+	_ = config.CFG.TelemetryNoticeShown.SetHomeString(noticeVersion)
 }
 
 // buildCommandProperties constructs the telemetry property map for a command.
@@ -134,13 +167,14 @@ func TrackCommand(cmd *cobra.Command) {
 	}
 
 	apiURL := sharedtel.GetTelemetryAPIURL()
+	token := currentToken()
 
 	if isDebugMode() {
-		sendDebug(payload, apiURL)
+		sendDebug(payload, apiURL, token)
 		return
 	}
 
-	spawnTelemetrySender(payload, apiURL)
+	spawnTelemetrySender(payload, apiURL, token)
 }
 
 // CreateTrackingHook returns a RunE function that tracks command execution
@@ -171,12 +205,17 @@ func isDebugMode() bool {
 	return val == "1" || strings.EqualFold(val, "true")
 }
 
-// sendDebug sends telemetry synchronously and prints debug output
-func sendDebug(payload sharedtel.TelemetryPayload, apiURL string) {
+// sendDebug sends telemetry synchronously and prints debug output.
+// It prints the event body and whether a token was attached, never the token.
+func sendDebug(payload sharedtel.TelemetryPayload, apiURL, token string) {
 	body, _ := json.MarshalIndent(payload, "", "  ")
-	fmt.Fprintf(os.Stderr, "[telemetry] POST %s\n%s\n", apiURL, body)
+	authState := "anonymous"
+	if token != "" {
+		authState = "authenticated"
+	}
+	fmt.Fprintf(os.Stderr, "[telemetry] POST %s (%s)\n%s\n", apiURL, authState, body)
 
-	status, err := sharedtel.Send(payload, apiURL)
+	status, err := sharedtel.SendWithToken(payload, apiURL, token)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[telemetry] error: %v\n", err)
 		return
@@ -184,16 +223,22 @@ func sendDebug(payload sharedtel.TelemetryPayload, apiURL string) {
 	fmt.Fprintf(os.Stderr, "[telemetry] response: %d OK\n", status)
 }
 
-// spawnTelemetrySender spawns a detached subprocess to send telemetry
-func spawnTelemetrySender(payload sharedtel.TelemetryPayload, apiURL string) {
+// spawnTelemetrySender spawns a detached subprocess to send telemetry.
+//
+// The struct below must match pkg/telemetry's unexported senderPayload field for
+// field, JSON tag for JSON tag — the subprocess unmarshals into that one. A
+// mismatch fails silently, dropping the affected field. See the note there.
+func spawnTelemetrySender(payload sharedtel.TelemetryPayload, apiURL, token string) {
 	type senderPayload struct {
 		sharedtel.TelemetryPayload
 		APIURL string `json:"api_url"`
+		Token  string `json:"token,omitempty"`
 	}
 
 	sp := senderPayload{
 		TelemetryPayload: payload,
 		APIURL:           apiURL,
+		Token:            token,
 	}
 	payloadJSON, err := json.Marshal(sp)
 	if err != nil {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -55,25 +55,24 @@ func IsInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
-// currentToken returns the Astro bearer token for the active context, or "" when
-// the user has not logged in and no API token is configured.
+// currentToken returns the bearer token for the active context, or "" when the
+// user is logged out — in which case the event still sends, unattributed.
 //
-// It reads local state only — no network call and no token refresh. The sender
-// runs in a detached subprocess alongside the main command, so refreshing here
-// would race the main process for ~/.astro/config.yaml. A stale token means the
-// server cannot attribute that one event, which is an acceptable loss for
-// telemetry and never blocks the user's actual command.
-//
-// An empty result is expected and fine: the event still sends, unattributed.
+// Deliberately does not refresh an expired token: the sender runs in a detached
+// subprocess, so refreshing would race the main process for ~/.astro/config.yaml.
+// A stale token costs one unattributed event.
+// Returns the raw token: contexts persist it with a "Bearer " prefix already
+// (see cmd/cloud/setup.go), while ASTRO_API_TOKEN holds it without one.
+// SendWithToken supplies the scheme.
 func currentToken() string {
 	if t := os.Getenv("ASTRO_API_TOKEN"); t != "" {
-		return t
+		return strings.TrimPrefix(t, "Bearer ")
 	}
 	ctx, err := config.GetCurrentContext()
 	if err != nil {
 		return ""
 	}
-	return ctx.Token
+	return strings.TrimPrefix(ctx.Token, "Bearer ")
 }
 
 // GetCommandPath extracts the command path from a cobra.Command
@@ -87,13 +86,10 @@ func GetCommandPath(cmd *cobra.Command) string {
 	return ""
 }
 
-// noticeVersion identifies the wording of the telemetry notice below. Bump it
-// whenever the notice makes a materially different claim about what is
-// collected, so users who accepted an earlier version are told about the change
-// instead of silently inheriting it.
-//
-// v1 (unversioned, stored as "true") promised fully anonymous collection.
-// v2 added organization attribution for logged-in users.
+// noticeVersion tracks the wording of the notice below. Bump it whenever the
+// notice makes a materially different claim about what is collected, so users
+// who accepted earlier wording see the change instead of inheriting it silently.
+// v1 predates this constant and is stored as "true".
 const noticeVersion = "2"
 
 // showFirstRunNotice prints a notice about telemetry on the first CLI invocation,
@@ -223,19 +219,9 @@ func sendDebug(payload sharedtel.TelemetryPayload, apiURL, token string) {
 	fmt.Fprintf(os.Stderr, "[telemetry] response: %d OK\n", status)
 }
 
-// spawnTelemetrySender spawns a detached subprocess to send telemetry.
-//
-// The struct below must match pkg/telemetry's unexported senderPayload field for
-// field, JSON tag for JSON tag — the subprocess unmarshals into that one. A
-// mismatch fails silently, dropping the affected field. See the note there.
+// spawnTelemetrySender spawns a detached subprocess to send telemetry
 func spawnTelemetrySender(payload sharedtel.TelemetryPayload, apiURL, token string) {
-	type senderPayload struct {
-		sharedtel.TelemetryPayload
-		APIURL string `json:"api_url"`
-		Token  string `json:"token,omitempty"`
-	}
-
-	sp := senderPayload{
+	sp := sharedtel.SenderPayload{
 		TelemetryPayload: payload,
 		APIURL:           apiURL,
 		Token:            token,

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,17 +1,20 @@
 package telemetry
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
 	"github.com/astronomer/astro-cli/config"
+	"github.com/astronomer/astro-cli/pkg/domainutil"
 	sharedtel "github.com/astronomer/astro-cli/pkg/telemetry"
 	"github.com/astronomer/astro-cli/version"
 )
@@ -55,24 +58,68 @@ func IsInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
-// currentToken returns the bearer token for the active context, or "" when the
-// user is logged out — in which case the event still sends, unattributed.
-//
-// Deliberately does not refresh an expired token: the sender runs in a detached
-// subprocess, so refreshing would race the main process for ~/.astro/config.yaml.
-// A stale token costs one unattributed event.
-// Returns the raw token: contexts persist it with a "Bearer " prefix already
-// (see cmd/cloud/setup.go), while ASTRO_API_TOKEN holds it without one.
-// SendWithToken supplies the scheme.
-func currentToken() string {
-	if t := os.Getenv("ASTRO_API_TOKEN"); t != "" {
-		return strings.TrimPrefix(t, "Bearer ")
+// jwtSections is the header.payload.signature shape a JWT must have.
+const jwtSections = 3
+
+// jwtExpiry reads the exp claim without verifying the signature. The second
+// return is false when the token is not a readable JWT.
+func jwtExpiry(token string) (expiry time.Time, ok bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != jwtSections {
+		return time.Time{}, false
 	}
-	ctx, err := config.GetCurrentContext()
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
+		return time.Time{}, false
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(claims.Exp, 0), true
+}
+
+// tokenFreshnessMargin is how much life a token must have left to be worth
+// attaching. The sender runs asynchronously, so a token expiring in the next
+// moment would likely be rejected by the time the request lands.
+const tokenFreshnessMargin = 30 * time.Second
+
+// currentToken returns a bearer token to attach, or "" to send anonymously.
+//
+// It only returns a token that can plausibly be accepted: the gateway validates
+// the JWT and rejects the whole request when it fails, so attaching a token we
+// already know is bad loses the event outright, where attaching none still
+// records it anonymously. Expired tokens are dropped rather than refreshed —
+// the sender is a detached subprocess and refreshing would race the main process
+// for ~/.astro/config.yaml.
+//
+// Returns the raw token. Contexts persist it with a "Bearer " prefix (see
+// cmd/cloud/setup.go) while ASTRO_API_TOKEN holds it without one; SendWithToken
+// supplies the scheme.
+func currentToken() string {
+	token := strings.TrimPrefix(os.Getenv("ASTRO_API_TOKEN"), "Bearer ")
+	if token == "" {
+		ctx, err := config.GetCurrentContext()
+		if err != nil {
+			return ""
+		}
+		// Telemetry always posts to the production endpoint, which does not
+		// recognize tokens issued by a dev or stage domain. An explicit endpoint
+		// override means someone is pointing at their own listener, so trust it.
+		defaultEndpoint := sharedtel.GetTelemetryAPIURL() == sharedtel.TelemetryAPIURL
+		if defaultEndpoint && domainutil.FormatDomain(ctx.Domain) != domainutil.DefaultDomain {
+			return ""
+		}
+		token = strings.TrimPrefix(ctx.Token, "Bearer ")
+	}
+
+	expiry, ok := jwtExpiry(token)
+	if !ok || time.Now().Add(tokenFreshnessMargin).After(expiry) {
 		return ""
 	}
-	return strings.TrimPrefix(ctx.Token, "Bearer ")
+	return token
 }
 
 // GetCommandPath extracts the command path from a cobra.Command

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -146,12 +146,15 @@ func TrackCommand(cmd *cobra.Command) {
 		return
 	}
 
-	showFirstRunNotice()
-
 	commandPath := GetCommandPath(cmd)
 	if commandPath == "" || cmd.Hidden || strings.HasPrefix(commandPath, "telemetry") || strings.HasPrefix(commandPath, "_telemetry") {
 		return
 	}
+
+	// After the filter above, so that commands which send nothing say nothing —
+	// notably `astro telemetry disable`, which otherwise announces collection to
+	// someone in the act of opting out.
+	showFirstRunNotice()
 
 	properties := buildCommandProperties(cmd)
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -107,13 +107,37 @@ func TestShowFirstRunNotice(t *testing.T) {
 		os.Stderr = oldStderr
 
 		output := string(out[:n])
-		assert.Contains(t, output, "anonymous usage data")
+		assert.Contains(t, output, "usage data")
+		assert.Contains(t, output, "linked to your Astro organization")
 		assert.Contains(t, output, "astro telemetry disable")
 
-		assert.Equal(t, "true", config.CFG.TelemetryNoticeShown.GetHomeString())
+		assert.Equal(t, noticeVersion, config.CFG.TelemetryNoticeShown.GetHomeString())
 	})
 
 	t.Run("does not print on subsequent calls", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		configRaw := []byte("telemetry:\n  enabled: true\n  notice_shown: \"" + noticeVersion + "\"\n")
+		require.NoError(t, afero.WriteFile(fs, config.HomeConfigFile, configRaw, 0o777))
+		config.InitConfig(fs)
+
+		oldStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		showFirstRunNotice()
+
+		w.Close()
+		out := make([]byte, 1024)
+		n, _ := r.Read(out)
+		os.Stderr = oldStderr
+
+		assert.Equal(t, 0, n, "Should not print anything on subsequent calls")
+	})
+
+	// Users who accepted the v1 notice agreed to fully anonymous collection. The
+	// v2 notice adds organization attribution, so they must be told once rather
+	// than inheriting the change silently.
+	t.Run("reprints when the accepted notice predates the current version", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		configRaw := []byte("telemetry:\n  enabled: true\n  notice_shown: \"true\"\n")
 		require.NoError(t, afero.WriteFile(fs, config.HomeConfigFile, configRaw, 0o777))
@@ -130,7 +154,42 @@ func TestShowFirstRunNotice(t *testing.T) {
 		n, _ := r.Read(out)
 		os.Stderr = oldStderr
 
-		assert.Equal(t, 0, n, "Should not print anything on subsequent calls")
+		assert.Contains(t, string(out[:n]), "linked to your Astro organization")
+		assert.Equal(t, noticeVersion, config.CFG.TelemetryNoticeShown.GetHomeString())
+	})
+}
+
+func TestCurrentToken(t *testing.T) {
+	origEnv := os.Getenv("ASTRO_API_TOKEN")
+	defer os.Setenv("ASTRO_API_TOKEN", origEnv)
+
+	// A context with a stored token, as `astro login` would leave it.
+	withContext := func(t *testing.T) {
+		t.Helper()
+		fs := afero.NewMemMapFs()
+		configRaw := []byte("context: test_com\ncontexts:\n  test_com:\n    domain: test.com\n    token: ctx-token\n    organization: org-1\ntelemetry:\n  enabled: true\n")
+		require.NoError(t, afero.WriteFile(fs, config.HomeConfigFile, configRaw, 0o777))
+		config.InitConfig(fs)
+	}
+
+	t.Run("returns the context token when logged in", func(t *testing.T) {
+		os.Setenv("ASTRO_API_TOKEN", "")
+		withContext(t)
+		assert.Equal(t, "ctx-token", currentToken())
+	})
+
+	t.Run("prefers ASTRO_API_TOKEN over the context token", func(t *testing.T) {
+		withContext(t)
+		os.Setenv("ASTRO_API_TOKEN", "env-token")
+		assert.Equal(t, "env-token", currentToken())
+	})
+
+	// Logged-out users must not error or block the event — they just send
+	// unattributed, which is the whole point of measuring them.
+	t.Run("returns empty when there is no context and no env token", func(t *testing.T) {
+		os.Setenv("ASTRO_API_TOKEN", "")
+		initTestConfig(t)
+		assert.Empty(t, currentToken())
 	})
 }
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,8 +1,11 @@
 package telemetry
 
 import (
+	"encoding/base64"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -159,31 +162,84 @@ func TestShowFirstRunNotice(t *testing.T) {
 	})
 }
 
+// testJWT builds an unsigned JWT with the given expiry. currentToken only reads
+// the exp claim, so the signature is irrelevant here.
+func testJWT(exp time.Time) string {
+	enc := func(v string) string {
+		return base64.RawURLEncoding.EncodeToString([]byte(v))
+	}
+	return enc(`{"alg":"RS256","typ":"JWT"}`) + "." +
+		enc(fmt.Sprintf(`{"exp":%d,"sub":"test"}`, exp.Unix())) + ".sig"
+}
+
+func TestJWTExpiry(t *testing.T) {
+	want := time.Now().Add(time.Hour).Truncate(time.Second)
+	got, ok := jwtExpiry(testJWT(want))
+	assert.True(t, ok)
+	assert.Equal(t, want.Unix(), got.Unix())
+
+	for _, bad := range []string{"", "not-a-jwt", "a.b", "a.b.c", "a.!!!.c"} {
+		_, ok := jwtExpiry(bad)
+		assert.False(t, ok, "expected %q to be unreadable", bad)
+	}
+}
+
 func TestCurrentToken(t *testing.T) {
 	origEnv := os.Getenv("ASTRO_API_TOKEN")
 	defer os.Setenv("ASTRO_API_TOKEN", origEnv)
 
-	// A context as `astro login` leaves it: the token is stored WITH its
-	// "Bearer " prefix, which currentToken must strip.
-	withContext := func(t *testing.T) {
+	// A context as `astro login` leaves it on the production domain: the token is
+	// stored WITH its "Bearer " prefix, which currentToken must strip.
+	withContext := func(t *testing.T, domain, token string) {
 		t.Helper()
 		fs := afero.NewMemMapFs()
-		configRaw := []byte("context: test_com\ncontexts:\n  test_com:\n    domain: test.com\n    token: Bearer ctx-token\n    organization: org-1\ntelemetry:\n  enabled: true\n")
+		configRaw := []byte("context: prod\ncontexts:\n  prod:\n    domain: " + domain +
+			"\n    token: \"Bearer " + token + "\"\n    organization: org-1\ntelemetry:\n  enabled: true\n")
 		require.NoError(t, afero.WriteFile(fs, config.HomeConfigFile, configRaw, 0o777))
 		config.InitConfig(fs)
 	}
 
 	t.Run("strips the stored Bearer prefix from the context token", func(t *testing.T) {
 		os.Setenv("ASTRO_API_TOKEN", "")
-		withContext(t)
-		assert.Equal(t, "ctx-token", currentToken())
+		live := testJWT(time.Now().Add(time.Hour))
+		withContext(t, "astronomer.io", live)
+		assert.Equal(t, live, currentToken())
+	})
+
+	// The gateway rejects the whole request on a bad token, so an event that
+	// would have been recorded anonymously is lost instead. Never send one.
+	t.Run("drops an expired token so the event still sends anonymously", func(t *testing.T) {
+		os.Setenv("ASTRO_API_TOKEN", "")
+		withContext(t, "astronomer.io", testJWT(time.Now().Add(-time.Hour)))
+		assert.Empty(t, currentToken())
+	})
+
+	// Expiring within the margin counts as expired: the sender is asynchronous.
+	t.Run("drops a token expiring inside the freshness margin", func(t *testing.T) {
+		os.Setenv("ASTRO_API_TOKEN", "")
+		withContext(t, "astronomer.io", testJWT(time.Now().Add(tokenFreshnessMargin/2)))
+		assert.Empty(t, currentToken())
+	})
+
+	// Telemetry always posts to the production endpoint, which does not know
+	// issuers from other environments.
+	t.Run("drops a token from a non-production domain", func(t *testing.T) {
+		os.Setenv("ASTRO_API_TOKEN", "")
+		withContext(t, "astronomer-dev.io", testJWT(time.Now().Add(time.Hour)))
+		assert.Empty(t, currentToken())
+	})
+
+	t.Run("drops a token that is not a readable JWT", func(t *testing.T) {
+		os.Setenv("ASTRO_API_TOKEN", "")
+		withContext(t, "astronomer.io", "not-a-jwt")
+		assert.Empty(t, currentToken())
 	})
 
 	// A context that was never populated stores the bare prefix.
 	t.Run("returns empty for a context holding only the Bearer prefix", func(t *testing.T) {
 		os.Setenv("ASTRO_API_TOKEN", "")
 		fs := afero.NewMemMapFs()
-		configRaw := []byte("context: test_com\ncontexts:\n  test_com:\n    domain: test.com\n    token: \"Bearer \"\ntelemetry:\n  enabled: true\n")
+		configRaw := []byte("context: prod\ncontexts:\n  prod:\n    domain: astronomer.io\n    token: \"Bearer \"\ntelemetry:\n  enabled: true\n")
 		require.NoError(t, afero.WriteFile(fs, config.HomeConfigFile, configRaw, 0o777))
 		config.InitConfig(fs)
 		assert.Empty(t, currentToken())
@@ -191,9 +247,16 @@ func TestCurrentToken(t *testing.T) {
 
 	// ASTRO_API_TOKEN holds a raw token; the prefix is only added when persisted.
 	t.Run("prefers ASTRO_API_TOKEN over the context token", func(t *testing.T) {
-		withContext(t)
-		os.Setenv("ASTRO_API_TOKEN", "env-token")
-		assert.Equal(t, "env-token", currentToken())
+		withContext(t, "astronomer.io", testJWT(time.Now().Add(time.Hour)))
+		envToken := testJWT(time.Now().Add(time.Hour))
+		os.Setenv("ASTRO_API_TOKEN", envToken)
+		assert.Equal(t, envToken, currentToken())
+	})
+
+	t.Run("drops an expired ASTRO_API_TOKEN", func(t *testing.T) {
+		withContext(t, "astronomer.io", testJWT(time.Now().Add(time.Hour)))
+		os.Setenv("ASTRO_API_TOKEN", testJWT(time.Now().Add(-time.Hour)))
+		assert.Empty(t, currentToken())
 	})
 
 	// Logged-out users must not error or block the event — they just send

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -163,21 +163,33 @@ func TestCurrentToken(t *testing.T) {
 	origEnv := os.Getenv("ASTRO_API_TOKEN")
 	defer os.Setenv("ASTRO_API_TOKEN", origEnv)
 
-	// A context with a stored token, as `astro login` would leave it.
+	// A context as `astro login` leaves it: the token is stored WITH its
+	// "Bearer " prefix, which currentToken must strip.
 	withContext := func(t *testing.T) {
 		t.Helper()
 		fs := afero.NewMemMapFs()
-		configRaw := []byte("context: test_com\ncontexts:\n  test_com:\n    domain: test.com\n    token: ctx-token\n    organization: org-1\ntelemetry:\n  enabled: true\n")
+		configRaw := []byte("context: test_com\ncontexts:\n  test_com:\n    domain: test.com\n    token: Bearer ctx-token\n    organization: org-1\ntelemetry:\n  enabled: true\n")
 		require.NoError(t, afero.WriteFile(fs, config.HomeConfigFile, configRaw, 0o777))
 		config.InitConfig(fs)
 	}
 
-	t.Run("returns the context token when logged in", func(t *testing.T) {
+	t.Run("strips the stored Bearer prefix from the context token", func(t *testing.T) {
 		os.Setenv("ASTRO_API_TOKEN", "")
 		withContext(t)
 		assert.Equal(t, "ctx-token", currentToken())
 	})
 
+	// A context that was never populated stores the bare prefix.
+	t.Run("returns empty for a context holding only the Bearer prefix", func(t *testing.T) {
+		os.Setenv("ASTRO_API_TOKEN", "")
+		fs := afero.NewMemMapFs()
+		configRaw := []byte("context: test_com\ncontexts:\n  test_com:\n    domain: test.com\n    token: \"Bearer \"\ntelemetry:\n  enabled: true\n")
+		require.NoError(t, afero.WriteFile(fs, config.HomeConfigFile, configRaw, 0o777))
+		config.InitConfig(fs)
+		assert.Empty(t, currentToken())
+	})
+
+	// ASTRO_API_TOKEN holds a raw token; the prefix is only added when persisted.
 	t.Run("prefers ASTRO_API_TOKEN over the context token", func(t *testing.T) {
 		withContext(t)
 		os.Setenv("ASTRO_API_TOKEN", "env-token")

--- a/pkg/telemetry/send.go
+++ b/pkg/telemetry/send.go
@@ -18,9 +18,24 @@ const (
 	maxStdinBytes = 64 * 1024 // 64KB
 )
 
-// Send posts a TelemetryPayload to the given API URL synchronously.
-// It returns the HTTP status code and any error encountered.
+// Send posts a TelemetryPayload to the given API URL synchronously, without
+// credentials. It returns the HTTP status code and any error encountered.
+//
+// Kept for callers outside this repo (e.g. Desktop) that have no Astro token.
+// Callers that do have one should use SendWithToken so the server can attribute
+// the event to an organization.
 func Send(payload TelemetryPayload, apiURL string) (int, error) {
+	return SendWithToken(payload, apiURL, "")
+}
+
+// SendWithToken posts a TelemetryPayload synchronously, attaching the given
+// Astro token as a bearer credential when it is non-empty.
+//
+// An empty token is normal, not an error: users who have never run `astro login`
+// are exactly the population these events measure, so the request still goes out
+// and simply lands unattributed. The token is never written into the payload
+// body — it travels only as a header, so it cannot leak into debug output.
+func SendWithToken(payload TelemetryPayload, apiURL, token string) (int, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return 0, err
@@ -34,6 +49,9 @@ func Send(payload TelemetryPayload, apiURL string) (int, error) {
 		return 0, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -64,6 +82,6 @@ func SendEvent() error {
 		return err
 	}
 
-	_, err = Send(sp.TelemetryPayload, sp.APIURL)
+	_, err = SendWithToken(sp.TelemetryPayload, sp.APIURL, sp.Token)
 	return err
 }

--- a/pkg/telemetry/send.go
+++ b/pkg/telemetry/send.go
@@ -18,23 +18,18 @@ const (
 	maxStdinBytes = 64 * 1024 // 64KB
 )
 
-// Send posts a TelemetryPayload to the given API URL synchronously, without
-// credentials. It returns the HTTP status code and any error encountered.
-//
-// Kept for callers outside this repo (e.g. Desktop) that have no Astro token.
-// Callers that do have one should use SendWithToken so the server can attribute
-// the event to an organization.
+// Send posts a TelemetryPayload synchronously without credentials, returning the
+// HTTP status code. Callers holding an Astro token should use SendWithToken.
 func Send(payload TelemetryPayload, apiURL string) (int, error) {
 	return SendWithToken(payload, apiURL, "")
 }
 
-// SendWithToken posts a TelemetryPayload synchronously, attaching the given
-// Astro token as a bearer credential when it is non-empty.
+// SendWithToken posts a TelemetryPayload synchronously, attaching token as a
+// bearer credential when it is non-empty.
 //
-// An empty token is normal, not an error: users who have never run `astro login`
-// are exactly the population these events measure, so the request still goes out
-// and simply lands unattributed. The token is never written into the payload
-// body — it travels only as a header, so it cannot leak into debug output.
+// An empty token is normal, not an error — logged-out usage is still recorded,
+// just unattributed. The token is sent as a header only, never serialized into
+// the payload body.
 func SendWithToken(payload TelemetryPayload, apiURL, token string) (int, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -77,7 +72,7 @@ func SendEvent() error {
 		return err
 	}
 
-	var sp senderPayload
+	var sp SenderPayload
 	if err := json.Unmarshal(payloadBytes, &sp); err != nil {
 		return err
 	}

--- a/pkg/telemetry/send_test.go
+++ b/pkg/telemetry/send_test.go
@@ -1,0 +1,113 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testPayload() TelemetryPayload {
+	return TelemetryPayload{
+		Source:      "astro-cli",
+		Event:       "CLI Command",
+		AnonymousID: "anon-123",
+		Properties:  map[string]interface{}{"command": "deploy"},
+	}
+}
+
+// captureRequest runs fn against a test server and returns the request the
+// server saw, so assertions can be made on headers and body together.
+func captureRequest(t *testing.T, fn func(url string)) (header http.Header, body []byte) {
+	t.Helper()
+
+	var gotHeader http.Header
+	var gotBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Clone()
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		gotBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	fn(srv.URL)
+	return gotHeader, gotBody
+}
+
+func TestSendWithTokenSetsAuthorizationHeader(t *testing.T) {
+	header, body := captureRequest(t, func(url string) {
+		status, err := SendWithToken(testPayload(), url, "tok-abc")
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, status)
+	})
+
+	assert.Equal(t, "Bearer tok-abc", header.Get("Authorization"))
+	assert.Equal(t, "application/json", header.Get("Content-Type"))
+
+	// The token authenticates the request; it must never be part of the event.
+	assert.NotContains(t, string(body), "tok-abc")
+}
+
+func TestSendWithTokenOmitsHeaderWhenTokenEmpty(t *testing.T) {
+	// Logged-out users are the population these events exist to measure, so an
+	// empty token must still produce a normal, successful request.
+	header, _ := captureRequest(t, func(url string) {
+		status, err := SendWithToken(testPayload(), url, "")
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, status)
+	})
+
+	assert.Empty(t, header.Get("Authorization"))
+}
+
+func TestSendStaysAnonymous(t *testing.T) {
+	// Send is the compatibility entry point for callers outside this repo.
+	header, _ := captureRequest(t, func(url string) {
+		_, err := Send(testPayload(), url)
+		assert.NoError(t, err)
+	})
+
+	assert.Empty(t, header.Get("Authorization"))
+}
+
+// TestSenderPayloadWireFormat pins the JSON contract between the CLI's
+// spawnTelemetrySender and this package's SendEvent. The two structs are
+// declared separately, in different modules, and a tag mismatch fails silently —
+// the field just arrives empty. This test encodes the keys the CLI actually
+// writes, so a rename on either side breaks the build here rather than quietly
+// dropping the token in production.
+func TestSenderPayloadWireFormat(t *testing.T) {
+	const wire = `{
+		"source": "astro-cli",
+		"event": "CLI Command",
+		"anonymousId": "anon-123",
+		"properties": {"command": "deploy"},
+		"api_url": "https://example.test/v1alpha1/telemetry",
+		"token": "tok-abc"
+	}`
+
+	var sp senderPayload
+	require.NoError(t, json.Unmarshal([]byte(wire), &sp))
+
+	assert.Equal(t, "astro-cli", sp.Source)
+	assert.Equal(t, "CLI Command", sp.Event)
+	assert.Equal(t, "anon-123", sp.AnonymousID)
+	assert.Equal(t, "https://example.test/v1alpha1/telemetry", sp.APIURL)
+	assert.Equal(t, "tok-abc", sp.Token)
+}
+
+func TestSenderPayloadOmitsEmptyToken(t *testing.T) {
+	body, err := json.Marshal(senderPayload{
+		TelemetryPayload: testPayload(),
+		APIURL:           "https://example.test",
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "token")
+}

--- a/pkg/telemetry/send_test.go
+++ b/pkg/telemetry/send_test.go
@@ -20,91 +20,60 @@ func testPayload() TelemetryPayload {
 	}
 }
 
-// captureRequest runs fn against a test server and returns the request the
-// server saw, so assertions can be made on headers and body together.
-func captureRequest(t *testing.T, fn func(url string)) (header http.Header, body []byte) {
-	t.Helper()
+func TestSendAuthorization(t *testing.T) {
+	tests := []struct {
+		name       string
+		send       func(url string) (int, error)
+		expectAuth string
+	}{
+		{
+			"attaches bearer token when present",
+			func(url string) (int, error) { return SendWithToken(testPayload(), url, "tok-abc") },
+			"Bearer tok-abc",
+		},
+		{
+			// Logged-out usage still has to be recorded, so an empty token must
+			// produce a normal, successful request rather than an error.
+			"omits header when token is empty",
+			func(url string) (int, error) { return SendWithToken(testPayload(), url, "") },
+			"",
+		},
+		{
+			"Send stays anonymous",
+			func(url string) (int, error) { return Send(testPayload(), url) },
+			"",
+		},
+	}
 
-	var gotHeader http.Header
-	var gotBody []byte
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotHeader http.Header
+			var gotBody []byte
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeader = r.Header.Clone()
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		gotBody = body
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotHeader = r.Header.Clone()
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				gotBody = body
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
 
-	fn(srv.URL)
-	return gotHeader, gotBody
-}
+			status, err := tt.send(srv.URL)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, status)
 
-func TestSendWithTokenSetsAuthorizationHeader(t *testing.T) {
-	header, body := captureRequest(t, func(url string) {
-		status, err := SendWithToken(testPayload(), url, "tok-abc")
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, status)
-	})
+			assert.Equal(t, tt.expectAuth, gotHeader.Get("Authorization"))
+			assert.Equal(t, "application/json", gotHeader.Get("Content-Type"))
 
-	assert.Equal(t, "Bearer tok-abc", header.Get("Authorization"))
-	assert.Equal(t, "application/json", header.Get("Content-Type"))
-
-	// The token authenticates the request; it must never be part of the event.
-	assert.NotContains(t, string(body), "tok-abc")
-}
-
-func TestSendWithTokenOmitsHeaderWhenTokenEmpty(t *testing.T) {
-	// Logged-out users are the population these events exist to measure, so an
-	// empty token must still produce a normal, successful request.
-	header, _ := captureRequest(t, func(url string) {
-		status, err := SendWithToken(testPayload(), url, "")
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, status)
-	})
-
-	assert.Empty(t, header.Get("Authorization"))
-}
-
-func TestSendStaysAnonymous(t *testing.T) {
-	// Send is the compatibility entry point for callers outside this repo.
-	header, _ := captureRequest(t, func(url string) {
-		_, err := Send(testPayload(), url)
-		assert.NoError(t, err)
-	})
-
-	assert.Empty(t, header.Get("Authorization"))
-}
-
-// TestSenderPayloadWireFormat pins the JSON contract between the CLI's
-// spawnTelemetrySender and this package's SendEvent. The two structs are
-// declared separately, in different modules, and a tag mismatch fails silently —
-// the field just arrives empty. This test encodes the keys the CLI actually
-// writes, so a rename on either side breaks the build here rather than quietly
-// dropping the token in production.
-func TestSenderPayloadWireFormat(t *testing.T) {
-	const wire = `{
-		"source": "astro-cli",
-		"event": "CLI Command",
-		"anonymousId": "anon-123",
-		"properties": {"command": "deploy"},
-		"api_url": "https://example.test/v1alpha1/telemetry",
-		"token": "tok-abc"
-	}`
-
-	var sp senderPayload
-	require.NoError(t, json.Unmarshal([]byte(wire), &sp))
-
-	assert.Equal(t, "astro-cli", sp.Source)
-	assert.Equal(t, "CLI Command", sp.Event)
-	assert.Equal(t, "anon-123", sp.AnonymousID)
-	assert.Equal(t, "https://example.test/v1alpha1/telemetry", sp.APIURL)
-	assert.Equal(t, "tok-abc", sp.Token)
+			// The token authenticates the request; it must never be part of the event.
+			assert.NotContains(t, string(gotBody), "tok-abc")
+		})
+	}
 }
 
 func TestSenderPayloadOmitsEmptyToken(t *testing.T) {
-	body, err := json.Marshal(senderPayload{
+	body, err := json.Marshal(SenderPayload{
 		TelemetryPayload: testPayload(),
 		APIURL:           "https://example.test",
 	})

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -31,17 +31,10 @@ type TelemetryPayload struct {
 	Properties  map[string]interface{} `json:"properties,omitempty"`
 }
 
-// senderPayload wraps TelemetryPayload with the API URL for the subprocess.
-//
-// The CLI builds the equivalent struct in internal/telemetry before spawning the
-// sender, so the JSON tags here and there must stay identical — a mismatch is
-// silent, and the field simply arrives empty. TestSenderPayloadWireFormat guards
-// the shape.
-//
-// Token is the caller's Astro bearer token. It rides on stdin to the sender
-// subprocess (never argv, so it stays out of `ps`) and is set as a header, not
-// serialized into the event body.
-type senderPayload struct {
+// SenderPayload is what the sender subprocess reads from stdin: an event plus
+// the two things it needs to deliver it. Token is sent as a bearer header, not
+// serialized into the event body, and is empty for logged-out users.
+type SenderPayload struct {
 	TelemetryPayload
 	APIURL string `json:"api_url"`
 	Token  string `json:"token,omitempty"`

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -31,10 +31,20 @@ type TelemetryPayload struct {
 	Properties  map[string]interface{} `json:"properties,omitempty"`
 }
 
-// senderPayload wraps TelemetryPayload with the API URL for the subprocess
+// senderPayload wraps TelemetryPayload with the API URL for the subprocess.
+//
+// The CLI builds the equivalent struct in internal/telemetry before spawning the
+// sender, so the JSON tags here and there must stay identical — a mismatch is
+// silent, and the field simply arrives empty. TestSenderPayloadWireFormat guards
+// the shape.
+//
+// Token is the caller's Astro bearer token. It rides on stdin to the sender
+// subprocess (never argv, so it stays out of `ps`) and is set as a header, not
+// serialized into the event body.
 type senderPayload struct {
 	TelemetryPayload
 	APIURL string `json:"api_url"`
+	Token  string `json:"token,omitempty"`
 }
 
 // envMapping pairs an environment variable with a context name


### PR DESCRIPTION
## Description

The CLI's telemetry request is unauthenticated, so events arrive with no way to associate them with an organization.

This attaches the caller's existing Astro bearer token to the telemetry POST when one is available. Requests without credentials are unchanged and still send — that path has to keep working.

- `SendWithToken()` sets `Authorization: Bearer` when the token is non-empty. `Send()` keeps its current signature and delegates with an empty token, so callers of `pkg/telemetry` outside this repo are unaffected.
- `currentToken()` reads `ASTRO_API_TOKEN`, then the active context. Local reads only — no network call and no token refresh, since the sender runs in a detached subprocess and refreshing would race the main process for `~/.astro/config.yaml`. A stale token costs one unattributed event and never blocks the user's command.
- Contexts persist the token with a `Bearer ` prefix already, while `ASTRO_API_TOKEN` holds it raw. Both are normalized to the raw token and the scheme is added when the header is set, matching `cmd/auth.go`.
- The token is passed to the sender subprocess on stdin rather than argv, and is sent as a header. It is not written into the event body.
- `SenderPayload` is exported from `pkg/telemetry` and used directly by the caller, rather than redeclared per module with hand-matched JSON tags.

The notice was also printed before the filter that skips untracked commands, so `astro telemetry disable` announced what we collect to someone in the act of opting out. It now prints only on commands that actually send telemetry — so the first time it appears is the first time it is true.

The first-run notice previously described collection as anonymous. It is reworded, and versioned so users who saw the earlier wording are shown the update once rather than inheriting the change.

No behavior change until the telemetry endpoint reads the header.

Verified against the live endpoint with a real token: a valid token returns `200`, an expired one
returns `401 Jwt is expired`, and no header returns `200`. The change is inert until the server also
stamps org/user onto the event — safe to merge before then, just not yet visible in the data.

## 🎟 Issue(s)

Server-side counterpart tracked separately.

## 🧪 Functional Testing

Unit tests cover `SendWithToken` and `currentToken`. The subprocess hand-off is not covered by unit tests, so it was checked end to end against a local listener:

| Case | Expected | Result |
|---|---|---|
| Logged in | `Authorization` header present | pass |
| Logged out | no header, event still sends | pass |
| `ASTRO_API_TOKEN` set | `Authorization` header present | pass |

Notice behavior was checked the same way, since `TrackCommand` returns early in test binaries and cannot be unit-tested:

| Command | Expected | Result |
|---|---|---|
| `astro version` | notice shown | pass |
| `astro telemetry disable` | no notice | pass |
| `astro telemetry enable` | no notice | pass |

Token absent from the event body in all three.

To reproduce: point `ASTRO_TELEMETRY_API_URL` at a local listener, set `HOME` to a temporary directory containing `.astro/config.yaml`, run any command, and inspect the received request.

## 📸 Screenshots

n/a — no user-visible output beyond the reworded notice.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary)
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary)
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/) — telemetry docs need the reworded notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)





