### PR TITLE
Report and track commands and flags the CLI does not have

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,6 +104,7 @@ Welcome to the Astro CLI, the modern command line interface for data orchestrati
 		apcCmd.VersionMatchCmds(rootCmd, []string{"astro"})
 	}
 
+	rootCmd.SetFlagErrorFunc(trackUnknownFlag)
 	rootCmd.SetHelpTemplate(getResourcesHelpTemplate(houstonVersion, ctx))
 	rootCmd.PersistentFlags().StringVarP(&verboseLevel, "verbosity", "", logrus.WarnLevel.String(), "Log level (debug, info, warn, error, fatal, panic")
 

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -19,7 +19,7 @@ func newTelemetryCmd(out io.Writer) *cobra.Command {
 Telemetry helps us understand how the CLI is used and improve it.
 We collect usage data including:
 - Commands used (not arguments or values)
-- Commands the CLI does not have, when one is typed
+- Commands and flags the CLI does not have, when one is typed
 - CLI version
 - Operating system
 - Invocation context (CI, interactive, etc.)

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -19,6 +19,7 @@ func newTelemetryCmd(out io.Writer) *cobra.Command {
 Telemetry helps us understand how the CLI is used and improve it.
 We collect usage data including:
 - Commands used (not arguments or values)
+- Commands the CLI does not have, when one is typed
 - CLI version
 - Operating system
 - Invocation context (CI, interactive, etc.)

--- a/cmd/unknown.go
+++ b/cmd/unknown.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/astronomer/astro-cli/internal/telemetry"
+)
+
+// unknownCommand is a word the CLI has no command for, under the command it
+// was typed against.
+type unknownCommand struct {
+	parent      *cobra.Command
+	word        string
+	suggestions []string
+}
+
+// HandleUnknownCommand reports and tracks a command the CLI does not have, and
+// returns true when it found one. It runs before Execute, so it first registers
+// the help and completion commands that Execute would otherwise add after this
+// point, which would make `astro help` read as a command we do not have.
+//
+// Cobra handles this in two ways and neither is much use. At the root it
+// returns an error from Execute, which is too late for the hook that tracks
+// commands. Under a parent such as `dev` it prints the help and exits 0, so a
+// wrong guess reads as a success.
+//
+// The fix cobra would want, an Args validator on each parent, does not work
+// here: cobra returns the help for a command that does not run before it
+// validates the arguments, so every parent would have to become runnable. That
+// would run their pre-run hooks on a bare `astro dev`, which checks for a
+// container runtime, and `astro dev` would report a missing Docker where today
+// it prints the help.
+func HandleUnknownCommand(root *cobra.Command, args []string, out io.Writer) bool {
+	if isShellCompletion(args) {
+		return false
+	}
+
+	root.InitDefaultHelpCmd()
+	root.InitDefaultCompletionCmd(args...)
+
+	unknown := findUnknownCommand(root, args)
+	if unknown == nil {
+		return false
+	}
+
+	telemetry.TrackUnknownCommand(unknown.parent, unknown.word, unknown.suggestion())
+	unknown.report(out)
+	return true
+}
+
+// isShellCompletion reports whether the shell is asking cobra for completions.
+// Cobra registers __complete from a private call we cannot make, so the command
+// does not exist yet when we resolve the tree. The shell is talking to itself
+// here, and a word it has not finished typing is not a guess at a command.
+func isShellCompletion(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	return args[0] == cobra.ShellCompRequestCmd || args[0] == cobra.ShellCompNoDescRequestCmd
+}
+
+// findUnknownCommand returns the first word that names no command, or nil when
+// every word resolves.
+//
+// A command that runs takes its own arguments, so a word after it is an
+// argument and not a guess at a command name.
+func findUnknownCommand(root *cobra.Command, args []string) *unknownCommand {
+	matched, rest, _ := root.Find(args)
+	if matched.Runnable() || !matched.HasSubCommands() {
+		return nil
+	}
+
+	operands := stripFlags(matched, rest)
+	if len(operands) == 0 {
+		return nil
+	}
+
+	return &unknownCommand{
+		parent:      matched,
+		word:        operands[0],
+		suggestions: suggestionsFor(matched, operands[0]),
+	}
+}
+
+// suggestion returns the nearest command name, or "" when the word is nothing
+// like a command we have. An empty suggestion is the interesting case: it marks
+// a command someone expected to exist.
+func (u *unknownCommand) suggestion() string {
+	if len(u.suggestions) == 0 {
+		return ""
+	}
+	return u.suggestions[0]
+}
+
+// message is worded as cobra words it, so that an unknown subcommand reads the
+// same as an unknown command at the root.
+func (u *unknownCommand) message() string {
+	message := fmt.Sprintf("unknown command %q for %q", u.word, u.parent.CommandPath())
+	if len(u.suggestions) == 0 {
+		return message
+	}
+
+	var sb strings.Builder
+	sb.WriteString(message)
+	sb.WriteString("\n\nDid you mean this?\n")
+	for _, suggestion := range u.suggestions {
+		fmt.Fprintf(&sb, "\t%v\n", suggestion)
+	}
+	return sb.String()
+}
+
+func (u *unknownCommand) report(out io.Writer) {
+	fmt.Fprintln(out, u.parent.ErrPrefix(), u.message())
+	fmt.Fprintf(out, "Run '%v --help' for usage.\n", u.parent.CommandPath())
+}
+
+// suggestionDistance is the edit distance cobra uses for "Did you mean this?".
+// SuggestionsFor reads it from the command, which cobra fills in only on the
+// error path, so we set it ourselves to get the same answer.
+const suggestionDistance = 2
+
+func suggestionsFor(parent *cobra.Command, word string) []string {
+	if parent.DisableSuggestions {
+		return nil
+	}
+	if parent.SuggestionsMinimumDistance <= 0 {
+		parent.SuggestionsMinimumDistance = suggestionDistance
+	}
+	return parent.SuggestionsFor(word)
+}
+
+// stripFlags drops flags and their values, leaving the words cobra would read
+// as commands. It follows cobra's own stripFlags, which is private, so that the
+// word we report is the word cobra failed to match.
+func stripFlags(cmd *cobra.Command, args []string) []string {
+	flags := cmd.Flags()
+	flags.AddFlagSet(cmd.InheritedFlags())
+
+	operands := []string{}
+	for len(args) > 0 {
+		arg := args[0]
+		args = args[1:]
+
+		switch {
+		case arg == "--":
+			return operands
+		case strings.HasPrefix(arg, "--") && !strings.Contains(arg, "=") && !takesNoValue(flags.Lookup(arg[2:])),
+			strings.HasPrefix(arg, "-") && !strings.Contains(arg, "=") && len(arg) == 2 && !takesNoValue(flags.ShorthandLookup(arg[1:])):
+			if len(args) <= 1 {
+				return operands
+			}
+			args = args[1:]
+		case arg != "" && !strings.HasPrefix(arg, "-"):
+			operands = append(operands, arg)
+		}
+	}
+	return operands
+}
+
+func takesNoValue(flag *pflag.Flag) bool {
+	return flag != nil && flag.NoOptDefVal != ""
+}

--- a/cmd/unknown.go
+++ b/cmd/unknown.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -51,6 +53,40 @@ func HandleUnknownCommand(root *cobra.Command, args []string, out io.Writer) boo
 	telemetry.TrackUnknownCommand(unknown.parent, unknown.word, unknown.suggestion())
 	unknown.report(out)
 	return true
+}
+
+// trackUnknownFlag records a flag the CLI does not have, then hands the error
+// back for cobra to report as it always has. Cobra parses the flags before it
+// runs the hook that tracks commands, so a wrong flag sends nothing at all
+// without this.
+//
+// The root sets it once. A command with no error function of its own asks its
+// parent for one, so this covers every command in the tree.
+func trackUnknownFlag(cmd *cobra.Command, err error) error {
+	if isShellCompletion(os.Args[1:]) {
+		return err
+	}
+	if flag := unknownFlag(err); flag != "" {
+		telemetry.TrackUnknownFlag(cmd, flag)
+	}
+	return err
+}
+
+// unknownFlag returns the flag as it was typed when pflag has no such flag,
+// and "" for every other parse error. A missing value, or a value of the wrong
+// type, is a mistake on a flag we do have, which is not what we are counting.
+//
+// pflag reports the name on its own, so `--api-token=secret` arrives here as
+// `--api-token` and the value never reaches us.
+func unknownFlag(err error) string {
+	var notExist *pflag.NotExistError
+	if !errors.As(err, &notExist) {
+		return ""
+	}
+	if notExist.GetSpecifiedShortnames() != "" {
+		return "-" + notExist.GetSpecifiedName()
+	}
+	return "--" + notExist.GetSpecifiedName()
 }
 
 // isShellCompletion reports whether the shell is asking cobra for completions.

