### PR TITLE
Publish a versioned install.sh with every release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -210,6 +210,13 @@ jobs:
           restore-keys: |
             release-go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}-
 
+      - name: Stamp the installer so the snapshot matches a real release
+        env:
+          TAG: ${{ needs.preflight.outputs.tag }}
+        run: |
+          set -e
+          sed "s/^LATEST_VERSION=.*/LATEST_VERSION=${TAG}/" godownloader.sh > install.sh
+
       - name: Build release artifacts without publishing
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,6 +92,19 @@ jobs:
           scope: astronomer
           identity: astro-cli-homebrew
 
+      - name: Stamp the installer with this release's version
+        env:
+          TAG: ${{ needs.detect.outputs.tag }}
+        run: |
+          set -e
+          sed "s/^LATEST_VERSION=.*/LATEST_VERSION=${TAG}/" godownloader.sh > install.sh
+          chmod +x install.sh
+          if ! grep -qx "LATEST_VERSION=${TAG}" install.sh; then
+            echo "::error::install.sh was not stamped with ${TAG}. Did the constant in godownloader.sh get renamed?"
+            exit 1
+          fi
+          echo "Stamped install.sh with ${TAG}"
+
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: v2.15.2
@@ -102,6 +115,9 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ needs.detect.outputs.tag }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.prev-tag.outputs.tag }}
 
+  # install.astronomer.io fetches godownloader.sh from main, so this job keeps
+  # that path current. Pinned installs use the install.sh release asset instead,
+  # which carries its own version and does not depend on the PR this job opens.
   update-godownloader:
     needs: [detect, release]
     if: always() && !cancelled() && needs.detect.outputs.type == 'ga' && needs.release.result != 'skipped'

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ coverage-2.txt
 coverage.txt
 dist/
 hello-astro/
+# generated at release time from godownloader.sh, uploaded as a release asset
+install.sh
 meta/
 packages.txt
 requirements.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,10 @@ release:
   # "auto" marks prerelease tags (e.g. v1.43.0-rc.1, v1.43.0-nightly.20260522) as prerelease,
   # and clean semver tags (e.g. v1.43.0) as full releases.
   prerelease: auto
+  # install.sh is godownloader.sh with LATEST_VERSION set to this release, so
+  # the asset installs the release it ships with and nothing else.
+  extra_files:
+    - glob: ./install.sh
 changelog:
   sort: asc
   use: github
@@ -122,3 +126,5 @@ snapshot:
   name_template: SNAPSHOT-{{ .Commit }}
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  extra_files:
+    - glob: ./install.sh

--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ To install a specific version of the CLI, specify the version number as a flag a
 curl -sSL install.astronomer.io | sudo bash -s -- v1.1.0
 ```
 
+Every release also publishes an `install.sh` asset. That copy installs the release it ships with and no other, so the URL itself names the version. Use it in a Dockerfile or a CI job, where a pinned URL is easier to audit than a flag:
+
+```sh
+# a fixed version
+curl -sSL https://github.com/astronomer/astro-cli/releases/download/v1.45.0/install.sh | sudo bash -s -- -b /usr/local/bin
+
+# whichever version is newest
+curl -sSL https://github.com/astronomer/astro-cli/releases/latest/download/install.sh | sudo bash -s -- -b /usr/local/bin
+```
+
+Do not fetch `godownloader.sh` from a Git tag. That copy carries the version that was current when the release branch was cut, which is the release before the tag. Use the `install.sh` asset to pin a version.
+
 > If you receive a `mkdir` error during installation, download and run the [godownloader](https://raw.githubusercontent.com/astronomer/astro-cli/main/godownloader.sh) script locally using:
 >
 >```sh


### PR DESCRIPTION
## Description

Fetch `godownloader.sh` at tag `v1.44.0` and it installs 1.43.1. At `v1.45.0` it installs 1.44.0. Every GA tag ships an installer for the release before it:

| tag | `LATEST_VERSION` in that tag |
|---|---|
| v1.43.1 | v1.42.1 |
| v1.44.0 | v1.43.1 |
| v1.45.0 | v1.44.0 |

The cause is a branch mismatch, not a timing one. `update-godownloader` opens its PR against `main`, but GA tags are cut from `release-X.Y`:

```
$ git branch -r --contains v1.45.0
  origin/release-1.45
```

