### PR TITLE
add token type column

### DIFF
--- a/cloud/deployment/deployment_token.go
+++ b/cloud/deployment/deployment_token.go
@@ -33,14 +33,14 @@ const (
 func newTokenTableOut() *printutil.Table {
 	return &printutil.Table{
 		DynamicPadding: true,
-		Header:         []string{"ID", "NAME", "DESCRIPTION", "SCOPE", "DEPLOYMENT ROLE", "CREATED", "CREATED BY"},
+		Header:         []string{"ID", "NAME", "DESCRIPTION", "SCOPE", "TYPE", "DEPLOYMENT ROLE", "CREATED", "CREATED BY"},
 	}
 }
 
 func newTokenSelectionTableOut() *printutil.Table {
 	return &printutil.Table{
 		DynamicPadding: true,
-		Header:         []string{"#", "ID", "NAME", "DESCRIPTION", "SCOPE", "DEPLOYMENT ROLE", "CREATED", "CREATED BY"},
+		Header:         []string{"#", "ID", "NAME", "DESCRIPTION", "SCOPE", "TYPE", "DEPLOYMENT ROLE", "CREATED", "CREATED BY"},
 	}
 }
 
@@ -123,6 +123,7 @@ func ListTokens(client astrov1.APIClient, deploymentID string, tokenTypes *[]Dep
 			apiTokens[i].Name,
 			apiTokens[i].Description,
 			string(apiTokens[i].Scope),
+			string(apiTokens[i].Kind),
 			deploymentRoleOf(apiTokens[i], deploymentID),
 			created,
 			createdBy,
@@ -360,6 +361,7 @@ func selectTokens(deploymentID string, apiTokens []astrov1.ApiToken) (astrov1.Ap
 			apiTokens[i].Name,
 			apiTokens[i].Description,
 			string(apiTokens[i].Scope),
+			string(apiTokens[i].Kind),
 			deploymentRoleOf(apiTokens[i], deploymentID),
 			created,
 			createdBy,

--- a/cloud/organization/organization_token.go
+++ b/cloud/organization/organization_token.go
@@ -35,7 +35,7 @@ const (
 func newTokenTableOut() *printutil.Table {
 	return &printutil.Table{
 		DynamicPadding: true,
-		Header:         []string{"ID", "NAME", "DESCRIPTION", "SCOPE", "ORGANIZATION ROLE", "CREATED", "CREATED BY"},
+		Header:         []string{"ID", "NAME", "DESCRIPTION", "SCOPE", "TYPE", "ORGANIZATION ROLE", "CREATED", "CREATED BY"},
 	}
 }
 
@@ -263,6 +263,7 @@ func ListTokens(client astrov1.APIClient, out io.Writer) error {
 			apiTokens[i].Name,
 			apiTokens[i].Description,
 			string(apiTokens[i].Scope),
+			string(apiTokens[i].Kind),
 			orgRoleOf(apiTokens[i]),
 			created,
 			createdBy,

--- a/cloud/workspace-token/workspace_token.go
+++ b/cloud/workspace-token/workspace_token.go
@@ -34,14 +34,14 @@ const (
 func newTokenTableOut() *printutil.Table {
 	return &printutil.Table{
 		DynamicPadding: true,
-		Header:         []string{"ID", "NAME", "DESCRIPTION", "SCOPE", "WORKSPACE ROLE", "CREATED", "CREATED BY"},
+		Header:         []string{"ID", "NAME", "DESCRIPTION", "SCOPE", "TYPE", "WORKSPACE ROLE", "CREATED", "CREATED BY"},
 	}
 }
 
 func newTokenSelectionTableOut() *printutil.Table {
 	return &printutil.Table{
 		DynamicPadding: true,
-		Header:         []string{"#", "ID", "NAME", "DESCRIPTION", "SCOPE", "WORKSPACE ROLE", "CREATED", "CREATED BY"},
+		Header:         []string{"#", "ID", "NAME", "DESCRIPTION", "SCOPE", "TYPE", "WORKSPACE ROLE", "CREATED", "CREATED BY"},
 	}
 }
 
@@ -133,6 +133,7 @@ func ListTokens(client astrov1.APIClient, workspaceID string, tokenTypes *[]Toke
 			apiTokens[i].Name,
 			apiTokens[i].Description,
 			string(apiTokens[i].Scope),
+			string(apiTokens[i].Kind),
 			workspaceRoleOf(apiTokens[i], workspaceID),
 			created,
 			createdBy,
@@ -393,6 +394,7 @@ func selectTokens(workspaceID string, apiTokens []astrov1.ApiToken) (astrov1.Api
 			apiTokens[i].Name,
 			apiTokens[i].Description,
 			string(apiTokens[i].Scope),
+			string(apiTokens[i].Kind),
 			workspaceRoleOf(apiTokens[i], workspaceID),
 			created,
 			createdBy,


### PR DESCRIPTION
## Description

  Adds a TYPE column (STANDARD / DIRECT_ACCESS) to the token list output for astro deployment token list, astro workspace token list, and astro organization token list. The API already returned this via ApiToken.Kind, but it was never surfaced
  in the CLI table, only SCOPE (workspace/organization/deployment) was shown.


## 🎟 Issue(s)

Related [#2250](https://github.com/astronomer/astro-cli/issues/2250)

## 🧪 Functional Testing

```
./astro organization token list --organization-id clilt----xnz94
 ID                            NAME                      DESCRIPTION                                    SCOPE            TYPE              ORGANIZATION ROLE       CREATED           CREATED BY                                    
              
 cm---w18l8r     Ax-Direct-Access                                                       ORGANIZATION     DIRECT_ACCESS     ORGANIZATION_OWNER      91 days ago       REDACTED                   
 
 cll----ve8x     test-token                test                                           ORGANIZATION     STANDARD          ORGANIZATION_OWNER      1100 days ago     REDACTED     

            
astro-cli % ./astro workspace token list --workspace-id clilt7---fz65--b1      
 ID                            NAME                         DESCRIPTION                                                   SCOPE         TYPE              WORKSPACE ROLE         CREATED            CREATED BY                                    
 cmss-----7yfodsg6     test123                                                                                    WORKSPACE     DIRECT_ACCESS     WORKSPACE_ACCESSOR     17 minutes ago     REDACTED 
 cmr297-----47cjuued     m----ats                                                                            WORKSPACE     STANDARD          WORKSPACE_OWNER        43 days ago     REDACTED                  
 cmm---02----5tx     c--e----endant         Token used by F--li---ant to clean up the workspace.     WORKSPACE     STANDARD          WORKSPACE_OWNER        151 days ago       REDACTED           


                            

                           
 astro-cli % ./astro deployment token list --deployment-id cm-----i2or    
 ID                            NAME          DESCRIPTION     SCOPE          TYPE              DEPLOYMENT ROLE       CREATED         CREATED BY                                    
 cm-----6i1jhf     9--84                         DEPLOYMENT     DIRECT_ACCESS     Deployment_Viewer     2 hours ago     REDACTED     
 cmsp----p6ahq2sy     t---9-43                     DEPLOYMENT     STANDARD          DEPLOYMENT_ADMIN      1 days ago      REDACTED                    
```
## 📸 Screenshots

> Add screenshots to illustrate the validity of these changes.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [ ] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [x] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