--- a/cmd/unknown.go
+++ b/cmd/unknown.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -13,8 +12,6 @@ import (
 	"github.com/astronomer/astro-cli/internal/telemetry"
 )
 
-// unknownCommand is a word the CLI has no command for, under the command it
-// was typed against.
 type unknownCommand struct {
 	parent      *cobra.Command
 	word        string
@@ -22,21 +19,15 @@ type unknownCommand struct {
 }
 
 // HandleUnknownCommand reports and tracks a command the CLI does not have, and
-// returns true when it found one. It runs before Execute, so it first registers
-// the help and completion commands that Execute would otherwise add after this
-// point, which would make `astro help` read as a command we do not have.
+// returns true when it found one. It runs before Execute, and so registers the
+// help and completion commands that Execute adds after this point, which would
+// otherwise make `astro help` read as a command we do not have.
 //
-// Cobra handles this in two ways and neither is much use. At the root it
-// returns an error from Execute, which is too late for the hook that tracks
-// commands. Under a parent such as `dev` it prints the help and exits 0, so a
-// wrong guess reads as a success.
-//
-// The fix cobra would want, an Args validator on each parent, does not work
-// here: cobra returns the help for a command that does not run before it
-// validates the arguments, so every parent would have to become runnable. That
-// would run their pre-run hooks on a bare `astro dev`, which checks for a
-// container runtime, and `astro dev` would report a missing Docker where today
-// it prints the help.
+// An Args validator on each parent is the cobra way and does not work here:
+// cobra returns the help for a command that does not run before it validates
+// the arguments, so every parent would have to become runnable. Their pre-run
+// hooks would then fire on a bare `astro dev`, which checks for a container
+// runtime, and `astro dev` would report a missing Docker instead of the help.
 func HandleUnknownCommand(root *cobra.Command, args []string, out io.Writer) bool {
 	if isShellCompletion(args) {
 		return false
@@ -57,27 +48,20 @@ func HandleUnknownCommand(root *cobra.Command, args []string, out io.Writer) boo
 
 // trackUnknownFlag records a flag the CLI does not have, then hands the error
 // back for cobra to report as it always has. Cobra parses the flags before it
-// runs the hook that tracks commands, so a wrong flag sends nothing at all
-// without this.
-//
-// The root sets it once. A command with no error function of its own asks its
-// parent for one, so this covers every command in the tree.
+// runs the hook that tracks commands, so a wrong flag sends nothing without
+// this. The root sets it once: a command with no error function of its own asks
+// its parent for one.
 func trackUnknownFlag(cmd *cobra.Command, err error) error {
-	if isShellCompletion(os.Args[1:]) {
-		return err
-	}
 	if flag := unknownFlag(err); flag != "" {
 		telemetry.TrackUnknownFlag(cmd, flag)
 	}
 	return err
 }
 
-// unknownFlag returns the flag as it was typed when pflag has no such flag,
-// and "" for every other parse error. A missing value, or a value of the wrong
-// type, is a mistake on a flag we do have, which is not what we are counting.
-//
-// pflag reports the name on its own, so `--api-token=secret` arrives here as
-// `--api-token` and the value never reaches us.
+// unknownFlag returns the flag as it was typed when pflag has no such flag, and
+// "" for every other parse error: a missing value, or a value of the wrong
+// type, is a mistake on a flag we do have. pflag reports the name on its own,
+// so `--api-token=secret` arrives here as `--api-token`.
 func unknownFlag(err error) string {
 	var notExist *pflag.NotExistError
 	if !errors.As(err, &notExist) {
@@ -91,8 +75,7 @@ func unknownFlag(err error) string {
 
 // isShellCompletion reports whether the shell is asking cobra for completions.
 // Cobra registers __complete from a private call we cannot make, so the command
-// does not exist yet when we resolve the tree. The shell is talking to itself
-// here, and a word it has not finished typing is not a guess at a command.
+// does not exist yet when we resolve the tree.
 func isShellCompletion(args []string) bool {
 	if len(args) == 0 {
 		return false
@@ -101,10 +84,8 @@ func isShellCompletion(args []string) bool {
 }
 
 // findUnknownCommand returns the first word that names no command, or nil when
-// every word resolves.
-//
-// A command that runs takes its own arguments, so a word after it is an
-// argument and not a guess at a command name.
+// every word resolves. A command that runs takes its own arguments, so a word
+// after one is an argument and not a guess at a command name.
 func findUnknownCommand(root *cobra.Command, args []string) *unknownCommand {
 	matched, rest, _ := root.Find(args)
 	if matched.Runnable() || !matched.HasSubCommands() {
@@ -123,9 +104,6 @@ func findUnknownCommand(root *cobra.Command, args []string) *unknownCommand {
 	}
 }
 
-// suggestion returns the nearest command name, or "" when the word is nothing
-// like a command we have. An empty suggestion is the interesting case: it marks
-// a command someone expected to exist.
 func (u *unknownCommand) suggestion() string {
 	if len(u.suggestions) == 0 {
 		return ""
@@ -156,8 +134,8 @@ func (u *unknownCommand) report(out io.Writer) {
 }
 
 // suggestionDistance is the edit distance cobra uses for "Did you mean this?".
-// SuggestionsFor reads it from the command, which cobra fills in only on the
-// error path, so we set it ourselves to get the same answer.
+// SuggestionsFor reads it from the command, which cobra fills in only on its
+// own error path.
 const suggestionDistance = 2
 
 func suggestionsFor(parent *cobra.Command, word string) []string {
@@ -185,8 +163,7 @@ func stripFlags(cmd *cobra.Command, args []string) []string {
 		switch {
 		case arg == "--":
 			return operands
-		case strings.HasPrefix(arg, "--") && !strings.Contains(arg, "=") && !takesNoValue(flags.Lookup(arg[2:])),
-			strings.HasPrefix(arg, "-") && !strings.Contains(arg, "=") && len(arg) == 2 && !takesNoValue(flags.ShorthandLookup(arg[1:])):
+		case consumesNextValue(flags, arg):
 			if len(args) <= 1 {
 				return operands
 			}
@@ -196,6 +173,19 @@ func stripFlags(cmd *cobra.Command, args []string) []string {
 		}
 	}
 	return operands
+}
+
+// consumesNextValue reports whether arg is a flag that takes the word after it
+// as its value. A flag we do not have is assumed to take one, which is what
+// cobra assumes.
+func consumesNextValue(flags *pflag.FlagSet, arg string) bool {
+	if strings.Contains(arg, "=") {
+		return false
+	}
+	if strings.HasPrefix(arg, "--") {
+		return !takesNoValue(flags.Lookup(arg[2:]))
+	}
+	return len(arg) == 2 && strings.HasPrefix(arg, "-") && !takesNoValue(flags.ShorthandLookup(arg[1:]))
 }
 
 func takesNoValue(flag *pflag.Flag) bool {

--- a/cmd/unknown_test.go
+++ b/cmd/unknown_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -227,19 +226,6 @@ func TestTrackUnknownFlagPassesTheErrorThrough(t *testing.T) {
 	testUtil.InitTestConfig(testUtil.LocalPlatform)
 
 	err := parseError(t, "--wait-for-deploy")
-	cmd := &cobra.Command{Use: "deploy"}
-
-	assert.Equal(t, err, trackUnknownFlag(cmd, err))
-}
-
-func TestTrackUnknownFlagSkipsShellCompletion(t *testing.T) {
-	testUtil.InitTestConfig(testUtil.LocalPlatform)
-
-	original := os.Args
-	defer func() { os.Args = original }()
-	os.Args = []string{"astro", cobra.ShellCompRequestCmd, "deploy", "--wai"}
-
-	err := parseError(t, "--wai")
 	cmd := &cobra.Command{Use: "deploy"}
 
 	assert.Equal(t, err, trackUnknownFlag(cmd, err))

--- a/cmd/unknown_test.go
+++ b/cmd/unknown_test.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	testUtil "github.com/astronomer/astro-cli/pkg/testing"
+)
+
+// newUnknownTestTree builds a command tree shaped like the real one: a root
+// that does not run, a parent that does not run, and commands that run.
+func newUnknownTestTree() *cobra.Command {
+	root := &cobra.Command{Use: "astro"}
+	root.PersistentFlags().String("verbosity", "warn", "log level")
+
+	dev := &cobra.Command{Use: "dev"}
+	dev.PersistentFlags().Bool("no-cache", false, "do not use a cache")
+	dev.AddCommand(
+		&cobra.Command{Use: "start", Run: func(*cobra.Command, []string) {}},
+		&cobra.Command{Use: "restart", Run: func(*cobra.Command, []string) {}},
+	)
+
+	root.AddCommand(
+		dev,
+		&cobra.Command{Use: "deploy", Run: func(*cobra.Command, []string) {}},
+		&cobra.Command{Use: "telemetry", Run: func(*cobra.Command, []string) {}},
+	)
+	return root
+}
+
+func TestFindUnknownCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantParent string
+		wantWord   string
+	}{
+		{"unknown at root", []string{"fly"}, "astro", "fly"},
+		{"unknown under a parent", []string{"dev", "restrt"}, "astro dev", "restrt"},
+		{"unknown after a flag with a value", []string{"--verbosity", "debug", "fly"}, "astro", "fly"},
+		{"unknown after a boolean flag", []string{"dev", "--no-cache", "restrt"}, "astro dev", "restrt"},
+		{"unknown with a flag after it", []string{"fly", "--verbosity", "debug"}, "astro", "fly"},
+		{"known command", []string{"dev", "start"}, "", ""},
+		{"known parent alone", []string{"dev"}, "", ""},
+		{"argument to a command that runs", []string{"deploy", "my-deployment"}, "", ""},
+		{"no arguments", []string{}, "", ""},
+		{"flags only", []string{"--verbosity", "debug"}, "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unknown := findUnknownCommand(newUnknownTestTree(), tt.args)
+
+			if tt.wantWord == "" {
+				assert.Nil(t, unknown)
+				return
+			}
+			assert.Equal(t, tt.wantWord, unknown.word)
+			assert.Equal(t, tt.wantParent, unknown.parent.CommandPath())
+		})
+	}
+}
+
+func TestUnknownCommandSuggestion(t *testing.T) {
+	root := newUnknownTestTree()
+
+	assert.Equal(t, "deploy", findUnknownCommand(root, []string{"deploi"}).suggestion())
+	assert.Equal(t, "telemetry", findUnknownCommand(root, []string{"telem"}).suggestion())
+	assert.Equal(t, "restart", findUnknownCommand(root, []string{"dev", "restrt"}).suggestion())
+	assert.Empty(t, findUnknownCommand(root, []string{"fly"}).suggestion())
+
+	root.DisableSuggestions = true
+	assert.Empty(t, findUnknownCommand(root, []string{"deploi"}).suggestion())
+}
+
+// TestHandleUnknownCommandMatchesCobra checks our wording against the wording
+// cobra prints for the same mistake at the root.
+func TestHandleUnknownCommandMatchesCobra(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"no suggestion", []string{"fly"}},
+		{"with a suggestion", []string{"deploi"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cobraRoot := newUnknownTestTree()
+			fromCobra := new(bytes.Buffer)
+			cobraRoot.SetOut(fromCobra)
+			cobraRoot.SetErr(fromCobra)
+			cobraRoot.SetArgs(tt.args)
+			require.Error(t, cobraRoot.Execute())
+
+			ours := new(bytes.Buffer)
+			assert.True(t, HandleUnknownCommand(newUnknownTestTree(), tt.args, ours))
+
+			assert.Equal(t, fromCobra.String(), ours.String())
+		})
+	}
+}
+
+func TestHandleUnknownCommandUnderAParent(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	out := new(bytes.Buffer)
+
+	assert.True(t, HandleUnknownCommand(newUnknownTestTree(), []string{"dev", "restrt"}, out))
+	assert.Equal(t, "Error: unknown command \"restrt\" for \"astro dev\"\n\nDid you mean this?\n\trestart\n\nRun 'astro dev --help' for usage.\n", out.String())
+}
+
+func TestHandleUnknownCommandLeavesKnownCommandsAlone(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	out := new(bytes.Buffer)
+
+	assert.False(t, HandleUnknownCommand(newUnknownTestTree(), []string{"dev", "start"}, out))
+	assert.Empty(t, out.String())
+}
+
+// TestHandleUnknownCommandLeavesCobrasOwnCommandsAlone guards the commands
+// cobra adds inside Execute, after the point where we resolve the tree.
+func TestHandleUnknownCommandLeavesCobrasOwnCommandsAlone(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	tests := [][]string{
+		{"help"},
+		{"help", "dev"},
+		{"help", "fly"},
+		{"completion"},
+		{"completion", "zsh"},
+		{"__complete", "dev", "res"},
+		{"__completeNoDesc", "dev", "res"},
+	}
+
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			out := new(bytes.Buffer)
+
+			assert.False(t, HandleUnknownCommand(newUnknownTestTree(), args, out))
+			assert.Empty(t, out.String())
+		})
+	}
+}
+
+// TestHandleUnknownCommandOnTheRealTree runs against the command tree the CLI
+// actually builds, on both platforms, since each builds a different one.
+func TestHandleUnknownCommandOnTheRealTree(t *testing.T) {
+	platforms := []struct {
+		name     string
+		platform string
+	}{
+		{"cloud", testUtil.LocalPlatform},
+		{"software", testUtil.SoftwarePlatform},
+	}
+
+	for _, p := range platforms {
+		t.Run(p.name, func(t *testing.T) {
+			testUtil.InitTestConfig(p.platform)
+			root := NewRootCmd()
+			out := new(bytes.Buffer)
+
+			assert.True(t, HandleUnknownCommand(root, []string{"fly"}, out))
+			assert.Equal(t, "Error: unknown command \"fly\" for \"astro\"\nRun 'astro --help' for usage.\n", out.String())
+
+			for _, args := range [][]string{{"version"}, {"help"}, {"completion", "zsh"}, {"__complete", "dev", "res"}, {}} {
+				out := new(bytes.Buffer)
+				assert.False(t, HandleUnknownCommand(NewRootCmd(), args, out), args)
+				assert.Empty(t, out.String())
+			}
+		})
+	}
+}

--- a/cmd/unknown_test.go
+++ b/cmd/unknown_test.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -178,4 +182,84 @@ func TestHandleUnknownCommandOnTheRealTree(t *testing.T) {
 			}
 		})
 	}
+}
+
+// parseError returns the error pflag gives for args, which is the error cobra
+// hands to the flag error function.
+func parseError(t *testing.T, args ...string) error {
+	t.Helper()
+
+	flags := pflag.NewFlagSet("astro", pflag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.String("verbosity", "warn", "log level")
+	flags.BoolP("all", "a", false, "every one of them")
+
+	return flags.Parse(args)
+}
+
+func TestUnknownFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"a long flag we do not have", []string{"--wait-for-deploy"}, "--wait-for-deploy"},
+		{"a long flag with a value", []string{"--api-token=sekret-123"}, "--api-token"},
+		{"a shorthand we do not have", []string{"-Z"}, "-Z"},
+		{"a shorthand inside a group", []string{"-aZ"}, "-Z"},
+		{"a flag we do have", []string{"--verbosity", "debug"}, ""},
+		{"a flag missing its value", []string{"--verbosity"}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, unknownFlag(parseError(t, tt.args...)))
+		})
+	}
+
+	assert.Empty(t, unknownFlag(nil))
+	assert.Empty(t, unknownFlag(errors.New("something else")))
+}
+
+// TestTrackUnknownFlagPassesTheErrorThrough checks that the hook only listens.
+// Cobra reports the error, and it has to arrive unchanged.
+func TestTrackUnknownFlagPassesTheErrorThrough(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	err := parseError(t, "--wait-for-deploy")
+	cmd := &cobra.Command{Use: "deploy"}
+
+	assert.Equal(t, err, trackUnknownFlag(cmd, err))
+}
+
+func TestTrackUnknownFlagSkipsShellCompletion(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	original := os.Args
+	defer func() { os.Args = original }()
+	os.Args = []string{"astro", cobra.ShellCompRequestCmd, "deploy", "--wai"}
+
+	err := parseError(t, "--wai")
+	cmd := &cobra.Command{Use: "deploy"}
+
+	assert.Equal(t, err, trackUnknownFlag(cmd, err))
+}
+
+// TestUnknownFlagOnTheRealTree checks that the root's error function reaches a
+// command several levels down, and that the CLI still reports what it always
+// reported.
+func TestUnknownFlagOnTheRealTree(t *testing.T) {
+	testUtil.InitTestConfig(testUtil.LocalPlatform)
+
+	root := NewRootCmd()
+	out := new(bytes.Buffer)
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"deployment", "list", "--wait-for-deploy"})
+
+	err := root.Execute()
+
+	require.Error(t, err)
+	assert.Equal(t, "unknown flag: --wait-for-deploy", err.Error())
+	assert.Contains(t, out.String(), "Error: unknown flag: --wait-for-deploy")
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -190,21 +190,33 @@ func buildCommandProperties(cmd *cobra.Command) map[string]interface{} {
 // TrackCommand sends telemetry data for a command execution.
 // It spawns a subprocess to send the data asynchronously.
 func TrackCommand(cmd *cobra.Command) {
-	if !IsEnabled() || isTestRun() {
+	if commandPath := GetCommandPath(cmd); commandPath == "" || cmd.Hidden {
 		return
+	}
+	if !canTrack(cmd) {
+		return
+	}
+
+	track(EventCommandExecution, buildCommandProperties(cmd))
+}
+
+// canTrack reports whether an event for cmd should be sent, and shows the
+// first-run notice when it should. It runs before every event, so that a
+// command which sends nothing says nothing — notably `astro telemetry
+// disable`, which would otherwise announce collection to someone in the act of
+// opting out, and a mistyped version of it, which would report the mistake.
+func canTrack(cmd *cobra.Command) bool {
+	if !IsEnabled() || isTestRun() {
+		return false
 	}
 
 	commandPath := GetCommandPath(cmd)
-	if commandPath == "" || cmd.Hidden || strings.HasPrefix(commandPath, "telemetry") || strings.HasPrefix(commandPath, "_telemetry") {
-		return
+	if strings.HasPrefix(commandPath, "telemetry") || strings.HasPrefix(commandPath, "_telemetry") {
+		return false
 	}
 
-	// After the filter above, so that commands which send nothing say nothing —
-	// notably `astro telemetry disable`, which otherwise announces collection to
-	// someone in the act of opting out.
 	showFirstRunNotice()
-
-	track(EventCommandExecution, buildCommandProperties(cmd))
+	return true
 }
 
 // track sends one event. It goes out in the background, unless debug mode asks

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -137,7 +137,7 @@ func GetCommandPath(cmd *cobra.Command) string {
 // notice makes a materially different claim about what is collected, so users
 // who accepted earlier wording see the change instead of inheriting it silently.
 // v1 predates this constant and is stored as "true".
-const noticeVersion = "2"
+const noticeVersion = "3"
 
 // showFirstRunNotice prints a notice about telemetry on the first CLI invocation,
 // and again whenever noticeVersion changes.
@@ -148,6 +148,7 @@ func showFirstRunNotice() {
 	fmt.Fprintln(os.Stderr,
 		"The Astro CLI collects usage data to help us prioritize and invest in CLI features.\n"+
 			"Commands, OS, and CLI version are tracked — never arguments or their values.\n"+
+			"A command the CLI does not have is tracked too, so we can see what to add.\n"+
 			"While you are logged in, events are linked to your Astro organization.\n"+
 			"Logged-out usage stays anonymous.\n"+
 			"Opt out anytime: `astro telemetry disable` or ASTRO_TELEMETRY_DISABLED=1")
@@ -203,11 +204,15 @@ func TrackCommand(cmd *cobra.Command) {
 	// someone in the act of opting out.
 	showFirstRunNotice()
 
-	properties := buildCommandProperties(cmd)
+	track(EventCommandExecution, buildCommandProperties(cmd))
+}
 
+// track sends one event. It goes out in the background, unless debug mode asks
+// for it in the foreground.
+func track(event string, properties map[string]interface{}) {
 	payload := sharedtel.TelemetryPayload{
 		Source:      SourceName,
-		Event:       EventCommandExecution,
+		Event:       event,
 		AnonymousID: GetAnonymousID(),
 		Properties:  properties,
 	}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -148,7 +148,7 @@ func showFirstRunNotice() {
 	fmt.Fprintln(os.Stderr,
 		"The Astro CLI collects usage data to help us prioritize and invest in CLI features.\n"+
 			"Commands, OS, and CLI version are tracked — never arguments or their values.\n"+
-			"A command the CLI does not have is tracked too, so we can see what to add.\n"+
+			"A command or flag the CLI does not have is tracked too, so we can see what to add.\n"+
 			"While you are logged in, events are linked to your Astro organization.\n"+
 			"Logged-out usage stays anonymous.\n"+
 			"Opt out anytime: `astro telemetry disable` or ASTRO_TELEMETRY_DISABLED=1")

--- a/internal/telemetry/unknown.go
+++ b/internal/telemetry/unknown.go
@@ -1,0 +1,63 @@
+package telemetry
+
+import (
+	"regexp"
+
+	"github.com/spf13/cobra"
+)
+
+// EventUnknownCommand is the event type for a command the CLI does not have.
+// It is kept apart from EventCommandExecution so that a run which did nothing
+// is never counted as a run which did something.
+const EventUnknownCommand = "CLI Unknown Command"
+
+// RedactedCommand stands in for a word that does not look like a command name,
+// so that the event is still counted without carrying what the user typed.
+const RedactedCommand = "<redacted>"
+
+// maxCommandLength is the longest word we will report. The longest command the
+// CLI has is `organization-token`, at 18, so this leaves room for a guess at a
+// longer name while dropping the opaque strings a secret tends to be.
+const maxCommandLength = 30
+
+// commandPattern describes what a command name may look like: a lower-case
+// letter, then lower-case letters, digits, dashes or underscores. Every command
+// the CLI has fits this. A token or a path does not.
+var commandPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+
+// TrackUnknownCommand sends an event for a word the CLI has no command for.
+// parent is the command it was typed under, and suggestion is the nearest
+// command name, or "" when there is none.
+func TrackUnknownCommand(parent *cobra.Command, word, suggestion string) {
+	if !IsEnabled() || isTestRun() {
+		return
+	}
+
+	showFirstRunNotice()
+
+	properties := buildCommandProperties(parent)
+	if properties["command"] == "" {
+		delete(properties, "command")
+	}
+	properties["unknown_command"] = unknownCommandPath(parent, word)
+	if suggestion != "" {
+		properties["suggestion"] = suggestion
+	}
+
+	track(EventUnknownCommand, properties)
+}
+
+// unknownCommandPath joins the parent path and the unknown word, so that
+// `astro dev restrt` reads as "dev restrt". The parent path is made of command
+// names the CLI defines. Only the unknown word comes from the user, so only
+// the unknown word is redacted.
+func unknownCommandPath(parent *cobra.Command, word string) string {
+	if len(word) > maxCommandLength || !commandPattern.MatchString(word) {
+		word = RedactedCommand
+	}
+	path := GetCommandPath(parent)
+	if path == "" {
+		return word
+	}
+	return path + " " + word
+}

--- a/internal/telemetry/unknown.go
+++ b/internal/telemetry/unknown.go
@@ -6,10 +6,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// EventUnknownCommand is the event type for a command the CLI does not have.
-// It is kept apart from EventCommandExecution so that a run which did nothing
-// is never counted as a run which did something.
-const EventUnknownCommand = "CLI Unknown Command"
+// EventUnknownCommand is the event type for a command the CLI does not have,
+// and EventUnknownFlag for a flag it does not have. Both are kept apart from
+// EventCommandExecution so that a run which did nothing is never counted as a
+// run which did something.
+const (
+	EventUnknownCommand = "CLI Unknown Command"
+	EventUnknownFlag    = "CLI Unknown Flag"
+)
 
 // RedactedCommand stands in for a word that does not look like a command name,
 // so that the event is still counted without carrying what the user typed.
@@ -25,6 +29,13 @@ const maxCommandLength = 30
 // the CLI has fits this. A token or a path does not.
 var commandPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 
+// maxFlagLength leaves room for the two dashes on a long flag.
+const maxFlagLength = maxCommandLength + 2
+
+// flagPattern describes what a flag looks like: a long flag holds to the shape
+// of a command name, and a shorthand is one letter or digit.
+var flagPattern = regexp.MustCompile(`^--[a-z][a-z0-9_-]*$|^-[a-zA-Z0-9]$`)
+
 // TrackUnknownCommand sends an event for a word the CLI has no command for.
 // parent is the command it was typed under, and suggestion is the nearest
 // command name, or "" when there is none.
@@ -35,16 +46,48 @@ func TrackUnknownCommand(parent *cobra.Command, word, suggestion string) {
 
 	showFirstRunNotice()
 
-	properties := buildCommandProperties(parent)
-	if properties["command"] == "" {
-		delete(properties, "command")
-	}
+	properties := unknownProperties(parent)
 	properties["unknown_command"] = unknownCommandPath(parent, word)
 	if suggestion != "" {
 		properties["suggestion"] = suggestion
 	}
 
 	track(EventUnknownCommand, properties)
+}
+
+// TrackUnknownFlag sends an event for a flag the CLI has no such flag for.
+// cmd is the command it was typed against.
+func TrackUnknownFlag(cmd *cobra.Command, flag string) {
+	if !IsEnabled() || isTestRun() {
+		return
+	}
+
+	showFirstRunNotice()
+
+	properties := unknownProperties(cmd)
+	properties["unknown_flag"] = unknownFlagName(flag)
+
+	track(EventUnknownFlag, properties)
+}
+
+// unknownProperties builds the properties both events share. A command path is
+// empty at the root, where nothing resolved, and an empty property is noise.
+func unknownProperties(cmd *cobra.Command) map[string]interface{} {
+	properties := buildCommandProperties(cmd)
+	if properties["command"] == "" {
+		delete(properties, "command")
+	}
+	return properties
+}
+
+// unknownFlagName redacts a flag that does not look like a flag name. pflag
+// reports the name without its value, so `--api-token=secret` arrives as
+// `--api-token`, but the name is still what the user typed.
+func unknownFlagName(flag string) string {
+	if len(flag) > maxFlagLength || !flagPattern.MatchString(flag) {
+		return RedactedCommand
+	}
+	return flag
 }
 
 // unknownCommandPath joins the parent path and the unknown word, so that

--- a/internal/telemetry/unknown.go
+++ b/internal/telemetry/unknown.go
@@ -15,36 +15,32 @@ const (
 	EventUnknownFlag    = "CLI Unknown Flag"
 )
 
-// RedactedCommand stands in for a word that does not look like a command name,
+// redacted stands in for a word that does not look like a command or a flag,
 // so that the event is still counted without carrying what the user typed.
-const RedactedCommand = "<redacted>"
+const redacted = "<redacted>"
 
 // maxCommandLength is the longest word we will report. The longest command the
 // CLI has is `organization-token`, at 18, so this leaves room for a guess at a
 // longer name while dropping the opaque strings a secret tends to be.
 const maxCommandLength = 30
 
-// commandPattern describes what a command name may look like: a lower-case
-// letter, then lower-case letters, digits, dashes or underscores. Every command
-// the CLI has fits this. A token or a path does not.
-var commandPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
-
 // maxFlagLength leaves room for the two dashes on a long flag.
 const maxFlagLength = maxCommandLength + 2
 
-// flagPattern describes what a flag looks like: a long flag holds to the shape
-// of a command name, and a shorthand is one letter or digit.
-var flagPattern = regexp.MustCompile(`^--[a-z][a-z0-9_-]*$|^-[a-zA-Z0-9]$`)
+// Every command the CLI has fits commandPattern, and every flag fits
+// flagPattern. A token or a path fits neither.
+var (
+	commandPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+	flagPattern    = regexp.MustCompile(`^--[a-z][a-z0-9_-]*$|^-[a-zA-Z0-9]$`)
+)
 
 // TrackUnknownCommand sends an event for a word the CLI has no command for.
 // parent is the command it was typed under, and suggestion is the nearest
 // command name, or "" when there is none.
 func TrackUnknownCommand(parent *cobra.Command, word, suggestion string) {
-	if !IsEnabled() || isTestRun() {
+	if !canTrack(parent) {
 		return
 	}
-
-	showFirstRunNotice()
 
 	properties := unknownProperties(parent)
 	properties["unknown_command"] = unknownCommandPath(parent, word)
@@ -58,11 +54,9 @@ func TrackUnknownCommand(parent *cobra.Command, word, suggestion string) {
 // TrackUnknownFlag sends an event for a flag the CLI has no such flag for.
 // cmd is the command it was typed against.
 func TrackUnknownFlag(cmd *cobra.Command, flag string) {
-	if !IsEnabled() || isTestRun() {
+	if !canTrack(cmd) {
 		return
 	}
-
-	showFirstRunNotice()
 
 	properties := unknownProperties(cmd)
 	properties["unknown_flag"] = unknownFlagName(flag)
@@ -80,12 +74,11 @@ func unknownProperties(cmd *cobra.Command) map[string]interface{} {
 	return properties
 }
 
-// unknownFlagName redacts a flag that does not look like a flag name. pflag
-// reports the name without its value, so `--api-token=secret` arrives as
-// `--api-token`, but the name is still what the user typed.
+// unknownFlagName redacts a flag that does not look like a flag name. The name
+// arrives without its value, but the name is still what the user typed.
 func unknownFlagName(flag string) string {
 	if len(flag) > maxFlagLength || !flagPattern.MatchString(flag) {
-		return RedactedCommand
+		return redacted
 	}
 	return flag
 }
@@ -96,7 +89,7 @@ func unknownFlagName(flag string) string {
 // the unknown word is redacted.
 func unknownCommandPath(parent *cobra.Command, word string) string {
 	if len(word) > maxCommandLength || !commandPattern.MatchString(word) {
-		word = RedactedCommand
+		word = redacted
 	}
 	path := GetCommandPath(parent)
 	if path == "" {

--- a/internal/telemetry/unknown_test.go
+++ b/internal/telemetry/unknown_test.go
@@ -23,11 +23,11 @@ func TestUnknownCommandPath(t *testing.T) {
 		{"under a parent", dev, "restrt", "dev restrt"},
 		{"dashes and digits are command-like", root, "run-dag2", "run-dag2"},
 		{"punctuation is redacted", dev, "tok_ab123!!", "dev <redacted>"},
-		{"a token-shaped word is redacted", root, "ey_JhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", RedactedCommand},
-		{"capitals are redacted", root, "Deploy", RedactedCommand},
-		{"a leading digit is redacted", root, "2fly", RedactedCommand},
-		{"a path is redacted", root, "/Users/me/project", RedactedCommand},
-		{"an over-long word is redacted", root, strings.Repeat("a", maxCommandLength+1), RedactedCommand},
+		{"a token-shaped word is redacted", root, "ey_JhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", redacted},
+		{"capitals are redacted", root, "Deploy", redacted},
+		{"a leading digit is redacted", root, "2fly", redacted},
+		{"a path is redacted", root, "/Users/me/project", redacted},
+		{"an over-long word is redacted", root, strings.Repeat("a", maxCommandLength+1), redacted},
 		{"a word at the limit is kept", root, strings.Repeat("a", maxCommandLength), strings.Repeat("a", maxCommandLength)},
 	}
 
@@ -56,12 +56,12 @@ func TestUnknownFlagName(t *testing.T) {
 		{"a shorthand", "-Z", "-Z"},
 		{"a digit shorthand", "-3", "-3"},
 		{"digits and dashes", "--dag-2", "--dag-2"},
-		{"capitals are redacted", "--waitForDeploy", RedactedCommand},
-		{"a token-shaped flag is redacted", "--ey_JhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", RedactedCommand},
-		{"a long shorthand is redacted", "-abc", RedactedCommand},
-		{"punctuation is redacted", "--wait!", RedactedCommand},
-		{"a bare word is redacted", "wait", RedactedCommand},
-		{"an over-long flag is redacted", "--" + strings.Repeat("a", maxCommandLength+1), RedactedCommand},
+		{"capitals are redacted", "--waitForDeploy", redacted},
+		{"a token-shaped flag is redacted", "--ey_JhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", redacted},
+		{"a long shorthand is redacted", "-abc", redacted},
+		{"punctuation is redacted", "--wait!", redacted},
+		{"a bare word is redacted", "wait", redacted},
+		{"an over-long flag is redacted", "--" + strings.Repeat("a", maxCommandLength+1), redacted},
 	}
 
 	for _, tt := range tests {

--- a/internal/telemetry/unknown_test.go
+++ b/internal/telemetry/unknown_test.go
@@ -45,3 +45,36 @@ func TestTrackUnknownCommandSendsNothingInTests(t *testing.T) {
 		TrackUnknownCommand(&cobra.Command{Use: "astro"}, "fly", "")
 	})
 }
+
+func TestUnknownFlagName(t *testing.T) {
+	tests := []struct {
+		name string
+		flag string
+		want string
+	}{
+		{"a long flag", "--wait-for-deploy", "--wait-for-deploy"},
+		{"a shorthand", "-Z", "-Z"},
+		{"a digit shorthand", "-3", "-3"},
+		{"digits and dashes", "--dag-2", "--dag-2"},
+		{"capitals are redacted", "--waitForDeploy", RedactedCommand},
+		{"a token-shaped flag is redacted", "--ey_JhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", RedactedCommand},
+		{"a long shorthand is redacted", "-abc", RedactedCommand},
+		{"punctuation is redacted", "--wait!", RedactedCommand},
+		{"a bare word is redacted", "wait", RedactedCommand},
+		{"an over-long flag is redacted", "--" + strings.Repeat("a", maxCommandLength+1), RedactedCommand},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, unknownFlagName(tt.flag))
+		})
+	}
+}
+
+func TestTrackUnknownFlagSendsNothingInTests(t *testing.T) {
+	initTestConfig(t)
+
+	assert.NotPanics(t, func() {
+		TrackUnknownFlag(&cobra.Command{Use: "deploy"}, "--wait-for-deploy")
+	})
+}

--- a/internal/telemetry/unknown_test.go
+++ b/internal/telemetry/unknown_test.go
@@ -1,0 +1,47 @@
+package telemetry
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnknownCommandPath(t *testing.T) {
+	root := &cobra.Command{Use: "astro"}
+	dev := &cobra.Command{Use: "dev"}
+	root.AddCommand(dev)
+
+	tests := []struct {
+		name   string
+		parent *cobra.Command
+		word   string
+		want   string
+	}{
+		{"at root", root, "fly", "fly"},
+		{"under a parent", dev, "restrt", "dev restrt"},
+		{"dashes and digits are command-like", root, "run-dag2", "run-dag2"},
+		{"punctuation is redacted", dev, "tok_ab123!!", "dev <redacted>"},
+		{"a token-shaped word is redacted", root, "ey_JhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", RedactedCommand},
+		{"capitals are redacted", root, "Deploy", RedactedCommand},
+		{"a leading digit is redacted", root, "2fly", RedactedCommand},
+		{"a path is redacted", root, "/Users/me/project", RedactedCommand},
+		{"an over-long word is redacted", root, strings.Repeat("a", maxCommandLength+1), RedactedCommand},
+		{"a word at the limit is kept", root, strings.Repeat("a", maxCommandLength), strings.Repeat("a", maxCommandLength)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, unknownCommandPath(tt.parent, tt.word))
+		})
+	}
+}
+
+func TestTrackUnknownCommandSendsNothingInTests(t *testing.T) {
+	initTestConfig(t)
+
+	assert.NotPanics(t, func() {
+		TrackUnknownCommand(&cobra.Command{Use: "astro"}, "fly", "")
+	})
+}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,11 @@ func main() {
 	// TODO: Remove this when version logic is implemented
 	fs := afero.NewOsFs()
 	config.InitConfig(fs)
-	if err := cmd.NewRootCmd().Execute(); err != nil {
+	rootCmd := cmd.NewRootCmd()
+	if cmd.HandleUnknownCommand(rootCmd, os.Args[1:], os.Stderr) {
+		os.Exit(1)
+	}
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Description

`astro dev restrt` prints the `dev` help and exits 0 today, so a guess at a command we do not have reads as a success and we keep no record of it. `astro deploy --wait-for-deploy` is worse: an unknown flag fails before the hook that tracks commands ever runs, so it sends no event at all, not even the ordinary command one. Agents guess at both, and a pattern in the guesses tells us what to add.

The CLI now resolves the command tree before `Execute` and sends a `CLI Unknown Command` event, then reports the mistake in cobra's own wording with exit 1. A flag error function on the root sends a `CLI Unknown Flag` event and hands the error straight back, so cobra reports flags exactly as it always has. Both events carry everything `CLI Command` already carries, including `agent`.

```
astro fly                    CLI Unknown Command  unknown_command "fly"         suggestion ""
astro deploi                 CLI Unknown Command  unknown_command "deploi"      suggestion "deploy"
astro dev restrt             CLI Unknown Command  unknown_command "dev restrt"  suggestion "restart"
astro deploy --wait-for-x    CLI Unknown Flag     unknown_flag "--wait-for-x"   command "deploy"
astro dev start -Z           CLI Unknown Flag     unknown_flag "-Z"             command "dev start"
```

An empty `suggestion` is the interesting row: a typo has a near match, an invented command does not.

Only a word shaped like a command or a flag is sent. A command name must start lower-case and hold to lower-case letters, digits, dashes and underscores, 30 characters at most — every command we have fits, and the longest is `organization-token` at 18. A path, a token or an emoji becomes `<redacted>`, and the event is still counted. Flags carry less risk to begin with, since pflag reports the name on its own and `--api-token=secret` arrives as `--api-token`. The first-run notice moves to v3 and says a command or flag we do not have is tracked too, since the v2 wording promised arguments are never tracked and this sits close to that line.

### Call-stack diff

```diff
  main()                                          main.go
  ├─ config.InitConfig(fs)                        # unchanged
+ ├─ cmd.HandleUnknownCommand(root, os.Args[1:])  cmd/unknown.go
+ │  ├─ root.InitDefaultHelpCmd()                 # cobra adds these inside
+ │  ├─ root.InitDefaultCompletionCmd(args...)    # Execute, after this point
+ │  ├─ findUnknownCommand()                      # root.Find, then stripFlags
+ │  ├─ telemetry.TrackUnknownCommand()           internal/telemetry/unknown.go
+ │  └─ report(os.Stderr)                         # then exit 1
  └─ rootCmd.Execute()
     ├─ ParseFlags()
+    │  └─ trackUnknownFlag(cmd, err)             cmd/unknown.go
+    │     ├─ telemetry.TrackUnknownFlag()        # pflag.NotExistError only
+    │     └─ return err                          # cobra reports it, unchanged
     └─ PersistentPreRunE
        └─ telemetry.TrackCommand()               # unchanged
-          └─ payload + spawnTelemetrySender()
+          └─ track("CLI Command", props)         # shared send path
```

Unchanged: every command that resolves, every error cobra already printed, `help`, `completion`, `__complete`, and the `CLI Command` event itself.

- **Where to start.** `cmd/unknown.go`. `HandleUnknownCommand` runs before `Execute` and owns the command decision; `trackUnknownFlag` is the whole flag path.
- **What I chose against.** An `Args` validator on each parent, which is what cobra would want. Cobra returns the help for a command that does not run *before* it validates arguments, so every parent would have to become runnable, and their pre-run hooks would then fire on a bare `astro dev`. That one checks for a container runtime, so `astro dev` would report a missing Docker where today it prints the help. Resolving the tree ourselves costs a duplicate of cobra's private `stripFlags`, kept next to the code that needs it.
- **What is not counted.** `flag needs an argument` and a bad value are mistakes on a flag we do have, so neither sends an event; pflag returns a typed `NotExistError`, which is what separates them. Nor is anything under `astro telemetry`, so a mistake made while opting out is not reported.
- **Least sure.** `astro completion bogus-shell` now errors instead of printing the completion help. Cobra owns that command and the same rule catches it. It reads as an improvement, but it is a change to something we did not write.

## 🧪 Functional Testing

Build the branch, then:

```
$ astro dev restrt
Error: unknown command "restrt" for "astro dev"

Did you mean this?
	restart

Run 'astro dev --help' for usage.
$ echo $?
1
$ astro deploy --wait-for-deploy
Error: unknown flag: --wait-for-deploy
```

To see what is sent without sending it, point the endpoint at a dead port:

```
$ ASTRO_TELEMETRY_DEBUG=1 ASTRO_TELEMETRY_API_URL=http://127.0.0.1:1/x astro fly
[telemetry] POST http://127.0.0.1:1/x (authenticated)
{ "event": "CLI Unknown Command", "properties": { "unknown_command": "fly", ... } }
```

Check that these are untouched: `astro help`, `astro help dev`, `astro completion zsh`, `astro __complete dev res`, `astro dev`, `astro dev start --help`, `astro deploy --verbosity`.

<details>
<summary>Old and new binaries compared across 86 invocations</summary>

I built the branch and its base and ran both through the same matrix, comparing exit code, output length and first line. Four regressions showed up and are fixed: cobra registers `help`, `completion` and `__complete` inside `ExecuteC`, after the point where we resolve the tree, so all three read as commands we do not have. `InitDefaultHelpCmd` and `InitDefaultCompletionCmd` now run first, and `__complete` is skipped, since cobra registers it from a private call we cannot make. The `completion zsh` script and the `__complete` output are byte-identical between the two binaries.

The matrix covered flags around the unknown word (`--verbosity debug fly`, `--workspace-id=a fooo`, `--`, a flag value that looks like a command), aliases, `-h`, shell metacharacters, an emoji, a path, a token-shaped word, the completion commands, unknown flags at four depths, and the real command tree on both the cloud and software platforms.

Every flag error is byte-identical to the base binary, exit code included:

```
SAME  deploy --wait-for-deploy   exit=1 | Error: unknown flag: --wait-for-deploy
SAME  dev start -Z               exit=1 | Error: unknown shorthand flag: 'Z' in -Z
SAME  deploy --verbosity         exit=1 | Error: flag needs an argument: --verbosity
```

Every remaining difference is the intended one, a guessed subcommand under `dev`, `deployment`, `workspace`, `organization` or `deployment variable`:

```
CHANGED dev restrt
   old: exit=0 lines=35 | Run an Apache Airflow environment on your local machine...
   new: exit=1 lines=5  | Error: unknown command "restrt" for "astro dev"
```

A test asserts our wording is byte-identical to cobra's for the root case, so the two paths cannot drift apart.
</details>

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Ran `make test` before taking out of draft
- [x] Ran `make lint` before taking out of draft
- [x] Added/updated applicable tests
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/) (if necessary).
- [ ] Tested against [Houston-API](https://github.com/astronomer/houston-api/) and [Astronomer](https://github.com/astronomer/astronomer/) (if necessary).
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
