### PR TITLE
feat: Create a slim dbt `manifest.json` on project root

### DIFF
--- a/cloud/deploy/cosmosboost_hook_test.go
+++ b/cloud/deploy/cosmosboost_hook_test.go
@@ -57,23 +57,23 @@ func TestUploadBundleRunsPreDeployWhenEnabled(t *testing.T) {
 }
 
 // TestUploadBundleSlimManifest pins the slim manifest's gating end to end: on
-// by default once the step is enabled, and off only when the per-feature env
-// var disables it. Either way the hash sidecar still lands - the two
-// optimizations are independent.
+// by default once the step is enabled, and off when the per-feature env var
+// says so. Either way the hash sidecar still lands - the two optimizations are
+// independent.
 func TestUploadBundleSlimManifest(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
-		disable  string // value for the disable env var; "" leaves it unset
+		envVar   string // value for the per-feature env var; "" leaves it unset
 		wantSlim bool
 	}{
 		{name: "on by default", wantSlim: true},
-		{name: "env var disables it", disable: "true", wantSlim: false},
+		{name: "env var switches it off", envVar: "false", wantSlim: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			setupCosmosBoostEnv(t)
 			require.NoError(t, config.CFG.CosmosBoostPreDeploy.SetHomeString("true"))
-			if tc.disable != "" {
-				t.Setenv("ASTRO_COSMOS_BOOST_SLIM_MANIFEST_DISABLED", tc.disable)
+			if tc.envVar != "" {
+				t.Setenv("ASTRO_COSMOS_BOOST_SLIM_MANIFEST_ENABLED", tc.envVar)
 			}
 
 			bundleDir := writeDbtBundle(t)

--- a/pkg/cosmosboost/precompute/precompute.go
+++ b/pkg/cosmosboost/precompute/precompute.go
@@ -58,11 +58,11 @@ type Options struct {
 // problem, such as a root that cannot be walked. version is recorded in each
 // sidecar's generated_by.
 //
-// With opts.SlimManifest set, every discovered manifest.json also gets a slim,
-// field-filtered copy (see buildSlimManifest) written next to its sidecar, for
-// the Cosmos Boost plugin to load in place of the full manifest at DAG-parse
-// time. A manifest.json sitting directly in a project's root is excluded from
-// discovery (see findManifests) and so gets no slim copy either.
+// With opts.SlimManifest set, every dbt manifest.json also gets a slim,
+// field-filtered copy (see buildSlimManifest) written into the .astro/ beside
+// it, for the Cosmos Boost plugin to load in place of the full manifest at
+// DAG-parse time. That includes one in a project's own root, which is not a
+// discovery unit of its own and is handled by processProject.
 func Run(roots []string, version string, opts Options) (Summary, error) {
 	start := time.Now()
 
@@ -112,7 +112,7 @@ func Run(roots []string, version string, opts Options) (Summary, error) {
 			defer wg.Done()
 			defer func() { <-sem }() // release the slot
 			if u.kind == kindProject {
-				results[i] = processProject(u.path, version)
+				results[i] = processProject(u.path, version, opts)
 			} else {
 				results[i] = processManifest(u.path, version, opts)
 			}
@@ -126,7 +126,7 @@ func Run(roots []string, version string, opts Options) (Summary, error) {
 // processProject hashes one dbt project directory and writes its sidecar. It reads
 // dbt_project.yml once (readDbtConfig) and threads the result through hashing and the
 // templated-packages warning, so the file isn't parsed more than once per project.
-func processProject(dir, version string) Result {
+func processProject(dir, version string, opts Options) Result {
 	start := time.Now()
 	cfg := readDbtConfig(dir)
 	hash, files, totalBytes, err := hashProject(dir, cfg)
@@ -139,7 +139,24 @@ func processProject(dir, version string) Result {
 		r.Warning = strings.Join(cfg.templatedSettings, ", ") +
 			" in dbt_project.yml hold unresolved Jinja templates; using the dbt default directories for exclusion (the real ones may add cache churn)"
 	}
-	r.Err = writeSidecar(dir, algoProjectTree, hash, version, nil)
+
+	// A manifest.json in the project root is not a unit of its own - its .astro/
+	// is this project's, so it would collide with the sidecar written below - and
+	// findManifests skips it for that reason. Slim it here instead, leaving the
+	// project's own hash as the anchor the pointer hangs off.
+	var filtered *FilteredManifest
+	if opts.SlimManifest {
+		if doc, _, isDbt, readErr := readManifestDoc(filepath.Join(dir, manifestFile)); readErr == nil && isDbt {
+			// Nothing mutates doc afterward here, unlike processManifest.
+			data, _ := json.Marshal(buildSlimManifest(doc, version))
+			if filtered, r.Err = writeSlimManifest(dir, data); r.Err != nil {
+				r.Duration = time.Since(start)
+				return r
+			}
+		}
+	}
+
+	r.Err = writeSidecar(dir, algoProjectTree, hash, version, filtered)
 	r.Duration = time.Since(start)
 	return r
 }
@@ -176,19 +193,27 @@ func processManifest(path, version string, opts Options) Result {
 		// safe.
 		var filtered *FilteredManifest
 		if slimData != nil {
-			if r.Err = writeArtifact(dir, slimManifestName, slimData); r.Err == nil {
-				filtered = &FilteredManifest{
-					Schema:  slimSchemaVersion,
-					Path:    slimManifestName,
-					Version: ProjectVersion{Algo: algoFilteredManifest, Hash: sha256Hex(slimData)},
-				}
-			}
+			filtered, r.Err = writeSlimManifest(dir, slimData)
 		}
 		if r.Err == nil {
 			r.Err = writeSidecar(dir, algoManifestJSON, hash, version, filtered)
 		}
 	}
 	return r
+}
+
+// writeSlimManifest writes data as dir's slim manifest and returns the sidecar
+// pointer describing it. data must already be marshaled, so a caller that later
+// mutates the source doc cannot leak into it (see processManifest).
+func writeSlimManifest(dir string, data []byte) (*FilteredManifest, error) {
+	if err := writeArtifact(dir, slimManifestName, data); err != nil {
+		return nil, err
+	}
+	return &FilteredManifest{
+		Schema:  slimSchemaVersion,
+		Path:    slimManifestName,
+		Version: ProjectVersion{Algo: algoFilteredManifest, Hash: sha256Hex(data)},
+	}, nil
 }
 
 // CountFailed returns the number of units that errored.

--- a/pkg/cosmosboost/precompute/precompute_test.go
+++ b/pkg/cosmosboost/precompute/precompute_test.go
@@ -410,25 +410,6 @@ func TestRunErrorsOnUnreadableTargetDir(t *testing.T) {
 	}
 }
 
-// TestRunSkipsManifestInProjectRoot: a manifest sitting in a discovered
-// project's root is covered by the project's tree hash and gets no unit of
-// its own.
-func TestRunSkipsManifestInProjectRoot(t *testing.T) {
-	dir := t.TempDir()
-	writeFiles(t, dir, map[string]string{
-		"proj/dbt_project.yml": "name: shop\n",
-		"proj/manifest.json":   `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json"},"nodes":{}}`,
-	})
-
-	summary, err := Run([]string{dir}, "test", Options{SlimManifest: true})
-	if err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-	if len(summary.Results) != 1 || summary.Results[0].Kind != kindProject {
-		t.Fatalf("results = %+v, want exactly one project unit", summary.Results)
-	}
-}
-
 // TestRunReportsFailedUnits: per-unit failures land in the unit's Result and
 // do not abort the run.
 func TestRunReportsFailedUnits(t *testing.T) {
@@ -545,6 +526,94 @@ func TestRunSkipsSlimManifestWhenNotRequested(t *testing.T) {
 	}
 	if strings.Contains(string(raw), "filtered_manifest") {
 		t.Fatalf("filtered_manifest emitted with the slim manifest disabled: %s", raw)
+	}
+}
+
+// TestRunSlimsManifestInProjectRoot: a manifest.json beside dbt_project.yml is
+// not a discovery unit (its .astro/ is the project's own), so it used to get no
+// slim copy at all - the projects most likely to have one got nothing from this
+// feature. It is slimmed into the project's .astro/, with the project sidecar
+// carrying the pointer and keeping its own tree hash.
+func TestRunSlimsManifestInProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"proj/dbt_project.yml": "name: shop\n",
+		"proj/models/a.sql":    "select 1",
+		"proj/manifest.json":   `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json","project_name":"shop"},"nodes":{"model.shop.orders":{"original_file_path":"models/orders.sql","package_name":"shop","resource_type":"model","fqn":["shop","orders"],"raw_code":"select 1"}}}`,
+	})
+
+	summary, err := Run([]string{root}, "test", Options{SlimManifest: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One unit only: the manifest must not also be discovered on its own.
+	if len(summary.Results) != 1 || summary.Results[0].Kind != kindProject || summary.Results[0].Err != nil {
+		t.Fatalf("want 1 successful project result, got %+v", summary.Results)
+	}
+
+	astroDir := filepath.Join(root, "proj", sidecarDir)
+	var slim map[string]any
+	readJSON(t, filepath.Join(astroDir, slimManifestName), &slim)
+	if _, ok := slim["nodes"].(map[string]any)["model.shop.orders"]; !ok {
+		t.Fatalf("slim manifest missing expected node: %+v", slim)
+	}
+
+	var meta Metadata
+	readJSON(t, filepath.Join(astroDir, sidecarName), &meta)
+	if meta.Version.Algo != algoProjectTree {
+		t.Fatalf("project sidecar algo = %q, want %q", meta.Version.Algo, algoProjectTree)
+	}
+	if meta.FilteredManifest == nil || meta.FilteredManifest.Path != slimManifestName {
+		t.Fatalf("project sidecar does not point at the slim manifest: %+v", meta.FilteredManifest)
+	}
+}
+
+// TestRunProjectHashIgnoresRootSlimManifest: the slim manifest lands inside the
+// hashed tree, so the project hash must not move because of it - otherwise
+// enabling the optimization would invalidate every cache key once.
+func TestRunProjectHashIgnoresRootSlimManifest(t *testing.T) {
+	hashWith := func(t *testing.T, opts Options) string {
+		t.Helper()
+		root := t.TempDir()
+		writeFiles(t, root, map[string]string{
+			"proj/dbt_project.yml": "name: shop\n",
+			"proj/models/a.sql":    "select 1",
+			"proj/manifest.json":   `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json"},"nodes":{}}`,
+		})
+		summary, err := Run([]string{root}, "test", opts)
+		if err != nil || len(summary.Results) != 1 {
+			t.Fatalf("Run: err=%v results=%+v", err, summary.Results)
+		}
+		return summary.Results[0].Hash
+	}
+
+	if with, without := hashWith(t, Options{SlimManifest: true}), hashWith(t, Options{}); with != without {
+		t.Fatalf("writing the slim manifest changed the project hash:\n with    %s\n without %s", with, without)
+	}
+}
+
+// TestRunSkipsNonDbtManifestInProjectRoot: a project root can hold an unrelated
+// manifest.json (a web app's PWA manifest), which must not be slimmed or
+// pointed at.
+func TestRunSkipsNonDbtManifestInProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	writeFiles(t, root, map[string]string{
+		"proj/dbt_project.yml": "name: shop\n",
+		"proj/manifest.json":   `{"name":"My App","short_name":"App","icons":[]}`,
+	})
+
+	if _, err := Run([]string{root}, "test", Options{SlimManifest: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	astroDir := filepath.Join(root, "proj", sidecarDir)
+	if _, err := os.Stat(filepath.Join(astroDir, slimManifestName)); !os.IsNotExist(err) {
+		t.Fatalf("a non-dbt manifest.json must not be slimmed: %v", err)
+	}
+	var meta Metadata
+	readJSON(t, filepath.Join(astroDir, sidecarName), &meta)
+	if meta.FilteredManifest != nil {
+		t.Fatalf("project sidecar points at a slim manifest that was never written: %+v", meta.FilteredManifest)
 	}
 }
 

--- a/pkg/cosmosboost/predeploy.go
+++ b/pkg/cosmosboost/predeploy.go
@@ -13,15 +13,19 @@ import (
 	"github.com/astronomer/astro-cli/version"
 )
 
-// slimManifestDisabledEnvVar opts out of the slim manifest without disabling
-// the step. cosmos_boost.pre_deploy is the master switch; optimizations under
-// it are on by default and disabled per-feature by env var, as the plugin does.
-// Named for the disable so CheckEnvBool's "only an explicit truthy value
-// counts" leaves the optimization on for an unset or misspelled value.
-const slimManifestDisabledEnvVar = "ASTRO_COSMOS_BOOST_SLIM_MANIFEST_DISABLED"
+// slimManifestEnvVar switches the slim manifest without disabling the step.
+// cosmos_boost.pre_deploy is the master switch; optimizations under it are on by
+// default and switched per-feature by env var. The name matches the plugin's
+// convention for its own optimizations.
+const slimManifestEnvVar = "ASTRO_COSMOS_BOOST_SLIM_MANIFEST_ENABLED"
 
+// slimManifestEnabled reports whether to write the slim manifest: on when unset,
+// otherwise only for a value util.CheckEnvBool reads as true. The plugin keeps
+// an unrecognized value on; here it turns the optimization off, because reusing
+// this repo's only bool-env helper beats hand-rolling a second parser.
 func slimManifestEnabled() bool {
-	return !util.CheckEnvBool(os.Getenv(slimManifestDisabledEnvVar))
+	value := os.Getenv(slimManifestEnvVar)
+	return value == "" || util.CheckEnvBool(value)
 }
 
 // PreDeploy runs the Cosmos Boost pre-deploy step over path: every dbt project

--- a/pkg/cosmosboost/predeploy_test.go
+++ b/pkg/cosmosboost/predeploy_test.go
@@ -55,7 +55,7 @@ func TestPreDeployWritesArtifact(t *testing.T) {
 // TestPreDeployWritesSlimManifest pins that PreDeploy writes a slim manifest
 // next to a discovered manifest.json's hash sidecar. It is on by default: the
 // only switch is the step itself (cosmos_boost.pre_deploy), with a per-feature
-// opt-out below.
+// env var below.
 func TestPreDeployWritesSlimManifest(t *testing.T) {
 	dir := t.TempDir()
 	manifest := `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json"},"nodes":{}}`
@@ -66,13 +66,13 @@ func TestPreDeployWritesSlimManifest(t *testing.T) {
 	require.FileExists(t, filepath.Join(dir, ".astro", "manifest.slim.json"))
 }
 
-// TestPreDeployRespectsSlimManifestOptOut: the env var disables this one
+// TestPreDeployRespectsSlimManifestEnvVar: the env var disables this one
 // optimization without disabling the step, so the hash sidecar still lands.
-func TestPreDeployRespectsSlimManifestOptOut(t *testing.T) {
+func TestPreDeployRespectsSlimManifestEnvVar(t *testing.T) {
 	dir := t.TempDir()
 	manifest := `{"metadata":{"dbt_schema_version":"https://schemas.getdbt.com/dbt/manifest/v12.json"},"nodes":{}}`
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(manifest), 0o644))
-	t.Setenv(slimManifestDisabledEnvVar, "true")
+	t.Setenv(slimManifestEnvVar, "false")
 
 	require.NoError(t, PreDeploy(dir))
 
@@ -80,21 +80,23 @@ func TestPreDeployRespectsSlimManifestOptOut(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(dir, ".astro", "manifest.slim.json"))
 }
 
-// TestSlimManifestEnabled: only an explicit truthy value in the disable var
-// turns the optimization off, so unset - and a misspelled value - leaves it on.
+// TestSlimManifestEnabled: unset leaves the optimization on; otherwise only a
+// value util.CheckEnvBool reads as true keeps it on.
 func TestSlimManifestEnabled(t *testing.T) {
 	for _, tc := range []struct {
 		value string
 		want  bool
 	}{
-		{value: "", want: true},
-		{value: "flase", want: true}, // a typo must not silently disable
-		{value: "true"},
-		{value: "TRUE"},
-		{value: "1"},
-		{value: "yes"},
+		{value: "", want: true}, // unset: on by default under the master switch
+		{value: "true", want: true},
+		{value: "TRUE", want: true}, // case-insensitive
+		{value: "1", want: true},
+		{value: "yes", want: true},
+		{value: "false"},
+		{value: "0"},
+		{value: "off"},
 	} {
-		t.Setenv(slimManifestDisabledEnvVar, tc.value)
+		t.Setenv(slimManifestEnvVar, tc.value)
 		require.Equal(t, tc.want, slimManifestEnabled(), "value %q", tc.value)
 	}
 }


### PR DESCRIPTION
Two follow-ups to review feedback on #2242, which merged before they were addressed.

Linear: [BOSS-598](https://linear.app/astronomer/issue/BOSS-598/boost-plugin-astro-cli-generate-a-slim-field-filtered-dbt-manifest-at)

## 1. Slim a `manifest.json` in a dbt project's root

A `manifest.json` beside `dbt_project.yml` got no slim copy, so the projects most likely to keep one there gained nothing from BOSS-598.

It can't be a discovery unit of its own: its `.astro/` is the project's own, so a manifest sidecar there would collide with the project sidecar, which is why `findManifests` skips it. `processProject` handles it instead, writing the slim copy and carrying the `filtered_manifest` pointer in the sidecar it already writes.

- The project hash can't move: `hashProject` skips `.astro` at any depth, pinned by a test since a moved hash would invalidate every cache key once.
- The root manifest is read twice per deploy: streamed for the folder hash, parsed for slimming.
- Project sidecars can now carry `filtered_manifest`, so the plugin sees it from both sidecar-resolution paths.

## 2. Rename the env var to `..._SLIM_MANIFEST_ENABLED`

Was `..._SLIM_MANIFEST_DISABLED`; renamed to match the plugin's convention. Still on by default under `cosmos_boost.pre_deploy`, and still parsed by `util.CheckEnvBool`: unset means on, otherwise only a value that helper reads as true keeps it on.

## Testing

`go build`, `go vet`, `gofumpt`, `golangci-lint` (v2.11.4) and `go test ./...` all clean in a `golang:1.26` container, except the pre-existing `airflow`/`cmd`/`pkg/git` failures that also fail on `main`.

Also ran end to end on a 200-node / 567 KiB fixture: both a root and a `target/` manifest slimmed to 61 KiB, each sidecar carrying its own algo plus the pointer, `manifest.json` byte-identical, and nothing written with the env var off.
