### PR TITLE
fix(deploy): don't require Astro project dir for --dags with --dags-path

### DIFF
--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -75,7 +75,9 @@ func NewDeployCmd() *cobra.Command {
 			// A DAG-only deploy sourcing its DAGs from --dags-path doesn't read anything else
 			// from the working directory, unless --pytest/--parse is also used, which builds
 			// and runs a local image to test-parse the DAGs and so still needs the project root.
-			if cmd.Flags().Changed("dags") && cmd.Flags().Changed(dagsPathFlag) && !cmd.Flags().Changed("pytest") && !cmd.Flags().Changed("parse") {
+			// Check the bound values (not cmd.Flags().Changed) so --dags=false or an explicit
+			// empty --dags-path can't be misread as enabling the bypass.
+			if dags && dagsPath != "" && !pytest && !parse {
 				return nil
 			}
 			return EnsureProjectDir(cmd, args)

--- a/cmd/cloud/deploy.go
+++ b/cmd/cloud/deploy.go
@@ -59,6 +59,7 @@ const (
 
 	imageNameFlag = "image-name"
 	nonDagsFlag   = "non-dags"
+	dagsPathFlag  = "dags-path"
 )
 
 func NewDeployCmd() *cobra.Command {
@@ -69,6 +70,12 @@ func NewDeployCmd() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed(imageNameFlag) || cmd.Flags().Changed(nonDagsFlag) {
+				return nil
+			}
+			// A DAG-only deploy sourcing its DAGs from --dags-path doesn't read anything else
+			// from the working directory, unless --pytest/--parse is also used, which builds
+			// and runs a local image to test-parse the DAGs and so still needs the project root.
+			if cmd.Flags().Changed("dags") && cmd.Flags().Changed(dagsPathFlag) && !cmd.Flags().Changed("pytest") && !cmd.Flags().Changed("parse") {
 				return nil
 			}
 			return EnsureProjectDir(cmd, args)
@@ -89,12 +96,11 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().StringVar(&dagBundleName, "dag-bundle-name", "", "Deploy DAGs to a named DAG bundle on the Deployment instead of the default bundle. Requires Airflow 3, and the bundle must already exist on the Deployment")
 	cmd.Flags().MarkHidden("dag-bundle-name") //nolint:errcheck
 	cmd.Flags().BoolVarP(&image, "image", "", false, "Push only an image to your Astro Deployment. If you have DAG Deploy enabled your DAGs will not be affected.")
-	cmd.Flags().StringVar(&dagsPath, "dags-path", "", "If set deploy dags from this path instead of the dags from working directory")
+	cmd.Flags().StringVar(&dagsPath, dagsPathFlag, "", "If set deploy dags from this path instead of the dags from working directory")
 	cmd.Flags().StringVarP(&deploymentName, "deployment-name", "n", "", "Name of the deployment to deploy to")
 	cmd.Flags().BoolVar(&parse, "parse", false, "Succeed only if all DAGs in your Astro project parse without errors")
 	cmd.Flags().BoolVarP(&waitForDeploy, "wait", "w", false, "Wait for the Deployment to become healthy before ending the command")
 	cmd.Flags().DurationVar(&waitTime, "wait-time", deployWaitTime, "Wait time for the Deployment to become healthy before ending the command. Can only be used with --wait=true")
-	cmd.Flags().MarkHidden("dags-path") //nolint:errcheck
 	cmd.Flags().StringVarP(&deployDescription, "description", "", "", "Add a description for more context on this deploy")
 	utils.AddBuildSecretFlags(cmd.Flags(), &buildSecrets)
 	cmd.Flags().Bool("force-upgrade-to-af3", false, "This flag is no longer required for Airflow 2 to Airflow 3 upgrades. Support will be removed in a future release.")
@@ -114,7 +120,7 @@ func NewDeployCmd() *cobra.Command {
 	annotateDeployFlag(cmd, "dags", "dag")
 	annotateDeployFlag(cmd, "no-dags-base-dir", "dag")
 	annotateDeployFlag(cmd, "dag-bundle-name", "dag")
-	annotateDeployFlag(cmd, "dags-path", "dag")
+	annotateDeployFlag(cmd, dagsPathFlag, "dag")
 	annotateDeployFlag(cmd, "pytest", "test")
 	annotateDeployFlag(cmd, "test", "test")
 	annotateDeployFlag(cmd, "env", "test")

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -188,6 +188,16 @@ func TestDeploySkipsEnsureProjectDirWhenDagsPathSet(t *testing.T) {
 
 	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--dags-path", "./external-dags", "--parse")
 	assert.ErrorIs(t, err, assert.AnError)
+
+	// Explicitly passing --dags=false must not be misread as enabling the bypass just because
+	// the flag was mentioned on the command line - this is really a full image+dags deploy.
+	err = execDeployCmd("-f", "test-deployment-id", "--dags=false", "--dags-path", "./external-dags")
+	assert.ErrorIs(t, err, assert.AnError)
+
+	// An explicit empty --dags-path falls back to the working directory's dags/ folder
+	// (cloud/deploy/deploy.go), so it must not be misread as enabling the bypass either.
+	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--dags-path", "")
+	assert.ErrorIs(t, err, assert.AnError)
 }
 
 func TestDeployImageNameRejectsIncompatibleFlags(t *testing.T) {

--- a/cmd/cloud/deploy_test.go
+++ b/cmd/cloud/deploy_test.go
@@ -153,6 +153,43 @@ func TestDeploySkipsEnsureProjectDirWhenImageNameSet(t *testing.T) {
 	assert.ErrorIs(t, err, assert.AnError)
 }
 
+func TestDeploySkipsEnsureProjectDirWhenDagsPathSet(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	EnsureProjectDir = func(cmd *cobra.Command, args []string) error {
+		return assert.AnError
+	}
+	defer func() {
+		EnsureProjectDir = func(cmd *cobra.Command, args []string) error { return nil }
+	}()
+
+	DeployImage = func(deployInput cloud.InputDeploy, astroV1Client astrov1.APIClient, astroV1Alpha1Client astrov1alpha1.APIClient) error {
+		return nil
+	}
+
+	// With --dags and --dags-path, the DAGs are read entirely from --dags-path, so the
+	// project-dir check should be skipped.
+	err := execDeployCmd("-f", "test-deployment-id", "--dags", "--dags-path", "./external-dags")
+	assert.NoError(t, err)
+
+	// --dags alone (DAGs read from the working directory) still needs the project-dir check.
+	err = execDeployCmd("-f", "test-deployment-id", "--dags")
+	assert.ErrorIs(t, err, assert.AnError)
+
+	// --dags-path alone (without --dags, i.e. a full image+dags deploy) still needs the project
+	// root as the Docker build context.
+	err = execDeployCmd("-f", "test-deployment-id", "--dags-path", "./external-dags")
+	assert.ErrorIs(t, err, assert.AnError)
+
+	// --pytest/--parse build and run a local image to test-parse the DAGs, so the project-dir
+	// check should still run even with --dags-path set.
+	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--dags-path", "./external-dags", "--pytest")
+	assert.ErrorIs(t, err, assert.AnError)
+
+	err = execDeployCmd("-f", "test-deployment-id", "--dags", "--dags-path", "./external-dags", "--parse")
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
 func TestDeployImageNameRejectsIncompatibleFlags(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 


### PR DESCRIPTION
## Summary
- `astro deploy --dags --dags-path <path>` no longer requires being run from an Astro project root, since DAG-only deploys sourcing DAGs via `--dags-path` don't read anything else from the working directory.
- The check still runs for plain `--dags` (DAGs read from the working directory's `dags/` folder), for `--dags-path` without `--dags` (full image+dags deploy, which needs the project root as the Docker build context), and whenever `--pytest`/`--parse` is also set (these build and run a local image from the project's Dockerfile to test-parse the DAGs).
- `--dags-path` is no longer a hidden flag.

Context: astronomer/astro-cli#2107 established the precedent of bypassing this check for `--image-name` for the same underlying reason (nothing is read from the working directory in that case).

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/cloud/...`
- [x] Added `TestDeploySkipsEnsureProjectDirWhenDagsPathSet` covering: bypass with `--dags --dags-path`; check still enforced for `--dags` alone, `--dags-path` alone, and `--dags --dags-path` combined with `--pytest`/`--parse`
- [x] `astro deploy --help` shows `--dags-path` under DAG Flags