The fix lands on a branch the tag cannot see. `release-1.45` still reads `v1.44.0` and `release-1.44` still reads `v1.43.1` — neither was ever touched. So merging that PR faster changes nothing; the constant on a release branch is frozen at whatever `main` said when the branch was cut, which is always the previous release. That is why the drift is exactly one release, every release.

Rather than chase the constant across branches, each release now publishes `install.sh` — a copy of `godownloader.sh` with `LATEST_VERSION` set to the release it ships with. Two URLs then mean what they say:

| URL | installs |
|---|---|
| `releases/download/v1.44.0/install.sh` | 1.44.0, forever |
| `releases/latest/download/install.sh` | the newest GA |

RCs get this too, so `releases/download/v1.46.0-rc.1/install.sh` installs exactly that RC — a URL RC testers do not have today.

`godownloader.sh` itself is unchanged. `install.astronomer.io` is a shim hosted on GCS that reads the script from `main` and pipes it to bash, so that path was never broken and is untouched; `update-godownloader` still keeps it current, and the comment above that job now says so.

**The raw-at-a-tag URL stays one release behind, silently, and nothing in this repo can repair it.** The README now says not to use it and points at the asset. Making it fail loudly instead would mean dropping `LATEST_VERSION`, which breaks `install.astronomer.io`, since the shim often passes no tag — that needs whoever owns the GCS bucket.

### Call-stack diff

```diff
  push tag v1.46.0                         .github/workflows/release.yaml
  └─ detect                                # parses the tag, type=ga
     ├─ release (macos-15)
+    │  ├─ stamp install.sh                # sed LATEST_VERSION -> v1.46.0, or fail
     │  └─ goreleaser release --clean
     │     ├─ build, archive, Homebrew PR  # unchanged
+    │     ├─ upload install.sh            # release.extra_files
+    │     └─ checksums.txt                # now covers install.sh
     ├─ update-godownloader                # unchanged, feeds install.astronomer.io
     ├─ update-winget                      # unchanged
     └─ notify                             # unchanged
```

```diff
  curl .../releases/download/v1.44.0/install.sh | sudo bash
+ └─ LATEST_VERSION=v1.44.0                # stamped at release time
     └─ tag_to_version()                   # unchanged, and never asks GitHub
        └─ astro_1.44.0_linux_amd64.tar.gz
```

Unchanged: every flag `godownloader.sh` takes, the download and checksum path, and the nightly cleanup job.

## 🎟 Issue(s)

None.

## 🧪 Functional Testing

A stamped copy installs its own version, end to end in a Linux container against live GitHub:

```
$ sed "s/^LATEST_VERSION=.*/LATEST_VERSION=v1.44.0/" godownloader.sh > install.sh
$ sh install.sh -b /tmp/bin
astronomer/astro-cli info Using Latest(v1.44.0) version
astronomer/astro-cli info found version: 1.44.0 for v1.44.0/linux/arm64
astronomer/astro-cli info installed /tmp/bin/astro
$ /tmp/bin/astro version
Astro CLI Version: 1.44.0
```

- `goreleaser check` in the pinned v2.15.2 container accepts the config. It reports four deprecations — `snapshot.name_template`, `archives.format`, `archives.builds`, `brews` — and `main` reports the same four. Nothing new.
- The stamp step fails the release if the sed does not take. Tested both ways: a good stamp passes, and renaming the constant in `godownloader.sh` fires the guard instead of publishing an installer that points at the wrong version.
- `releases/latest/download/<asset>` resolves on this repo — checked against an existing checksums asset, which redirected to the v1.45.0 copy.
- RC assets are named `astro_1.45.0-rc.1_*`, so a stamped RC installer resolves its archive correctly.
- `warm-release-cache` in `create-release.yaml` stamps as well, or its snapshot build would hit a glob matching nothing.

Not tested: the upload itself, which needs a real tag. The first release after this merges is where that shows up — worth a look at the assets list before announcing.

Did not run `make test` or `make lint` — no Go code changed.

## 📸 Screenshots

N/A.

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Ran `make test` before taking out of draft — no Go code changed
- [ ] Ran `make lint` before taking out of draft — no Go code changed; ran `goreleaser check` instead
- [ ] Added/updated applicable tests — nothing here is reachable from the Go suite; testing steps above
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/) — README only; the docs site still tells people to use `install.astronomer.io`, which is correct and unchanged.
